### PR TITLE
Chore: Disable job CredScan for ADO sceurity concern

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,32 +8,32 @@ trigger:
     - '*'
 
 jobs:
-- job: CredScan
-  displayName: "Credential Scan"
-
-  pool:
-    vmImage: "windows-2019"
-  steps:
-  - task: CredScan@2
-    inputs:
-      toolMajorVersion: 'V2'
-
-  - task: PostAnalysis@1
-    inputs:
-      AllTools: false
-      APIScan: false
-      BinSkim: false
-      CodesignValidation: false
-      CredScan: true
-      FortifySCA: false
-      FxCop: false
-      ModernCop: false
-      PoliCheck: false
-      RoslynAnalyzers: false
-      SDLNativeRules: false
-      Semmle: false
-      TSLint: false
-      ToolLogsNotFoundAction: 'Standard'
+#- job: CredScan
+#  displayName: "Credential Scan"
+#
+#  pool:
+#    vmImage: "windows-2019"
+#  steps:
+#  - task: CredScan@2
+#    inputs:
+#      toolMajorVersion: 'V2'
+#
+#  - task: PostAnalysis@1
+#    inputs:
+#      AllTools: false
+#      APIScan: false
+#      BinSkim: false
+#      CodesignValidation: false
+#      CredScan: true
+#      FortifySCA: false
+#      FxCop: false
+#      ModernCop: false
+#      PoliCheck: false
+#      RoslynAnalyzers: false
+#      SDLNativeRules: false
+#      Semmle: false
+#      TSLint: false
+#      ToolLogsNotFoundAction: 'Standard'
 
 - job: StaticAnalysis
   displayName: "Static Analysis"


### PR DESCRIPTION
Disable temporary until CredScan task of **Microsoft Security Code Analysis (Preview)** installed.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).
