### PR TITLE
Travis to ado

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,7 +66,7 @@ jobs:
       python ./scripts/ci/test_index.py -v
     displayName: "Verify Extensions Index"
 
-- job: TestSource
+- job: SourceTests
   displayName: "Unittest Test, Build Test"
   pool:
     vmImage: 'ubuntu-16.04'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,21 +89,25 @@ jobs:
         ADO_PULL_REQUEST_LATEST_COMMIT: $(System.PullRequest.SourceCommitId)
         ADO_PULL_REQUEST_TARGET_BRANCH: $(System.PullRequest.TargetBranch)
 
+- job: LintModifiedExtensions
+  displayName: "CLI Linter on Modified Extensions"
+  pool:
+    vmImage: 'ubuntu-16.04'
+  steps:
+    - task: UsePythonVersion@0
+      displayName: 'Use Python 3.6'
+      inputs:
+        versionSpec: 3.6
+    - bash: |
+        set -ev
 
-  # - job: LintModifiedExtensions
-#   displayName: "CLI Linter on Modified Extensions"
-#   pool:
-#     vmImage: 'ubuntu-16.04'
-#   steps:
-#   - task: UsePythonVersion@0
-#     displayName: 'Use Python 3.7'
-#     inputs:
-#       versionSpec: 3.7
-#   - task: Bash@3
-#     displayName: "CLI Linter on Modified Extension"
-#     inputs:
-#       targetType: 'filePath'
-#       filePath: scripts/ci/verify_modified_index.sh
+        # prepare and activate virtualenv
+        pip install virtualenv
+        python -m virtualenv venv/
+        source ./venv/bin/activate
+
+        ./scripts/ci/verify_modified_index.sh
+      displayName: "CLI Linter on Modified Extension"
 
 - job: IndexRefDocVerify
   displayName: "Verify Ref Docs"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,10 +71,11 @@ jobs:
   pool:
     vmImage: 'ubuntu-16.04'
   strategy:
-    Python36:
-      python.version: '3.6'
-    Python38:
-      python.version: '3.8'
+    matrix:
+      Python36:
+        python.version: '3.6'
+      Python38:
+        python.version: '3.8'
   steps:
     - task: UsePythonVersion@0
       displayName: 'Use Python $(python.version)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,7 +82,11 @@ jobs:
       inputs:
         versionSpec: '$(python.version)'
     - bash: pip install wheel==0.30.0
+      displayName: 'Install wheel==0.30.0'
     - bash: ./scripts/ci/test_source.sh
+      displayName: 'Run unittest and build test'
+      env:
+        BUILD_SOURCE_VERSION: $(Build.SourceVersion)
 
 # - job: LintModifiedExtensions
 #   displayName: "CLI Linter on Modified Extensions"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -86,9 +86,11 @@ jobs:
     - bash: ./scripts/ci/test_source.sh
       displayName: 'Run unittest and build test'
       env:
-        BUILD_SOURCE_VERSION: $(Build.SourceVersion)
+        ADO_PULL_REQUEST_LATEST_COMMIT: $(System.PullRequest.SourceCommitId)
+        ADO_PULL_REQUEST_TARGET_BRANCH: $(System.PullRequest.TargetBranch)
 
-# - job: LintModifiedExtensions
+
+  # - job: LintModifiedExtensions
 #   displayName: "CLI Linter on Modified Extensions"
 #   pool:
 #     vmImage: 'ubuntu-16.04'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,35 +66,22 @@ jobs:
       python ./scripts/ci/test_index.py -v
     displayName: "Verify Extensions Index"
 
-# - job: TestsPython27
-#   displayName: "Tests Python 2.7"
-#   pool:
-#     vmImage: 'ubuntu-16.04'
-#   steps:
-#   - task: UsePythonVersion@0
-#     displayName: 'Use Python 2.7'
-#     inputs:
-#       versionSpec: 2.7
-#   - task: Bash@3
-#     displayName: "Tests Python 2.7"
-#     inputs:
-#       targetType: 'filePath'
-#       filePath: scripts/ci/test_source.sh
-
-# - job: TestsPython37
-#   displayName: "Tests Python 3.7"
-#   pool:
-#     vmImage: 'ubuntu-16.04'
-#   steps:
-#   - task: UsePythonVersion@0
-#     displayName: 'Use Python 3.7'
-#     inputs:
-#       versionSpec: 3.7
-#   - task: Bash@3
-#     displayName: "Tests Python 3.7"
-#     inputs:
-#       targetType: 'filePath'
-#       filePath: scripts/ci/test_source.sh
+- job: TestSource
+  displayName: "Unittest Test, Build Test"
+  pool:
+    vmImage: 'ubuntu-16.04'
+  strategy:
+    Python36:
+      python.version: '3.6'
+    Python38:
+      python.version: '3.8'
+  steps:
+    - task: UsePythonVersion@0
+      displayName: 'Use Python $(python.version)'
+      inputs:
+        versionSpec: '$(python.version)'
+    - bash: pip install wheel==0.30.0
+    - bash: ./scripts/ci/test_source.sh
 
 # - job: LintModifiedExtensions
 #   displayName: "CLI Linter on Modified Extensions"

--- a/scripts/ci/test_source.py
+++ b/scripts/ci/test_source.py
@@ -31,19 +31,16 @@ for src_d in os.listdir(SRC_PATH):
     pkg_name = next((d for d in os.listdir(src_d_full) if d.startswith('azext_')), None)
 
     # If running in Travis CI, only run tests for edited extensions
-    cmd_tpl = 'git --no-pager diff --name-only {commit_start} -- {code_dir}'
-
-    # If running in Travis CI, only run tests for edited extensions
     commit_range = os.environ.get('TRAVIS_COMMIT_RANGE')
     if commit_range and not check_output(['git', '--no-pager', 'diff', '--name-only', commit_range, '--', src_d_full]):
         continue
 
     # Running in Azure DevOps
-    ado_source_version = os.environ.get('BUILD_SOURCE_VERSION')
-    print('*' * 70)
-    print(ado_source_version)
-    if ado_source_version:
-        cmd = cmd_tpl.format(commit_start=ado_source_version, code_dir=src_d_full)
+    cmd_tpl = 'git --no-pager diff --name-only origin/{commit_start} {commit_end} {code_dir}'
+    ado_branch_last_commit = os.environ.get('ADO_PULL_REQUEST_LATEST_COMMIT')
+    ado_target_branch = os.environ.get('ADO_PULL_REQUEST_TARGET_BRANCH')
+    if ado_branch_last_commit and ado_target_branch:
+        cmd = cmd_tpl.format(commit_start=ado_target_branch, commit_end=ado_branch_last_commit, code_dir=src_d_full)
         if not check_output(shlex.split(cmd)):
             continue
 


### PR DESCRIPTION
This is the 2nd move for CI that migrate from Travis to ADO which [move job SourceTests to ADO](https://github.com/Azure/azure-cli-extensions/issues/1140) 

Respect #867

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).
