### PR TITLE
[Storage] az storage blob directory move: Fix the problem that the directory fails to move when the source path contains spaces (#1277)

### DIFF
--- a/src/storage-preview/HISTORY.rst
+++ b/src/storage-preview/HISTORY.rst
@@ -3,6 +3,9 @@
  Release History
 ===============
 
+0.2.11 (2020-06-04)
+* Fix the bug for command `az storage blob directory move`
+
 0.2.10 (2019-11-25)
 ++++++++++++++++
 * Fix bugs for ADLS Gen2

--- a/src/storage-preview/azext_storage_preview/operations/blob.py
+++ b/src/storage-preview/azext_storage_preview/operations/blob.py
@@ -5,6 +5,7 @@
 
 from __future__ import print_function
 
+from urllib.parse import quote
 from knack.util import CLIError
 from knack.log import get_logger
 
@@ -177,6 +178,10 @@ def rename_directory(client, container_name, new_path, source_path,
          The timeout parameter is expressed in seconds.
 
      """
+
+    # In order to find the required blob, `x-ms-rename-source` in header needs to encode the special character in URL.
+    source_path = quote(source_path)
+
     marker = client.rename_path(container_name, new_path, source_path,
                                 mode=mode, lease_id=lease_id, source_lease_id=source_lease_id,
                                 source_if_modified_since=source_if_modified_since,


### PR DESCRIPTION
Issue: #1277

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
