### PR TITLE
update vmware extension to 0.5.5

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -3373,8 +3373,8 @@
         ],
         "vmware": [
             {
-                "downloadUrl": "https://github.com/virtustream/azure-vmware-virtustream-cli-extension/releases/download/0.5.4/vmware-0.5.4-py2.py3-none-any.whl",
-                "filename": "vmware-0.5.4-py2.py3-none-any.whl",
+                "downloadUrl": "https://github.com/virtustream/azure-vmware-virtustream-cli-extension/releases/download/0.5.5/vmware-0.5.5-py2.py3-none-any.whl",
+                "filename": "vmware-0.5.5-py2.py3-none-any.whl",
                 "metadata": {
                     "azext.isPreview": true,
                     "azext.minCliCoreVersion": "2.0.66",
@@ -3400,9 +3400,9 @@
                     "metadata_version": "2.0",
                     "name": "vmware",
                     "summary": "Preview Azure VMware Solution by Virtustream commands.",
-                    "version": "0.5.4"
+                    "version": "0.5.5"
                 },
-                "sha256Digest": "b53b5d4c3166f4dafc7768b46c780824c1dc41d03ba5f28fde095fc0f2e1394a"
+                "sha256Digest": "89c5c09ee859b4b03c57cf2d2c477054aef97a5cca6f9a67da8a19d792572b02"
             }
         ],
         "webapp": [


### PR DESCRIPTION
#1367 was version 0.5.4. This updates the extension to [version 0.5.5](https://github.com/virtustream/azure-vmware-virtustream-cli-extension/releases/tag/0.5.5) which fixes a bug.