### PR TITLE
Added CI test to verify that all command modules load successfully

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ ENV/
 
 # Sphinx
 _build/
+
+# Pycharm
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,10 @@ jobs:
       script: ./scripts/ci/verify_linter.sh
       python: 3.6
     - stage: verify
+      env: PURPOSE='Load All Commands'
+      script: ./scripts/ci/verify_module_load.sh
+      python: 3.6
+    - stage: verify
       env: PURPOSE='IndexRefDocVerify'
       script: ./scripts/ci/test_index_ref_doc.sh
       python: 3.6

--- a/scripts/ci/verify_module_load.sh
+++ b/scripts/ci/verify_module_load.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -ex
+
+# Install CLI & Dev Tools
+echo "Installing azure-cli-dev-tools and azure-cli..."
+pip install --pre azure-cli --extra-index-url https://azurecliprod.blob.core.windows.net/edge
+pip install -e "git+https://github.com/Azure/azure-cli@dev#egg=azure-cli-dev-tools&subdirectory=tools" -q
+echo "Installed."
+az --version
+set +x
+
+# check for index updates
+modified_extensions=$(python ./scripts/ci/index_changes.py)
+echo "Found the following modified extension entries:"
+echo "$modified_extensions"
+
+# add each modified extension entry.
+while read line; do
+    if [ -z "$line" ]; then
+        continue
+    fi
+    part_array=($line)
+    ext=${part_array[0]}
+    source=${part_array[1]}
+    echo
+    echo "New index entries detected for extension:" $ext
+    echo "Adding latest entry from source:" $source
+    set +e
+    az extension add -s $source -y
+    if [ $? != 0 ]; then
+        continue
+    fi
+    set -e
+done <<< "$modified_extensions"
+
+exit_code=0
+msg="OK. All modules loaded successfuly."
+
+# verify that all modules are loaded properly.
+echo
+echo "Loading all modules..."
+
+set +e
+azdev verify load-all
+if [ $? != 0 ]
+then
+    exit_code=1
+    msg="A module load was unsuccessful."
+fi
+
+# remove the added extensions
+while read line; do
+    if [ -z "$line" ]; then
+        continue
+    fi
+    part_array=($line)
+    ext=${part_array[0]}
+    az extension remove -n $ext
+    echo $ext "extension has been removed."
+done <<< "$modified_extensions"
+
+echo $msg
+exit $exit_code
+


### PR DESCRIPTION
Added CI test and script to verify that new extension does not prevent all modules from loading successfully.

P.s. I tested this with a dummy command module. 

The new CI test fails if there isn't help for a command group or if a command is registered to a method that doesn't exist.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `./scripts/ci/test_static.sh` locally? (`pip install pylint flake8` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).
