### PR TITLE
[hotfix] netappfiles download url 404

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -2053,7 +2053,7 @@
         ],
         "netappfiles-preview": [
             {
-                "downloadUrl": "https://anfclipython.blob.core.windows.net/cli-extensions/netappfiles_preview-0.3.2-py2.py3-none-any.whl",
+                "downloadUrl": "https://azurecliprod.blob.core.windows.net/cli-extensions/netappfiles_preview-0.3.2-py2.py3-none-any.whl",
                 "filename": "netappfiles_preview-0.3.2-py2.py3-none-any.whl",
                 "metadata": {
                     "azext.isPreview": true,
@@ -2103,7 +2103,7 @@
                     "summary": "Provides a preview for upcoming Azure NetApp Files (ANF) features.",
                     "version": "0.3.2"
                 },
-                "sha256Digest": "060152d0de8ff7af3076697b3d179dad1e14007278b7cea81e3381763f9d5a3e"
+                "sha256Digest": "d581bfefe3eb7fbceeed12c192ebdf5993fcf04ede7267d053aa416596bd0b53"
             }
         ],
         "notification-hub": [


### PR DESCRIPTION
The download URL seems to be invalid.

![image](https://user-images.githubusercontent.com/14357159/75084943-060d2400-555f-11ea-9d05-5dccfcd2e39b.png)

```
▶ dig anfclipython.blob.core.windows.net

; <<>> DiG 9.11.3-1ubuntu1.11-Ubuntu <<>> anfclipython.blob.core.windows.net
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 21311
;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 65494
;; QUESTION SECTION:
;anfclipython.blob.core.windows.net. IN A

;; Query time: 66 msec
;; SERVER: 127.0.0.53#53(127.0.0.53)
;; WHEN: Sat Feb 22 02:33:33 UTC 2020
;; MSG SIZE  rcvd: 63
```

it blocks PR by failed a CI check "IndexVerify":
1.  https://github.com/Azure/azure-cli-extensions/pull/1304
2.  https://github.com/Azure/azure-cli-extensions/pull/1241

Also, will fail CI of Azure/azure-cli

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).
