### PR TITLE
List credentials for different users via parameter `--user`

### DIFF
--- a/src/aks-preview/HISTORY.md
+++ b/src/aks-preview/HISTORY.md
@@ -2,13 +2,17 @@
 
 Release History
 ===============
+0.4.25
++++++
+* List credentials for different users via parameter `--user`
+
 0.4.24
 +++++
 * added custom header support
 
 0.4.23
 +++++
-* Enable GA support of apiserver authorized IP ranges via paramater `--api-server-authorized-ip-ranges` in `az aks create` and `az aks update`
+* Enable GA support of apiserver authorized IP ranges via parameter `--api-server-authorized-ip-ranges` in `az aks create` and `az aks update`
 
 0.4.21
 +++++

--- a/src/aks-preview/azext_aks_preview/_help.py
+++ b/src/aks-preview/azext_aks_preview/_help.py
@@ -523,6 +523,9 @@ parameters:
   - name: --admin -a
     type: bool
     short-summary: "Get cluster administrator credentials.  Default: cluster user credentials."
+  - name: --user -u
+    type: string
+    short-summary: "Get credentials for the user. Only valid when --admin is False.  Default: cluster user credentials."
   - name: --file -f
     type: string
     short-summary: Kubernetes configuration file to update. Use "-" to print YAML to stdout instead.

--- a/src/aks-preview/azext_aks_preview/_params.py
+++ b/src/aks-preview/azext_aks_preview/_params.py
@@ -20,7 +20,7 @@ from ._validators import (
     validate_ssh_key, validate_max_pods, validate_nodes_count, validate_ip_ranges,
     validate_nodepool_name, validate_vm_set_type, validate_load_balancer_sku,
     validate_load_balancer_outbound_ips, validate_load_balancer_outbound_ip_prefixes,
-    validate_taints, validate_priority, validate_eviction_policy, validate_acr)
+    validate_taints, validate_priority, validate_eviction_policy, validate_acr, validate_user)
 
 
 def load_arguments(self, _):
@@ -142,6 +142,7 @@ def load_arguments(self, _):
 
     with self.argument_context('aks get-credentials') as c:
         c.argument('admin', options_list=['--admin', '-a'], default=False)
+        c.argument('user', options_list=['--user', '-u'], default='clusterUser', validator=validate_user)
         c.argument('path', options_list=['--file', '-f'], type=file_type, completer=FilesCompleter(),
                    default=os.path.join(os.path.expanduser('~'), '.kube', 'config'))
 

--- a/src/aks-preview/azext_aks_preview/_validators.py
+++ b/src/aks-preview/azext_aks_preview/_validators.py
@@ -213,3 +213,9 @@ def validate_eviction_policy(namespace):
 def validate_acr(namespace):
     if namespace.attach_acr and namespace.detach_acr:
         raise CLIError('Cannot specify "--attach-acr" and "--detach-acr" at the same time.')
+
+
+def validate_user(namespace):
+    if namespace.user.lower() != "clusteruser" and \
+            namespace.user.lower() != "clustermonitoringuser":
+        raise CLIError("--user can only be clusterUser or clusterMonitoringUser")

--- a/src/aks-preview/azext_aks_preview/custom.py
+++ b/src/aks-preview/azext_aks_preview/custom.py
@@ -1069,14 +1069,19 @@ def aks_get_credentials(cmd,    # pylint: disable=unused-argument
                         resource_group_name,
                         name,
                         admin=False,
+                        user='clusterUser',
                         path=os.path.join(os.path.expanduser('~'), '.kube', 'config'),
                         overwrite_existing=False):
     credentialResults = None
     if admin:
         credentialResults = client.list_cluster_admin_credentials(resource_group_name, name)
     else:
-        credentialResults = client.list_cluster_user_credentials(resource_group_name, name)
-
+        if user.lower() == 'clusteruser':
+            credentialResults = client.list_cluster_user_credentials(resource_group_name, name)
+        elif user.lower() == 'clustermonitoringuser':
+            credentialResults = client.list_cluster_monitoring_user_credentials(resource_group_name, name)
+        else:
+            raise CLIError("The user is invalid.")
     if not credentialResults:
         raise CLIError("No Kubernetes credentials found.")
 

