### PR TITLE
[CI] Remove wheel usage

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -162,8 +162,6 @@ jobs:
     displayName: 'Use Python 3.7'
     inputs:
       versionSpec: 3.7
-  - bash: pip install wheel==0.30.0
-    displayName: 'Install wheel==0.30.0'
   - task: Bash@3
     displayName: "Verify Extension Ref Docs"
     inputs:

--- a/scripts/ci/util.py
+++ b/scripts/ci/util.py
@@ -19,6 +19,7 @@ WHEEL_INFO_RE = re.compile(
     \.whl|\.dist-info)$""",
     re.VERBOSE).match
 
+
 def get_repo_root():
     current_dir = os.path.dirname(os.path.abspath(__file__))
     while not os.path.exists(os.path.join(current_dir, 'CONTRIBUTING.rst')):

--- a/scripts/ci/util.py
+++ b/scripts/ci/util.py
@@ -4,14 +4,20 @@
 # --------------------------------------------------------------------------------------------
 
 import os
+import re
 import json
 import zipfile
-from wheel.install import WHEEL_INFO_RE
 
 # Dependencies that will not be checked.
 # This is for packages starting with 'azure-' but do not use the 'azure' namespace.
 SKIP_DEP_CHECK = ['azure-batch-extensions']
 
+# copy from wheel==0.30.0
+WHEEL_INFO_RE = re.compile(
+    r"""^(?P<namever>(?P<name>.+?)(-(?P<ver>\d.+?))?)
+    ((-(?P<build>\d.*?))?-(?P<pyver>.+?)-(?P<abi>.+?)-(?P<plat>.+?)
+    \.whl|\.dist-info)$""",
+    re.VERBOSE).match
 
 def get_repo_root():
     current_dir = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
remove wheel usage since Docs team might use this script and we don't have wheel preinstalled

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
