### PR TITLE
Update for IoT extension.

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -433,7 +433,7 @@
                 "downloadUrl": "https://github.com/Azure/azure-iot-cli-extension/releases/download/v0.8.0/azure_cli_iot_ext-0.8.0-py2.py3-none-any.whl",
                 "filename": "azure_cli_iot_ext-0.8.0-py2.py3-none-any.whl",
                 "metadata": {
-                    "azext.minCliCoreVersion": "2.0.24",
+                    "azext.minCliCoreVersion": "2.0.70",
                     "classifiers": [
                         "Development Status :: 4 - Beta",
                         "Intended Audience :: Developers",
@@ -479,7 +479,59 @@
                     "summary": "Provides the data plane command layer for Azure IoT Hub, IoT Edge and IoT Device Provisioning Service",
                     "version": "0.8.0"
                 },
-                "sha256Digest": "cef95efd63c21f6ea29e8a5aba939a5b29c67734a857bf45f13749e6b07aa898"
+                "sha256Digest": "b56db2a2513b2aa20077a7b49ebe5dbf1c22a195d38305162282731f57fb9dd3"
+            },
+            {
+                "downloadUrl": "https://github.com/Azure/azure-iot-cli-extension/releases/download/v0.7.1/azure_cli_iot_ext-0.7.1-py2.py3-none-any.whl",
+                "filename": "azure_cli_iot_ext-0.7.1-py2.py3-none-any.whl",
+                "metadata": {
+                    "azext.minCliCoreVersion": "2.0.24",
+                    "classifiers": [
+                        "Development Status :: 4 - Beta",
+                        "Intended Audience :: Developers",
+                        "Intended Audience :: System Administrators",
+                        "Programming Language :: Python",
+                        "Programming Language :: Python :: 2",
+                        "Programming Language :: Python :: 2.7",
+                        "Programming Language :: Python :: 3",
+                        "Programming Language :: Python :: 3.4",
+                        "Programming Language :: Python :: 3.5",
+                        "Programming Language :: Python :: 3.6",
+                        "License :: OSI Approved :: MIT License"
+                    ],
+                    "extensions": {
+                        "python.details": {
+                            "contacts": [
+                                {
+                                    "email": "iotupx@microsoft.com",
+                                    "name": "Microsoft",
+                                    "role": "author"
+                                }
+                            ],
+                            "document_names": {
+                                "description": "DESCRIPTION.rst"
+                            },
+                            "project_urls": {
+                                "Home": "https://github.com/azure/azure-iot-cli-extension"
+                            }
+                        }
+                    },
+                    "extras": [],
+                    "generator": "bdist_wheel (0.30.0)",
+                    "license": "MIT",
+                    "metadata_version": "2.0",
+                    "name": "azure-cli-iot-ext",
+                    "run_requires": [
+                        {
+                            "requires": [
+                                "paho-mqtt (==1.3.1)"
+                            ]
+                        }
+                    ],
+                    "summary": "Provides the data plane command layer for Azure IoT Hub, IoT Edge and IoT Device Provisioning Service",
+                    "version": "0.7.1"
+                },
+                "sha256Digest": "0a8431db427db693ba6bcfe9572b4fceda6b20190be99990b1bb8c75a7c89405"
             }
         ],
         "azure-cli-ml": [


### PR DESCRIPTION
There are a couple factors to this index PR related to the IoT extension.
- First the v0.8.0 extension metadata had to be updated with azext.minCliCoreVersion set to 2.0.70. Package was recreated (thus the new hash).
- Second the existing extension version (v0.7.1) remains in the collection for users who are unable to upgrade their Azure CLI installations.

