### PR TITLE
Fix az webapp container up - use new ACR API version

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -1967,7 +1967,7 @@
                     "summary": "Additional commands for Azure AppService.",
                     "version": "0.2.22"
                 },
-                "sha256Digest": "48c6b1b16d028c7c9490c55a1e551d19e718834b705e47071f5b790e294fa430"
+                "sha256Digest": "c90a5f139d9193dc77bb4e9c620afdf02cedd523c9c6bcd70936b56f4aae7786"
             }
         ]
     },

--- a/src/index.json
+++ b/src/index.json
@@ -1967,7 +1967,7 @@
                     "summary": "Additional commands for Azure AppService.",
                     "version": "0.2.22"
                 },
-                "sha256Digest": "427c8793956b75873686eae6b65b98ce4e2209217452985a8c4c905d98d8bb08"
+                "sha256Digest": "48c6b1b16d028c7c9490c55a1e551d19e718834b705e47071f5b790e294fa430"
             }
         ]
     },

--- a/src/index.json
+++ b/src/index.json
@@ -1925,8 +1925,8 @@
         ],
         "webapp": [
             {
-                "downloadUrl": "https://github.com/panchagnula/azure-cli-extensions/raw/sisirap-extensions-whl/dist/webapp-0.2.21-py2.py3-none-any.whl",
-                "filename": "webapp-0.2.21-py2.py3-none-any.whl",
+                "downloadUrl": "https://github.com/panchagnula/azure-cli-extensions/raw/sisirap-extensions-whl/dist/webapp-0.2.22-py2.py3-none-any.whl",
+                "filename": "webapp-0.2.22-py2.py3-none-any.whl",
                 "metadata": {
                     "azext.isPreview": true,
                     "azext.minCliCoreVersion": "2.0.46",
@@ -1965,7 +1965,7 @@
                     "metadata_version": "2.0",
                     "name": "webapp",
                     "summary": "Additional commands for Azure AppService.",
-                    "version": "0.2.21"
+                    "version": "0.2.22"
                 },
                 "sha256Digest": "427c8793956b75873686eae6b65b98ce4e2209217452985a8c4c905d98d8bb08"
             }

--- a/src/webapp/azext_webapp/_help.py
+++ b/src/webapp/azext_webapp/_help.py
@@ -48,4 +48,9 @@ helps['webapp container'] = """
 helps['webapp container up'] = """
     type: command
     short-summary: Experimental command to create and deploy a container webapp.
+    examples:
+        - name: Deploy a container using an image from DockerHub. This example uses nginx.
+          text: az webapp container up -n AppName -i nginx
+        - name: Upload files from the current directory to an Azure Container Registry, then build a container image and deploy it to a web app.
+          text: az webapp container up -n AppName --registry-rg ContainerRegistryResourceGroup --registry-name ContainerRegistryName
 """

--- a/src/webapp/azext_webapp/_help.py
+++ b/src/webapp/azext_webapp/_help.py
@@ -51,6 +51,6 @@ helps['webapp container up'] = """
     examples:
         - name: Deploy a container using an image from DockerHub. This example uses nginx.
           text: az webapp container up -n AppName -i nginx
-        - name: Upload files from the current directory to an Azure Container Registry, then build a container image and deploy it to a web app.
+        - name: Upload files from the current directory to an Azure Container Registry, then build a container image and deploy it to a web app. The Azure Container Registry must already exist.
           text: az webapp container up -n AppName --registry-rg ContainerRegistryResourceGroup --registry-name ContainerRegistryName
 """

--- a/src/webapp/azext_webapp/acr_util.py
+++ b/src/webapp/azext_webapp/acr_util.py
@@ -18,6 +18,7 @@ from azure.cli.core.commands import LongRunningOperation
 logger = get_logger(__name__)
 VERSION_2019_06_01_PREVIEW = "2019-06-01-preview"
 
+
 def queue_acr_build(cmd, registry_rg, registry_name, img_name, src_dir):
     import os
     client_registries = get_acr_service_client(cmd.cli_ctx, VERSION_2019_06_01_PREVIEW).registries
@@ -90,4 +91,3 @@ def generate_img_name(src_dir):
     import os
     img_name = os.path.basename(src_dir) + ':' + datetime.now().strftime('%Y%m%d_%H%M%S')
     return img_name
-

--- a/src/webapp/azext_webapp/acr_util.py
+++ b/src/webapp/azext_webapp/acr_util.py
@@ -16,11 +16,11 @@ from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.commands import LongRunningOperation
 
 logger = get_logger(__name__)
-
+VERSION_2019_06_01_PREVIEW = "2019-06-01-preview"
 
 def queue_acr_build(cmd, registry_rg, registry_name, img_name, src_dir):
     import os
-    client_registries = get_acr_service_client(cmd.cli_ctx).registries
+    client_registries = get_acr_service_client(cmd.cli_ctx, VERSION_2019_06_01_PREVIEW).registries
 
     if not os.path.isdir(src_dir):
         raise CLIError("Source directory should be a local directory path.")
@@ -75,7 +75,7 @@ def queue_acr_build(cmd, registry_rg, registry_name, img_name, src_dir):
     logger.warning("Queued a build with ID: %s", run_id)
     logger.warning("Waiting for agent...")
 
-    client_runs = get_acr_service_client(cmd.cli_ctx).runs
+    client_runs = get_acr_service_client(cmd.cli_ctx, VERSION_2019_06_01_PREVIEW).runs
 
     return stream_logs(client_runs, run_id, registry_name, registry_rg, False, True)
 

--- a/src/webapp/azext_webapp/acr_util.py
+++ b/src/webapp/azext_webapp/acr_util.py
@@ -90,3 +90,4 @@ def generate_img_name(src_dir):
     import os
     img_name = os.path.basename(src_dir) + ':' + datetime.now().strftime('%Y%m%d_%H%M%S')
     return img_name
+

--- a/src/webapp/setup.py
+++ b/src/webapp/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup, find_packages
 
-VERSION = "0.2.21"
+VERSION = "0.2.22"
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',


### PR DESCRIPTION
Description
---
This is a small fix to the new 'az webapp container up' extension. Azure Container Registry recently updated their API version in the latest Azure CLI release, which broke some of our code.

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).