--- a/src/aks-preview/azext_aks_preview/vendored_sdks/azure_mgmt_preview_aks/v2019_10_01/operations/_managed_clusters_operations.py
+++ b/src/aks-preview/azext_aks_preview/vendored_sdks/azure_mgmt_preview_aks/v2019_10_01/operations/_managed_clusters_operations.py
@@ -449,7 +449,7 @@ class ManagedClustersOperations(object):
 
     def list_cluster_monitoring_user_credentials(
             self, resource_group_name, resource_name, custom_headers=None, raw=False, **operation_config):
-        """Gets cluster user credential of a managed cluster.
+        """Gets cluster monitoring user credential of a managed cluster.
 
         Gets cluster monitoring user credential of the managed cluster with a
         specified resource group and name.

--- a/src/aks-preview/azext_aks_preview/vendored_sdks/azure_mgmt_preview_aks/v2019_10_01/operations/_managed_clusters_operations.py
+++ b/src/aks-preview/azext_aks_preview/vendored_sdks/azure_mgmt_preview_aks/v2019_10_01/operations/_managed_clusters_operations.py
@@ -447,6 +447,71 @@ class ManagedClustersOperations(object):
         return deserialized
     list_cluster_user_credentials.metadata = {'url': '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/listClusterUserCredential'}
 
