### PR TITLE
Tunneling improvements

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -325,9 +325,9 @@
         ],
         "webapp": [
             {
-                "filename": "webapp-0.2.4-py2.py3-none-any.whl",
-                "sha256Digest": "0a00e039ff91b28e4286d45fb7bf2f0eb4fdd0a40d250798d488b32ada76a4a1",
-                "downloadUrl": "https://github.com/panchagnula/azure-cli-extensions/raw/sisirap-extensions-whl/dist/webapp-0.2.4-py2.py3-none-any.whl",
+                "filename": "webapp-0.2.5-py2.py3-none-any.whl",
+                "sha256Digest": "1def923fa2ad729191824382bc96c98b35686c38e4746699a8dc89bd78394fa3",
+                "downloadUrl": "https://github.com/panchagnula/azure-cli-extensions/raw/sisirap-extensions-whl/dist/webapp-0.2.5-py2.py3-none-any.whl",
                 "metadata": {
                     "azext.isPreview": true,
                     "azext.minCliCoreVersion": "2.0.24",
@@ -366,7 +366,7 @@
                     "metadata_version": "2.0",
                     "name": "webapp",
                     "summary": "An Azure CLI Extension to manage appservice resources",
-                    "version": "0.2.4"
+                    "version": "0.2.5"
                 }
             }
         ],

--- a/src/webapp/azext_webapp/__init__.py
+++ b/src/webapp/azext_webapp/__init__.py
@@ -35,7 +35,7 @@ class WebappExtCommandLoader(AzCommandsLoader):
                        help="shows summary of the create and deploy operation instead of executing it",
                        default=False, action='store_true')
         with self.argument_context('webapp remote-connection create') as c:
-            c.argument('port', options_list=['--port', '-p'], help='Port for the remote connection', type=int)
+            c.argument('port', options_list=['--port', '-p'], help='Port for the remote connection. Default: Random available port', type=int)
             c.argument('name', options_list=['--name', '-n'], help='Name of the webapp to connect to')
         with self.argument_context('webapp config snapshot list') as c:
             c.argument('resource_group', options_list=['--resource-group', '-g'], help='Name of resource group.')

