### PR TITLE
Check for cloud shell before calling localhost endpoint to close port

### DIFF
--- a/src/aks-preview/azext_aks_preview/custom.py
+++ b/src/aks-preview/azext_aks_preview/custom.py
@@ -465,8 +465,8 @@ def aks_browse(cmd, client, resource_group_name, name, disable_browser=False,
         # Let command processing finish gracefully after the user presses [Ctrl+C]
         pass
     finally:
-        # TODO: Better error handling here.
-        requests.post('http://localhost:8888/closeport/8001')
+        if in_cloud_console():
+            requests.post('http://localhost:8888/closeport/8001')
 
 
 def _trim_nodepoolname(nodepool_name):


### PR DESCRIPTION
https://github.com/Azure/azure-cli/pull/7336 introduced support for `az aks browse` in cloud shell using a  special localhost endpoint to manage opening and closing ports for the underlying port-forward. However, the close was not wrapped in a check of whether the user was actually in cloud shell, causing an ugly (albeit innocuous) error message when users terminated the browse command. 

---

- [X] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [X] Have you run `python scripts/ci/test_index.py -q` locally?