### PR TITLE
[AKS] Rename ACR integration options

### DIFF
--- a/src/aks-preview/HISTORY.md
+++ b/src/aks-preview/HISTORY.md
@@ -2,6 +2,12 @@
 
 Release History
 ===============
+0.4.13
+++++++
+* Rename a few options for ACR integration, which includes
+  * Rename `--attach-acr <acr-name-or-resource-id>` in `az aks create` command, which allows for attach the ACR to AKS cluster.
+  * Rename `--attach-acr <acr-name-or-resource-id>` and `--detach-acr <acr-name-or-resource-id>` in `az aks update` command, which allows to attach or detach the ACR from AKS cluster.
+
 0.4.12
 +++++
 * Bring back "enable-vmss" flag  for backward compatibility

--- a/src/aks-preview/azext_aks_preview/_client_factory.py
+++ b/src/aks-preview/azext_aks_preview/_client_factory.py
@@ -4,8 +4,10 @@
 # --------------------------------------------------------------------------------------------
 
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
+from azure.cli.core.commands.parameters import get_resources_in_subscription
 from azure.cli.core.profiles import ResourceType
 from azure.cli.core.profiles import CustomResourceType
+from knack.util import CLIError
 
 CUSTOM_MGMT_AKS_PREVIEW = CustomResourceType('azext_aks_preview.vendored_sdks.azure_mgmt_preview_aks',
                                              'ContainerServiceClient')
@@ -43,8 +45,9 @@ def cf_resources(cli_ctx, subscription_id=None):
                                    subscription_id=subscription_id).resources
 
 
-def cf_container_registry_service(cli_ctx, *_):
-    return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_CONTAINERREGISTRY, api_version="2019-05-01")
+def cf_container_registry_service(cli_ctx, subscription_id=None):
+    return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_CONTAINERREGISTRY,
+                                   subscription_id=subscription_id)
 
 
 def get_auth_management_client(cli_ctx, scope=None, **_):
@@ -71,3 +74,34 @@ def get_graph_rbac_management_client(cli_ctx, **_):
         base_url=cli_ctx.cloud.endpoints.active_directory_graph_resource_id)
     configure_common_settings(cli_ctx, client)
     return client
+
+
+# pylint: disable=inconsistent-return-statements
+def get_resource_by_name(cli_ctx, resource_name, resource_type):
+    """Returns the ARM resource in the current subscription with resource_name.
+    :param str resource_name: The name of resource
+    :param str resource_type: The type of resource
+    """
+    result = get_resources_in_subscription(cli_ctx, resource_type)
+    elements = [item for item in result if item.name.lower() == resource_name.lower()]
+
+    if not elements:
+        from azure.cli.core._profile import Profile
+        profile = Profile(cli_ctx=cli_ctx)
+        message = "The resource with name '{}' and type '{}' could not be found".format(
+            resource_name, resource_type)
+        try:
+            subscription = profile.get_subscription(
+                cli_ctx.data['subscription_id'])
+            raise CLIError(
+                "{} in subscription '{} ({})'.".format(message, subscription['name'], subscription['id']))
+        except (KeyError, TypeError):
+            raise CLIError(
+                "{} in the current subscription.".format(message))
+
+    elif len(elements) == 1:
+        return elements[0]
+    else:
+        raise CLIError(
+            "More than one resources with type '{}' are found with name '{}'.".format(
+                resource_type, resource_name))

--- a/src/aks-preview/azext_aks_preview/_help.py
+++ b/src/aks-preview/azext_aks_preview/_help.py
@@ -172,12 +172,9 @@ helps['aks create'] = """
         - name: --node-resource-group
           type: string
           short-summary: The node resource group is the resource group where all customer's resources will be created in, such as virtual machines.
-        - name: --enable-acr
-          type: bool
-          short-summary: (PREVIEW) Grant the 'acrpull' role assignment for the ACR set by --acr.
-        - name: --acr
+        - name: --attach-acr
           type: string
-          short-summary: (PREVIEW) ACR name in AKS resource group or ACR resource ID. If it's empty and --enable-acr is true, then a new ACR with name 'aks<resource-group>acr' would be created.
+          short-summary: Grant the 'acrpull' role assignment to the ACR specified by name or resource ID.
     examples:
         - name: Create a Kubernetes cluster with an existing SSH public key.
           text: az aks create -g MyResourceGroup -n MyManagedCluster --ssh-key-value /path/to/publickey
@@ -263,15 +260,12 @@ helps['aks update'] = """
         - name: --disable-pod-security-policy
           type: bool
           short-summary: (PREVIEW) Disable pod security policy.
