### PR TITLE
[Interactive] Pin max CLI core version

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -1142,6 +1142,7 @@
                 "filename": "interactive-0.4.1-py2.py3-none-any.whl",
                 "metadata": {
                     "azext.isPreview": true,
+                    "azext.maxCliCoreVersion": "2.0.61",
                     "azext.minCliCoreVersion": "2.0.50.dev0",
                     "extensions": {
                         "python.details": {
@@ -1161,7 +1162,7 @@
                         }
                     },
                     "extras": [],
-                    "generator": "bdist_wheel (0.29.0)",
+                    "generator": "bdist_wheel (0.30.0)",
                     "license": "MIT",
                     "metadata_version": "2.0",
                     "name": "interactive",
@@ -1175,7 +1176,7 @@
                     "summary": "Microsoft Azure Command-Line Interactive Shell",
                     "version": "0.4.1"
                 },
-                "sha256Digest": "85bec0d72f27bf9227b86434bfabd8b6f5121b317d6f06233469ae3d0c48562b"
+                "sha256Digest": "22b940493972b77c62606b0ae3c834283209d8619bb740e69dd115530a328e3b"
             }
         ],
         "keyvault-preview": [

--- a/src/interactive/azext_interactive/azext_metadata.json
+++ b/src/interactive/azext_interactive/azext_metadata.json
@@ -1,4 +1,5 @@
 {
     "azext.isPreview": true,
-    "azext.minCliCoreVersion": "2.0.50.dev0"     
+    "azext.minCliCoreVersion": "2.0.50.dev0",
+    "azext.maxCliCoreVersion": "2.0.61"
 }


### PR DESCRIPTION
The interactive extension is not compatible with Azure CLI 2.0.62's core. This PR pins the existing release, which will work with <2.0.61. A subsequent PR will have a release compatible with 2.0.62.