### PR TITLE
Fix webapp remote-connection create fails if specifying --port

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -284,9 +284,9 @@
         ],
         "webapp": [
             {
-                "filename": "webapp-0.2.9-py2.py3-none-any.whl",
-                "sha256Digest": "bbf4db820ab03e1a140942b8899741b67c61e8fbfb909ad8817470b32edc6361",
-                "downloadUrl": "https://github.com/panchagnula/azure-cli-extensions/raw/sisirap-extensions-whl/dist/webapp-0.2.9-py2.py3-none-any.whl",
+                "filename": "webapp-0.2.10-py2.py3-none-any.whl",
+                "sha256Digest": "3b2a32fb5958f06b7d4d2d68cf9224487d642a4f6271106506da00a544ec9b30",
+                "downloadUrl": "https://github.com/patricklee2/extensions-whl/raw/master/webapp-0.2.10-py2.py3-none-any.whl",
                 "metadata": {
                     "azext.isPreview": true,
                     "azext.minCliCoreVersion": "2.0.46",
@@ -325,7 +325,7 @@
                     "metadata_version": "2.0",
                     "name": "webapp",
                     "summary": "Additional commands for Azure AppService.",
-                    "version": "0.2.9"
+                    "version": "0.2.10"
                 }
             }
         ],

--- a/src/webapp/azext_webapp/tunnel.py
+++ b/src/webapp/azext_webapp/tunnel.py
@@ -66,7 +66,7 @@ class TunnelServer(object):
     def is_port_open(self):
         is_port_open = False
         with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
-            if sock.connect_ex('', self.local_port) == 0:
+            if sock.connect_ex(('', self.local_port)) == 0:
                 logger.info('Port %s is NOT open', self.local_port)
             else:
                 logger.warning('Port %s is open', self.local_port)

--- a/src/webapp/setup.py
+++ b/src/webapp/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup, find_packages
 
-VERSION = "0.2.9"
+VERSION = "0.2.10"
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',


### PR DESCRIPTION
fixes #268 

I tested it and was able to open the port

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] Have you run `./scripts/ci/test_static.sh` locally? (`pip install pylint flake8` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [x] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).
