### PR TITLE
[Express-Route] if no bandwidth is given, stop validation

### DIFF
--- a/src/express-route/azext_express_route/_validators.py
+++ b/src/express-route/azext_express_route/_validators.py
@@ -67,9 +67,9 @@ def bandwidth_validator_factory(mbps=True):
 def validate_circuit_bandwidth(namespace, mbps=True):
     # use gbps if mbps is False
     unit = 'mbps' if mbps else 'gbps'
-    try:
-        bandwidth = getattr(namespace, 'bandwidth_in_{}'.format(unit))
-    except AttributeError:
+    bandwidth = None
+    bandwidth = getattr(namespace, 'bandwidth_in_{}'.format(unit), None)
+    if bandwidth is None:
         return
 
     if len(bandwidth) == 1:


### PR DESCRIPTION
---
Found further issues with the validation that fails `express-route update` if not updating bandwidth.

-Tests need to be added to this extension so that bugs like can be caught from day 1, I'll open an issue for that.