### PR TITLE
Fixed: can not connect when using slot option.

### DIFF
--- a/src/webapp/azext_webapp/custom.py
+++ b/src/webapp/azext_webapp/custom.py
@@ -247,7 +247,10 @@ def create_tunnel(cmd, resource_group_name, name, port=None, slot=None):
     if port is None:
         port = 0  # Will auto-select a free port from 1024-65535
         logger.info('No port defined, creating on random free port')
-    tunnel_server = TunnelServer('', port, name, user_name, user_password)
+    host_name = name
+    if slot is not None:
+        host_name += "-" + slot
+    tunnel_server = TunnelServer('', port, host_name, user_name, user_password)
     config = get_site_configs(cmd, resource_group_name, name, slot)
     _ping_scm_site(cmd, resource_group_name, name)
 


### PR DESCRIPTION
I can not connect when using slot option and I got following errors.

```
urllib3.connectionpool : Starting new HTTPS connection (1): appname.scm.azurewebsites.net:443
urllib3.connectionpool : https://appname.scm.azurewebsites.net:443 "GET /api/settings HTTP/1.1" 200 757
urllib3.connectionpool : Starting new HTTPS connection (1): appname.scm.azurewebsites.net:443
urllib3.connectionpool : https://appname.scm.azurewebsites.net:443 "GET /AppServiceTunnel/Tunnel.ashx?GetStatus HTTP/1.1" 403 2399
Exception in thread Thread-1:
Traceback (most recent call last):
  File "~/.pyenv/versions/2.7.15/lib/python2.7/threading.py", line 801, in __bootstrap_inner
    self.run()
  File "~/.pyenv/versions/2.7.15/lib/python2.7/threading.py", line 754, in run
    self.__target(*self.__args, **self.__kwargs)
  File "~/.azure/cliextensions/webapp/azext_webapp/custom.py", line 270, in _start_tunnel
    if not _check_for_ready_tunnel(remote_debugging_enabled, tunnel_server):
  File "~/.azure/cliextensions/webapp/azext_webapp/custom.py", line 240, in _check_for_ready_tunnel
    default_port = tunnel_server.is_port_set_to_default()
  File "~/.azure/cliextensions/webapp/azext_webapp/tunnel.py", line 95, in is_port_set_to_default
    raise CLIError("Failed to connect to '{}' with status code '{}' and reason '{}'".format(url, r.status, r.reason))
CLIError: Failed to connect to 'https://appname.scm.azurewebsites.net/AppServiceTunnel/Tunnel.ashx?GetStatus' with status code '403' and reason 'Forbidden'
```

I think after appname "-slotname" is required for example 
"appname-slotname.scm.azurewebsites.net".
This implementation was successful connect to WebApp using slot option.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] Have you run `./scripts/ci/test_static.sh` locally? (`pip install pylint flake8` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli-extensions/blob/master/docs/extension_summary_guidelines.md).
