### PR TITLE
remove botservice

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -345,49 +345,6 @@
                 "sha256Digest": "f0e6114e5b4c08845a2ba0ea1d332d9f88d895ef122ef3a0fd2d960584b9feff"
             }
         ],
-        "botservice": [
-            {
-                "downloadUrl": "https://icscratch.blob.core.windows.net/bot-packages/botservice-0.4.3-py2.py3-none-any.whl",
-                "filename": "botservice-0.4.3-py2.py3-none-any.whl",
-                "metadata": {
-                    "azext.isPreview": true,
-                    "azext.maxCliCoreVersion": "2.0.52",
-                    "azext.minCliCoreVersion": "2.0.52",
-                    "extensions": {
-                        "python.details": {
-                            "contacts": [
-                                {
-                                    "email": "swagatm@microsoft.com",
-                                    "name": "Swagat Mishra",
-                                    "role": "author"
-                                }
-                            ],
-                            "document_names": {
-                                "description": "DESCRIPTION.rst"
-                            },
-                            "project_urls": {
-                                "Home": "https://github.com/Azure/azure-cli-extensions"
-                            }
-                        }
-                    },
-                    "extras": [],
-                    "generator": "bdist_wheel (0.30.0)",
-                    "license": "MIT",
-                    "metadata_version": "2.0",
-                    "name": "botservice",
-                    "run_requires": [
-                        {
-                            "requires": [
-                                "requests"
-                            ]
-                        }
-                    ],
-                    "summary": "Bug fixes for issues in the native botservice cli command module.",
-                    "version": "0.4.3"
-                },
-                "sha256Digest": "3ae265dd7b07d0710671b3930c98b45951d9a334d6b066b6bba35df93cd61b02"
-            }
-        ],
         "dev-spaces-preview": [
             {
                 "downloadUrl": "https://azuredevspacestools.blob.core.windows.net/azdssetup/LKS/dev_spaces_preview-0.1.6-py2.py3-none-any.whl",


### PR DESCRIPTION
---
- Blob url for botservice gives 404, blob might have been deleted from storage account. 
- To bypass CI failures and prevent users from getting 404 errors upon trying to add the extension, I am removing the extension from our index.

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `./scripts/ci/test_static.sh` locally? (`pip install pylint flake8` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).
