### PR TITLE
[AKS] Fix test not found in aks-preview

### DIFF
--- a/src/aks-preview/azext_aks_preview/tests/__init__.py
+++ b/src/aks-preview/azext_aks_preview/tests/__init__.py
@@ -1,0 +1,4 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------

--- a/src/aks-preview/azext_aks_preview/tests/latest/__init__.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/__init__.py
@@ -1,0 +1,4 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------


### PR DESCRIPTION
According [docs of unittest, Test Discover](https://docs.python.org/3/library/unittest.html#test-discovery):
> Unittest supports simple test discovery. In order to be compatible with test discovery, all of the test files must be modules or packages (including namespace packages) importable from the top-level directory of the project

The tests of aks-preview didn't respect the [Python Namesapce](https://packaging.python.org/guides/packaging-namespace-packages/), so tests couldn't find. 

You could find the scenario in this build of this [PR](https://github.com/Azure/azure-cli-extensions/pull/1417).

Please also take care about the tests will fail:
![image](https://user-images.githubusercontent.com/14357159/77301424-9c816080-6d2a-11ea-9806-92317cb3bb3e.png)


---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
