### PR TITLE
support negate flag in waf-policy custom-rules match-conditions

### DIFF
--- a/src/front-door/azext_front_door/_help.py
+++ b/src/front-door/azext_front_door/_help.py
@@ -275,7 +275,7 @@ helps['network waf-policy custom-rule create'] = """
           short-summary: Match condition for the rule.
           long-summary: |
 
-            Usage:   --match-condition VARIABLE OPERATOR [VALUE [VALUE ...]]
+            Usage:   --match-condition [!] VARIABLE OPERATOR [VALUE [VALUE ...]]
 
               Variable allowed values: {variables}
 

--- a/src/front-door/azext_front_door/_validators.py
+++ b/src/front-door/azext_front_door/_validators.py
@@ -89,14 +89,21 @@ class MatchConditionAction(argparse._AppendAction):
             values = values.split(' ')
 
         try:
+            negate = False
+            argstart = 0
+            if values[0] == "!":
+                negate = True
+                argstart = 1
+
             return MatchCondition1(
-                match_variable=values[0],
-                operator=values[1],
-                match_value=values[2:]
+                match_variable=values[argstart],
+                operator=values[argstart+1],
+                match_value=values[argstart+2:],
+                negate_condition=negate
             )
         except IndexError:
             from knack.util import CLIError
-            raise CLIError('usage error: --match-condition VARIABLE OPERATOR [VALUE [VALUE ...]]')
+            raise CLIError('usage error: --match-condition [!] VARIABLE OPERATOR [VALUE [VALUE ...]]')
 
     def __call__(self, parser, namespace, values, option_string=None):
         match_condition = self.parse_match_condition(values)


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [x] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).
