### PR TITLE
Docs repo renamed; changing ref in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ jobs:
           -e TRAVIS_REPO_SLUG=$TRAVIS_REPO_SLUG \
           -e TRAVIS_COMMIT=$TRAVIS_COMMIT \
           -e GH_TOKEN=$GH_TOKEN \
-          -e DOC_REPO_SLUG='Azure/azure-docs-cli-python' \
+          -e DOC_REPO_SLUG='Azure/azure-docs-cli' \
           -e REPO_LOCATION=/repo \
           -v $PWD:/repo \
           sttramer/az-ext-list-publisher:0.3.0


### PR DESCRIPTION
Not critical to merge (302 redirect should be handled correctly) but still necessary.
