### PR TITLE
Change version to be compatible with Azure DevOps

### DIFF
--- a/src/eventgrid/azext_eventgrid/azext_metadata.json
+++ b/src/eventgrid/azext_eventgrid/azext_metadata.json
@@ -1,4 +1,4 @@
 {
-    "azext.minCliCoreVersion": "2.0.49",
+    "azext.minCliCoreVersion": "2.0.46",
     "azext.isPreview": true
 }


### PR DESCRIPTION
Azure DevOps will no longer allow me to install this extension when I use the `Azure CLI` task on a hosted agent. The installed version on the hosted agent is `azure-cli (2.0.46)`. Can this file be edited to allow that to work?

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] Have you run `./scripts/ci/test_static.sh` locally? (`pip install pylint flake8` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?
