### PR TITLE
Add support for ACR role assignment during AKS creation

### DIFF
--- a/src/aks-preview/HISTORY.md
+++ b/src/aks-preview/HISTORY.md
@@ -2,6 +2,10 @@
 
 Release History
 ===============
+0.4.7
++++++
+* Add support for `--enable-acr` and `--acr-name`
+
 0.4.4
 +++++
 * Add support for per node pool auto scaler settings.

--- a/src/aks-preview/azext_aks_preview/_client_factory.py
+++ b/src/aks-preview/azext_aks_preview/_client_factory.py
@@ -43,6 +43,10 @@ def cf_resources(cli_ctx, subscription_id=None):
                                    subscription_id=subscription_id).resources
 
 
+def cf_container_registry_service(cli_ctx, *_):
+    return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_CONTAINERREGISTRY, api_version="2018-09-01")
+
+
 def get_auth_management_client(cli_ctx, scope=None, **_):
     import re
 

--- a/src/aks-preview/azext_aks_preview/_help.py
+++ b/src/aks-preview/azext_aks_preview/_help.py
@@ -160,6 +160,12 @@ helps['aks create'] = """
         - name: --node-resource-group
           type: string
           short-summary: The node resource group is the resource group where all customer's resources will be created in, such as virtual machines.
+        - name: --enable-acr
+          type: bool
+          short-summary: Grant the 'acrpull' role assignment for the ACR set by --acr-name.
+        - name: --acr-name
+          type: string
+          short-summary: The name of the ACR in AKS resource group. If it's empty and --enable-acr is true, then a new ACR with name 'aks<resource-group>acr' would be created.
     examples:
         - name: Create a Kubernetes cluster with an existing SSH public key.
           text: az aks create -g MyResourceGroup -n MyManagedCluster --ssh-key-value /path/to/publickey

--- a/src/aks-preview/azext_aks_preview/_params.py
+++ b/src/aks-preview/azext_aks_preview/_params.py
@@ -72,6 +72,8 @@ def load_arguments(self, _):
         c.argument('node_zones', zones_type, options_list='--node-zones', help='(PREVIEW) Space-separated list of availability zones where agent nodes will be placed.')
         c.argument('enable_pod_security_policy', action='store_true')
         c.argument('node_resource_group')
+        c.argument('enable_acr', is_preview=True)
+        c.argument('acr_name', is_preview=True)
 
     with self.argument_context('aks update') as c:
         c.argument('enable_cluster_autoscaler', options_list=["--enable-cluster-autoscaler", "-e"], action='store_true')

--- a/src/aks-preview/setup.py
+++ b/src/aks-preview/setup.py
@@ -8,7 +8,7 @@
 from codecs import open as open1
 from setuptools import setup, find_packages
 
-VERSION = "0.4.6"
+VERSION = "0.4.7"
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',


### PR DESCRIPTION
This PR adds support for ACR role assignment during AKS creation. To support this, two new command-line options are added: `--enable-acr` and `--acr-name`.

Usage: `az aks create ... --enable-acr --acr-name <acr-name>`.

