### PR TITLE
aem: fix a bug on detecting linux os type

### DIFF
--- a/src/aem/azext_aem/custom.py
+++ b/src/aem/azext_aem/custom.py
@@ -54,8 +54,8 @@ class EnhancedMonitoring(object):
         self._resource_group = resource_group
         self._cmd = cmd
         self._vm = vm_client.virtual_machines.get(resource_group, vm_name, expand='instanceView')
-        self._extension = (aem_extension_info['Linux'] if (self._vm.storage_profile.os_disk.os_type.value.lower() == 'linux')
-                           else aem_extension_info['Windows'])
+        os_type = self._vm.storage_profile.os_disk.os_type.value.lower()
+        self._extension = aem_extension_info['Linux'] if (os_type == 'linux') else aem_extension_info['Windows']
         self._skip_storage_analytics = skip_storage_analytics
 
     def enable(self):

--- a/src/aem/azext_aem/custom.py
+++ b/src/aem/azext_aem/custom.py
@@ -54,7 +54,7 @@ class EnhancedMonitoring(object):
         self._resource_group = resource_group
         self._cmd = cmd
         self._vm = vm_client.virtual_machines.get(resource_group, vm_name, expand='instanceView')
-        self._extension = (aem_extension_info['Linux'] if bool(self._vm.os_profile.linux_configuration)
+        self._extension = (aem_extension_info['Linux'] if (self._vm.storage_profile.os_disk.os_type.value.lower() == 'linux')
                            else aem_extension_info['Windows'])
         self._skip_storage_analytics = skip_storage_analytics
 
@@ -268,10 +268,10 @@ class EnhancedMonitoring(object):
 
     def _get_aem_extension(self):
         existing_ext = None
-        if self._vm.instance_view.extensions:
-            full_type_name = '.'.join([self._extension['publisher'], self._extension['name']])
-            existing_ext = next((x for x in self._vm.instance_view.extensions
-                                 if x.type and (x.type.lower() == full_type_name.lower())), None)
+        if self._vm.resources:
+            existing_ext = next((x for x in self._vm.resources
+                                 if x.virtual_machine_extension_type.lower() == self._extension['name'].lower() and
+                                 x.publisher.lower() == self._extension['publisher'].lower()), None)
         return existing_ext
 
     def _get_disk_info(self):


### PR DESCRIPTION
Also, the extension response payload appears have a breaking change which I have to adjust the code

### General Guidelines

- [x] Have you run `./scripts/ci/test_static.sh` locally? (`pip install pylint flake8` required)
- [x] Have you run `python scripts/ci/test_integration.py -q` locally?
