### PR TITLE
[AKS] fix: avoid clearing the autoscaler profile when its not specified

### DIFF
--- a/src/aks-preview/azext_aks_preview/custom.py
+++ b/src/aks-preview/azext_aks_preview/custom.py
@@ -1175,9 +1175,11 @@ def aks_update(cmd,     # pylint: disable=too-many-statements,too-many-branches,
         instance.agent_pool_profiles[0].min_count = None
         instance.agent_pool_profiles[0].max_count = None
 
-    if not cluster_autoscaler_profile:
+    # if intention is to clear profile
+    if cluster_autoscaler_profile == {}:
         instance.auto_scaler_profile = {}
-    else:
+    # else profile is provided, update instance profile if it exists
+    elif cluster_autoscaler_profile:
         instance.auto_scaler_profile = _update_dict(instance.auto_scaler_profile.__dict__,
                                                     dict((key.replace("-", "_"), value)
                                                          for (key, value) in cluster_autoscaler_profile.items())) \


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 

Description for Change:
Before any `aks update` command that doesn't specify the autoscaler profile would lead to clearing it because `if cluster_autoscaler_profile` is truthful. This changes that to only clear the profile when an empty string is passed as the autoscaler profile `--cluster-autoscaler-profile ""`, else it would preserve it.
