### PR TITLE
[Interactive] Remove dependency of ENV_ADDITIONAL_USER_AGENT

### DIFF
--- a/src/interactive/HISTORY.rst
+++ b/src/interactive/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.4.4
++++++
+* Remove dependency of azure-cli-core's ENV_ADDITIONAL_USER_AGENT
+
 0.4.3
 +++++
 * Fix config problem in interactive

--- a/src/interactive/azext_interactive/azclishell/__init__.py
+++ b/src/interactive/azext_interactive/azclishell/__init__.py
@@ -3,4 +3,4 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-VERSION = '0.4.3'
+VERSION = '0.4.4'

--- a/src/interactive/azext_interactive/azclishell/app.py
+++ b/src/interactive/azext_interactive/azclishell/app.py
@@ -98,7 +98,10 @@ class AzInteractiveShell(object):
             self.completer = AzCompleter(self, None)
             self.lexer = None
         self.history = history or FileHistory(os.path.join(self.config.get_config_dir(), self.config.get_history()))
-        os.environ[_ENV_ADDITIONAL_USER_AGENT] = 'AZURECLISHELL/' + VERSION
+        if os.environ.get(_ENV_ADDITIONAL_USER_AGENT):
+            os.environ[_ENV_ADDITIONAL_USER_AGENT] += ' AZURECLISHELL/' + VERSION
+        else:
+            os.environ[_ENV_ADDITIONAL_USER_AGENT] = 'AZURECLISHELL/' + VERSION
 
         # OH WHAT FUN TO FIGURE OUT WHAT THESE ARE!
         self._cli = None

--- a/src/interactive/azext_interactive/azclishell/app.py
+++ b/src/interactive/azext_interactive/azclishell/app.py
@@ -17,7 +17,6 @@ from threading import Thread
 from six.moves import configparser
 from knack.log import get_logger
 from knack.util import CLIError
-from azure.cli.core.commands.client_factory import ENV_ADDITIONAL_USER_AGENT
 from azure.cli.core._profile import _SUBSCRIPTION_NAME, Profile
 from azure.cli.core._session import ACCOUNT, CONFIG, SESSION
 from azure.cli.core.api import get_config_dir
@@ -53,6 +52,7 @@ NOTIFICATIONS = ""
 PART_SCREEN_EXAMPLE = .3
 START_TIME = datetime.datetime.utcnow()
 CLEAR_WORD = get_os_clear_screen_word()
+_ENV_ADDITIONAL_USER_AGENT = 'AZURE_HTTP_USER_AGENT'
 
 logger = get_logger(__name__)
 
@@ -98,7 +98,7 @@ class AzInteractiveShell(object):
             self.completer = AzCompleter(self, None)
             self.lexer = None
         self.history = history or FileHistory(os.path.join(self.config.get_config_dir(), self.config.get_history()))
-        os.environ[ENV_ADDITIONAL_USER_AGENT] = 'AZURECLISHELL/' + VERSION
+        os.environ[_ENV_ADDITIONAL_USER_AGENT] = 'AZURECLISHELL/' + VERSION
 
         # OH WHAT FUN TO FIGURE OUT WHAT THESE ARE!
         self._cli = None


### PR DESCRIPTION
Fix #1480: `az interactive` crashes with "cannot import name 'ENV_ADDITIONAL_USER_AGENT'"

This issue is introduced by https://github.com/Azure/azure-cli/pull/12734 which removed the redundant logic of `ENV_ADDITIONAL_USER_AGENT`, because it is already taken care of by msrest. 

This PR removes the dependency of `AZURE_HTTP_USER_AGENT` and hard-codes it because msrest doesn't expose it:

https://github.com/Azure/msrest-for-python/blob/4cc8bc84e96036f03b34716466230fb257e27b36/msrest/pipeline/universal.py#L70

```py
class UserAgentPolicy(SansIOHTTPPolicy):
    _USERAGENT = "User-Agent"
    _ENV_ADDITIONAL_USER_AGENT = 'AZURE_HTTP_USER_AGENT'
```

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [x] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