-        - name: --enable-acr
-          type: bool
-          short-summary: (PREVIEW) Grant the 'acrpull' role assignment for the ACR set by --acr.
-        - name: --disable-acr
-          type: bool
-          short-summary: (PREVIEW) Disable the 'acrpull' role assignment for the ACR set by --acr.
-        - name: --acr
+        - name: --attach-acr
           type: string
-          short-summary: (PREVIEW) ACR name in AKS resource group or ACR resource ID.
+          short-summary: Grant the 'acrpull' role assignment to the ACR specified by name or resource ID.
+        - name: --detach-acr
+          type: string
+          short-summary: Disable the 'acrpull' role assignment to the ACR specified by name or resource ID.
     examples:
       - name: Enable cluster-autoscaler within node count range [1,5]
         text: az aks update --enable-cluster-autoscaler --min-count 1 --max-count 5 -g MyResourceGroup -n MyManagedCluster

--- a/src/aks-preview/azext_aks_preview/_params.py
+++ b/src/aks-preview/azext_aks_preview/_params.py
@@ -11,6 +11,7 @@ import platform
 from argcomplete.completers import FilesCompleter
 from azure.cli.core.commands.parameters import (
     file_type, get_resource_name_completion_list, name_type, tags_type, zones_type)
+from knack.arguments import CLIArgumentType
 
 from ._completers import (
     get_vm_size_completion_list, get_k8s_versions_completion_list, get_k8s_upgrades_completion_list)
@@ -22,6 +23,8 @@ from ._validators import (
 
 
 def load_arguments(self, _):
+
+    acr_arg_type = CLIArgumentType(metavar='ACR_NAME_OR_RESOURCE_ID')
 
     # AKS command argument configuration
     with self.argument_context('aks') as c:
@@ -77,8 +80,7 @@ def load_arguments(self, _):
         c.argument('node_zones', zones_type, options_list='--node-zones', help='(PREVIEW) Space-separated list of availability zones where agent nodes will be placed.')
         c.argument('enable_pod_security_policy', action='store_true')
         c.argument('node_resource_group')
-        c.argument('enable_acr')
-        c.argument('acr')
+        c.argument('attach_acr', acr_arg_type)
 
     with self.argument_context('aks update') as c:
         c.argument('enable_cluster_autoscaler', options_list=["--enable-cluster-autoscaler", "-e"], action='store_true')
@@ -92,9 +94,8 @@ def load_arguments(self, _):
         c.argument('api_server_authorized_ip_ranges', type=str, validator=validate_ip_ranges)
         c.argument('enable_pod_security_policy', action='store_true')
         c.argument('disable_pod_security_policy', action='store_true')
-        c.argument('enable_acr')
-        c.argument('disable_acr')
-        c.argument('acr')
+        c.argument('attach_acr', acr_arg_type)
+        c.argument('detach_acr', acr_arg_type)
 
     with self.argument_context('aks scale') as c:
         c.argument('nodepool_name', type=str,


### PR DESCRIPTION
Rename ACR integration options:

  * Rename `--attach-acr <acr-name-or-resource-id>` in `az aks create` command, which allows for attach the ACR to AKS cluster.
  * Rename `--attach-acr <acr-name-or-resource-id>` and `--detach-acr <acr-name-or-resource-id>` in `az aks update` command, which allows to attach or detach the ACR from AKS cluster.

This PR actually backports https://github.com/Azure/azure-cli/pull/10379 to extension, so that they're aligned.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [x] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).

