### PR TITLE
[Image-Copy] Update to version 0.0.9

### DIFF
--- a/src/image-copy/azext_imagecopy/create_target.py
+++ b/src/image-copy/azext_imagecopy/create_target.py
@@ -168,6 +168,9 @@ def wait_for_blob_copy_operation(blob_name, target_container_name, target_storag
 
     if copy_status != 'success':
         logger.error("The copy operation didn't succeed. Last status: %s", copy_status)
+        logger.error("Command run: %s", cli_cmd)
+        logger.error("Command output: %s", json_output)
+
         raise CLIError('Blob copy failed')
 
 

--- a/src/image-copy/setup.py
+++ b/src/image-copy/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup, find_packages
 
-VERSION = "0.0.8"
+VERSION = "0.0.9"
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',

--- a/src/index.json
+++ b/src/index.json
@@ -802,8 +802,8 @@
         ],
         "image-copy-extension": [
             {
-                "downloadUrl": "https://files.pythonhosted.org/packages/22/2e/0cbdf151f48f788a817b2f3808bf4be0e30d5d4693726cd794d3ba69f59a/image_copy_extension-0.0.8-py2.py3-none-any.whl",
-                "filename": "image_copy_extension-0.0.8-py2.py3-none-any.whl",
+                "downloadUrl": "https://files.pythonhosted.org/packages/0b/3a/c8e02e8af6941fe55ed55d6011c15a60ba8ce3ddd52a34ae7c2c5043958f/image_copy_extension-0.0.9-py2.py3-none-any.whl",
+                "filename": "image_copy_extension-0.0.9-py2.py3-none-any.whl",
                 "metadata": {
                     "azext.minCliCoreVersion": "2.0.24",
                     "classifiers": [
@@ -841,9 +841,9 @@
                     "metadata_version": "2.0",
                     "name": "image-copy-extension",
                     "summary": "Support for copying managed vm images between regions",
-                    "version": "0.0.8"
+                    "version": "0.0.9"
                 },
-                "sha256Digest": "a2173b62dd942a8c62e35ef53abea7094508f59e05e79ca03f2296c44313c903"
+                "sha256Digest": "7f77f6c2ba940fb64ff157555ee26cc688bd4b5f8b3b5b3fef738158a16ac7b1"
             }
         ],
         "interactive": [


### PR DESCRIPTION
This PR updates the published version of the extension to include a timeout parameter to handle large images that fail to copy in 60 minutes.
Actual change is on #426, this closes #423
FYI @afengli

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `./scripts/ci/test_static.sh` locally? (`pip install pylint flake8` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).
