### PR TITLE
AKS kollect command implementation

### DIFF
--- a/src/aks-preview/azext_aks_preview/_client_factory.py
+++ b/src/aks-preview/azext_aks_preview/_client_factory.py
@@ -15,6 +15,10 @@ CUSTOM_MGMT_AKS = CustomResourceType('azext_aks_preview.vendored_sdks.azure_mgmt
                                      'ContainerServiceClient')
 
 
+def cf_storage(cli_ctx, subscription_id=None):
+    return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_STORAGE, subscription_id=subscription_id)
+
+
 def cf_compute_service(cli_ctx, *_):
     return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_COMPUTE)
 

--- a/src/aks-preview/azext_aks_preview/_help.py
+++ b/src/aks-preview/azext_aks_preview/_help.py
@@ -293,6 +293,34 @@ helps['aks update'] = """
         text: az aks update -g MyResourceGroup -n MyManagedCluster --load-balancer-outbound-ip-prefixes <ip-prefix-resource-id-1,ip-prefix-resource-id-2>
 """
 
+helps['aks kollect'] = """
+    type: command
+    short-summary: Collecting diagnostic information for the Kubernetes cluster.
+    long-summary: |-
+        Collecting diagnostic information for the Kubernetes cluster and store them in the specified storage account.
+        You can provider the storage account in three ways:
+          storage account name and a shared access signature with write permission.
+          resource Id to a storage account you own.
+          the storagea account in diagnostics settings for your managed cluster.
+    parameters:
+        - name: --storage-account-name
+          type: string
+          short-summary: The name of the storage account to save the diagnostic information.
+        - name: --sas-token
+          type: string
+          short-summary: The SAS token with writable permission for the storage account.
+        - name: --storage-account-id
+          type: string
+          short-summary: The resource Id of the storage account to save the diag info.
+    examples:
+      - name: using storagea account name and a shared access signature token with write permission
+        text: az aks kollect -g MyResourceGroup -n MyManagedCluster --storage-account-name MyStorageAccount --sas-token "MySasToken"
+      - name: using the resource id of a storagea account resource you own.
+        text: az aks kollect -g MyResourceGroup -n MyManagedCluster --storage-account-id "MyStoreageAccountResourceId"
+      - name: using the storagea account in diagnostics settings for your managed cluster.
+        text: az aks kollect -g MyResourceGroup -n MyManagedCluster
+"""
+
 helps['aks nodepool'] = """
     type: group
     short-summary: Commands to manage node pools in Kubernetes kubernetes cluster.

--- a/src/aks-preview/azext_aks_preview/_help.py
+++ b/src/aks-preview/azext_aks_preview/_help.py
@@ -297,26 +297,23 @@ helps['aks kollect'] = """
     type: command
     short-summary: Collecting diagnostic information for the Kubernetes cluster.
     long-summary: |-
-        Collecting diagnostic information for the Kubernetes cluster and store them in the specified storage account.
-        You can provider the storage account in three ways:
+        Collect diagnostic information for the Kubernetes cluster and store it in the specified storage account.
+        You can provide the storage account in three ways:
           storage account name and a shared access signature with write permission.
           resource Id to a storage account you own.
           the storagea account in diagnostics settings for your managed cluster.
     parameters:
-        - name: --storage-account-name
+        - name: --storage-account
           type: string
-          short-summary: The name of the storage account to save the diagnostic information.
+          short-summary: Name or ID of the storage account to save the diagnostic information.
         - name: --sas-token
           type: string
           short-summary: The SAS token with writable permission for the storage account.
-        - name: --storage-account-id
-          type: string
-          short-summary: The resource Id of the storage account to save the diag info.
     examples:
-      - name: using storagea account name and a shared access signature token with write permission
-        text: az aks kollect -g MyResourceGroup -n MyManagedCluster --storage-account-name MyStorageAccount --sas-token "MySasToken"
+      - name: using storage account name and a shared access signature token with write permission
+        text: az aks kollect -g MyResourceGroup -n MyManagedCluster --storage-account MyStorageAccount --sas-token "MySasToken"
       - name: using the resource id of a storagea account resource you own.
