### PR TITLE
Re-add sap-hana to index.json

### DIFF
--- a/scripts/ci/test_index.py
+++ b/scripts/ci/test_index.py
@@ -129,11 +129,8 @@ class TestIndex(unittest.TestCase):
                               "{}: 'generator' should be one of {}. "
                               "Build the extension with a different version of the 'wheel' package "
                               "(e.g. `pip install wheel==0.30.0`). "
-                              "This is due to https://github.com/pypa/wheel/issues/195; the actual "
-                              "metadata is {}, ext_file is {}".format(ext_name,
-                                                                      supported_generators,
-                                                                      metadata,
-                                                                      ext_file))
+                              "This is due to https://github.com/pypa/wheel/issues/195".format(ext_name,
+                                                                                               supported_generators))
                 self.assertDictEqual(metadata, item['metadata'],
                                      "Metadata for {} in index doesn't match the expected of: \n"
                                      "{}".format(item['filename'], json.dumps(metadata, indent=2, sort_keys=True,

--- a/scripts/ci/test_index.py
+++ b/scripts/ci/test_index.py
@@ -129,8 +129,11 @@ class TestIndex(unittest.TestCase):
                               "{}: 'generator' should be one of {}. "
                               "Build the extension with a different version of the 'wheel' package "
                               "(e.g. `pip install wheel==0.30.0`). "
-                              "This is due to https://github.com/pypa/wheel/issues/195".format(ext_name,
-                                                                                               supported_generators))
+                              "This is due to https://github.com/pypa/wheel/issues/195; the actual "
+                              "metadata is {}, ext_file is {}".format(ext_name,
+                                                                      supported_generators,
+                                                                      metadata,
+                                                                      ext_file))
                 self.assertDictEqual(metadata, item['metadata'],
                                      "Metadata for {} in index doesn't match the expected of: \n"
                                      "{}".format(item['filename'], json.dumps(metadata, indent=2, sort_keys=True,

--- a/src/index.json
+++ b/src/index.json
@@ -1497,6 +1497,7 @@
                 "downloadUrl": "https://github.com/Azure/azure-hanaonazure-cli-extension/releases/download/0.3.8/sap_hana-0.3.8-py2.py3-none-any.whl",
                 "filename": "sap_hana-0.3.8-py2.py3-none-any.whl",
                 "metadata": {
+                    "azext.maxCliCoreVersion": "2.0.66",
                     "azext.minCliCoreVersion": "2.0.46",
                     "classifiers": [
                         "Development Status :: 4 - Beta",

--- a/src/index.json
+++ b/src/index.json
@@ -1529,14 +1529,14 @@
                             }
                         }
                     },
-                    "generator": "bdist_wheel (0.29.0)",
+                    "generator": "bdist_wheel (0.30.0)",
                     "license": "MIT",
                     "metadata_version": "2.0",
                     "name": "sap-hana",
                     "summary": "Additional commands for working with SAP HanaOnAzure instances.",
                     "version": "0.3.8"
                 },
-                "sha256Digest": "b446d54954ad520019da0f57cb0818e4a4235a5f098445fd544ec7682c165138"
+                "sha256Digest": "2706614388711a8b712c0049245d916a1ce34984e1aac31fceb5ed85bfe00bbf"
             }
         ],
         "storage-preview": [

--- a/src/index.json
+++ b/src/index.json
@@ -1536,7 +1536,7 @@
                     "summary": "Additional commands for working with SAP HanaOnAzure instances.",
                     "version": "0.3.8"
                 },
-                "sha256Digest": "f13c1b06a534d51b64dde104fe18d059f23f0261e58a0e49ccf9250f6a06e706"
+                "sha256Digest": "6f26e20dacca214fc65f6dd14eda3d3268d60f037932f97a5b998dffb3ad170f"
             }
         ],
         "storage-preview": [

--- a/src/index.json
+++ b/src/index.json
@@ -1492,6 +1492,52 @@
                 "sha256Digest": "073d8dce3861e82f739586c652f67344f910ed853d17edea4ad86702a693b157"
             }
         ],