+    def list_cluster_monitoring_user_credentials(
+            self, resource_group_name, resource_name, custom_headers=None, raw=False, **operation_config):
+        """Gets cluster user credential of a managed cluster.
+
+        Gets cluster monitoring user credential of the managed cluster with a
+        specified resource group and name.
+
+        :param resource_group_name: The name of the resource group.
+        :type resource_group_name: str
+        :param resource_name: The name of the managed cluster resource.
+        :type resource_name: str
+        :param dict custom_headers: headers that will be added to the request
+        :param bool raw: returns the direct response alongside the
+        deserialized response
+        :param operation_config: :ref:`Operation configuration
+        overrides<msrest:optionsforoperations>`.
+        :return: CredentialResults or ClientRawResponse if raw=true
+        :rtype:
+        ~azure.mgmt.containerservice.v2019_10_01.models.CredentialResults or
+        ~msrest.pipeline.ClientRawResponse
+        :raises: :class:`CloudError<msrestazure.azure_exceptions.CloudError>`
+        """
+        # Construct URL
+        url = self.list_cluster_monitoring_user_credentials.metadata['url']
+        path_format_arguments = {
+            'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str'),
+            'resourceGroupName': self._serialize.url("resource_group_name", resource_group_name, 'str', min_length=1),
+            'resourceName': self._serialize.url("resource_name", resource_name, 'str', max_length=63, min_length=1, pattern=r'^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$')
+        }
+        url = self._client.format_url(url, **path_format_arguments)
+
+        # Construct parameters
+        query_parameters = {}
+        query_parameters['api-version'] = self._serialize.query("self.api_version", self.api_version, 'str')
+
+        # Construct headers
+        header_parameters = {}
+        header_parameters['Accept'] = 'application/json'
+        if self.config.generate_client_request_id:
+            header_parameters['x-ms-client-request-id'] = str(uuid.uuid1())
+        if custom_headers:
+            header_parameters.update(custom_headers)
+        if self.config.accept_language is not None:
+            header_parameters['accept-language'] = self._serialize.header("self.config.accept_language", self.config.accept_language, 'str')
+
+        # Construct and send request
+        request = self._client.post(url, query_parameters, header_parameters)
+        response = self._client.send(request, stream=False, **operation_config)
+
+        if response.status_code not in [200]:
+            exp = CloudError(response)
+            exp.request_id = response.headers.get('x-ms-request-id')
+            raise exp
+
+        deserialized = None
+        if response.status_code == 200:
+            deserialized = self._deserialize('CredentialResults', response)
+
+        if raw:
+            client_raw_response = ClientRawResponse(deserialized, response)
+            return client_raw_response
+
+        return deserialized
+    list_cluster_monitoring_user_credentials.metadata = {'url': '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/listClusterMonitoringUserCredential'}
+
     def get(
             self, resource_group_name, resource_name, custom_headers=None, raw=False, **operation_config):
         """Gets a managed cluster.

--- a/src/aks-preview/setup.py
+++ b/src/aks-preview/setup.py
@@ -8,7 +8,7 @@
 from codecs import open as open1
 from setuptools import setup, find_packages
 
-VERSION = "0.4.24"
+VERSION = "0.4.25"
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',

--- a/src/index.json
+++ b/src/index.json
@@ -90,7 +90,7 @@
                     "summary": "Provides a preview for upcoming AKS features",
                     "version": "0.4.25"
                 },
-                "sha256Digest": "36b066365db2f7f55d2613f80d9394cb1cad65f6a2e553c67dcf73e1b475b2c1"
+                "sha256Digest": "58f04bc4417783b102ae83481338e9a16567a9183a021dff5a1f6c444b591f80"
             }
         ],
         "alias": [

--- a/src/index.json
+++ b/src/index.json
@@ -48,8 +48,8 @@
         ],
         "aks-preview": [
             {
-                "downloadUrl": "https://azurecliaks.blob.core.windows.net/azure-cli-extension/aks_preview-0.4.24-py2.py3-none-any.whl",
-                "filename": "aks_preview-0.4.24-py2.py3-none-any.whl",
+                "downloadUrl": "https://azurecliaks.blob.core.windows.net/azure-cli-extension/aks_preview-0.4.25-py2.py3-none-any.whl",
+                "filename": "aks_preview-0.4.25-py2.py3-none-any.whl",
                 "metadata": {
                     "azext.isPreview": true,
                     "azext.minCliCoreVersion": "2.0.49",
@@ -88,9 +88,9 @@
                     "metadata_version": "2.0",
                     "name": "aks-preview",
                     "summary": "Provides a preview for upcoming AKS features",
-                    "version": "0.4.24"
+                    "version": "0.4.25"
                 },
-                "sha256Digest": "93e70b30da3620975b52b5fe8ae8b97064ce8ba9922d4fbd33dcdaf68a2c861f"
+                "sha256Digest": "36b066365db2f7f55d2613f80d9394cb1cad65f6a2e553c67dcf73e1b475b2c1"
             }
         ],
         "alias": [


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).

Manual test:

```
➜  azure-container-networking git:(master) az aks get-credentials -g <resource-group-name> -n <cluster-name>
The behavior of this command has been altered by the following extension: aks-preview
Merged "<cluster-name>" as current context in /Users/<user>/.kube/config
➜  azure-container-networking git:(master) az aks get-credentials -g <resource-group-name> -n <cluster-name> --admin
The behavior of this command has been altered by the following extension: aks-preview
Merged "<cluster-name>-admin" as current context in /Users/<user>/.kube/config
➜  azure-container-networking git:(master) az aks get-credentials -g <resource-group-name> -n <cluster-name> --user=clusterAdmin
The behavior of this command has been altered by the following extension: aks-preview
--user can only be clusterUser or clusterMonitoringUser
➜  azure-container-networking git:(master) az aks get-credentials -g <resource-group-name> -n <cluster-name> --user=clusterUser
The behavior of this command has been altered by the following extension: aks-preview
Merged "<cluster-name>" as current context in /Users/<user>/.kube/config
➜  azure-container-networking git:(master) az aks get-credentials -g <resource-group-name> -n <cluster-name> --user=clusterMonitoringUser
The behavior of this command has been altered by the following extension: aks-preview
A different object named <cluster-name> already exists in your kubeconfig file.
Overwrite? (y/n): y
Merged "<cluster-name>" as current context in /Users/<user>/.kube/config
```
