### PR TITLE
[botservice] remove old version of botservice extension

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -347,38 +347,6 @@
         ],
         "botservice": [
             {
-                "downloadUrl": "https://icscratch.blob.core.windows.net/bot-packages/botservice-0.4.1-py2.py3-none-any.whl",
-                "filename": "botservice-0.4.1-py2.py3-none-any.whl",
-                "metadata": {
-                    "azext.isPreview": true,
-                    "azext.minCliCoreVersion": "2.0.45",
-                    "extensions": {
-                        "python.details": {
-                            "contacts": [
-                                {
-                                    "email": "swagatm@microsoft.com",
-                                    "name": "Swagat Mishra",
-                                    "role": "author"
-                                }
-                            ],
-                            "document_names": {
-                                "description": "DESCRIPTION.rst"
-                            },
-                            "project_urls": {
-                                "Home": "https://github.com/Azure/azure-cli-extensions"
-                            }
-                        }
-                    },
-                    "generator": "bdist_wheel (0.30.0)",
-                    "license": "MIT",
-                    "metadata_version": "2.0",
-                    "name": "botservice",
-                    "summary": "Bug fixes for issues in the native botservice cli command module.",
-                    "version": "0.4.1"
-                },
-                "sha256Digest": "8c84c0c2806c2fc0bfb182b2819151c15a33bb6fa46ae208063cbfde1cf98fe3"
-            },
-            {
                 "downloadUrl": "https://icscratch.blob.core.windows.net/bot-packages/botservice-0.4.3-py2.py3-none-any.whl",
                 "filename": "botservice-0.4.3-py2.py3-none-any.whl",
                 "metadata": {


### PR DESCRIPTION
---

@stevengum v0.4.1 does not specify a max cli version, while v0.4.3 is only valid for CLI version 2.0.52. 
This means that for CLI v2.0.53, users would see v0.4.1 of the botservice extension, which I dont believe you want.
Removing the older extension from the index in this PR to unblock CI and reference document generation.

Closes: https://github.com/Azure/azure-cli-extensions/issues/449