### PR TITLE
suppress gen ref docs for botservice for now

### DIFF
--- a/scripts/ci/index_ref_doc.py
+++ b/scripts/ci/index_ref_doc.py
@@ -33,6 +33,8 @@ ALL_TESTS = []
 CLI_VERSION = get_distribution('azure-cli').version
 
 for extension_name, exts in get_index_data()['extensions'].items():
+    if extension_name == 'botservice':
+        continue
     parsed_cli_version = parse_version(CLI_VERSION)
     filtered_exts = []
     for ext in exts:


### PR DESCRIPTION
Changes in botservice CLI module are blocking the CI for extensions.
Suppressing this for now.

@swagatmishra2007 can you update the botservice extension to specify a max-cli-version of 2.0.51?