### PR TITLE
[CI] Overwrite AZURE_EXTENSION_DIR to fix bug that CI will fail if installing azure-devops extension

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -144,9 +144,10 @@ jobs:
 
         azdev setup -c ../azure-cli -r ./
 
-        az --version
+        # overwrite the default AZURE_EXTENSION_DIR set by ADO
+        AZURE_EXTENSION_DIR=~/.azure/cliextensions az --version
 
-        python scripts/ci/verify_linter.py
+        AZURE_EXTENSION_DIR=~/.azure/cliextensions python scripts/ci/verify_linter.py
       displayName: "CLI Linter on Modified Extension"
       env:
         ADO_PULL_REQUEST_LATEST_COMMIT: $(System.PullRequest.SourceCommitId)

--- a/src/index.json
+++ b/src/index.json
@@ -1210,6 +1210,58 @@
                     "version": "0.17.0"
                 },
                 "sha256Digest": "1e891afc8b6ee52c62c4f99802d77728ff60e89e4c08972325178cc4fdac6be9"
+            },
+            {
+                "downloadUrl": "https://github.com/Azure/azure-devops-cli-extension/releases/download/20200401.4/azure_devops-0.18.0-py2.py3-none-any.whl",
+                "filename": "azure_devops-0.18.0-py2.py3-none-any.whl",
+                "metadata": {
+                    "azext.minCliCoreVersion": "2.2.0",
+                    "classifiers": [
+                        "Development Status :: 4 - Beta",
+                        "Intended Audience :: Developers",
+                        "Intended Audience :: System Administrators",
+                        "Programming Language :: Python",
+                        "Programming Language :: Python :: 3",
+                        "Programming Language :: Python :: 3.4",
+                        "Programming Language :: Python :: 3.5",
+                        "Programming Language :: Python :: 3.6",
+                        "License :: OSI Approved :: MIT License"
+                    ],
+                    "extensions": {
+                        "python.details": {
+                            "contacts": [
+                                {
+                                    "email": "VSTS_Social@microsoft.com",
+                                    "name": "Microsoft",
+                                    "role": "author"
+                                }
+                            ],
+                            "document_names": {
+                                "description": "DESCRIPTION.rst"
+                            },
+                            "project_urls": {
+                                "Home": "https://github.com/Microsoft/azure-devops-cli-extension"
+                            }
+                        }
+                    },
+                    "extras": [],
+                    "generator": "bdist_wheel (0.30.0)",
+                    "license": "MIT",
+                    "metadata_version": "2.0",
+                    "name": "azure-devops",
+                    "run_requires": [
+                        {
+                            "requires": [
+                                "distro (==1.3.0)",
+                                "msrest (<0.7.0,>=0.6.0)",
+                                "python-dateutil (==2.7.3)"
+                            ]
+                        }
+                    ],
+                    "summary": "Tools for managing Azure DevOps.",
+                    "version": "0.18.0"
+                },
+                "sha256Digest": "21fd9bf9c01a315184f11d7f709f354075118c298fd662472273cb003bfbe23e"
             }
         ],
         "azure-firewall": [

--- a/src/index.json
+++ b/src/index.json
@@ -1210,58 +1210,6 @@
                     "version": "0.17.0"
                 },
                 "sha256Digest": "1e891afc8b6ee52c62c4f99802d77728ff60e89e4c08972325178cc4fdac6be9"
-            },
-            {
-                "downloadUrl": "https://github.com/Azure/azure-devops-cli-extension/releases/download/20200401.4/azure_devops-0.18.0-py2.py3-none-any.whl",
-                "filename": "azure_devops-0.18.0-py2.py3-none-any.whl",
-                "metadata": {
-                    "azext.minCliCoreVersion": "2.2.0",
-                    "classifiers": [
-                        "Development Status :: 4 - Beta",
-                        "Intended Audience :: Developers",
-                        "Intended Audience :: System Administrators",
-                        "Programming Language :: Python",
-                        "Programming Language :: Python :: 3",
-                        "Programming Language :: Python :: 3.4",
-                        "Programming Language :: Python :: 3.5",
-                        "Programming Language :: Python :: 3.6",
-                        "License :: OSI Approved :: MIT License"
-                    ],
-                    "extensions": {
-                        "python.details": {
-                            "contacts": [
-                                {
-                                    "email": "VSTS_Social@microsoft.com",
-                                    "name": "Microsoft",
-                                    "role": "author"
-                                }
-                            ],
-                            "document_names": {
-                                "description": "DESCRIPTION.rst"
-                            },
-                            "project_urls": {
-                                "Home": "https://github.com/Microsoft/azure-devops-cli-extension"
-                            }
-                        }
-                    },
-                    "extras": [],
-                    "generator": "bdist_wheel (0.30.0)",
-                    "license": "MIT",
-                    "metadata_version": "2.0",
-                    "name": "azure-devops",
-                    "run_requires": [
-                        {
-                            "requires": [
-                                "distro (==1.3.0)",
-                                "msrest (<0.7.0,>=0.6.0)",
-                                "python-dateutil (==2.7.3)"
-                            ]
-                        }
-                    ],
-                    "summary": "Tools for managing Azure DevOps.",
-                    "version": "0.18.0"
-                },
-                "sha256Digest": "21fd9bf9c01a315184f11d7f709f354075118c298fd662472273cb003bfbe23e"
             }
         ],
         "azure-firewall": [


### PR DESCRIPTION
It's caused by ADO would install a global Azure CLI in /opt/az and pre-install azure-devops extension in /opt/az/azcliextenions. Besides, it will overwrite a environment variables  AZURE_EXTENSION_DIR.

The value of overwritten `AZURE_EXTENSION_DIR` is /opt/az/azcliextensions, so when tring to install the same extension azure-devops but with different version like this https://github.com/Azure/azure-cli-extensions/pull/1482 does, CLI will complain about there is already an existing extension installed, so, CI will fail.

Have to overwrite the AZURE_EXTENSION_DIR back to normal to fix that.

Test Result in previous one commit:
![image](https://user-images.githubusercontent.com/14357159/78224351-005e1300-74fb-11ea-95e2-d6dae6e7ad9f.png)

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
