### PR TITLE
fix: CI job "SourceTests" will fail in non PR trigger build

### DIFF
--- a/scripts/ci/test_source.py
+++ b/scripts/ci/test_source.py
@@ -39,14 +39,17 @@ for src_d in os.listdir(SRC_PATH):
     cmd_tpl = 'git --no-pager diff --name-only origin/{commit_start} {commit_end} -- {code_dir}'
     ado_branch_last_commit = os.environ.get('ADO_PULL_REQUEST_LATEST_COMMIT')
     ado_target_branch = os.environ.get('ADO_PULL_REQUEST_TARGET_BRANCH')
-    if not ado_branch_last_commit or ado_branch_last_commit == '$(System.PullRequest.SourceCommitId)':
-        continue
-    elif not ado_target_branch or ado_target_branch == '$(System.PullRequest.TargetBranch)':
-        continue
-    else:
-        cmd = cmd_tpl.format(commit_start=ado_target_branch, commit_end=ado_branch_last_commit, code_dir=src_d_full)
-        if not check_output(shlex.split(cmd)):
+    if ado_branch_last_commit and ado_target_branch:
+        if ado_branch_last_commit == '$(System.PullRequest.SourceCommitId)':
+            # default value if ADO_PULL_REQUEST_LATEST_COMMIT not set in ADO
             continue
+        elif ado_target_branch == '$(System.PullRequest.TargetBranch)':
+            # default value if ADO_PULL_REQUEST_TARGET_BRANCH not set in ADO
+            continue
+        else:
+            cmd = cmd_tpl.format(commit_start=ado_target_branch, commit_end=ado_branch_last_commit, code_dir=src_d_full)
+            if not check_output(shlex.split(cmd)):
+                continue
 
     # Find the package and check it has tests
     if pkg_name and os.path.isdir(os.path.join(src_d_full, pkg_name, 'tests')):

--- a/scripts/ci/test_source.py
+++ b/scripts/ci/test_source.py
@@ -41,7 +41,11 @@ for src_d in os.listdir(SRC_PATH):
     ado_target_branch = os.environ.get('ADO_PULL_REQUEST_TARGET_BRANCH')
     print("ado_branch_last_commit =", ado_branch_last_commit)
     print("ado_target_branch =", ado_target_branch)
-    if ado_branch_last_commit and ado_target_branch:
+    if not ado_branch_last_commit or ado_branch_last_commit == '$(System.PullRequest.SourceCommitId)':
+        continue
+    elif not ado_target_branch or ado_target_branch == '$(System.PullRequest.TargetBranch)':
+        continue
+    else:
         cmd = cmd_tpl.format(commit_start=ado_target_branch, commit_end=ado_branch_last_commit, code_dir=src_d_full)
         if not check_output(shlex.split(cmd)):
             continue

--- a/scripts/ci/test_source.py
+++ b/scripts/ci/test_source.py
@@ -39,8 +39,6 @@ for src_d in os.listdir(SRC_PATH):
     cmd_tpl = 'git --no-pager diff --name-only origin/{commit_start} {commit_end} -- {code_dir}'
     ado_branch_last_commit = os.environ.get('ADO_PULL_REQUEST_LATEST_COMMIT')
     ado_target_branch = os.environ.get('ADO_PULL_REQUEST_TARGET_BRANCH')
-    print("ado_branch_last_commit =", ado_branch_last_commit)
-    print("ado_target_branch =", ado_target_branch)
     if not ado_branch_last_commit or ado_branch_last_commit == '$(System.PullRequest.SourceCommitId)':
         continue
     elif not ado_target_branch or ado_target_branch == '$(System.PullRequest.TargetBranch)':

--- a/scripts/ci/test_source.py
+++ b/scripts/ci/test_source.py
@@ -39,6 +39,8 @@ for src_d in os.listdir(SRC_PATH):
     cmd_tpl = 'git --no-pager diff --name-only origin/{commit_start} {commit_end} {code_dir}'
     ado_branch_last_commit = os.environ.get('ADO_PULL_REQUEST_LATEST_COMMIT')
     ado_target_branch = os.environ.get('ADO_PULL_REQUEST_TARGET_BRANCH')
+    print("ado_branch_last_commit =", ado_branch_last_commit)
+    print("ado_target_branch =", ado_target_branch)
     if ado_branch_last_commit and ado_target_branch:
         cmd = cmd_tpl.format(commit_start=ado_target_branch, commit_end=ado_branch_last_commit, code_dir=src_d_full)
         if not check_output(shlex.split(cmd)):

--- a/scripts/ci/test_source.py
+++ b/scripts/ci/test_source.py
@@ -36,7 +36,7 @@ for src_d in os.listdir(SRC_PATH):
         continue
 
     # Running in Azure DevOps
-    cmd_tpl = 'git --no-pager diff --name-only origin/{commit_start} {commit_end} {code_dir}'
+    cmd_tpl = 'git --no-pager diff --name-only origin/{commit_start} {commit_end} -- {code_dir}'
     ado_branch_last_commit = os.environ.get('ADO_PULL_REQUEST_LATEST_COMMIT')
     ado_target_branch = os.environ.get('ADO_PULL_REQUEST_TARGET_BRANCH')
     print("ado_branch_last_commit =", ado_branch_last_commit)


### PR DESCRIPTION
Build will fail in master branch as ADO envrionment variable `$(System.PullRequest.SourceCommitId)` and `$(System.PullRequest.TargetBranch)` is missing in BatchCI run (BatchCI is the reason to build after PR merge).

Job SouceTest runs `scripts/ci/test_source.py` require those 2 environment variables to make incremental test.

Test Plan:
1. Create a PR https://github.com/Azure/azure-cli-extensions/pull/1199
2. PR from hotfix-ci-test-source-src to hotfix-ci-test-in-master, job `Integration Test` succeed. ( [build ](https://dev.azure.com/azure-sdk/public/_build/results?buildId=233379&view=results))
3. PR merged, job `integration Test` succeed also. ( [build ](https://dev.azure.com/azure-sdk/public/_build/results?buildId=233381&view=results))

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).
