### PR TITLE
Add support for connecting ACR registry during AKS create

### DIFF
--- a/src/aks-preview/azext_aks_preview/_params.py
+++ b/src/aks-preview/azext_aks_preview/_params.py
@@ -72,6 +72,8 @@ def load_arguments(self, _):
         c.argument('node_zones', zones_type, options_list='--node-zones', help='(PREVIEW) Space-separated list of availability zones where agent nodes will be placed.')
         c.argument('enable_pod_security_policy', action='store_true')
         c.argument('node_resource_group')
+        c.argument('acr_name')
+        c.argument('acr_resource_group')
 
     with self.argument_context('aks update') as c:
         c.argument('enable_cluster_autoscaler', options_list=["--enable-cluster-autoscaler", "-e"], action='store_true')

--- a/src/aks-preview/azext_aks_preview/custom.py
+++ b/src/aks-preview/azext_aks_preview/custom.py
@@ -656,8 +656,6 @@ def aks_create(cmd, client, resource_group_name, name, ssh_key_value,  # pylint:
         name=acr_name
     )
 
-    logger.info("ACR Resource ID: %s", acr_resource_id)
-
     if acr_name:
         _add_role_assignment(
             cmd.cli_ctx,


### PR DESCRIPTION
This PR adds the ability to connect an ACR registry to an AKS cluster at cluster creation time by performing the service principal role assignment implicitly. Two new optional properties are added to the `create` command:

- **acrName**: the name of the registry to be attached
- **acrResourceGroup**: the name of the resource group where the ACR can be found. If not specified, it is assumed to be the same as the RG where the AKS cluster is being created.

---
- [X] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [X] Have you run `python scripts/ci/test_index.py -q` locally?