### PR TITLE
Fix doc gen issue. Updated .gitignore. Proper parameter information should now be loaded from _params.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,9 @@ env27/
 # VS Code
 .vscode
 
+# PyCharm
+.idea
+
 # mypy
 .mypy_cache/
 


### PR DESCRIPTION
Fix doc gen issue. Updated .gitignore. 
Proper parameter information should now be loaded from _params.py, such as option names.

Closes #479 

Follow up issue opened [here](https://github.com/Azure/azure-cli-dev-tools/issues/22)

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `./scripts/ci/test_static.sh` locally? (`pip install pylint flake8` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).