-        text: az aks kollect -g MyResourceGroup -n MyManagedCluster --storage-account-id "MyStoreageAccountResourceId"
+        text: az aks kollect -g MyResourceGroup -n MyManagedCluster --storage-account "MyStoreageAccountResourceId"
       - name: using the storagea account in diagnostics settings for your managed cluster.
         text: az aks kollect -g MyResourceGroup -n MyManagedCluster
 """

--- a/src/aks-preview/azext_aks_preview/commands.py
+++ b/src/aks-preview/azext_aks_preview/commands.py
@@ -37,6 +37,7 @@ def load_command_table(self, _):
 
     # AKS managed cluster commands
     with self.command_group('aks', managed_clusters_sdk, client_factory=cf_managed_clusters) as g:
+        g.custom_command('kollect', 'aks_kollect')
         g.custom_command('browse', 'aks_browse')
         g.custom_command('create', 'aks_create', supports_no_wait=True)
         g.custom_command('update', 'aks_update', supports_no_wait=True)

--- a/src/aks-preview/azext_aks_preview/custom.py
+++ b/src/aks-preview/azext_aks_preview/custom.py
@@ -21,6 +21,7 @@ import tempfile
 import threading
 import time
 import uuid
+import base64
 import webbrowser
 from ipaddress import ip_network
 from distutils.version import StrictVersion  # pylint: disable=no-name-in-module,import-error
@@ -71,6 +72,7 @@ from ._client_factory import get_graph_rbac_management_client
 from ._client_factory import cf_resources
 from ._client_factory import get_resource_by_name
 from ._client_factory import cf_container_registry_service
+from ._client_factory import cf_storage
 
 
 logger = get_logger(__name__)
@@ -1083,6 +1085,98 @@ ADDONS = {
 }
 
 
+# pylint: disable=line-too-long
+def aks_kollect(cmd, client, resource_group_name, name, storage_account_name=None, sas_token=None, storage_account_id=None,):
+    mc = client.get(resource_group_name, name)
+
+    if not which('kubectl'):
+        raise CLIError('Can not find kubectl executable in PATH')
+
+    if (sas_token is None) != (storage_account_name is None):
+        raise CLIError("Please specify both storage account name and a SAS token with write permission.")
+
+    readonly_sas_token = None
+    if storage_account_name is None:
+        if storage_account_id is None:
+            print("No storage account resource id specified. Try getting storage account from diagnostic settings")
+            storage_account_id = get_storage_account_from_diag_settings(cmd.cli_ctx, resource_group_name, name)
+            if storage_account_id is None:
+                raise CLIError("A storage account must be specified, since there isn't one in the diagnostic settings.")
+
+        from msrestazure.tools import is_valid_resource_id, parse_resource_id
+        if is_valid_resource_id(storage_account_id):
+            try:
+                parsed_storage_account = parse_resource_id(storage_account_id)
+            except CloudError as ex:
+                raise CLIError(ex.message)
+        else:
+            raise CLIError("Invalid storage account id %s" % storage_account_id)
+
+        storage_account_name = parsed_storage_account['name']
+        storage_client = cf_storage(cmd.cli_ctx, parsed_storage_account['subscription'])
+        storage_account_keys = storage_client.storage_accounts.list_keys(parsed_storage_account['resource_group'], storage_account_name)
+        kwargs = {
+            'account_name': storage_account_name,
+            'account_key': storage_account_keys.keys[0].value
+        }
+        cloud_storage_client = cloud_storage_account_service_factory(cmd.cli_ctx, kwargs)
+
+        sas_token = cloud_storage_client.generate_shared_access_signature(
+            'b',
+            'sco',
+            'rwdlacup',
+            datetime.datetime.utcnow() + datetime.timedelta(days=1))
+
+        readonly_sas_token = cloud_storage_client.generate_shared_access_signature(
+            'b',
+            'sco',
+            'rl',
+            datetime.datetime.utcnow() + datetime.timedelta(days=1))
+
+        readonly_sas_token = readonly_sas_token.strip('?')
+
+    print("Confirmed. Diagnostic info will be stored in the storage account %s as outlined in aka.ms/AKSPeriscope." % storage_account_name)
+
+    from knack.prompting import prompt_y_n
+    msg = 'This will deploy a daemon set to your cluster to collect logs and diagnostic information and ' \
+        'save them to the specified storage account as outlined in aka.ms/AKSPeriscope. If you share access ' \
+        'to that storage account to Azure support, you consent to the terms outlined in aka.ms/DiagConsent. ' \
+        'Do you confirm?'
+
+    if not prompt_y_n(msg, default="n"):
+        return
+
+    print("Getting credentials for cluster %s " % name)
+    _, temp_kubeconfig_path = tempfile.mkstemp()
+    aks_get_credentials(cmd, client, resource_group_name, name, admin=True, path=temp_kubeconfig_path)
+
+    print("Starts collecting diag info for cluster %s " % name)
+
+    sas_token = sas_token.strip('?')
+    deployment_yaml = urlopen("https://raw.githubusercontent.com/Azure/aks-periscope/v0.1/deployment/aks-periscope.yaml").read().decode()
+    deployment_yaml = deployment_yaml.replace("# <accountName, base64 encoded>", (base64.b64encode(bytes(storage_account_name, 'ascii'))).decode('ascii'))
+    deployment_yaml = deployment_yaml.replace("# <saskey, base64 encoded>", (base64.b64encode(bytes("?" + sas_token, 'ascii'))).decode('ascii'))
+
+    fd, temp_yaml_path = tempfile.mkstemp()
+    temp_yaml_file = os.fdopen(fd, 'w+t')
+    try:
+        temp_yaml_file.write(deployment_yaml)
+        temp_yaml_file.flush()
+        temp_yaml_file.close()
+        try:
+            subprocess.check_output(["kubectl", "--kubeconfig", temp_kubeconfig_path, "apply", "-f",
+                                     temp_yaml_path], stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as err:
+            raise CLIError(err.output)
+    finally:
+        os.remove(temp_yaml_path)
+
+    if readonly_sas_token is not None:
+        print("You can find the diagnostic info in this readonly SAS Url: https://%s.blob.core.windows.net/%s?%s" % (storage_account_name, mc.fqdn.replace('.', '-'), readonly_sas_token))
+    else:
+        print("You can find the diagnostic info here: https://%s.blob.core.windows.net/%s" % (storage_account_name, mc.fqdn.replace('.', '-')))
+
+
 def aks_scale(cmd, client, resource_group_name, name, node_count, nodepool_name="", no_wait=False):
     instance = client.get(resource_group_name, name)
     # TODO: change this approach when we support multiple agent pools.
@@ -1959,3 +2053,27 @@ def _get_load_balancer_profile(load_balancer_managed_outbound_ip_count,
                 public_ip_prefixes=load_balancer_outbound_ip_prefix_resources
             )
     return load_balancer_profile
+
+
+def cloud_storage_account_service_factory(cli_ctx, kwargs):
+    from azure.cli.core.profiles import ResourceType, get_sdk
+    t_cloud_storage_account = get_sdk(cli_ctx, ResourceType.DATA_STORAGE, 'common#CloudStorageAccount')
+    account_name = kwargs.pop('account_name', None)
+    account_key = kwargs.pop('account_key', None)
+    sas_token = kwargs.pop('sas_token', None)
+    kwargs.pop('connection_string', None)
+    return t_cloud_storage_account(account_name, account_key, sas_token)
+
+
+def get_storage_account_from_diag_settings(cli_ctx, resource_group_name, name):
+    from azure.mgmt.monitor import MonitorManagementClient
+    diag_settings_client = get_mgmt_service_client(cli_ctx, MonitorManagementClient).diagnostic_settings
+    subscription_id = _get_subscription_id(cli_ctx)
+    aks_resource_id = '/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.ContainerService' \
+        '/managedClusters/{2}'.format(subscription_id, resource_group_name, name)
+    diag_settings = diag_settings_client.list(aks_resource_id)
+    if diag_settings.value:
+        return diag_settings.value[0].storage_account_id
+
+    print("No diag settings specified")
+    return None


### PR DESCRIPTION
Initial implementation of the `az aks kollect` command. This command will deploy a daemon set to customer 's aks cluster and collect logs and diag information. The logs and information will be saved to a storage account the user specified or the storage account specified in the diag settings of the cluster.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).
