### PR TITLE
Add support for ACR role assignment for AKS update

### DIFF
--- a/src/aks-preview/HISTORY.md
+++ b/src/aks-preview/HISTORY.md
@@ -2,6 +2,11 @@
 
 Release History
 ===============
+0.4.8
++++++
+* Add update support for `--enable-acr` together with `--acr <name-or-id>`
+* Merge `az aks create --acr-name` into `az aks create --acr <name-or-id>`
+
 0.4.7
 +++++
 * Add support for `--enable-acr` and `--acr-name`

--- a/src/aks-preview/azext_aks_preview/_client_factory.py
+++ b/src/aks-preview/azext_aks_preview/_client_factory.py
@@ -44,7 +44,7 @@ def cf_resources(cli_ctx, subscription_id=None):
 
 
 def cf_container_registry_service(cli_ctx, *_):
-    return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_CONTAINERREGISTRY, api_version="2018-09-01")
+    return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_CONTAINERREGISTRY, api_version="2019-05-01")
 
 
 def get_auth_management_client(cli_ctx, scope=None, **_):

--- a/src/aks-preview/azext_aks_preview/_help.py
+++ b/src/aks-preview/azext_aks_preview/_help.py
@@ -162,10 +162,10 @@ helps['aks create'] = """
           short-summary: The node resource group is the resource group where all customer's resources will be created in, such as virtual machines.
         - name: --enable-acr
           type: bool
-          short-summary: Grant the 'acrpull' role assignment for the ACR set by --acr-name.
-        - name: --acr-name
+          short-summary: (PREVIEW) Grant the 'acrpull' role assignment for the ACR set by --acr.
+        - name: --acr
           type: string
-          short-summary: The name of the ACR in AKS resource group. If it's empty and --enable-acr is true, then a new ACR with name 'aks<resource-group>acr' would be created.
+          short-summary: (PREVIEW) ACR name in AKS resource group or ACR resource ID. If it's empty and --enable-acr is true, then a new ACR with name 'aks<resource-group>acr' would be created.
     examples:
         - name: Create a Kubernetes cluster with an existing SSH public key.
           text: az aks create -g MyResourceGroup -n MyManagedCluster --ssh-key-value /path/to/publickey
@@ -227,6 +227,12 @@ helps['aks update'] = """
         - name: --disable-pod-security-policy
           type: bool
           short-summary: (PREVIEW) Disable pod security policy.
+        - name: --enable-acr
+          type: bool
+          short-summary: (PREVIEW) Grant the 'acrpull' role assignment for the ACR set by --acr.
+        - name: --acr
+          type: string
+          short-summary: (PREVIEW) ACR name in AKS resource group or ACR resource ID.
     examples:
       - name: Enable cluster-autoscaler within node count range [1,5]
         text: az aks update --enable-cluster-autoscaler --min-count 1 --max-count 5 -g MyResourceGroup -n MyManagedCluster

--- a/src/aks-preview/azext_aks_preview/_params.py
+++ b/src/aks-preview/azext_aks_preview/_params.py
@@ -72,8 +72,8 @@ def load_arguments(self, _):
         c.argument('node_zones', zones_type, options_list='--node-zones', help='(PREVIEW) Space-separated list of availability zones where agent nodes will be placed.')
         c.argument('enable_pod_security_policy', action='store_true')
         c.argument('node_resource_group')
-        c.argument('enable_acr', is_preview=True)
-        c.argument('acr_name', is_preview=True)
+        c.argument('enable_acr')
+        c.argument('acr')
 
     with self.argument_context('aks update') as c:
         c.argument('enable_cluster_autoscaler', options_list=["--enable-cluster-autoscaler", "-e"], action='store_true')
@@ -84,6 +84,8 @@ def load_arguments(self, _):
         c.argument('api_server_authorized_ip_ranges', type=str, validator=validate_ip_ranges)
         c.argument('enable_pod_security_policy', action='store_true')
         c.argument('disable_pod_security_policy', action='store_true')
+        c.argument('enable_acr')
+        c.argument('acr')
 
     with self.argument_context('aks scale') as c:
         c.argument('nodepool_name', type=str,

--- a/src/aks-preview/setup.py
+++ b/src/aks-preview/setup.py
@@ -8,7 +8,7 @@
 from codecs import open as open1
 from setuptools import setup, find_packages
 
-VERSION = "0.4.7"
+VERSION = "0.4.8"
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',


### PR DESCRIPTION
This PR adds support for ACR role assignment during AKS creation and update. 

Usage: 

* az aks create –n <name> -g <resource-group> --enable-acr --acr <name-or-id>
* az aks update –n <name> -g <resource-group> --enable-acr --acr <name-or-id>
