### PR TITLE
ref doc gen broken due to deprecation work

### DIFF
--- a/scripts/refdoc/azhelpgen/azhelpgen.py
+++ b/scripts/refdoc/azhelpgen/azhelpgen.py
@@ -33,7 +33,7 @@ def get_extension_help_files(cli_ctx):
     print('FOUND {} command(s) from the extension.'.format(len(cmd_table)))
     for cmd_name in cmd_table:
             invoker.commands_loader.load_arguments(cmd_name)
-    invoker.parser.load_command_table(invoker.commands_loader.command_table)
+    invoker.parser.load_command_table(invoker.commands_loader)
 
     parser_keys = []
     parser_values = []
@@ -44,10 +44,12 @@ def get_extension_help_files(cli_ctx):
         if cmd not in sub_parser_keys:
             sub_parser_keys.append(cmd)
             sub_parser_values.append(parser)
+    help_ctx = cli_ctx.help_cls(cli_ctx=cli_ctx)
     help_files = []
     for cmd, parser in zip(sub_parser_keys, sub_parser_values):
         try:
-            help_file = GroupHelpFile(cmd, parser) if _is_group(parser) else CliCommandHelpFile(cmd, parser)
+            help_file = GroupHelpFile(help_ctx, cmd, parser) if _is_group(parser) \
+                else CliCommandHelpFile(help_ctx, cmd, parser)
             help_file.load(parser)
             help_files.append(help_file)
         except Exception as ex:
@@ -73,6 +75,8 @@ class AzHelpGenDirective(Directive):
             yield ''
             yield '{}:summary: {}'.format(INDENT, help_file.short_summary)
             yield '{}:description: {}'.format(INDENT, help_file.long_summary)
+            if help_file.deprecate_info:
+                yield '{}:deprecated: {}'.format(INDENT, help_file.deprecate_info._get_message(help_file.deprecate_info))
             yield ''
 
             if is_command and help_file.parameters:
@@ -84,6 +88,8 @@ class AzHelpGenDirective(Directive):
                     yield '{}.. cliarg:: {}'.format(INDENT, arg.name)
                     yield ''
                     yield '{}:required: {}'.format(DOUBLEINDENT, arg.required)
+                    if arg.deprecate_info:
+                        yield '{}:deprecated: {}'.format(DOUBLEINDENT, arg.deprecate_info._get_message(arg.deprecate_info))
                     short_summary = arg.short_summary or ''
                     possible_values_index = short_summary.find(' Possible values include')
                     short_summary = short_summary[0:possible_values_index

--- a/scripts/refdoc/cligroup/cligroup.py
+++ b/scripts/refdoc/cligroup/cligroup.py
@@ -32,29 +32,35 @@ class CliBaseDirective(ObjectDescription):
 
 class CliGroupDirective(CliBaseDirective):
     doc_field_types = copy.copy(cli_field_types)
-    doc_field_types.append(
+    doc_field_types.extend([
         Field('docsource', label='Doc Source', has_arg=False,
-                   names=('docsource', 'documentsource'))
-    )
+              names=('docsource', 'documentsource')),
+        Field('deprecated', label='Deprecated', has_arg=False,
+              names=('deprecated'))
+    ])
 
 class CliCommandDirective(CliBaseDirective):
     doc_field_types = copy.copy(cli_field_types)
-    doc_field_types.append(
+    doc_field_types.extend([
         Field('docsource', label='Doc Source', has_arg=False,
-                   names=('docsource', 'documentsource'))
-    )
+              names=('docsource', 'documentsource')),
+        Field('deprecated', label='Deprecated', has_arg=False,
+              names=('deprecated'))
+    ])
 
 class CliArgumentDirective(CliBaseDirective):
     doc_field_types = copy.copy(cli_field_types)
     doc_field_types.extend([
         Field('required', label='Required', has_arg=False,
-            names=('required')),
+              names=('required')),
         Field('values', label='Allowed values', has_arg=False,
-            names=('values', 'choices', 'options')),
+              names=('values', 'choices', 'options')),
         Field('default', label='Default value', has_arg=False,
-            names=('default')),
+              names=('default')),
         Field('source', label='Values from', has_arg=False,
-            names=('source', 'sources'))
+              names=('source', 'sources')),
+        Field('deprecated', label='Deprecated', has_arg=False,
+              names=('deprecated'))
      ])
 
 class CliExampleDirective(CliBaseDirective):


### PR DESCRIPTION
---
-Ref doc gen was broken by: https://github.com/Azure/azure-cli/pull/6472
-extension script uses latest released version of CLI, hence why this wasn't picked up until now.