### PR TITLE
Setting Max CLI version for PostgreSQL and MySQL VNET extension

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -505,6 +505,7 @@
                 "sha256Digest": "c10d63f21308751212b3bd68448b0dfe27d6e79bf9c54412680229f69f9bcec7",
                 "downloadUrl": "https://prodrdbmsclipackages.blob.core.windows.net/cliextensions/rdbms_vnet-10.0.0-py2.py3-none-any.whl",
                 "metadata": {
+                    "azext.maxCliCoreVersion": "2.0.39",
                     "classifiers": [
                         "Development Status :: 4 - Beta",
                         "Intended Audience :: Developers",

--- a/src/index.json
+++ b/src/index.json
@@ -501,7 +501,7 @@
         ],
         "rdbms-vnet": [
             {
-                "filename": "rdbms_vnet-10.0.0-py2.py3-none-any.whl",
+                "filename": "rdbms_vnet-10.0.1-py2.py3-none-any.whl",
                 "sha256Digest": "c921b03f36e43f93d98caa060575845ecab0cdc98983731488d622f3edfd0c41",
                 "downloadUrl": "https://prodrdbmsclipackages.blob.core.windows.net/cliextensions/rdbms_vnet-10.0.1-py2.py3-none-any.whl",
                 "metadata": {

--- a/src/index.json
+++ b/src/index.json
@@ -502,8 +502,8 @@
         "rdbms-vnet": [
             {
                 "filename": "rdbms_vnet-10.0.0-py2.py3-none-any.whl",
-                "sha256Digest": "c10d63f21308751212b3bd68448b0dfe27d6e79bf9c54412680229f69f9bcec7",
-                "downloadUrl": "https://prodrdbmsclipackages.blob.core.windows.net/cliextensions/rdbms_vnet-10.0.0-py2.py3-none-any.whl",
+                "sha256Digest": "c921b03f36e43f93d98caa060575845ecab0cdc98983731488d622f3edfd0c41",
+                "downloadUrl": "https://prodrdbmsclipackages.blob.core.windows.net/cliextensions/rdbms_vnet-10.0.1-py2.py3-none-any.whl",
                 "metadata": {
                     "azext.maxCliCoreVersion": "2.0.39",
                     "classifiers": [

--- a/src/rdbms_vnet/azext_rdbms_vnet/azext_metadata.json
+++ b/src/rdbms_vnet/azext_rdbms_vnet/azext_metadata.json
@@ -1,3 +1,4 @@
 {
-    "azext.minCliCoreVersion": "2.0.24"
+    "azext.minCliCoreVersion": "2.0.24",
+    "azext.maxCliCoreVersion": "2.0.39"
 }

--- a/src/rdbms_vnet/setup.py
+++ b/src/rdbms_vnet/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup, find_packages
 
-VERSION = "10.0.0"
+VERSION = "10.0.1"
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',


### PR DESCRIPTION
Setting Max version for VNET extension

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `./scripts/ci/test_static.sh` locally? (`pip install pylint flake8` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli-extensions/blob/master/docs/extension_summary_guidelines.md).
