### PR TITLE
remove botservice from index.json

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -664,49 +664,6 @@
                 "sha256Digest": "31a24c8c88a6780696e69fe287e6377f97fd8e29f3bc60379040e1e601d1a0ed"
             }
         ],
-        "botservice": [
-            {
-                "downloadUrl": "https://github.com/Microsoft/botbuilder-tools/releases/download/az-cli-extension/botservice-0.4.3-py2.py3-none-any.whl",
-                "filename": "botservice-0.4.3-py2.py3-none-any.whl",
-                "metadata": {
-                    "azext.isPreview": true,
-                    "azext.maxCliCoreVersion": "2.0.52",
-                    "azext.minCliCoreVersion": "2.0.52",
-                    "extensions": {
-                        "python.details": {
-                            "contacts": [
-                                {
-                                    "email": "swagatm@microsoft.com",
-                                    "name": "Swagat Mishra",
-                                    "role": "author"
-                                }
-                            ],
-                            "document_names": {
-                                "description": "DESCRIPTION.rst"
-                            },
-                            "project_urls": {
-                                "Home": "https://github.com/Azure/azure-cli-extensions"
-                            }
-                        }
-                    },
-                    "extras": [],
-                    "generator": "bdist_wheel (0.30.0)",
-                    "license": "MIT",
-                    "metadata_version": "2.0",
-                    "name": "botservice",
-                    "run_requires": [
-                        {
-                            "requires": [
-                                "requests"
-                            ]
-                        }
-                    ],
-                    "summary": "Bug fixes for issues in the native botservice cli command module.",
-                    "version": "0.4.3"
-                },
-                "sha256Digest": "3ae265dd7b07d0710671b3930c98b45951d9a334d6b066b6bba35df93cd61b02"
-            }
-        ],
         "db-up": [
             {
                 "downloadUrl": "https://azurecliprod.blob.core.windows.net/cli-extensions/db_up-0.1.11-py2.py3-none-any.whl",


### PR DESCRIPTION
Removing the botservice extension because all features of the extension are already in the main [botservice command module](https://github.com/Azure/azure-cli/tree/dev/src/command_modules/azure-cli-botservice) in the Azure-CLI repo or are outdated. 

@williexu, @tjprescott, @yugangw-msft 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- ~[ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)~
- ~[ ] Have you run `python scripts/ci/test_index.py -q` locally?~

For new extensions:

- ~[ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).~