+        "sap-hana": [
+            {
+                "downloadUrl": "https://github.com/Azure/azure-hanaonazure-cli-extension/releases/download/0.3.8/sap_hana-0.3.8-py2.py3-none-any.whl",
+                "filename": "sap_hana-0.3.8-py2.py3-none-any.whl",
+                "metadata": {
+                    "azext.minCliCoreVersion": "2.0.46",
+                    "classifiers": [
+                        "Development Status :: 4 - Beta",
+                        "Intended Audience :: Developers",
+                        "Intended Audience :: System Administrators",
+                        "Programming Language :: Python",
+                        "Programming Language :: Python :: 2",
+                        "Programming Language :: Python :: 2.7",
+                        "Programming Language :: Python :: 3",
+                        "Programming Language :: Python :: 3.4",
+                        "Programming Language :: Python :: 3.5",
+                        "Programming Language :: Python :: 3.6",
+                        "License :: OSI Approved :: MIT License"
+                    ],
+                    "extensions": {
+                        "python.details": {
+                            "contacts": [
+                                {
+                                    "email": "azpycli@microsoft.com",
+                                    "name": "Microsoft Corporation",
+                                    "role": "author"
+                                }
+                            ],
+                            "document_names": {
+                                "description": "DESCRIPTION.rst"
+                            },
+                            "project_urls": {
+                                "Home": "https://github.com/Azure/azure-hanaonazure-cli-extension"
+                            }
+                        }
+                    },
+                    "generator": "bdist_wheel (0.29.0)",
+                    "license": "MIT",
+                    "metadata_version": "2.0",
+                    "name": "sap-hana",
+                    "summary": "Additional commands for working with SAP HanaOnAzure instances.",
+                    "version": "0.3.8"
+                },
+                "sha256Digest": "f13c1b06a534d51b64dde104fe18d059f23f0261e58a0e49ccf9250f6a06e706"
+            }
+        ],
         "storage-preview": [
             {
                 "downloadUrl": "https://azurecliprod.blob.core.windows.net/cli-extensions/storage_preview-0.2.6-py2.py3-none-any.whl",

--- a/src/index.json
+++ b/src/index.json
@@ -1536,7 +1536,7 @@
                     "summary": "Additional commands for working with SAP HanaOnAzure instances.",
                     "version": "0.3.8"
                 },
-                "sha256Digest": "fd6a9506eb651a0f2cab1fc24b151660bddb43580a63174eb76f063c14c6a5d5"
+                "sha256Digest": "e0eafa368166fd643cf81de2e37e8ea309eeb96affe3122f0316d2e0b8b63acd"
             }
         ],
         "storage-preview": [

--- a/src/index.json
+++ b/src/index.json
@@ -1536,7 +1536,7 @@
                     "summary": "Additional commands for working with SAP HanaOnAzure instances.",
                     "version": "0.3.8"
                 },
-                "sha256Digest": "6f26e20dacca214fc65f6dd14eda3d3268d60f037932f97a5b998dffb3ad170f"
+                "sha256Digest": "b446d54954ad520019da0f57cb0818e4a4235a5f098445fd544ec7682c165138"
             }
         ],
         "storage-preview": [

--- a/src/index.json
+++ b/src/index.json
@@ -1536,7 +1536,7 @@
                     "summary": "Additional commands for working with SAP HanaOnAzure instances.",
                     "version": "0.3.8"
                 },
-                "sha256Digest": "2706614388711a8b712c0049245d916a1ce34984e1aac31fceb5ed85bfe00bbf"
+                "sha256Digest": "fd6a9506eb651a0f2cab1fc24b151660bddb43580a63174eb76f063c14c6a5d5"
             }
         ],
         "storage-preview": [


### PR DESCRIPTION
It was removed in commit 43ed33d13552edc7d6b41ee141d9fd361234c28b due to using a feature not supported in CLI core version 2.0.67. The sap-hana extension was updated in https://github.com/Azure/azure-hanaonazure-cli-extension/pull/22 to cap the max CLI core version at 2.0.66 to avoid the breaking change. A follow-up change will be made once 2.0.67 is released to properly support it.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [X] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).
