### PR TITLE
[TimeSeriesInsights] Fix timeSeriesIdPropertyName is not parsed properly

### DIFF
--- a/src/timeseriesinsights/HISTORY.rst
+++ b/src/timeseriesinsights/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+0.1.1
+++++++
+* Fix #1657: ``timeSeriesIdPropertyName`` is not parsed properly
+* Fix #1658: When creating a new Standard Environment, ``--data-retention-time`` is not properly documented
+
 0.1.0
 ++++++
 * Initial release.

--- a/src/timeseriesinsights/azext_timeseriesinsights/_help.py
+++ b/src/timeseriesinsights/azext_timeseriesinsights/_help.py
@@ -29,7 +29,7 @@ type: command
 short-summary: Create or update a standard environment in the specified subscription and resource group.
 examples:
   - name: Create a standard environment
-    text: az timeseriesinsights environment standard create -g {rg} -n {env} --location westus --sku-name S1 --sku-capacity 1 --data-retention-time P31D --partition-key DeviceId1 --storage-limit-exceeded-behavior PauseIngress
+    text: az timeseriesinsights environment standard create -g {rg} -n {env} --location westus --sku-name S1 --sku-capacity 1 --data-retention-time 31 --partition-key DeviceId1 --storage-limit-exceeded-behavior PauseIngress
 """
 
 helps['timeseriesinsights environment standard update'] = """

--- a/src/timeseriesinsights/azext_timeseriesinsights/custom.py
+++ b/src/timeseriesinsights/azext_timeseriesinsights/custom.py
@@ -64,7 +64,7 @@ def create_timeseriesinsights_environment_longterm(cmd, client,
         location=location,
         tags=tags,
         sku=Sku(name=sku_name, capacity=sku_capacity),
-        time_series_id_properties=[TimeSeriesIdProperty(name=time_series_id_properties, type="String")],
+        time_series_id_properties=[TimeSeriesIdProperty(name=id_property, type="String") for id_property in time_series_id_properties],
         storage_configuration=LongTermStorageConfigurationInput(account_name=storage_account_name, management_key=storage_management_key),
         data_retention=data_retention)
     return sdk_no_wait(no_wait, client.create_or_update, resource_group_name=resource_group_name, environment_name=environment_name, parameters=parameters)

--- a/src/timeseriesinsights/azext_timeseriesinsights/tests/latest/recordings/test_timeseriesinsights_environment_longterm.yaml
+++ b/src/timeseriesinsights/azext_timeseriesinsights/tests/latest/recordings/test_timeseriesinsights_environment_longterm.yaml
@@ -15,8 +15,8 @@ interactions:
       ParameterSetName:
       - -g -n --query --output
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-storage/9.0.0 Azure-SDK-For-Python AZURECLI/2.4.0
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-storage/9.0.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: POST
@@ -32,7 +32,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 23 Apr 2020 08:58:47 GMT
+      - Fri, 08 May 2020 03:47:25 GMT
       expires:
       - '-1'
       pragma:
@@ -48,7 +48,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11999'
     status:
       code: 200
       message: OK
@@ -67,15 +67,15 @@ interactions:
       - --resource-group --name --sku-name --sku-capacity --data-retention --time-series-id-properties
         --storage-account-name --storage-management-key
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.4.0
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_timeseriesinsights000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001","name":"cli_test_timeseriesinsights000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-04-23T08:58:18Z","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001","name":"cli_test_timeseriesinsights000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-05-08T03:46:53Z","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -84,7 +84,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 23 Apr 2020 08:58:48 GMT
+      - Fri, 08 May 2020 03:47:26 GMT
       expires:
       - '-1'
       pragma:
@@ -100,7 +100,7 @@ interactions:
       message: OK
 - request:
     body: 'b''{"location": "westus", "sku": {"name": "L1", "capacity": 1}, "kind":
