### PR TITLE
Fix for --use-subdomain in azure storage extensions

### DIFF
--- a/src/storage-preview/azext_storage_preview/operations/account.py
+++ b/src/storage-preview/azext_storage_preview/operations/account.py
@@ -103,7 +103,7 @@ def update_storage_account(cmd, instance, sku=None, tags=None, custom_domain=Non
     if custom_domain is not None:
         domain = CustomDomain(name=custom_domain)
         if use_subdomain is not None:
-            domain.use_sub_domain_name = use_subdomain == 'true'
+            domain.use_sub_domain = use_subdomain == 'true'
 
     encryption = instance.encryption
     if encryption_services:

--- a/src/storage-preview/azext_storage_preview/operations/account.py
+++ b/src/storage-preview/azext_storage_preview/operations/account.py
@@ -21,7 +21,7 @@ def create_storage_account(cmd, resource_group_name, account_name, sku=None, loc
     scf = storage_client_factory(cmd.cli_ctx)
     params = StorageAccountCreateParameters(sku=Sku(name=sku), kind=Kind(kind), location=location, tags=tags)
     if custom_domain:
-        params.custom_domain = CustomDomain(name=custom_domain, use_sub_domain=None)
+        params.custom_domain = CustomDomain(name=custom_domain, use_sub_domain_name=None)
     if encryption_services:
         params.encryption = Encryption(services=encryption_services)
     if access_tier:
@@ -103,7 +103,7 @@ def update_storage_account(cmd, instance, sku=None, tags=None, custom_domain=Non
     if custom_domain is not None:
         domain = CustomDomain(name=custom_domain)
         if use_subdomain is not None:
-            domain.use_sub_domain = use_subdomain == 'true'
+            domain.use_sub_domain_name = use_subdomain == 'true'
 
     encryption = instance.encryption
     if encryption_services:

--- a/src/storage-preview/azext_storage_preview/operations/account.py
+++ b/src/storage-preview/azext_storage_preview/operations/account.py
@@ -103,7 +103,7 @@ def update_storage_account(cmd, instance, sku=None, tags=None, custom_domain=Non
     if custom_domain is not None:
         domain = CustomDomain(name=custom_domain)
         if use_subdomain is not None:
-            domain.use_sub_domain = use_subdomain == 'true'
+            domain.use_sub_domain_name = use_subdomain == 'true'
 
     encryption = instance.encryption
     if encryption_services:

--- a/src/storage-preview/azext_storage_preview/operations/account.py
+++ b/src/storage-preview/azext_storage_preview/operations/account.py
@@ -103,7 +103,7 @@ def update_storage_account(cmd, instance, sku=None, tags=None, custom_domain=Non
     if custom_domain is not None:
         domain = CustomDomain(name=custom_domain)
         if use_subdomain is not None:
-            domain.name = use_subdomain == 'true'
+            domain.use_sub_domain = use_subdomain == 'true'
 
     encryption = instance.encryption
     if encryption_services:

--- a/src/storage-preview/azext_storage_preview/vendored_sdks/azure_mgmt_storage/v2018_07_01/models/custom_domain.py
+++ b/src/storage-preview/azext_storage_preview/vendored_sdks/azure_mgmt_storage/v2018_07_01/models/custom_domain.py
@@ -32,10 +32,10 @@ class CustomDomain(Model):
 
     _attribute_map = {
         'name': {'key': 'name', 'type': 'str'},
-        'use_sub_domain': {'key': 'useSubDomainName', 'type': 'bool'},
+        'use_sub_domain_name': {'key': 'useSubDomainName', 'type': 'bool'},
     }
 
     def __init__(self, **kwargs):
         super(CustomDomain, self).__init__(**kwargs)
         self.name = kwargs.get('name', None)
-        self.use_sub_domain = kwargs.get('use_sub_domain', None)
+        self.use_sub_domain_name = kwargs.get('use_sub_domain_name', None)

--- a/src/storage-preview/azext_storage_preview/vendored_sdks/azure_mgmt_storage/v2018_07_01/models/custom_domain.py
+++ b/src/storage-preview/azext_storage_preview/vendored_sdks/azure_mgmt_storage/v2018_07_01/models/custom_domain.py
@@ -32,7 +32,7 @@ class CustomDomain(Model):
 
     _attribute_map = {
         'name': {'key': 'name', 'type': 'str'},
-        'use_sub_domain': {'key': 'useSubDomain', 'type': 'bool'},
+        'use_sub_domain': {'key': 'useSubDomainName', 'type': 'bool'},
     }
 
     def __init__(self, **kwargs):

--- a/src/storage-preview/azext_storage_preview/vendored_sdks/azure_mgmt_storage/v2018_07_01/models/custom_domain_py3.py
+++ b/src/storage-preview/azext_storage_preview/vendored_sdks/azure_mgmt_storage/v2018_07_01/models/custom_domain_py3.py
@@ -32,7 +32,7 @@ class CustomDomain(Model):
 
     _attribute_map = {
         'name': {'key': 'name', 'type': 'str'},
-        'use_sub_domain': {'key': 'useSubDomain', 'type': 'bool'},
+        'use_sub_domain': {'key': 'useSubDomainName', 'type': 'bool'},
     }
 
     def __init__(self, *, name: str, use_sub_domain: bool=None, **kwargs) -> None:

--- a/src/storage-preview/azext_storage_preview/vendored_sdks/azure_mgmt_storage/v2018_07_01/models/custom_domain_py3.py
+++ b/src/storage-preview/azext_storage_preview/vendored_sdks/azure_mgmt_storage/v2018_07_01/models/custom_domain_py3.py
@@ -32,10 +32,10 @@ class CustomDomain(Model):
 
     _attribute_map = {
         'name': {'key': 'name', 'type': 'str'},
-        'use_sub_domain': {'key': 'useSubDomainName', 'type': 'bool'},
+        'use_sub_domain_name': {'key': 'useSubDomainName', 'type': 'bool'},
     }
 
-    def __init__(self, *, name: str, use_sub_domain: bool=None, **kwargs) -> None:
+    def __init__(self, *, name: str, use_sub_domain_name: bool=None, **kwargs) -> None:
         super(CustomDomain, self).__init__(**kwargs)
         self.name = name
-        self.use_sub_domain = use_sub_domain
+        self.use_sub_domain_name = use_sub_domain_name

--- a/src/storage-preview/setup.py
+++ b/src/storage-preview/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup, find_packages
 
-VERSION = "0.2.0"
+VERSION = "0.2.1"
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',


### PR DESCRIPTION
There's a mistake in the 2018-07-01 arm schema, and there is a bug in the account.py overwriting the wrong parameter, the later is fixed in azure-cli. 
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] Have you run `./scripts/ci/test_static.sh` locally? (`pip install pylint flake8` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).
