### PR TITLE
publishing new version of cli extension

### DIFF
--- a/src/aks-preview/setup.py
+++ b/src/aks-preview/setup.py
@@ -8,7 +8,7 @@
 from codecs import open as open1
 from setuptools import setup, find_packages
 
-VERSION = "0.4.21"
+VERSION = "0.4.22"
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',

--- a/src/index.json
+++ b/src/index.json
@@ -48,24 +48,11 @@
         ],
         "aks-preview": [
             {
-                "downloadUrl": "https://azurecliaks.blob.core.windows.net/azure-cli-extension/aks_preview-0.4.21-py2.py3-none-any.whl",
-                "filename": "aks_preview-0.4.21-py2.py3-none-any.whl",
+                "downloadUrl": "https://azurecliaks.blob.core.windows.net/azure-cli-extension/aks_preview-0.4.22-py2.py3-none-any.whl",
+                "filename": "aks_preview-0.4.22-py2.py3-none-any.whl",
                 "metadata": {
                     "azext.isPreview": true,
                     "azext.minCliCoreVersion": "2.0.49",
-                    "classifiers": [
-                        "Development Status :: 4 - Beta",
-                        "Intended Audience :: Developers",
-                        "Intended Audience :: System Administrators",
-                        "Programming Language :: Python",
-                        "Programming Language :: Python :: 2",
-                        "Programming Language :: Python :: 2.7",
-                        "Programming Language :: Python :: 3",
-                        "Programming Language :: Python :: 3.4",
-                        "Programming Language :: Python :: 3.5",
-                        "Programming Language :: Python :: 3.6",
-                        "License :: OSI Approved :: MIT License"
-                    ],
                     "extensions": {
                         "python.details": {
                             "contacts": [
@@ -88,9 +75,9 @@
                     "metadata_version": "2.0",
                     "name": "aks-preview",
                     "summary": "Provides a preview for upcoming AKS features",
-                    "version": "0.4.21"
+                    "version": "0.4.22"
                 },
-                "sha256Digest": "29efc9b8044083f13eead6eb00e255ad17ad55ca3a4995fd734d26a22c77e47f"
+                "sha256Digest": "b40525f860f23707176076265e289a1f4579a46f1b6e57573a7dbd12b5e97420"
             }
         ],
         "alias": [


### PR DESCRIPTION
The last version aks-preview extension published (0.4.21) did not use the latest wheel package and missed the newly added kanalyze command. So I am publishing a new version with ALL the latest changes.
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [x] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).