-      "LongTerm", "properties": {"timeSeriesIdProperties": [{"name": "[\''DeviceId1\'']",
+      "LongTerm", "properties": {"timeSeriesIdProperties": [{"name": "DeviceId1",
       "type": "String"}], "storageConfiguration": {"accountName": "clitest000002",
       "managementKey": "veryFakedStorageAccountKey=="}, "warmStoreConfiguration":
       {"dataRetention": "P7D"}}}'''
@@ -114,31 +114,31 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '399'
+      - '395'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
       - --resource-group --name --sku-name --sku-capacity --data-retention --time-series-id-properties
         --storage-account-name --storage-management-key
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"sku":{"name":"L1","capacity":1},"kind":"LongTerm","location":"westus","tags":null,"properties":{"timeSeriesIdProperties":[{"name":"[''DeviceId1'']","type":"String"}],"storageConfiguration":{"accountName":"clitest000002"},"warmStoreConfiguration":{"dataRetention":"P7D"},"creationTime":"2020-04-23T08:58:56+00:00","provisioningState":"Accepted","dataAccessId":"a8cedca2-765a-49a9-bed1-0bfd10644403","dataAccessFqdn":"a8cedca2-765a-49a9-bed1-0bfd10644403.env.timeseries.azure.com","requestApiVersion":"2018-08-15-preview"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003","name":"cli-test-tsi-env000003","type":"Microsoft.TimeSeriesInsights/Environments"}'
+      string: '{"sku":{"name":"L1","capacity":1},"kind":"LongTerm","location":"westus","tags":null,"properties":{"timeSeriesIdProperties":[{"name":"DeviceId1","type":"String"}],"storageConfiguration":{"accountName":"clitest000002"},"warmStoreConfiguration":{"dataRetention":"P7D"},"creationTime":"2020-05-08T03:47:33.3693862+00:00","provisioningState":"Accepted","dataAccessId":"f0b7d698-58b0-49b6-96f2-ccb8bf7a6067","dataAccessFqdn":"f0b7d698-58b0-49b6-96f2-ccb8bf7a6067.env.timeseries.azure.com","requestApiVersion":"2018-08-15-preview"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003","name":"cli-test-tsi-env000003","type":"Microsoft.TimeSeriesInsights/Environments"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '844'
+      - '848'
       content-type:
       - application/json
       date:
-      - Thu, 23 Apr 2020 08:58:57 GMT
+      - Fri, 08 May 2020 03:47:35 GMT
       expires:
       - '-1'
       pragma:
@@ -150,7 +150,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1192'
+      - '1199'
     status:
       code: 201
       message: Created
@@ -169,23 +169,22 @@ interactions:
       - --resource-group --name --sku-name --sku-capacity --data-retention --time-series-id-properties
         --storage-account-name --storage-management-key
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.5.1
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"sku":{"name":"L1","capacity":1},"kind":"LongTerm","location":"westus","tags":null,"properties":{"timeSeriesIdProperties":[{"name":"[''DeviceId1'']","type":"String"}],"storageConfiguration":{"accountName":"clitest000002"},"warmStoreConfiguration":{"dataRetention":"P7D"},"creationTime":"Thu,
-        23 Apr 2020 08:58:56 GMT","provisioningState":"Creating","requestApiVersion":"2018-08-15-preview","dataAccessId":"a8cedca2-765a-49a9-bed1-0bfd10644403","dataAccessFqdn":"a8cedca2-765a-49a9-bed1-0bfd10644403.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003","name":"cli-test-tsi-env000003","type":"Microsoft.TimeSeriesInsights/Environments"}'
+      string: '{"sku":{"name":"L1","capacity":1},"kind":"LongTerm","location":"westus","tags":null,"properties":{"timeSeriesIdProperties":[{"name":"DeviceId1","type":"String"}],"storageConfiguration":{"accountName":"clitest000002"},"warmStoreConfiguration":{"dataRetention":"P7D"},"creationTime":"2020-05-08T03:47:33.3693862Z","provisioningState":"Creating","requestApiVersion":"2018-08-15-preview","dataAccessId":"f0b7d698-58b0-49b6-96f2-ccb8bf7a6067","dataAccessFqdn":"f0b7d698-58b0-49b6-96f2-ccb8bf7a6067.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003","name":"cli-test-tsi-env000003","type":"Microsoft.TimeSeriesInsights/Environments"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '848'
+      - '843'
       content-type:
       - application/json
       date:
-      - Thu, 23 Apr 2020 08:59:29 GMT
+      - Fri, 08 May 2020 03:48:06 GMT
       expires:
       - '-1'
       pragma:
@@ -218,23 +217,22 @@ interactions:
       - --resource-group --name --sku-name --sku-capacity --data-retention --time-series-id-properties
         --storage-account-name --storage-management-key
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.5.1
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"sku":{"name":"L1","capacity":1},"kind":"LongTerm","location":"westus","tags":null,"properties":{"timeSeriesIdProperties":[{"name":"[''DeviceId1'']","type":"String"}],"storageConfiguration":{"accountName":"clitest000002"},"warmStoreConfiguration":{"dataRetention":"P7D"},"creationTime":"Thu,
-        23 Apr 2020 08:58:56 GMT","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"a8cedca2-765a-49a9-bed1-0bfd10644403","dataAccessFqdn":"a8cedca2-765a-49a9-bed1-0bfd10644403.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003","name":"cli-test-tsi-env000003","type":"Microsoft.TimeSeriesInsights/Environments"}'
+      string: '{"sku":{"name":"L1","capacity":1},"kind":"LongTerm","location":"westus","tags":null,"properties":{"timeSeriesIdProperties":[{"name":"DeviceId1","type":"String"}],"storageConfiguration":{"accountName":"clitest000002"},"warmStoreConfiguration":{"dataRetention":"P7D"},"creationTime":"2020-05-08T03:47:33.3693862Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"f0b7d698-58b0-49b6-96f2-ccb8bf7a6067","dataAccessFqdn":"f0b7d698-58b0-49b6-96f2-ccb8bf7a6067.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003","name":"cli-test-tsi-env000003","type":"Microsoft.TimeSeriesInsights/Environments"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '849'
+      - '844'
       content-type:
       - application/json
       date:
-      - Thu, 23 Apr 2020 08:59:59 GMT
+      - Fri, 08 May 2020 03:48:37 GMT
       expires:
       - '-1'
       pragma:
@@ -270,25 +268,24 @@ interactions:
       ParameterSetName:
       - --resource-group --name --data-retention
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"sku":{"name":"L1","capacity":1},"kind":"LongTerm","location":"westus","tags":{},"properties":{"timeSeriesIdProperties":[{"name":"[''DeviceId1'']","type":"String"}],"storageConfiguration":{"accountName":"clitest000002"},"warmStoreConfiguration":{"dataRetention":"P8D"},"creationTime":"Thu,
-        23 Apr 2020 08:58:56 GMT","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"a8cedca2-765a-49a9-bed1-0bfd10644403","dataAccessFqdn":"a8cedca2-765a-49a9-bed1-0bfd10644403.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003","name":"cli-test-tsi-env000003","type":"Microsoft.TimeSeriesInsights/Environments"}'
+      string: '{"sku":{"name":"L1","capacity":1},"kind":"LongTerm","location":"westus","tags":{},"properties":{"timeSeriesIdProperties":[{"name":"DeviceId1","type":"String"}],"storageConfiguration":{"accountName":"clitest000002"},"warmStoreConfiguration":{"dataRetention":"P8D"},"creationTime":"2020-05-08T03:47:33.3693862Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"f0b7d698-58b0-49b6-96f2-ccb8bf7a6067","dataAccessFqdn":"f0b7d698-58b0-49b6-96f2-ccb8bf7a6067.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003","name":"cli-test-tsi-env000003","type":"Microsoft.TimeSeriesInsights/Environments"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '847'
+      - '842'
       content-type:
       - application/json
       date:
-      - Thu, 23 Apr 2020 09:00:02 GMT
+      - Fri, 08 May 2020 03:48:41 GMT
       expires:
       - '-1'
       pragma:
@@ -304,7 +301,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1194'
+      - '1199'
     status:
       code: 200
       message: OK
@@ -326,15 +323,15 @@ interactions:
       ParameterSetName:
       - -g -n --key --query --output
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-storage/9.0.0 Azure-SDK-For-Python AZURECLI/2.4.0
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-storage/9.0.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Storage/storageAccounts/clitest000002/regenerateKey?api-version=2019-06-01
   response:
     body:
-      string: '{"keys":[{"keyName":"key1","value":"rmG6CkIpQxBZVpdgwnnZrxPJxv5+jwWrxLOTLcEjr0/XZF0bseNyxLlSj58M2U1LD99xpCgfrD4k3seP9bigHQ==","permissions":"FULL"},{"keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
+      string: '{"keys":[{"keyName":"key1","value":"r7RjB6uTrqw/PZYWGY3YofQZ+416xbsedSMaA1OcpsVmk71mMzeGpWuXe4A1cW2jcaZ5iqFFDNj2H2KARaGNPg==","permissions":"FULL"},{"keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
     headers:
       cache-control:
       - no-cache
@@ -343,7 +340,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 23 Apr 2020 09:01:04 GMT
+      - Fri, 08 May 2020 03:49:41 GMT
       expires:
       - '-1'
       pragma:
@@ -359,12 +356,12 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
+      - '1199'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"properties": {"storageConfiguration": {"managementKey": "rmG6CkIpQxBZVpdgwnnZrxPJxv5+jwWrxLOTLcEjr0/XZF0bseNyxLlSj58M2U1LD99xpCgfrD4k3seP9bigHQ=="}}}'
+    body: '{"properties": {"storageConfiguration": {"managementKey": "r7RjB6uTrqw/PZYWGY3YofQZ+416xbsedSMaA1OcpsVmk71mMzeGpWuXe4A1cW2jcaZ5iqFFDNj2H2KARaGNPg=="}}}'
     headers:
       Accept:
       - application/json
@@ -381,25 +378,24 @@ interactions:
       ParameterSetName:
       - --resource-group --name --storage-management-key
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"sku":{"name":"L1","capacity":1},"kind":"LongTerm","location":"westus","tags":{},"properties":{"timeSeriesIdProperties":[{"name":"[''DeviceId1'']","type":"String"}],"storageConfiguration":{"accountName":"clitest000002"},"warmStoreConfiguration":{"dataRetention":"P8D"},"creationTime":"Thu,
-        23 Apr 2020 08:58:56 GMT","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"a8cedca2-765a-49a9-bed1-0bfd10644403","dataAccessFqdn":"a8cedca2-765a-49a9-bed1-0bfd10644403.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003","name":"cli-test-tsi-env000003","type":"Microsoft.TimeSeriesInsights/Environments"}'
+      string: '{"sku":{"name":"L1","capacity":1},"kind":"LongTerm","location":"westus","tags":{},"properties":{"timeSeriesIdProperties":[{"name":"DeviceId1","type":"String"}],"storageConfiguration":{"accountName":"clitest000002"},"warmStoreConfiguration":{"dataRetention":"P8D"},"creationTime":"2020-05-08T03:47:33.3693862Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"f0b7d698-58b0-49b6-96f2-ccb8bf7a6067","dataAccessFqdn":"f0b7d698-58b0-49b6-96f2-ccb8bf7a6067.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003","name":"cli-test-tsi-env000003","type":"Microsoft.TimeSeriesInsights/Environments"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '847'
+      - '842'
       content-type:
       - application/json
       date:
-      - Thu, 23 Apr 2020 09:01:21 GMT
+      - Fri, 08 May 2020 03:49:58 GMT
       expires:
       - '-1'
       pragma:
@@ -415,7 +411,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1194'
+      - '1199'
     status:
       code: 200
       message: OK

--- a/src/timeseriesinsights/azext_timeseriesinsights/tests/latest/test_timeseriesinsights_scenario.py
+++ b/src/timeseriesinsights/azext_timeseriesinsights/tests/latest/test_timeseriesinsights_scenario.py
@@ -95,7 +95,8 @@ class TimeSeriesInsightsClientScenarioTest(ScenarioTest):
                  '--time-series-id-properties DeviceId1 '
                  '--storage-account-name {sa} '
                  '--storage-management-key ' + key,
-                 checks=[self.check('name', '{env}')])
+                 checks=[self.check('name', '{env}'),
+                         self.check('timeSeriesIdProperties[0].name', 'DeviceId1')])
 
         self.cmd('az timeseriesinsights environment longterm update --resource-group {rg} --name {env} --data-retention 8',
                  checks=[self.check('dataRetention', '8 days, 0:00:00')])

--- a/src/timeseriesinsights/setup.py
+++ b/src/timeseriesinsights/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     from distutils import log as logger
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
 
-VERSION = '0.1.0'
+VERSION = '0.1.1'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
* Fix #1657: ``timeSeriesIdPropertyName`` is not parsed properly
* Fix #1658: When creating a new Standard Environment, ``--data-retention-time`` is not properly documented
