### PR TITLE
add vmware-vs to index

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -2979,10 +2979,41 @@
                     "license": "MIT",
                     "metadata_version": "2.0",
                     "name": "vmware-cs",
-                    "summary": "Manage Azure VMware Solution.",
+                    "summary": "Manage Azure VMware Solution by Cloud Simple.",
                     "version": "0.2.0"
                 },
                 "sha256Digest": "e462b1346fe3be6db89aead23dfc4e4f2e13f418392f1c7fae714fb2b5c5cc2a"
+            }
+        ],
+        "vmware-vs": [
+            {
+                "downloadUrl": "https://github.com/virtustream/azure-vmware-virtustream-cli-extension/releases/download/0.4.0/azure_vmware_virtustream_cli_extension-0.4.0-py2.py3-none-any.whl",
+                "filename": "azure_vmware_virtustream_cli_extension-0.4.0-py2.py3-none-any.whl",
+                "metadata": {
+                    "azext.isPreview": true,
+                    "azext.minCliCoreVersion": "2.0.67",
+                    "extensions": {
+                        "python.details": {
+                            "contacts": [
+                                {
+                                    "email": "cameron.taggart@virtustream.com",
+                                    "name": "Cameron Taggart",
+                                    "role": "author"
+                                }
+                            ],
+                            "project_urls": {
+                                "Home": "https://github.com/virtustream/azure-vmware-virtustream-cli-extension"
+                            }
+                        }
+                    },
+                    "generator": "bdist_wheel (0.30.0)",
+                    "license": "MIT",
+                    "metadata_version": "2.0",
+                    "name": "vmware-vs",
+                    "summary": "Manage Azure VMware Solution by Virtustream.",
+                    "version": "0.4.0"
+                },
+                "sha256Digest": "3ea2ff1033b3822d8c5cb59021784d88e383512a0e30c2eacf9b6618a3f59ac6"
             }
         ],
         "webapp": [

--- a/src/index.json
+++ b/src/index.json
@@ -2991,7 +2991,8 @@
                 "filename": "azure_vmware_virtustream_cli_extension-0.4.0-py2.py3-none-any.whl",
                 "metadata": {
                     "azext.isPreview": true,
-                    "azext.minCliCoreVersion": "2.0.67",
+                    "azext.minCliCoreVersion": "2.0.66",
+                    "azext.maxCliCoreVersion": "2.1.0",
                     "extensions": {
                         "python.details": {
                             "contacts": [
@@ -3009,7 +3010,7 @@
                     "generator": "bdist_wheel (0.30.0)",
                     "license": "MIT",
                     "metadata_version": "2.0",
-                    "name": "vmware-vs",
+                    "name": "azure-vmware-virtustream-cli-extension",
                     "summary": "Manage Azure VMware Solution by Virtustream.",
                     "version": "0.4.0"
                 },

--- a/src/index.json
+++ b/src/index.json
@@ -2979,7 +2979,7 @@
                     "license": "MIT",
                     "metadata_version": "2.0",
                     "name": "vmware-cs",
-                    "summary": "Manage Azure VMware Solution by Cloud Simple.",
+                    "summary": "Manage Azure VMware Solution.",
                     "version": "0.2.0"
                 },
                 "sha256Digest": "e462b1346fe3be6db89aead23dfc4e4f2e13f418392f1c7fae714fb2b5c5cc2a"

--- a/src/index.json
+++ b/src/index.json
@@ -1106,6 +1106,38 @@
                 "sha256Digest": "97e5ddd2ddef1ec829e112bc5e6d46ec34df930b528fdf591c6201f7d89b9119"
             }
         ],
+        "azure-vmware-virtustream-cli-extension": [
+            {
+                "downloadUrl": "https://github.com/virtustream/azure-vmware-virtustream-cli-extension/releases/download/0.4.0/azure_vmware_virtustream_cli_extension-0.4.0-py2.py3-none-any.whl",
+                "filename": "azure_vmware_virtustream_cli_extension-0.4.0-py2.py3-none-any.whl",
+                "metadata": {
+                    "azext.isPreview": true,
+                    "azext.minCliCoreVersion": "2.0.66",
+                    "azext.maxCliCoreVersion": "2.1.0",
+                    "extensions": {
+                        "python.details": {
+                            "contacts": [
+                                {
+                                    "email": "cameron.taggart@virtustream.com",
+                                    "name": "Cameron Taggart",
+                                    "role": "author"
+                                }
+                            ],
+                            "project_urls": {
+                                "Home": "https://github.com/virtustream/azure-vmware-virtustream-cli-extension"
+                            }
+                        }
+                    },
+                    "generator": "bdist_wheel (0.30.0)",
+                    "license": "MIT",
+                    "metadata_version": "2.0",
+                    "name": "azure-vmware-virtustream-cli-extension",
+                    "summary": "Manage Azure VMware Solution by Virtustream.",
+                    "version": "0.4.0"
+                },
+                "sha256Digest": "3ea2ff1033b3822d8c5cb59021784d88e383512a0e30c2eacf9b6618a3f59ac6"
+            }
+        ],
         "connectedmachine": [
             {
                 "downloadUrl": "https://azurecliprod.blob.core.windows.net/cli-extensions/connectedmachine-0.1.0-py2.py3-none-any.whl",
@@ -2983,38 +3015,6 @@
                     "version": "0.2.0"
                 },
                 "sha256Digest": "e462b1346fe3be6db89aead23dfc4e4f2e13f418392f1c7fae714fb2b5c5cc2a"
-            }
-        ],
-        "vmware-vs": [
-            {
-                "downloadUrl": "https://github.com/virtustream/azure-vmware-virtustream-cli-extension/releases/download/0.4.0/azure_vmware_virtustream_cli_extension-0.4.0-py2.py3-none-any.whl",
-                "filename": "azure_vmware_virtustream_cli_extension-0.4.0-py2.py3-none-any.whl",
-                "metadata": {
-                    "azext.isPreview": true,
-                    "azext.minCliCoreVersion": "2.0.66",
-                    "azext.maxCliCoreVersion": "2.1.0",
-                    "extensions": {
-                        "python.details": {
-                            "contacts": [
-                                {
-                                    "email": "cameron.taggart@virtustream.com",
-                                    "name": "Cameron Taggart",
-                                    "role": "author"
-                                }
-                            ],
-                            "project_urls": {
-                                "Home": "https://github.com/virtustream/azure-vmware-virtustream-cli-extension"
-                            }
-                        }
-                    },
-                    "generator": "bdist_wheel (0.30.0)",
-                    "license": "MIT",
-                    "metadata_version": "2.0",
-                    "name": "azure-vmware-virtustream-cli-extension",
-                    "summary": "Manage Azure VMware Solution by Virtustream.",
-                    "version": "0.4.0"
-                },
-                "sha256Digest": "3ea2ff1033b3822d8c5cb59021784d88e383512a0e30c2eacf9b6618a3f59ac6"
             }
         ],
         "webapp": [


### PR DESCRIPTION
That adds the current release of Azure VMWare Solution by Virtustream Extension to the index.
https://github.com/virtustream/azure-vmware-virtustream-cli-extension/releases/tag/0.4.0

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).
