### PR TITLE
Update index.json for new azure-batch-cli-extensions version

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -3,9 +3,9 @@
     "extensions": {
         "azure-batch-cli-extensions": [
             {
-                "filename": "azure_batch_cli_extensions-2.2.2-py2.py3-none-any.whl",
-                "sha256Digest": "212493c9b044a66271986f30efd8ac9dd7f736283272d0049fa4f125e9dc9323",
-                "downloadUrl": "https://github.com/Azure/azure-batch-cli-extensions/releases/download/azure-batch-cli-extensions-2.2.2/azure_batch_cli_extensions-2.2.2-py2.py3-none-any.whl",
+                "filename": "azure_batch_cli_extensions-2.3.0-py2.py3-none-any.whl",
+                "sha256Digest": "360FA1A71DA65DB1866EC6987BAD822868915D9CE5D2E6D5542C58836FF62816",
+                "downloadUrl": "https://github.com/Azure/azure-batch-cli-extensions/releases/download/azure-batch-cli-extensions-2.3.0/azure_batch_cli_extensions-2.3.0-py2.py3-none-any.whl",
                 "metadata": {
                     "azext.minCliCoreVersion": "2.0.24",
                     "azext.maxCliCoreVersion": "2.1.0",
@@ -31,7 +31,7 @@
                     "metadata_version": "2.0",
                     "name": "azure-batch-cli-extensions",
                     "summary": "Additional commands for working with Azure Batch service",
-                    "version": "2.2.2"
+                    "version": "2.3.0"
                 }
             }
         ],


### PR DESCRIPTION
azure-cli removes dependency of azure-batch-extensions and azure-batch-cli-extensions requires it (but did not specify the dependency in version 2.2.2)
