### PR TITLE
Revert "Release v0.8.4 for IoT extension"

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -471,8 +471,8 @@
         ],
         "azure-cli-iot-ext": [
             {
-                "downloadUrl": "https://github.com/Azure/azure-iot-cli-extension/releases/download/v0.8.4/azure_cli_iot_ext-0.8.4-py2.py3-none-any.whl",
-                "filename": "azure_cli_iot_ext-0.8.4-py2.py3-none-any.whl",
+                "downloadUrl": "https://github.com/Azure/azure-iot-cli-extension/releases/download/v0.8.3/azure_cli_iot_ext-0.8.3-py2.py3-none-any.whl",
+                "filename": "azure_cli_iot_ext-0.8.3-py2.py3-none-any.whl",
                 "metadata": {
                     "azext.minCliCoreVersion": "2.0.70",
                     "classifiers": [
@@ -521,9 +521,9 @@
                         }
                     ],
                     "summary": "Provides the data plane command layer for Azure IoT Hub, IoT Edge and IoT Device Provisioning Service",
-                    "version": "0.8.4"
+                    "version": "0.8.3"
                 },
-                "sha256Digest": "6f0905d035c8ea23908e839d92b195f89df0fd870b260b66141bf27eda1f2479"
+                "sha256Digest": "f3e1b0c0bcce57aaf82efa9145e6d0e6959d8501414a5f54ede6824dda4a7f09"
             },
             {
                 "downloadUrl": "https://github.com/Azure/azure-iot-cli-extension/releases/download/v0.7.1/azure_cli_iot_ext-0.7.1-py2.py3-none-any.whl",


### PR DESCRIPTION
Reverts Azure/azure-cli-extensions#1013 since it has breaking change that blocked existing Azure customers.
Related issue: https://github.com/Azure/azure-iot-cli-extension/issues/113