### PR TITLE
[aks-preview]: fix python3-only super() syntax

### DIFF
--- a/src/aks-preview/azext_aks_preview/__init__.py
+++ b/src/aks-preview/azext_aks_preview/__init__.py
@@ -31,8 +31,7 @@ class ContainerServiceCommandsLoader(AzCommandsLoader):
         return self.command_table
 
     def load_arguments(self, command):
-        # super(ContainerServiceCommandsLoader, self).load_arguments(command)
-        super().load_arguments(command)
+        super(ContainerServiceCommandsLoader, self).load_arguments(command)
         from ._params import load_arguments
         load_arguments(self, command)
 


### PR DESCRIPTION
Restores the old, Python2-compatible syntax for calling `super()`.

Fixes Azure/AKS#908

cc: @zqingqing1 @xizhamsft

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] Have you run `./scripts/ci/test_static.sh` locally? (`pip install pylint flake8` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).