--- a/src/webapp/azext_webapp/custom.py
+++ b/src/webapp/azext_webapp/custom.py
@@ -38,6 +38,8 @@ from .create_util import (
 
 from ._constants import (NODE_RUNTIME_NAME, OS_DEFAULT, JAVA_RUNTIME_NAME, STATIC_RUNTIME_NAME)
 
+import time
+
 logger = get_logger(__name__)
 
 # pylint:disable=no-member,too-many-lines,too-many-locals,too-many-statements
@@ -162,14 +164,7 @@ def create_deploy_webapp(cmd, name, location=None, dryrun=False):
             # work around until the timeout limits issue for linux is investigated & fixed
             # wakeup kudu, by making an SCM call
 
-        import requests
-        # work around until the timeout limits issue for linux is investigated & fixed
-        user_name, password = _get_site_credential(cmd.cli_ctx, rg_name, name)
-        scm_url = _get_scm_url(cmd, rg_name, name)
-
-        import urllib3
-        authorization = urllib3.util.make_headers(basic_auth='{0}:{1}'.format(user_name, password))
-        requests.get(scm_url + '/api/settings', headers=authorization)
+        _ping_scm_site(cmd, rg_name, name)
 
         if is_java:
             zip_file_path = src_path + '\\\\' + lang_details.get('file_loc')[0]
@@ -193,6 +188,7 @@ def create_deploy_webapp(cmd, name, location=None, dryrun=False):
     logger.warning("All done.")
     return create_json
 
+
 def _ping_scm_site(cmd, resource_group, name):
     #  wakeup kudu, by making an SCM call
     import requests
@@ -202,6 +198,7 @@ def _ping_scm_site(cmd, resource_group, name):
     import urllib3
     authorization = urllib3.util.make_headers(basic_auth='{}:{}'.format(user_name, password))
     requests.get(scm_url + '/api/settings', headers=authorization)
+
 
 def list_webapp_snapshots(cmd, resource_group, name, slot=None):
     client = web_client_factory(cmd.cli_ctx)
@@ -235,6 +232,11 @@ def restore_webapp_snapshot(cmd, resource_group, name, time, slot=None, restore_
             return client.web_apps.recover(resource_group, name, request)
 
 
+def _get_app_url(cmd, rg_name, app_name):
+    site = _generic_site_operation(cmd.cli_ctx, rg_name, app_name, 'get')
+    return "https://" + site.enabled_host_names[0]
+
+
 def _check_for_ready_tunnel(remote_debugging, tunnel_server):
     from .tunnel import TunnelServer
     default_port = tunnel_server.is_port_set_to_default()
@@ -247,32 +249,33 @@ def create_tunnel(cmd, resource_group_name, name, port=None, slot=None):
     profiles = list_publish_profiles(cmd, resource_group_name, name, slot)
     user_name = next(p['userName'] for p in profiles)
     user_password = next(p['userPWD'] for p in profiles)
-    import time
     import threading
     from .tunnel import TunnelServer
 
     if port is None:
-        port = 0 #  Will auto-select a free port from 1024-65535
+        port = 0  # Will auto-select a free port from 1024-65535
         logger.info('No port defined, creating on random free port')
     tunnel_server = TunnelServer('', port, name, user_name, user_password)
     config = get_site_configs(cmd, resource_group_name, name, slot)
     _ping_scm_site(cmd, resource_group_name, name)
 
-    t = threading.Thread()
+    t = threading.Thread(target=_start_tunnel, args=(tunnel_server, config.remote_debugging_enabled))
     t.daemon = True
     t.start()
-    if not _check_for_ready_tunnel(config.remote_debugging_enabled, tunnel_server):
+
+    # Wait indefinitely for CTRL-C
+    while True:
+        time.sleep(5)
+
+
+def _start_tunnel(tunnel_server, remote_debugging_enabled):
+    if not _check_for_ready_tunnel(remote_debugging_enabled, tunnel_server):
         logger.warning('Tunnel is not ready yet, please wait (may take up to 1 minute)')
         while True:
             time.sleep(1)
             logger.warning('.')
-            if _check_for_ready_tunnel(config.remote_debugging_enabled, tunnel_server):
+            if _check_for_ready_tunnel(remote_debugging_enabled, tunnel_server):
                 break
-    if config.remote_debugging_enabled is False:
+    if remote_debugging_enabled is False:
         logger.warning('SSH is available { username: root, password: Docker! }')
     tunnel_server.start_server()
-
-
-def _get_app_url(cmd, rg_name, app_name):
-    site = _generic_site_operation(cmd.cli_ctx, rg_name, app_name, 'get')
-    return "https://" + site.enabled_host_names[0]

--- a/src/webapp/azext_webapp/custom.py
+++ b/src/webapp/azext_webapp/custom.py
@@ -193,6 +193,15 @@ def create_deploy_webapp(cmd, name, location=None, dryrun=False):
     logger.warning("All done.")
     return create_json
 
+def _ping_scm_site(cmd, resource_group, name):
+    #  wakeup kudu, by making an SCM call
+    import requests
+    #  work around until the timeout limits issue for linux is investigated & fixed
+    user_name, password = _get_site_credential(cmd.cli_ctx, resource_group, name)
+    scm_url = _get_scm_url(cmd, resource_group, name)
+    import urllib3
+    authorization = urllib3.util.make_headers(basic_auth='{}:{}'.format(user_name, password))
+    requests.get(scm_url + '/api/settings', headers=authorization)
 
 def list_webapp_snapshots(cmd, resource_group, name, slot=None):
     client = web_client_factory(cmd.cli_ctx)
@@ -226,7 +235,7 @@ def restore_webapp_snapshot(cmd, resource_group, name, time, slot=None, restore_
             return client.web_apps.recover(resource_group, name, request)
 
 
-def _check_for_ready_tunnel(cmd, resource_group_name, name, remote_debugging, tunnel_server, slot=None):
+def _check_for_ready_tunnel(remote_debugging, tunnel_server):
     from .tunnel import TunnelServer
     default_port = tunnel_server.is_port_set_to_default()
     if default_port is not remote_debugging:
@@ -234,27 +243,33 @@ def _check_for_ready_tunnel(cmd, resource_group_name, name, remote_debugging, tu
     return False
 
 
-def create_tunnel(cmd, resource_group_name, name, port, slot=None):
+def create_tunnel(cmd, resource_group_name, name, port=None, slot=None):
     profiles = list_publish_profiles(cmd, resource_group_name, name, slot)
     user_name = next(p['userName'] for p in profiles)
     user_password = next(p['userPWD'] for p in profiles)
     import time
     import threading
     from .tunnel import TunnelServer
+
+    if port is None:
+        port = 0 #  Will auto-select a free port from 1024-65535
+        logger.info('No port defined, creating on random free port')
     tunnel_server = TunnelServer('', port, name, user_name, user_password)
     config = get_site_configs(cmd, resource_group_name, name, slot)
+    _ping_scm_site(cmd, resource_group_name, name)
 
     t = threading.Thread()
     t.daemon = True
     t.start()
-    if not _check_for_ready_tunnel(cmd, resource_group_name, name, config.remote_debugging_enabled, tunnel_server, slot):
+    if not _check_for_ready_tunnel(config.remote_debugging_enabled, tunnel_server):
         logger.warning('Tunnel is not ready yet, please wait (may take up to 1 minute)')
         while True:
             time.sleep(1)
             logger.warning('.')
-            if _check_for_ready_tunnel(cmd, resource_group_name, name, config.remote_debugging_enabled, tunnel_server, slot):
+            if _check_for_ready_tunnel(config.remote_debugging_enabled, tunnel_server):
                 break
-    logger.warning('Tunnel is ready! Creating on port %s', port)
+    if config.remote_debugging_enabled is False:
+        logger.warning('SSH is available { username: root, password: Docker! }')
     tunnel_server.start_server()
 
 

--- a/src/webapp/setup.py
+++ b/src/webapp/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup, find_packages
 
-VERSION = "0.2.4"
+VERSION = "0.2.5"
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',


### PR DESCRIPTION
This PR has the following improvements:

Implemented:
- State clearer message to connect on which port
- Show username and password when server-side ssh port is detected
- Increase ssh timeout from 30 seconds to 30 minutes
- (--port) argument is now optional, if not supplied, will pick a random available port
- ping scm site before creating tunnel
- Have CTRL-C terminate local server

Note: Will update index.json in subsequent commits

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] Have you run `./scripts/ci/test_static.sh` locally? (`pip install pylint flake8` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [x] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli-extensions/blob/master/docs/extension_summary_guidelines.md).
