### PR TITLE
vm-repair: hotfix for None replacement error for all linux VMs

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -2037,8 +2037,8 @@
         ],
         "vm-repair": [
             {
-                "downloadUrl": "https://azurecomputeaidrepair.blob.core.windows.net/prod/vm_repair-0.2.1-py2.py3-none-any.whl",
-                "filename": "vm_repair-0.2.1-py2.py3-none-any.whl",
+                "downloadUrl": "https://azurecomputeaidrepair.blob.core.windows.net/prod/vm_repair-0.2.2-py2.py3-none-any.whl",
+                "filename": "vm_repair-0.2.2-py2.py3-none-any.whl",
                 "metadata": {
                     "classifiers": [
                         "Development Status :: 4 - Beta",
@@ -2075,9 +2075,9 @@
                     "metadata_version": "2.0",
                     "name": "vm-repair",
                     "summary": "Auto repair commands to fix VMs.",
-                    "version": "0.2.1"
+                    "version": "0.2.2"
                 },
-                "sha256Digest": "5c1f4fce05924d764b78536dbcc98af8450859bd420b0a16df9758008351d408"
+                "sha256Digest": "42c6500e5587184026a398147b0a7b1a9cb7e59642de9b932dfcbe1a90f14697"
             }
         ],
         "webapp": [

--- a/src/vm-repair/azext_vm_repair/repair_utils.py
+++ b/src/vm-repair/azext_vm_repair/repair_utils.py
@@ -47,7 +47,8 @@ def _call_az_command(command_string, run_async=False, secure_params=None):
     # Hide sensitive data such as passwords from logs
     if secure_params:
         for param in secure_params:
-            command_string = command_string.replace(param, '********')
+            if param:
+                command_string = command_string.replace(param, '********')
     logger.debug("Calling: %s", command_string)
     process = subprocess.Popen(tokenized_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
 

--- a/src/vm-repair/setup.py
+++ b/src/vm-repair/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup, find_packages
 
-VERSION = "0.2.1"
+VERSION = "0.2.2"
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',


### PR DESCRIPTION
This is a urgent hotfix for an error that is happening for all Linux VMs. 

One line check has been added for null usernames. 

Clear to merge when reviewed.