### PR TITLE
[Log Analytics Solution] deprecate `--plan-publisher`, `--name`, `--plan-product` and add `--solution-type` for create

### DIFF
--- a/src/log-analytics-solution/HISTORY.rst
+++ b/src/log-analytics-solution/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.1.1
++++++++++++++++
+* deprecate --plan-publisher, --name, --plan-product and add --solution-type for create
+
 0.1.0
-++++++
++++++++++++++++
 * Initial release.

--- a/src/log-analytics-solution/README.md
+++ b/src/log-analytics-solution/README.md
@@ -16,9 +16,7 @@ Manage Log Analytics Solution: [more info](https://docs.microsoft.com/en-us/azur
 ```
 az monitor log-analytics solution create \
     --resource-group MyResourceGroup \
-    --name Containers({SolutionName}) \
-    --plan-publisher Microsoft \
-    --plan-product "OMSGallery/Containers" \
+    --solution-type Containers \
     --workspace "/subscriptions/{SubID}/resourceGroups/{ResourceGroup}/providers/ \
     Microsoft.OperationalInsights/workspaces/{WorkspaceName}" \
     --tags key=value

--- a/src/log-analytics-solution/azext_log_analytics_solution/_help.py
+++ b/src/log-analytics-solution/azext_log_analytics_solution/_help.py
@@ -18,11 +18,10 @@ helps['monitor log-analytics solution create'] = """
 type: command
 short-summary: Create a log-analytics solution.
 examples:
-  - name: Create a log-analytics solution for the plan product of OMSGallery/Containers
+  - name: Create a log-analytics solution of type Containers
     text: |-
            az monitor log-analytics solution create --resource-group MyResourceGroup \\
-           --name Containers({SolutionName}) --tags key=value \\
-           --plan-publisher Microsoft --plan-product "OMSGallery/Containers" \\
+           --solution-type Containers --tags key=value \\
            --workspace "/subscriptions/{SubID}/resourceGroups/{ResourceGroup}/providers/ \\
            Microsoft.OperationalInsights/workspaces/{WorkspaceName}"
 """

--- a/src/log-analytics-solution/azext_log_analytics_solution/_params.py
+++ b/src/log-analytics-solution/azext_log_analytics_solution/_params.py
@@ -11,20 +11,27 @@ from knack.arguments import CLIArgumentType
 from ._validators import validate_workspace_resource_id
 
 solution_name = CLIArgumentType(options_list=['--name', '-n'],
-                                help='Name of the log-analytics solution. For Microsoft published solution it '
-                                     'should be in the format of solutionType(workspaceName). SolutionType part is '
-                                     'case sensitive. For third party solution, it can be anything.')
+                                help='Name of the log-analytics solution. It should be in the format of '
+                                     'solutionType(workspaceName). SolutionType part is case sensitive. ')
 
 
 def load_arguments(self, _):
 
     with self.argument_context('monitor log-analytics solution create') as c:
         c.ignore('location')
-        c.argument('solution_name', solution_name)
+        c.argument('solution_type', options_list=['--solution-type', '-t'],
+                   help='Type of the log-analytics solution. The most used are: SecurityCenterFree, Security, Updates, '
+                        'ContainerInsights, ServiceMap, AzureActivity, ChangeTracking, VMInsights, SecurityInsights, '
+                        'NetworkMonitoring, SQLVulnerabilityAssessment, SQLAdvancedThreatProtection, AntiMalware, '
+                        'AzureAutomation, LogicAppsManagement, SQLDataClassification')
+        c.argument('solution_name', solution_name, deprecate_info=c.deprecate(hide=True))
         c.argument('tags', tags_type)
-        c.argument('plan_publisher', help='Publisher name of the plan for solution. For gallery solution, it is Microsoft.')
-        c.argument('plan_product', help='Product name of the plan for solution. '
-                                        'For Microsoft published gallery solution it should be in the format of OMSGallery/<solutionType>. This is case sensitive.')
+        c.argument('plan_publisher',
+                   help='Publisher name of the plan for solution. For gallery solution, it is Microsoft.',
+                   deprecate_info=c.deprecate(hide=True))
+        c.argument('plan_product',
+                   help='Product name of the plan for solution. It should be in the format of OMSGallery/<solutionType>. This is case sensitive.',
+                   deprecate_info=c.deprecate(hide=True))
         c.argument('workspace_resource_id', options_list=['--workspace', '-w'],
                    validator=validate_workspace_resource_id,
                    help='The name or resource ID of the log analytics workspace with which the solution will be linked.')

--- a/src/log-analytics-solution/azext_log_analytics_solution/_validators.py
+++ b/src/log-analytics-solution/azext_log_analytics_solution/_validators.py
@@ -34,3 +34,5 @@ def validate_workspace_resource_id(cmd, namespace):
 
         # The location of solution is the same as the location of the workspace
         namespace.location = workspaces.location
+
+        namespace.solution_name = namespace.solution_type + "(" + workspace_param['resource_name'] + ")"

--- a/src/log-analytics-solution/azext_log_analytics_solution/custom.py
+++ b/src/log-analytics-solution/azext_log_analytics_solution/custom.py
@@ -13,11 +13,12 @@ from azure.cli.core.util import sdk_no_wait
 
 def create_monitor_log_analytics_solution(client,
                                           resource_group_name,
-                                          solution_name,
-                                          plan_publisher,
-                                          plan_product,
+                                          solution_type,
                                           workspace_resource_id,
                                           location,
+                                          solution_name=None,
+                                          plan_publisher=None,
+                                          plan_product=None,
                                           tags=None,
                                           no_wait=False):
 
@@ -29,8 +30,8 @@ def create_monitor_log_analytics_solution(client,
         },
         "plan": {
             "name": solution_name,
-            "product": plan_product,
-            "publisher": plan_publisher,
+            "product": "OMSGallery/" + solution_type,
+            "publisher": "Microsoft",
             "promotion_code": ""
         }
     }

--- a/src/log-analytics-solution/azext_log_analytics_solution/tests/latest/recordings/test_log_analytics_solution.yaml
+++ b/src/log-analytics-solution/azext_log_analytics_solution/tests/latest/recordings/test_log_analytics_solution.yaml
@@ -14,7 +14,7 @@ interactions:
       - -g -n -l --resource-type -p
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
@@ -37,12 +37,7 @@ interactions:
         East","UK South","Central India","Canada Central","West US 2","Australia Central","Australia
         East","France Central","Korea Central","North Europe","Central US","East Asia","East
         US 2","South Central US","North Central US","West US","UK West","South Africa
-        North","Brazil South","Switzerland North","Switzerland West"],"apiVersions":["2020-03-01-preview","2019-08-01-preview","2015-11-01-preview"],"defaultApiVersion":"2015-11-01-preview","capabilities":"None"},{"resourceType":"workspaces/query","locations":["West
-        Central US","Australia Southeast","West Europe","East US","Southeast Asia","Japan
-        East","UK South","Central India","Canada Central","West US 2","Australia Central","Australia
-        East","France Central","Korea Central","North Europe","Central US","East Asia","East
-        US 2","South Central US","North Central US","West US","UK West","South Africa
-        North","Brazil South","Switzerland West","Switzerland North"],"apiVersions":["2017-10-01"],"capabilities":"None"},{"resourceType":"workspaces/dataSources","locations":["East
+        North","Brazil South","Switzerland North","Switzerland West"],"apiVersions":["2020-03-01-preview","2019-08-01-preview","2015-11-01-preview"],"defaultApiVersion":"2015-11-01-preview","capabilities":"None"},{"resourceType":"workspaces/query","locations":[],"apiVersions":["2017-10-01"],"capabilities":"None"},{"resourceType":"workspaces/metadata","locations":[],"apiVersions":["2017-10-01"],"capabilities":"None"},{"resourceType":"workspaces/dataSources","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central","West US 2","Australia Central","Australia
         East","France Central","Korea Central","North Europe","Central US","East Asia","East
@@ -70,11 +65,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '6229'
+      - '5930'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 29 Apr 2020 09:22:33 GMT
+      - Mon, 11 May 2020 02:57:16 GMT
       expires:
       - '-1'
       pragma:
@@ -108,7 +103,7 @@ interactions:
       - -g -n -l --resource-type -p
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: PUT
@@ -116,12 +111,12 @@ interactions:
   response:
     body:
       string: "{\r\n  \"properties\": {\r\n    \"source\": \"Azure\",\r\n    \"customerId\":
-        \"f70fe6d6-08c1-410b-ac48-9e5d6cf56aac\",\r\n    \"provisioningState\": \"Creating\",\r\n
-        \   \"sku\": {\r\n      \"name\": \"free\",\r\n      \"lastSkuUpdate\": \"Wed,
-        29 Apr 2020 09:22:40 GMT\"\r\n    },\r\n    \"retentionInDays\": 7,\r\n    \"features\":
+        \"ac2fa443-2f85-430e-aa7b-98c3c1d54cb4\",\r\n    \"provisioningState\": \"Creating\",\r\n
+        \   \"sku\": {\r\n      \"name\": \"free\",\r\n      \"lastSkuUpdate\": \"Mon,
+        11 May 2020 02:57:23 GMT\"\r\n    },\r\n    \"retentionInDays\": 7,\r\n    \"features\":
         {\r\n      \"legacy\": 0,\r\n      \"searchVersion\": 1,\r\n      \"enableLogAccessUsingOnlyResourcePermissions\":
         true\r\n    },\r\n    \"workspaceCapping\": {\r\n      \"dailyQuotaGb\": 0.5,\r\n
-        \     \"quotaNextResetTime\": \"Thu, 30 Apr 2020 07:00:00 GMT\",\r\n      \"dataIngestionStatus\":
+        \     \"quotaNextResetTime\": \"Mon, 11 May 2020 15:00:00 GMT\",\r\n      \"dataIngestionStatus\":
         \"RespectQuota\"\r\n    },\r\n    \"publicNetworkAccessForIngestion\": \"Enabled\",\r\n
         \   \"publicNetworkAccessForQuery\": \"Enabled\"\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/microsoft.operationalinsights/workspaces/workspace000004\",\r\n
         \ \"name\": \"workspace000004\",\r\n  \"type\": \"Microsoft.OperationalInsights/workspaces\",\r\n
@@ -134,7 +129,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 29 Apr 2020 09:22:41 GMT
+      - Mon, 11 May 2020 02:57:25 GMT
       pragma:
       - no-cache
       server:
@@ -167,18 +162,18 @@ interactions:
       - -g -n -l --resource-type -p
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.5.1
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.OperationalInsights/workspaces/workspace000004?api-version=2015-03-20
   response:
     body:
       string: "{\r\n  \"properties\": {\r\n    \"source\": \"Azure\",\r\n    \"customerId\":
-        \"f70fe6d6-08c1-410b-ac48-9e5d6cf56aac\",\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"sku\": {\r\n      \"name\": \"free\",\r\n      \"lastSkuUpdate\": \"Wed,
-        29 Apr 2020 09:22:40 GMT\"\r\n    },\r\n    \"retentionInDays\": 7,\r\n    \"features\":
+        \"ac2fa443-2f85-430e-aa7b-98c3c1d54cb4\",\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"sku\": {\r\n      \"name\": \"free\",\r\n      \"lastSkuUpdate\": \"Mon,
+        11 May 2020 02:57:23 GMT\"\r\n    },\r\n    \"retentionInDays\": 7,\r\n    \"features\":
         {\r\n      \"legacy\": 0,\r\n      \"searchVersion\": 1,\r\n      \"enableLogAccessUsingOnlyResourcePermissions\":
         true\r\n    },\r\n    \"workspaceCapping\": {\r\n      \"dailyQuotaGb\": 0.5,\r\n
-        \     \"quotaNextResetTime\": \"Thu, 30 Apr 2020 07:00:00 GMT\",\r\n      \"dataIngestionStatus\":
+        \     \"quotaNextResetTime\": \"Mon, 11 May 2020 15:00:00 GMT\",\r\n      \"dataIngestionStatus\":
         \"RespectQuota\"\r\n    },\r\n    \"publicNetworkAccessForIngestion\": \"Enabled\",\r\n
         \   \"publicNetworkAccessForQuery\": \"Enabled\"\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/microsoft.operationalinsights/workspaces/workspace000004\",\r\n
         \ \"name\": \"workspace000004\",\r\n  \"type\": \"Microsoft.OperationalInsights/workspaces\",\r\n
@@ -191,7 +186,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 29 Apr 2020 09:23:13 GMT
+      - Mon, 11 May 2020 02:57:56 GMT
       pragma:
       - no-cache
       server:
@@ -223,10 +218,10 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - --resource-group --name --plan-publisher --plan-product --workspace --tags
+      - --resource-group --solution-type --workspace --tags
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-loganalytics/0.5.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-loganalytics/0.5.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
@@ -234,12 +229,12 @@ interactions:
   response:
     body:
       string: "{\r\n  \"properties\": {\r\n    \"source\": \"Azure\",\r\n    \"customerId\":
-        \"f70fe6d6-08c1-410b-ac48-9e5d6cf56aac\",\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"sku\": {\r\n      \"name\": \"free\",\r\n      \"lastSkuUpdate\": \"Wed,
-        29 Apr 2020 09:22:40 GMT\"\r\n    },\r\n    \"retentionInDays\": 7,\r\n    \"features\":
+        \"ac2fa443-2f85-430e-aa7b-98c3c1d54cb4\",\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"sku\": {\r\n      \"name\": \"free\",\r\n      \"lastSkuUpdate\": \"Mon,
+        11 May 2020 02:57:23 GMT\"\r\n    },\r\n    \"retentionInDays\": 7,\r\n    \"features\":
         {\r\n      \"legacy\": 0,\r\n      \"searchVersion\": 1,\r\n      \"enableLogAccessUsingOnlyResourcePermissions\":
         true\r\n    },\r\n    \"workspaceCapping\": {\r\n      \"dailyQuotaGb\": 0.5,\r\n
-        \     \"quotaNextResetTime\": \"Thu, 30 Apr 2020 07:00:00 GMT\",\r\n      \"dataIngestionStatus\":
+        \     \"quotaNextResetTime\": \"Mon, 11 May 2020 15:00:00 GMT\",\r\n      \"dataIngestionStatus\":
         \"RespectQuota\"\r\n    },\r\n    \"publicNetworkAccessForIngestion\": \"Enabled\",\r\n
         \   \"publicNetworkAccessForQuery\": \"Enabled\"\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/microsoft.operationalinsights/workspaces/workspace000004\",\r\n
         \ \"name\": \"workspace000004\",\r\n  \"type\": \"Microsoft.OperationalInsights/workspaces\",\r\n
@@ -252,7 +247,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 29 Apr 2020 09:23:16 GMT
+      - Mon, 11 May 2020 02:57:58 GMT
       pragma:
       - no-cache
       server:
@@ -290,10 +285,10 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
-      - --resource-group --name --plan-publisher --plan-product --workspace --tags
+      - --resource-group --solution-type --workspace --tags
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-operationsmanagement/0.1.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-operationsmanagement/0.1.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: PUT
@@ -321,7 +316,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 29 Apr 2020 09:23:23 GMT
+      - Mon, 11 May 2020 02:58:06 GMT
       expires:
       - '-1'
       pragma:
@@ -336,7 +331,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
       x-powered-by:
       - ASP.NET
       - ASP.NET
@@ -358,7 +353,7 @@ interactions:
       - --resource-group --name
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-operationsmanagement/0.1.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-operationsmanagement/0.1.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
@@ -369,9 +364,9 @@ interactions:
         \   \"publisher\": \"Microsoft\",\r\n    \"promotionCode\": \"\",\r\n    \"product\":
         \"OMSGallery/Containers\"\r\n  },\r\n  \"properties\": {\r\n    \"workspaceResourceId\":
         \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.OperationalInsights/workspaces/workspace000004\",\r\n
-        \   \"provisioningState\": \"Succeeded\",\r\n    \"creationTime\": \"Wed,
-        29 Apr 2020 09:23:22 GMT\",\r\n    \"lastModifiedTime\": \"Wed, 29 Apr 2020
-        09:23:22 GMT\",\r\n    \"containedResources\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.OperationalInsights/workspaces/workspace000004/views/Containers(workspace000004)\"\r\n
+        \   \"provisioningState\": \"Succeeded\",\r\n    \"creationTime\": \"Mon,
+        11 May 2020 02:58:05 GMT\",\r\n    \"lastModifiedTime\": \"Mon, 11 May 2020
+        02:58:05 GMT\",\r\n    \"containedResources\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.OperationalInsights/workspaces/workspace000004/views/Containers(workspace000004)\"\r\n
         \   ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.OperationsManagement/solutions/Containers(workspace000004)\",\r\n
         \ \"name\": \"Containers(workspace000004)\",\r\n  \"type\": \"Microsoft.OperationsManagement/solutions\",\r\n
         \ \"location\": \"West US\",\r\n  \"tags\": {\r\n    \"key1\": \"value1\"\r\n
@@ -386,7 +381,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 29 Apr 2020 09:23:25 GMT
+      - Mon, 11 May 2020 02:58:08 GMT
       expires:
       - '-1'
       pragma:
@@ -429,7 +424,7 @@ interactions:
       - --resource-group --name --tags
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-operationsmanagement/0.1.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-operationsmanagement/0.1.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: PATCH
@@ -440,9 +435,9 @@ interactions:
         \   \"publisher\": \"Microsoft\",\r\n    \"promotionCode\": \"\",\r\n    \"product\":
         \"OMSGallery/Containers\"\r\n  },\r\n  \"properties\": {\r\n    \"workspaceResourceId\":
         \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.OperationalInsights/workspaces/workspace000004\",\r\n
-        \   \"provisioningState\": \"Succeeded\",\r\n    \"creationTime\": \"Wed,
-        29 Apr 2020 09:23:22 GMT\",\r\n    \"lastModifiedTime\": \"Wed, 29 Apr 2020
-        09:23:22 GMT\",\r\n    \"containedResources\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.OperationalInsights/workspaces/workspace000004/views/Containers(workspace000004)\"\r\n
+        \   \"provisioningState\": \"Succeeded\",\r\n    \"creationTime\": \"Mon,
+        11 May 2020 02:58:05 GMT\",\r\n    \"lastModifiedTime\": \"Mon, 11 May 2020
+        02:58:05 GMT\",\r\n    \"containedResources\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.OperationalInsights/workspaces/workspace000004/views/Containers(workspace000004)\"\r\n
         \   ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.OperationsManagement/solutions/Containers(workspace000004)\",\r\n
         \ \"name\": \"Containers(workspace000004)\",\r\n  \"type\": \"Microsoft.OperationsManagement/solutions\",\r\n
         \ \"location\": \"West US\",\r\n  \"tags\": {\r\n    \"key2\": \"value2\"\r\n
@@ -457,7 +452,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 29 Apr 2020 09:23:31 GMT
+      - Mon, 11 May 2020 02:58:15 GMT
       expires:
       - '-1'
       pragma:
@@ -476,7 +471,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1195'
+      - '1198'
       x-powered-by:
       - ASP.NET
       - ASP.NET
@@ -498,7 +493,7 @@ interactions:
       - --resource-group --name
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-operationsmanagement/0.1.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-operationsmanagement/0.1.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
@@ -509,9 +504,9 @@ interactions:
         \   \"publisher\": \"Microsoft\",\r\n    \"promotionCode\": \"\",\r\n    \"product\":
         \"OMSGallery/Containers\"\r\n  },\r\n  \"properties\": {\r\n    \"workspaceResourceId\":
         \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.OperationalInsights/workspaces/workspace000004\",\r\n
-        \   \"provisioningState\": \"Succeeded\",\r\n    \"creationTime\": \"Wed,
-        29 Apr 2020 09:23:22 GMT\",\r\n    \"lastModifiedTime\": \"Wed, 29 Apr 2020
-        09:23:29 GMT\",\r\n    \"containedResources\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.OperationalInsights/workspaces/workspace000004/views/Containers(workspace000004)\"\r\n
+        \   \"provisioningState\": \"Succeeded\",\r\n    \"creationTime\": \"Mon,
+        11 May 2020 02:58:05 GMT\",\r\n    \"lastModifiedTime\": \"Mon, 11 May 2020
+        02:58:11 GMT\",\r\n    \"containedResources\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.OperationalInsights/workspaces/workspace000004/views/Containers(workspace000004)\"\r\n
         \   ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.OperationsManagement/solutions/Containers(workspace000004)\",\r\n
         \ \"name\": \"Containers(workspace000004)\",\r\n  \"type\": \"Microsoft.OperationsManagement/solutions\",\r\n
         \ \"location\": \"West US\",\r\n  \"tags\": {\r\n    \"key2\": \"value2\"\r\n
@@ -526,7 +521,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 29 Apr 2020 09:23:34 GMT
+      - Mon, 11 May 2020 02:58:17 GMT
       expires:
       - '-1'
       pragma:
@@ -565,7 +560,7 @@ interactions:
       - -g -n -l --resource-type -p
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
@@ -588,12 +583,7 @@ interactions:
         East","UK South","Central India","Canada Central","West US 2","Australia Central","Australia
         East","France Central","Korea Central","North Europe","Central US","East Asia","East
         US 2","South Central US","North Central US","West US","UK West","South Africa
-        North","Brazil South","Switzerland North","Switzerland West"],"apiVersions":["2020-03-01-preview","2019-08-01-preview","2015-11-01-preview"],"defaultApiVersion":"2015-11-01-preview","capabilities":"None"},{"resourceType":"workspaces/query","locations":["West
-        Central US","Australia Southeast","West Europe","East US","Southeast Asia","Japan
-        East","UK South","Central India","Canada Central","West US 2","Australia Central","Australia
-        East","France Central","Korea Central","North Europe","Central US","East Asia","East
-        US 2","South Central US","North Central US","West US","UK West","South Africa
-        North","Brazil South","Switzerland West","Switzerland North"],"apiVersions":["2017-10-01"],"capabilities":"None"},{"resourceType":"workspaces/dataSources","locations":["East
+        North","Brazil South","Switzerland North","Switzerland West"],"apiVersions":["2020-03-01-preview","2019-08-01-preview","2015-11-01-preview"],"defaultApiVersion":"2015-11-01-preview","capabilities":"None"},{"resourceType":"workspaces/query","locations":[],"apiVersions":["2017-10-01"],"capabilities":"None"},{"resourceType":"workspaces/metadata","locations":[],"apiVersions":["2017-10-01"],"capabilities":"None"},{"resourceType":"workspaces/dataSources","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central","West US 2","Australia Central","Australia
         East","France Central","Korea Central","North Europe","Central US","East Asia","East
@@ -621,11 +611,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '6229'
+      - '5930'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 29 Apr 2020 09:23:34 GMT
+      - Mon, 11 May 2020 02:58:17 GMT
       expires:
       - '-1'
       pragma:
@@ -659,7 +649,7 @@ interactions:
       - -g -n -l --resource-type -p
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: PUT
@@ -667,12 +657,12 @@ interactions:
   response:
     body:
       string: "{\r\n  \"properties\": {\r\n    \"source\": \"Azure\",\r\n    \"customerId\":
-        \"b2de31a9-8c53-4f5f-a242-2a336aab42f8\",\r\n    \"provisioningState\": \"Creating\",\r\n
-        \   \"sku\": {\r\n      \"name\": \"free\",\r\n      \"lastSkuUpdate\": \"Wed,
-        29 Apr 2020 09:23:42 GMT\"\r\n    },\r\n    \"retentionInDays\": 7,\r\n    \"features\":
+        \"5811660e-3349-4a8a-9431-e7d9487078e9\",\r\n    \"provisioningState\": \"Creating\",\r\n
+        \   \"sku\": {\r\n      \"name\": \"free\",\r\n      \"lastSkuUpdate\": \"Mon,
+        11 May 2020 02:58:25 GMT\"\r\n    },\r\n    \"retentionInDays\": 7,\r\n    \"features\":
         {\r\n      \"legacy\": 0,\r\n      \"searchVersion\": 1,\r\n      \"enableLogAccessUsingOnlyResourcePermissions\":
         true\r\n    },\r\n    \"workspaceCapping\": {\r\n      \"dailyQuotaGb\": 0.5,\r\n
-        \     \"quotaNextResetTime\": \"Wed, 29 Apr 2020 22:00:00 GMT\",\r\n      \"dataIngestionStatus\":
+        \     \"quotaNextResetTime\": \"Mon, 11 May 2020 09:00:00 GMT\",\r\n      \"dataIngestionStatus\":
         \"RespectQuota\"\r\n    },\r\n    \"publicNetworkAccessForIngestion\": \"Enabled\",\r\n
         \   \"publicNetworkAccessForQuery\": \"Enabled\"\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002/providers/microsoft.operationalinsights/workspaces/workspace000005\",\r\n
         \ \"name\": \"workspace000005\",\r\n  \"type\": \"Microsoft.OperationalInsights/workspaces\",\r\n
@@ -685,7 +675,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 29 Apr 2020 09:23:42 GMT
+      - Mon, 11 May 2020 02:58:27 GMT
       pragma:
       - no-cache
       server:
@@ -696,7 +686,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1197'
       x-powered-by:
       - ASP.NET
       - ASP.NET
@@ -718,18 +708,18 @@ interactions:
       - -g -n -l --resource-type -p
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.5.1
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002/providers/Microsoft.OperationalInsights/workspaces/workspace000005?api-version=2015-03-20
   response:
     body:
       string: "{\r\n  \"properties\": {\r\n    \"source\": \"Azure\",\r\n    \"customerId\":
-        \"b2de31a9-8c53-4f5f-a242-2a336aab42f8\",\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"sku\": {\r\n      \"name\": \"free\",\r\n      \"lastSkuUpdate\": \"Wed,
-        29 Apr 2020 09:23:42 GMT\"\r\n    },\r\n    \"retentionInDays\": 7,\r\n    \"features\":
+        \"5811660e-3349-4a8a-9431-e7d9487078e9\",\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"sku\": {\r\n      \"name\": \"free\",\r\n      \"lastSkuUpdate\": \"Mon,
+        11 May 2020 02:58:25 GMT\"\r\n    },\r\n    \"retentionInDays\": 7,\r\n    \"features\":
         {\r\n      \"legacy\": 0,\r\n      \"searchVersion\": 1,\r\n      \"enableLogAccessUsingOnlyResourcePermissions\":
         true\r\n    },\r\n    \"workspaceCapping\": {\r\n      \"dailyQuotaGb\": 0.5,\r\n
-        \     \"quotaNextResetTime\": \"Wed, 29 Apr 2020 22:00:00 GMT\",\r\n      \"dataIngestionStatus\":
+        \     \"quotaNextResetTime\": \"Mon, 11 May 2020 09:00:00 GMT\",\r\n      \"dataIngestionStatus\":
         \"RespectQuota\"\r\n    },\r\n    \"publicNetworkAccessForIngestion\": \"Enabled\",\r\n
         \   \"publicNetworkAccessForQuery\": \"Enabled\"\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002/providers/microsoft.operationalinsights/workspaces/workspace000005\",\r\n
         \ \"name\": \"workspace000005\",\r\n  \"type\": \"Microsoft.OperationalInsights/workspaces\",\r\n
@@ -742,7 +732,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 29 Apr 2020 09:24:13 GMT
+      - Mon, 11 May 2020 02:58:58 GMT
       pragma:
       - no-cache
       server:
@@ -774,10 +764,10 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - --resource-group --name --plan-publisher --plan-product --workspace --tags
+      - --resource-group -t --workspace --tags
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-loganalytics/0.5.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-loganalytics/0.5.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
@@ -785,12 +775,12 @@ interactions:
   response:
     body:
       string: "{\r\n  \"properties\": {\r\n    \"source\": \"Azure\",\r\n    \"customerId\":
-        \"b2de31a9-8c53-4f5f-a242-2a336aab42f8\",\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"sku\": {\r\n      \"name\": \"free\",\r\n      \"lastSkuUpdate\": \"Wed,
-        29 Apr 2020 09:23:42 GMT\"\r\n    },\r\n    \"retentionInDays\": 7,\r\n    \"features\":
+        \"5811660e-3349-4a8a-9431-e7d9487078e9\",\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"sku\": {\r\n      \"name\": \"free\",\r\n      \"lastSkuUpdate\": \"Mon,
+        11 May 2020 02:58:25 GMT\"\r\n    },\r\n    \"retentionInDays\": 7,\r\n    \"features\":
         {\r\n      \"legacy\": 0,\r\n      \"searchVersion\": 1,\r\n      \"enableLogAccessUsingOnlyResourcePermissions\":
         true\r\n    },\r\n    \"workspaceCapping\": {\r\n      \"dailyQuotaGb\": 0.5,\r\n
-        \     \"quotaNextResetTime\": \"Wed, 29 Apr 2020 22:00:00 GMT\",\r\n      \"dataIngestionStatus\":
+        \     \"quotaNextResetTime\": \"Mon, 11 May 2020 09:00:00 GMT\",\r\n      \"dataIngestionStatus\":
         \"RespectQuota\"\r\n    },\r\n    \"publicNetworkAccessForIngestion\": \"Enabled\",\r\n
         \   \"publicNetworkAccessForQuery\": \"Enabled\"\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002/providers/microsoft.operationalinsights/workspaces/workspace000005\",\r\n
         \ \"name\": \"workspace000005\",\r\n  \"type\": \"Microsoft.OperationalInsights/workspaces\",\r\n
@@ -803,7 +793,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 29 Apr 2020 09:24:16 GMT
+      - Mon, 11 May 2020 02:59:01 GMT
       pragma:
       - no-cache
       server:
@@ -841,10 +831,10 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
-      - --resource-group --name --plan-publisher --plan-product --workspace --tags
+      - --resource-group -t --workspace --tags
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-operationsmanagement/0.1.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-operationsmanagement/0.1.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: PUT
@@ -872,7 +862,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 29 Apr 2020 09:24:23 GMT
+      - Mon, 11 May 2020 02:59:08 GMT
       expires:
       - '-1'
       pragma:
@@ -887,7 +877,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1179'
+      - '1198'
       x-powered-by:
       - ASP.NET
       - ASP.NET
@@ -909,31 +899,31 @@ interactions:
       - --query
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-operationsmanagement/0.1.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-operationsmanagement/0.1.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.OperationsManagement/solutions?api-version=2015-11-01-preview
   response:
     body:
-      string: '{"value":[{"plan":{"name":"Containers(zhoxing-test8)","publisher":"Microsoft","promotionCode":"","product":"OMSGallery/Containers"},"properties":{"workspaceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/zhoxing-test/providers/microsoft.operationalinsights/workspaces/zhoxing-test8","provisioningState":"Succeeded","creationTime":"Wed,
-        29 Apr 2020 04:57:39 GMT","lastModifiedTime":"Wed, 29 Apr 2020 07:29:13 GMT","containedResources":["/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/zhoxing-test/providers/microsoft.operationalinsights/workspaces/zhoxing-test8/views/Containers(zhoxing-test8)"]},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/zhoxing-test/providers/Microsoft.OperationsManagement/solutions/Containers(zhoxing-test8)","name":"Containers(zhoxing-test8)","type":"Microsoft.OperationsManagement/solutions","location":"Central
-        US","tags":{"key":"value"}},{"plan":{"name":"Containers(workspace000005)","publisher":"Microsoft","promotionCode":"","product":"OMSGallery/Containers"},"properties":{"workspaceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002/providers/microsoft.operationalinsights/workspaces/workspace000005","provisioningState":"Succeeded","creationTime":"Wed,
-        29 Apr 2020 09:24:21 GMT","lastModifiedTime":"Wed, 29 Apr 2020 09:24:21 GMT","containedResources":["/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002/providers/microsoft.operationalinsights/workspaces/workspace000005/views/Containers(workspace000005)"]},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002/providers/Microsoft.OperationsManagement/solutions/Containers(workspace000005)","name":"Containers(workspace000005)","type":"Microsoft.OperationsManagement/solutions","location":"West
-        US","tags":{"key3":"value3"}},{"plan":{"name":"Containers(workspace000004)","publisher":"Microsoft","promotionCode":"","product":"OMSGallery/Containers"},"properties":{"workspaceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/microsoft.operationalinsights/workspaces/workspace000004","provisioningState":"Succeeded","creationTime":"Wed,
-        29 Apr 2020 09:23:22 GMT","lastModifiedTime":"Wed, 29 Apr 2020 09:23:29 GMT","containedResources":["/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/microsoft.operationalinsights/workspaces/workspace000004/views/Containers(workspace000004)"]},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.OperationsManagement/solutions/Containers(workspace000004)","name":"Containers(workspace000004)","type":"Microsoft.OperationsManagement/solutions","location":"West
-        US","tags":{"key2":"value2"}},{"plan":{"name":"SecurityCenterFree(yu-test-ws1)","publisher":"Microsoft","promotionCode":"","product":"OMSGallery/SecurityCenterFree"},"properties":{"workspaceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/azure-cli-test-scus/providers/microsoft.operationalinsights/workspaces/yu-test-ws1","provisioningState":"Succeeded","creationTime":"Sat,
-        25 Apr 2020 01:11:55 GMT","lastModifiedTime":"Sat, 25 Apr 2020 17:12:10 GMT","containedResources":[]},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/azure-cli-test-scus/providers/Microsoft.OperationsManagement/solutions/SecurityCenterFree(yu-test-ws1)","name":"SecurityCenterFree(yu-test-ws1)","type":"Microsoft.OperationsManagement/solutions","location":"South
-        Central US"}]}'
+      string: '{"value":[{"plan":{"name":"SecurityCenterFree(azps-test-la3)","publisher":"Microsoft","promotionCode":"","product":"OMSGallery/SecurityCenterFree"},"properties":{"workspaceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/azps-test-group/providers/microsoft.operationalinsights/workspaces/azps-test-la3","provisioningState":"Succeeded","creationTime":"Sat,
+        09 May 2020 01:16:14 GMT","lastModifiedTime":"Sun, 10 May 2020 06:46:19 GMT","containedResources":[]},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/azps-test-group/providers/Microsoft.OperationsManagement/solutions/SecurityCenterFree(azps-test-la3)","name":"SecurityCenterFree(azps-test-la3)","type":"Microsoft.OperationsManagement/solutions","location":"East
+        US"},{"plan":{"name":"Containers(zhoxing-test11)","publisher":"Microsoft","promotionCode":"","product":"OMSGallery/Containers"},"properties":{"workspaceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/zhoxing-test/providers/microsoft.operationalinsights/workspaces/zhoxing-test11","provisioningState":"Succeeded","creationTime":"Mon,
+        11 May 2020 02:53:09 GMT","lastModifiedTime":"Mon, 11 May 2020 02:55:26 GMT","containedResources":["/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/zhoxing-test/providers/microsoft.operationalinsights/workspaces/zhoxing-test11/views/Containers(zhoxing-test11)"]},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/zhoxing-test/providers/Microsoft.OperationsManagement/solutions/Containers(zhoxing-test11)","name":"Containers(zhoxing-test11)","type":"Microsoft.OperationsManagement/solutions","location":"Central
+        US"},{"plan":{"name":"Containers(workspace000005)","publisher":"Microsoft","promotionCode":"","product":"OMSGallery/Containers"},"properties":{"workspaceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002/providers/microsoft.operationalinsights/workspaces/workspace000005","provisioningState":"Succeeded","creationTime":"Mon,
+        11 May 2020 02:59:07 GMT","lastModifiedTime":"Mon, 11 May 2020 02:59:07 GMT","containedResources":["/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002/providers/microsoft.operationalinsights/workspaces/workspace000005/views/Containers(workspace000005)"]},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002/providers/Microsoft.OperationsManagement/solutions/Containers(workspace000005)","name":"Containers(workspace000005)","type":"Microsoft.OperationsManagement/solutions","location":"West
+        US","tags":{"key3":"value3"}},{"plan":{"name":"Containers(workspace000004)","publisher":"Microsoft","promotionCode":"","product":"OMSGallery/Containers"},"properties":{"workspaceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/microsoft.operationalinsights/workspaces/workspace000004","provisioningState":"Succeeded","creationTime":"Mon,
+        11 May 2020 02:58:05 GMT","lastModifiedTime":"Mon, 11 May 2020 02:58:11 GMT","containedResources":["/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/microsoft.operationalinsights/workspaces/workspace000004/views/Containers(workspace000004)"]},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.OperationsManagement/solutions/Containers(workspace000004)","name":"Containers(workspace000004)","type":"Microsoft.OperationsManagement/solutions","location":"West
+        US","tags":{"key2":"value2"}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '4054'
+      - '4028'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 29 Apr 2020 09:24:25 GMT
+      - Mon, 11 May 2020 02:59:11 GMT
       expires:
       - '-1'
       pragma:
@@ -945,9 +935,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-original-request-ids:
-      - b4eecfc7-8fb8-4511-bfb8-0e0224d65d90
-      - 3d8266be-62d4-46fb-9c4a-56ca18ad323e
-      - 427ecb9d-19a1-4402-952e-98d5c8a77a98
+      - 5d008318-c215-40e1-a88e-89be6e3ef055
+      - e078ca37-7462-487d-af14-ff6b0c99e488
+      - 7fe67036-bb57-4df5-a1b4-916afcac65eb
     status:
       code: 200
       message: OK
@@ -966,7 +956,7 @@ interactions:
       - --resource-group --query
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-operationsmanagement/0.1.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-operationsmanagement/0.1.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
@@ -978,8 +968,8 @@ interactions:
         \       \"promotionCode\": \"\",\r\n        \"product\": \"OMSGallery/Containers\"\r\n
         \     },\r\n      \"properties\": {\r\n        \"workspaceResourceId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002/providers/microsoft.operationalinsights/workspaces/workspace000005\",\r\n
         \       \"provisioningState\": \"Succeeded\",\r\n        \"creationTime\":
-        \"Wed, 29 Apr 2020 09:24:21 GMT\",\r\n        \"lastModifiedTime\": \"Wed,
-        29 Apr 2020 09:24:21 GMT\",\r\n        \"containedResources\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002/providers/microsoft.operationalinsights/workspaces/workspace000005/views/Containers(workspace000005)\"\r\n
+        \"Mon, 11 May 2020 02:59:07 GMT\",\r\n        \"lastModifiedTime\": \"Mon,
+        11 May 2020 02:59:07 GMT\",\r\n        \"containedResources\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002/providers/microsoft.operationalinsights/workspaces/workspace000005/views/Containers(workspace000005)\"\r\n
         \       ]\r\n      },\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002/providers/Microsoft.OperationsManagement/solutions/Containers(workspace000005)\",\r\n
         \     \"name\": \"Containers(workspace000005)\",\r\n      \"type\": \"Microsoft.OperationsManagement/solutions\",\r\n
         \     \"location\": \"West US\",\r\n      \"tags\": {\r\n        \"key3\":
@@ -994,7 +984,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 29 Apr 2020 09:24:26 GMT
+      - Mon, 11 May 2020 02:59:13 GMT
       expires:
       - '-1'
       pragma:
@@ -1035,7 +1025,7 @@ interactions:
       - --resource-group --name -y
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-operationsmanagement/0.1.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-operationsmanagement/0.1.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: DELETE
@@ -1051,7 +1041,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 29 Apr 2020 09:24:32 GMT
+      - Mon, 11 May 2020 02:59:21 GMT
       expires:
       - '-1'
       pragma:
@@ -1090,7 +1080,7 @@ interactions:
       - --resource-group --name -y
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-operationsmanagement/0.1.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-operationsmanagement/0.1.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: DELETE
@@ -1106,7 +1096,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 29 Apr 2020 09:24:38 GMT
+      - Mon, 11 May 2020 02:59:27 GMT
       expires:
       - '-1'
       pragma:
@@ -1143,7 +1133,7 @@ interactions:
       - -g -n --resource-type
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
@@ -1166,12 +1156,7 @@ interactions:
         East","UK South","Central India","Canada Central","West US 2","Australia Central","Australia
         East","France Central","Korea Central","North Europe","Central US","East Asia","East
         US 2","South Central US","North Central US","West US","UK West","South Africa
-        North","Brazil South","Switzerland North","Switzerland West"],"apiVersions":["2020-03-01-preview","2019-08-01-preview","2015-11-01-preview"],"defaultApiVersion":"2015-11-01-preview","capabilities":"None"},{"resourceType":"workspaces/query","locations":["West
-        Central US","Australia Southeast","West Europe","East US","Southeast Asia","Japan
-        East","UK South","Central India","Canada Central","West US 2","Australia Central","Australia
-        East","France Central","Korea Central","North Europe","Central US","East Asia","East
-        US 2","South Central US","North Central US","West US","UK West","South Africa
-        North","Brazil South","Switzerland West","Switzerland North"],"apiVersions":["2017-10-01"],"capabilities":"None"},{"resourceType":"workspaces/dataSources","locations":["East
+        North","Brazil South","Switzerland North","Switzerland West"],"apiVersions":["2020-03-01-preview","2019-08-01-preview","2015-11-01-preview"],"defaultApiVersion":"2015-11-01-preview","capabilities":"None"},{"resourceType":"workspaces/query","locations":[],"apiVersions":["2017-10-01"],"capabilities":"None"},{"resourceType":"workspaces/metadata","locations":[],"apiVersions":["2017-10-01"],"capabilities":"None"},{"resourceType":"workspaces/dataSources","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central","West US 2","Australia Central","Australia
         East","France Central","Korea Central","North Europe","Central US","East Asia","East
@@ -1199,11 +1184,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '6229'
+      - '5930'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 29 Apr 2020 09:24:39 GMT
+      - Mon, 11 May 2020 02:59:28 GMT
       expires:
       - '-1'
       pragma:
@@ -1234,7 +1219,7 @@ interactions:
       - -g -n --resource-type
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: DELETE
@@ -1248,7 +1233,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 29 Apr 2020 09:24:41 GMT
+      - Mon, 11 May 2020 02:59:31 GMT
       pragma:
       - no-cache
       server:
@@ -1259,7 +1244,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-deletes:
-      - '14997'
+      - '14998'
       x-powered-by:
       - ASP.NET
       - ASP.NET
@@ -1281,7 +1266,7 @@ interactions:
       - -g -n --resource-type
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
@@ -1304,12 +1289,7 @@ interactions:
         East","UK South","Central India","Canada Central","West US 2","Australia Central","Australia
         East","France Central","Korea Central","North Europe","Central US","East Asia","East
         US 2","South Central US","North Central US","West US","UK West","South Africa
-        North","Brazil South","Switzerland North","Switzerland West"],"apiVersions":["2020-03-01-preview","2019-08-01-preview","2015-11-01-preview"],"defaultApiVersion":"2015-11-01-preview","capabilities":"None"},{"resourceType":"workspaces/query","locations":["West
-        Central US","Australia Southeast","West Europe","East US","Southeast Asia","Japan
-        East","UK South","Central India","Canada Central","West US 2","Australia Central","Australia
-        East","France Central","Korea Central","North Europe","Central US","East Asia","East
-        US 2","South Central US","North Central US","West US","UK West","South Africa
-        North","Brazil South","Switzerland West","Switzerland North"],"apiVersions":["2017-10-01"],"capabilities":"None"},{"resourceType":"workspaces/dataSources","locations":["East
+        North","Brazil South","Switzerland North","Switzerland West"],"apiVersions":["2020-03-01-preview","2019-08-01-preview","2015-11-01-preview"],"defaultApiVersion":"2015-11-01-preview","capabilities":"None"},{"resourceType":"workspaces/query","locations":[],"apiVersions":["2017-10-01"],"capabilities":"None"},{"resourceType":"workspaces/metadata","locations":[],"apiVersions":["2017-10-01"],"capabilities":"None"},{"resourceType":"workspaces/dataSources","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central","West US 2","Australia Central","Australia
         East","France Central","Korea Central","North Europe","Central US","East Asia","East
@@ -1337,11 +1317,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '6229'
+      - '5930'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 29 Apr 2020 09:24:42 GMT
+      - Mon, 11 May 2020 02:59:32 GMT
       expires:
       - '-1'
       pragma:
@@ -1372,7 +1352,7 @@ interactions:
       - -g -n --resource-type
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: DELETE
@@ -1386,7 +1366,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 29 Apr 2020 09:24:47 GMT
+      - Mon, 11 May 2020 02:59:37 GMT
       pragma:
       - no-cache
       server:
@@ -1397,7 +1377,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-deletes:
-      - '14997'
+      - '14999'
       x-powered-by:
       - ASP.NET
       - ASP.NET
@@ -1419,27 +1399,27 @@ interactions:
       - --query
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-operationsmanagement/0.1.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-operationsmanagement/0.1.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.OperationsManagement/solutions?api-version=2015-11-01-preview
   response:
     body:
-      string: '{"value":[{"plan":{"name":"Containers(zhoxing-test8)","publisher":"Microsoft","promotionCode":"","product":"OMSGallery/Containers"},"properties":{"workspaceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/zhoxing-test/providers/microsoft.operationalinsights/workspaces/zhoxing-test8","provisioningState":"Succeeded","creationTime":"Wed,
-        29 Apr 2020 04:57:39 GMT","lastModifiedTime":"Wed, 29 Apr 2020 07:29:13 GMT","containedResources":["/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/zhoxing-test/providers/microsoft.operationalinsights/workspaces/zhoxing-test8/views/Containers(zhoxing-test8)"]},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/zhoxing-test/providers/Microsoft.OperationsManagement/solutions/Containers(zhoxing-test8)","name":"Containers(zhoxing-test8)","type":"Microsoft.OperationsManagement/solutions","location":"Central
-        US","tags":{"key":"value"}},{"plan":{"name":"SecurityCenterFree(yu-test-ws1)","publisher":"Microsoft","promotionCode":"","product":"OMSGallery/SecurityCenterFree"},"properties":{"workspaceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/azure-cli-test-scus/providers/microsoft.operationalinsights/workspaces/yu-test-ws1","provisioningState":"Succeeded","creationTime":"Sat,
-        25 Apr 2020 01:11:55 GMT","lastModifiedTime":"Sat, 25 Apr 2020 17:12:10 GMT","containedResources":[]},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/azure-cli-test-scus/providers/Microsoft.OperationsManagement/solutions/SecurityCenterFree(yu-test-ws1)","name":"SecurityCenterFree(yu-test-ws1)","type":"Microsoft.OperationsManagement/solutions","location":"South
-        Central US"}]}'
+      string: '{"value":[{"plan":{"name":"SecurityCenterFree(azps-test-la3)","publisher":"Microsoft","promotionCode":"","product":"OMSGallery/SecurityCenterFree"},"properties":{"workspaceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/azps-test-group/providers/microsoft.operationalinsights/workspaces/azps-test-la3","provisioningState":"Succeeded","creationTime":"Sat,
+        09 May 2020 01:16:14 GMT","lastModifiedTime":"Sun, 10 May 2020 06:46:19 GMT","containedResources":[]},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/azps-test-group/providers/Microsoft.OperationsManagement/solutions/SecurityCenterFree(azps-test-la3)","name":"SecurityCenterFree(azps-test-la3)","type":"Microsoft.OperationsManagement/solutions","location":"East
+        US"},{"plan":{"name":"Containers(zhoxing-test11)","publisher":"Microsoft","promotionCode":"","product":"OMSGallery/Containers"},"properties":{"workspaceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/zhoxing-test/providers/microsoft.operationalinsights/workspaces/zhoxing-test11","provisioningState":"Succeeded","creationTime":"Mon,
+        11 May 2020 02:53:09 GMT","lastModifiedTime":"Mon, 11 May 2020 02:55:26 GMT","containedResources":["/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/zhoxing-test/providers/microsoft.operationalinsights/workspaces/zhoxing-test11/views/Containers(zhoxing-test11)"]},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/zhoxing-test/providers/Microsoft.OperationsManagement/solutions/Containers(zhoxing-test11)","name":"Containers(zhoxing-test11)","type":"Microsoft.OperationsManagement/solutions","location":"Central
+        US"}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1724'
+      - '1698'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 29 Apr 2020 09:24:50 GMT
+      - Mon, 11 May 2020 02:59:39 GMT
       expires:
       - '-1'
       pragma:
@@ -1451,8 +1431,8 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-original-request-ids:
-      - c0d91f8d-a4b5-469c-84c8-6e6d8c8da7f1
-      - 07dfeb9e-2e31-464c-add0-6f9d89848681
+      - a8abae67-3e78-4ec8-a004-d05c3f9db796
+      - de73015e-5859-4f8f-9785-bde9f0a16d3b
     status:
       code: 200
       message: OK
@@ -1471,7 +1451,7 @@ interactions:
       - --resource-group --query
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-operationsmanagement/0.1.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-operationsmanagement/0.1.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
@@ -1487,7 +1467,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 29 Apr 2020 09:24:51 GMT
+      - Mon, 11 May 2020 02:59:40 GMT
       expires:
       - '-1'
       pragma:

--- a/src/log-analytics-solution/azext_log_analytics_solution/tests/latest/test_log_analytics_solution_scenario.py
+++ b/src/log-analytics-solution/azext_log_analytics_solution/tests/latest/test_log_analytics_solution_scenario.py
@@ -29,7 +29,8 @@ class OperationsScenarioTest(ScenarioTest):
             'sub': self.get_subscription_id(),
             'la_prop_path': os.path.join(TEST_DIR, 'log_analytics.json')
         })
-        self.kwargs['solution_name'] = 'Containers(' + self.kwargs['workspace_name'] + ')'
+        self.kwargs['solution_type'] = 'Containers'
+        self.kwargs['solution_name'] = self.kwargs['solution_type'] + '(' + self.kwargs['workspace_name'] + ')'
 
         workspace = self.cmd('resource create -g {rg} -n {workspace_name} -l {loc} --resource-type '
                              'Microsoft.OperationalInsights/workspaces -p @"{la_prop_path}"').get_output_in_json()
@@ -41,26 +42,20 @@ class OperationsScenarioTest(ScenarioTest):
         with self.assertRaises(CLIError) as err:
             self.cmd('az monitor log-analytics solution create '
                      '--resource-group {rg} '
-                     '--name {solution_name} '
-                     '--plan-publisher "Microsoft" '
-                     '--plan-product "OMSGallery/Containers" '
+                     '--solution-type {solution_type} '
                      '--workspace "{wrong_workspace_resource_id}" ')
             self.assertTrue("usage error: --workspace is invalid" == err.exception)
 
         with self.assertRaises(CLIError) as err:
             self.cmd('az monitor log-analytics solution create '
                      '--resource-group {rg2} '
-                     '--name {solution_name} '
-                     '--plan-publisher "Microsoft" '
-                     '--plan-product "OMSGallery/Containers" '
+                     '--solution-type {solution_type} '
                      '--workspace "{workspace_resource_id}" ')
             self.assertTrue("usage error: workspace and solution must be under the same resource group" == err.exception)
 
         self.cmd('az monitor log-analytics solution create '
                  '--resource-group {rg} '
-                 '--name {solution_name} '
-                 '--plan-publisher "Microsoft" '
-                 '--plan-product "OMSGallery/Containers" '
+                 '--solution-type {solution_type} '
                  '--workspace "{workspace_resource_id}" '
                  '--tags key1=value1',
                  checks=[self.check('name', '{solution_name}')])
@@ -89,9 +84,7 @@ class OperationsScenarioTest(ScenarioTest):
 
         self.cmd('az monitor log-analytics solution create '
                  '--resource-group {rg2} '
-                 '--name {solution_name2} '
-                 '--plan-publisher "Microsoft" '
-                 '--plan-product "OMSGallery/Containers" '
+                 '-t {solution_type} '
                  '--workspace "{workspace_name2}" '
                  '--tags key3=value3',
                  checks=[self.check('name', '{solution_name2}')])

--- a/src/log-analytics-solution/setup.py
+++ b/src/log-analytics-solution/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
-VERSION = '0.1.0'
+VERSION = '0.1.1'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
@@ -43,7 +43,7 @@ with open('HISTORY.rst', 'r', encoding='utf-8') as f:
 setup(
     name='log_analytics_solution',
     version=VERSION,
-    description='Microsoft Azure Command-Line Tools Operations Extension',
+    description='Support for Azure Log Analytics Solution',
    # TODO: Update author and email, if applicable
     author='Microsoft Corporation',
     author_email='azpycli@microsoft.com',


### PR DESCRIPTION
Issue: #1677

Because log analytics solution does not support third party solutions,  so annotate `--plan-publisher`, `--name` and` --plan-product` with `deprecate_info`, add a new parameter `--solution-type` and remove any mention to Microsoft or 3rd party solutions.
Since the solution does not modify the logic of any old parameters, they are only declared to be deleted temporarily and will be deleted when the customers no longer uses them, so there will be no breaking change.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [x] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
