### PR TITLE
[TimeSeriesInsights] Fix #1712: --timestamp-property-name should be made optional

### DIFF
--- a/src/timeseriesinsights/HISTORY.rst
+++ b/src/timeseriesinsights/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+0.1.2
+++++++
+
+* Fix #1712: ``--timestamp-property-name`` should be made optional
+
 0.1.1
 ++++++
 * Fix #1657: ``timeSeriesIdPropertyName`` is not parsed properly

--- a/src/timeseriesinsights/README.md
+++ b/src/timeseriesinsights/README.md
@@ -7,11 +7,31 @@ This package is for the 'timeseriesinsights' extension:
 az timeseriesinsights
 ```
 
+## Install
+
+```sh
+az extension add --name timeseriesinsights
+```
+
+## Uninstall
+
+```sh
+az extension remove --name timeseriesinsights
+```
+
+## Examples
+
+All commands are for Bash. For PowerShell, please set the variables like 
+
+```powershell
+$rg='rg1'
+```
+
 ### Create a resource group for the environments
 
 ```sh
 rg={resource_group_name}
-az group create -n $rg
+az group create --name $rg --location westus
 ```
 
 ### Create a standard environment

--- a/src/timeseriesinsights/azext_timeseriesinsights/custom.py
+++ b/src/timeseriesinsights/azext_timeseriesinsights/custom.py
@@ -92,8 +92,9 @@ def list_timeseriesinsights_environment(cmd, client, resource_group_name=None):
 
 def create_timeseriesinsights_event_source_eventhub(cmd, client,
                                                     resource_group_name, environment_name, event_source_name,
-                                                    timestamp_property_name, event_source_resource_id,
+                                                    event_source_resource_id,
                                                     consumer_group_name, key_name, shared_access_key,
+                                                    timestamp_property_name=None,
                                                     location=None, tags=None):
     from azext_timeseriesinsights.vendored_sdks.timeseriesinsights.models import EventHubEventSourceCreateOrUpdateParameters
     from msrestazure.tools import parse_resource_id
@@ -135,8 +136,9 @@ def update_timeseriesinsights_event_source_eventhub(cmd, client, resource_group_
 
 def create_timeseriesinsights_event_source_iothub(cmd, client,
                                                   resource_group_name, environment_name, event_source_name,
-                                                  timestamp_property_name, event_source_resource_id,
+                                                  event_source_resource_id,
                                                   consumer_group_name, key_name, shared_access_key,
+                                                  timestamp_property_name=None,
                                                   location=None, tags=None):
     from .vendored_sdks.timeseriesinsights.models import IoTHubEventSourceCreateOrUpdateParameters
     from msrestazure.tools import parse_resource_id

--- a/src/timeseriesinsights/azext_timeseriesinsights/tests/latest/recordings/test_timeseriesinsights_access_policy.yaml
+++ b/src/timeseriesinsights/azext_timeseriesinsights/tests/latest/recordings/test_timeseriesinsights_access_policy.yaml
@@ -15,14 +15,14 @@ interactions:
         --storage-limit-exceeded-behavior
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_timeseriesinsights000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001","name":"cli_test_timeseriesinsights000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-04-23T08:52:27Z","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001","name":"cli_test_timeseriesinsights000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-05-18T07:05:29Z","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -31,7 +31,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 23 Apr 2020 08:52:33 GMT
+      - Mon, 18 May 2020 07:05:34 GMT
       expires:
       - '-1'
       pragma:
@@ -67,23 +67,23 @@ interactions:
         --storage-limit-exceeded-behavior
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P31D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-04-23T08:52:40+00:00","provisioningState":"Accepted","dataAccessId":"def09b9c-9580-41a8-b1e1-d74e50d8d85a","dataAccessFqdn":"def09b9c-9580-41a8-b1e1-d74e50d8d85a.env.timeseries.azure.com","requestApiVersion":"2018-08-15-preview"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}'
+      string: '{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P31D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-05-18T07:05:46.6439947+00:00","provisioningState":"Accepted","dataAccessId":"38c2b3bb-202d-409b-b6af-13165ba509ef","dataAccessFqdn":"38c2b3bb-202d-409b-b6af-13165ba509ef.env.timeseries.azure.com","requestApiVersion":"2018-08-15-preview"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '798'
+      - '806'
       content-type:
       - application/json
       date:
-      - Thu, 23 Apr 2020 08:52:42 GMT
+      - Mon, 18 May 2020 07:05:48 GMT
       expires:
       - '-1'
       pragma:
@@ -95,7 +95,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1192'
+      - '1189'
     status:
       code: 201
       message: Created
@@ -115,22 +115,21 @@ interactions:
         --storage-limit-exceeded-behavior
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P31D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"Thu,
-        23 Apr 2020 08:52:40 GMT","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"def09b9c-9580-41a8-b1e1-d74e50d8d85a","dataAccessFqdn":"def09b9c-9580-41a8-b1e1-d74e50d8d85a.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}'
+      string: '{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P31D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-05-18T07:05:46.6439947Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"38c2b3bb-202d-409b-b6af-13165ba509ef","dataAccessFqdn":"38c2b3bb-202d-409b-b6af-13165ba509ef.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '803'
+      - '802'
       content-type:
       - application/json
       date:
-      - Thu, 23 Apr 2020 08:53:13 GMT
+      - Mon, 18 May 2020 07:06:19 GMT
       expires:
       - '-1'
       pragma:
@@ -168,7 +167,7 @@ interactions:
       - -g --environment-name --name --principal-object-id --description --roles
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: PUT
@@ -184,7 +183,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 23 Apr 2020 08:53:15 GMT
+      - Mon, 18 May 2020 07:06:22 GMT
       expires:
       - '-1'
       pragma:
@@ -200,7 +199,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1195'
+      - '1188'
     status:
       code: 200
       message: OK
@@ -223,7 +222,7 @@ interactions:
       - -g --environment-name --name --description
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: PATCH
@@ -240,7 +239,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 23 Apr 2020 08:53:17 GMT
+      - Mon, 18 May 2020 07:06:23 GMT
       expires:
       - '-1'
       pragma:
@@ -256,7 +255,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1190'
+      - '1187'
     status:
       code: 200
       message: OK
@@ -279,7 +278,7 @@ interactions:
       - -g --environment-name --name --roles
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: PATCH
@@ -296,7 +295,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 23 Apr 2020 08:53:19 GMT
+      - Mon, 18 May 2020 07:06:25 GMT
       expires:
       - '-1'
       pragma:
@@ -312,7 +311,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1193'
+      - '1194'
     status:
       code: 200
       message: OK
@@ -331,7 +330,7 @@ interactions:
       - -g --environment-name --name
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: GET
@@ -348,7 +347,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 23 Apr 2020 08:53:21 GMT
+      - Mon, 18 May 2020 07:06:27 GMT
       expires:
       - '-1'
       pragma:
@@ -381,7 +380,7 @@ interactions:
       - -g --environment-name
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: GET
@@ -398,7 +397,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 23 Apr 2020 08:53:23 GMT
+      - Mon, 18 May 2020 07:06:28 GMT
       expires:
       - '-1'
       pragma:
@@ -430,10 +429,10 @@ interactions:
       Content-Length:
       - '0'
       ParameterSetName:
-      - -g --environment-name --name
+      - -g --environment-name --name --yes
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: DELETE
@@ -447,7 +446,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 23 Apr 2020 08:53:25 GMT
+      - Mon, 18 May 2020 07:06:29 GMT
       expires:
       - '-1'
       pragma:

--- a/src/timeseriesinsights/azext_timeseriesinsights/tests/latest/recordings/test_timeseriesinsights_environment_longterm.yaml
+++ b/src/timeseriesinsights/azext_timeseriesinsights/tests/latest/recordings/test_timeseriesinsights_environment_longterm.yaml
@@ -15,8 +15,8 @@ interactions:
       ParameterSetName:
       - -g -n --query --output
       User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-storage/9.0.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
+        azure-mgmt-storage/9.0.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: POST
@@ -32,7 +32,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 08 May 2020 03:47:25 GMT
+      - Mon, 18 May 2020 07:05:59 GMT
       expires:
       - '-1'
       pragma:
@@ -67,15 +67,15 @@ interactions:
       - --resource-group --name --sku-name --sku-capacity --data-retention --time-series-id-properties
         --storage-account-name --storage-management-key
       User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
+        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_timeseriesinsights000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001","name":"cli_test_timeseriesinsights000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-05-08T03:46:53Z","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001","name":"cli_test_timeseriesinsights000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-05-18T07:05:29Z","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -84,7 +84,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 08 May 2020 03:47:26 GMT
+      - Mon, 18 May 2020 07:06:00 GMT
       expires:
       - '-1'
       pragma:
@@ -121,24 +121,24 @@ interactions:
       - --resource-group --name --sku-name --sku-capacity --data-retention --time-series-id-properties
         --storage-account-name --storage-management-key
       User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"sku":{"name":"L1","capacity":1},"kind":"LongTerm","location":"westus","tags":null,"properties":{"timeSeriesIdProperties":[{"name":"DeviceId1","type":"String"}],"storageConfiguration":{"accountName":"clitest000002"},"warmStoreConfiguration":{"dataRetention":"P7D"},"creationTime":"2020-05-08T03:47:33.3693862+00:00","provisioningState":"Accepted","dataAccessId":"f0b7d698-58b0-49b6-96f2-ccb8bf7a6067","dataAccessFqdn":"f0b7d698-58b0-49b6-96f2-ccb8bf7a6067.env.timeseries.azure.com","requestApiVersion":"2018-08-15-preview"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003","name":"cli-test-tsi-env000003","type":"Microsoft.TimeSeriesInsights/Environments"}'
+      string: '{"sku":{"name":"L1","capacity":1},"kind":"LongTerm","location":"westus","tags":null,"properties":{"timeSeriesIdProperties":[{"name":"DeviceId1","type":"String"}],"storageConfiguration":{"accountName":"clitest000002"},"warmStoreConfiguration":{"dataRetention":"P7D"},"creationTime":"2020-05-18T07:06:07.0622679+00:00","provisioningState":"Succeeded","dataAccessId":"d6ad1bd9-084f-403c-bf5f-cab12ef5ad28","dataAccessFqdn":"d6ad1bd9-084f-403c-bf5f-cab12ef5ad28.env.timeseries.azure.com","requestApiVersion":"2018-08-15-preview"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003","name":"cli-test-tsi-env000003","type":"Microsoft.TimeSeriesInsights/Environments"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '848'
+      - '849'
       content-type:
       - application/json
       date:
-      - Fri, 08 May 2020 03:47:35 GMT
+      - Mon, 18 May 2020 07:06:08 GMT
       expires:
       - '-1'
       pragma:
@@ -150,106 +150,10 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1190'
     status:
       code: 201
       message: Created
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - timeseriesinsights environment longterm create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --resource-group --name --sku-name --sku-capacity --data-retention --time-series-id-properties
-        --storage-account-name --storage-management-key
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.5.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003?api-version=2018-08-15-preview
-  response:
-    body:
-      string: '{"sku":{"name":"L1","capacity":1},"kind":"LongTerm","location":"westus","tags":null,"properties":{"timeSeriesIdProperties":[{"name":"DeviceId1","type":"String"}],"storageConfiguration":{"accountName":"clitest000002"},"warmStoreConfiguration":{"dataRetention":"P7D"},"creationTime":"2020-05-08T03:47:33.3693862Z","provisioningState":"Creating","requestApiVersion":"2018-08-15-preview","dataAccessId":"f0b7d698-58b0-49b6-96f2-ccb8bf7a6067","dataAccessFqdn":"f0b7d698-58b0-49b6-96f2-ccb8bf7a6067.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003","name":"cli-test-tsi-env000003","type":"Microsoft.TimeSeriesInsights/Environments"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '843'
-      content-type:
-      - application/json
-      date:
-      - Fri, 08 May 2020 03:48:06 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - timeseriesinsights environment longterm create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --resource-group --name --sku-name --sku-capacity --data-retention --time-series-id-properties
-        --storage-account-name --storage-management-key
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.5.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003?api-version=2018-08-15-preview
-  response:
-    body:
-      string: '{"sku":{"name":"L1","capacity":1},"kind":"LongTerm","location":"westus","tags":null,"properties":{"timeSeriesIdProperties":[{"name":"DeviceId1","type":"String"}],"storageConfiguration":{"accountName":"clitest000002"},"warmStoreConfiguration":{"dataRetention":"P7D"},"creationTime":"2020-05-08T03:47:33.3693862Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"f0b7d698-58b0-49b6-96f2-ccb8bf7a6067","dataAccessFqdn":"f0b7d698-58b0-49b6-96f2-ccb8bf7a6067.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003","name":"cli-test-tsi-env000003","type":"Microsoft.TimeSeriesInsights/Environments"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '844'
-      content-type:
-      - application/json
-      date:
-      - Fri, 08 May 2020 03:48:37 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
 - request:
     body: '{"properties": {"warmStoreConfiguration": {"dataRetention": "P8D"}}}'
     headers:
@@ -268,15 +172,15 @@ interactions:
       ParameterSetName:
       - --resource-group --name --data-retention
       User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"sku":{"name":"L1","capacity":1},"kind":"LongTerm","location":"westus","tags":{},"properties":{"timeSeriesIdProperties":[{"name":"DeviceId1","type":"String"}],"storageConfiguration":{"accountName":"clitest000002"},"warmStoreConfiguration":{"dataRetention":"P8D"},"creationTime":"2020-05-08T03:47:33.3693862Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"f0b7d698-58b0-49b6-96f2-ccb8bf7a6067","dataAccessFqdn":"f0b7d698-58b0-49b6-96f2-ccb8bf7a6067.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003","name":"cli-test-tsi-env000003","type":"Microsoft.TimeSeriesInsights/Environments"}'
+      string: '{"sku":{"name":"L1","capacity":1},"kind":"LongTerm","location":"WestUs","tags":{},"properties":{"timeSeriesIdProperties":[{"name":"DeviceId1","type":"String"}],"storageConfiguration":{"accountName":"clitest000002"},"warmStoreConfiguration":{"dataRetention":"P8D"},"creationTime":"2020-05-18T07:06:07.0622679Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"d6ad1bd9-084f-403c-bf5f-cab12ef5ad28","dataAccessFqdn":"d6ad1bd9-084f-403c-bf5f-cab12ef5ad28.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003","name":"cli-test-tsi-env000003","type":"Microsoft.TimeSeriesInsights/Environments"}'
     headers:
       cache-control:
       - no-cache
@@ -285,7 +189,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 08 May 2020 03:48:41 GMT
+      - Mon, 18 May 2020 07:06:10 GMT
       expires:
       - '-1'
       pragma:
@@ -301,7 +205,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1195'
     status:
       code: 200
       message: OK
@@ -323,15 +227,15 @@ interactions:
       ParameterSetName:
       - -g -n --key --query --output
       User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-storage/9.0.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
+        azure-mgmt-storage/9.0.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Storage/storageAccounts/clitest000002/regenerateKey?api-version=2019-06-01
   response:
     body:
-      string: '{"keys":[{"keyName":"key1","value":"r7RjB6uTrqw/PZYWGY3YofQZ+416xbsedSMaA1OcpsVmk71mMzeGpWuXe4A1cW2jcaZ5iqFFDNj2H2KARaGNPg==","permissions":"FULL"},{"keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
+      string: '{"keys":[{"keyName":"key1","value":"jo2mIEeB+0YCeNK7yPPkFyWwViIQiP2R88AeWYo5UxOTN+JOAxwTPW6WUQzk618VzF09bSdWiMrDawM8vv4aUg==","permissions":"FULL"},{"keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
     headers:
       cache-control:
       - no-cache
@@ -340,7 +244,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 08 May 2020 03:49:41 GMT
+      - Mon, 18 May 2020 07:07:12 GMT
       expires:
       - '-1'
       pragma:
@@ -356,12 +260,12 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"properties": {"storageConfiguration": {"managementKey": "r7RjB6uTrqw/PZYWGY3YofQZ+416xbsedSMaA1OcpsVmk71mMzeGpWuXe4A1cW2jcaZ5iqFFDNj2H2KARaGNPg=="}}}'
+    body: '{"properties": {"storageConfiguration": {"managementKey": "jo2mIEeB+0YCeNK7yPPkFyWwViIQiP2R88AeWYo5UxOTN+JOAxwTPW6WUQzk618VzF09bSdWiMrDawM8vv4aUg=="}}}'
     headers:
       Accept:
       - application/json
@@ -378,15 +282,15 @@ interactions:
       ParameterSetName:
       - --resource-group --name --storage-management-key
       User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"sku":{"name":"L1","capacity":1},"kind":"LongTerm","location":"westus","tags":{},"properties":{"timeSeriesIdProperties":[{"name":"DeviceId1","type":"String"}],"storageConfiguration":{"accountName":"clitest000002"},"warmStoreConfiguration":{"dataRetention":"P8D"},"creationTime":"2020-05-08T03:47:33.3693862Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"f0b7d698-58b0-49b6-96f2-ccb8bf7a6067","dataAccessFqdn":"f0b7d698-58b0-49b6-96f2-ccb8bf7a6067.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003","name":"cli-test-tsi-env000003","type":"Microsoft.TimeSeriesInsights/Environments"}'
+      string: '{"sku":{"name":"L1","capacity":1},"kind":"LongTerm","location":"WestUs","tags":{},"properties":{"timeSeriesIdProperties":[{"name":"DeviceId1","type":"String"}],"storageConfiguration":{"accountName":"clitest000002"},"warmStoreConfiguration":{"dataRetention":"P8D"},"creationTime":"2020-05-18T07:06:07.0622679Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"d6ad1bd9-084f-403c-bf5f-cab12ef5ad28","dataAccessFqdn":"d6ad1bd9-084f-403c-bf5f-cab12ef5ad28.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003","name":"cli-test-tsi-env000003","type":"Microsoft.TimeSeriesInsights/Environments"}'
     headers:
       cache-control:
       - no-cache
@@ -395,7 +299,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 08 May 2020 03:49:58 GMT
+      - Mon, 18 May 2020 07:07:29 GMT
       expires:
       - '-1'
       pragma:
@@ -411,7 +315,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1189'
     status:
       code: 200
       message: OK

--- a/src/timeseriesinsights/azext_timeseriesinsights/tests/latest/recordings/test_timeseriesinsights_environment_standard.yaml
+++ b/src/timeseriesinsights/azext_timeseriesinsights/tests/latest/recordings/test_timeseriesinsights_environment_standard.yaml
@@ -15,14 +15,14 @@ interactions:
         --storage-limit-exceeded-behavior
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_timeseriesinsights000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001","name":"cli_test_timeseriesinsights000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-04-23T08:52:27Z","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001","name":"cli_test_timeseriesinsights000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-05-18T07:05:29Z","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -31,7 +31,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 23 Apr 2020 08:52:32 GMT
+      - Mon, 18 May 2020 07:05:34 GMT
       expires:
       - '-1'
       pragma:
@@ -67,23 +67,23 @@ interactions:
         --storage-limit-exceeded-behavior
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P7D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-04-23T08:52:48+00:00","provisioningState":"Accepted","dataAccessId":"62ae24e5-6a5e-4752-945f-1dc74218f1fd","dataAccessFqdn":"62ae24e5-6a5e-4752-945f-1dc74218f1fd.env.timeseries.azure.com","requestApiVersion":"2018-08-15-preview"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}'
+      string: '{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P7D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-05-18T07:05:43.4408437+00:00","provisioningState":"Accepted","dataAccessId":"04c71581-6f41-4b84-8068-5c68bc25a17b","dataAccessFqdn":"04c71581-6f41-4b84-8068-5c68bc25a17b.env.timeseries.azure.com","requestApiVersion":"2018-08-15-preview"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '797'
+      - '805'
       content-type:
       - application/json
       date:
-      - Thu, 23 Apr 2020 08:52:54 GMT
+      - Mon, 18 May 2020 07:05:47 GMT
       expires:
       - '-1'
       pragma:
@@ -95,7 +95,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
+      - '1191'
     status:
       code: 201
       message: Created
@@ -115,13 +115,12 @@ interactions:
         --storage-limit-exceeded-behavior
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P7D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"Thu,
-        23 Apr 2020 08:52:48 GMT","provisioningState":"Creating","requestApiVersion":"2018-08-15-preview","dataAccessId":"62ae24e5-6a5e-4752-945f-1dc74218f1fd","dataAccessFqdn":"62ae24e5-6a5e-4752-945f-1dc74218f1fd.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}'
+      string: '{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P7D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-05-18T07:05:43.4408437Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"04c71581-6f41-4b84-8068-5c68bc25a17b","dataAccessFqdn":"04c71581-6f41-4b84-8068-5c68bc25a17b.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}'
     headers:
       cache-control:
       - no-cache
@@ -130,56 +129,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 23 Apr 2020 08:53:24 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - timeseriesinsights environment standard create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --resource-group --name --sku-name --sku-capacity --data-retention-time --partition-key-properties
-        --storage-limit-exceeded-behavior
-      User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002?api-version=2018-08-15-preview
-  response:
-    body:
-      string: '{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P7D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"Thu,
-        23 Apr 2020 08:52:48 GMT","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"62ae24e5-6a5e-4752-945f-1dc74218f1fd","dataAccessFqdn":"62ae24e5-6a5e-4752-945f-1dc74218f1fd.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '802'
-      content-type:
-      - application/json
-      date:
-      - Thu, 23 Apr 2020 08:53:56 GMT
+      - Mon, 18 May 2020 07:06:19 GMT
       expires:
       - '-1'
       pragma:
@@ -216,24 +166,23 @@ interactions:
       - --resource-group --name --sku-name --sku-capacity
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"sku":{"name":"S1","capacity":2},"kind":"Standard","location":"westus","tags":{},"properties":{"dataRetentionTime":"P7D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"Thu,
-        23 Apr 2020 08:52:48 GMT","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"62ae24e5-6a5e-4752-945f-1dc74218f1fd","dataAccessFqdn":"62ae24e5-6a5e-4752-945f-1dc74218f1fd.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}'
+      string: '{"sku":{"name":"S1","capacity":2},"kind":"Standard","location":"westus","tags":{},"properties":{"dataRetentionTime":"P7D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-05-18T07:05:43.4408437Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"04c71581-6f41-4b84-8068-5c68bc25a17b","dataAccessFqdn":"04c71581-6f41-4b84-8068-5c68bc25a17b.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '800'
+      - '799'
       content-type:
       - application/json
       date:
-      - Thu, 23 Apr 2020 08:54:02 GMT
+      - Mon, 18 May 2020 07:06:26 GMT
       expires:
       - '-1'
       pragma:
@@ -249,7 +198,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1193'
+      - '1198'
     status:
       code: 200
       message: OK
@@ -272,24 +221,23 @@ interactions:
       - --resource-group --name --data-retention-time
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"sku":{"name":"S1","capacity":2},"kind":"Standard","location":"westus","tags":{},"properties":{"dataRetentionTime":"P8D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"Thu,
-        23 Apr 2020 08:52:48 GMT","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"62ae24e5-6a5e-4752-945f-1dc74218f1fd","dataAccessFqdn":"62ae24e5-6a5e-4752-945f-1dc74218f1fd.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}'
+      string: '{"sku":{"name":"S1","capacity":2},"kind":"Standard","location":"westus","tags":{},"properties":{"dataRetentionTime":"P8D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-05-18T07:05:43.4408437Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"04c71581-6f41-4b84-8068-5c68bc25a17b","dataAccessFqdn":"04c71581-6f41-4b84-8068-5c68bc25a17b.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '800'
+      - '799'
       content-type:
       - application/json
       date:
-      - Thu, 23 Apr 2020 08:54:04 GMT
+      - Mon, 18 May 2020 07:06:28 GMT
       expires:
       - '-1'
       pragma:
@@ -328,24 +276,23 @@ interactions:
       - --resource-group --name --storage-limit-exceeded-behavior
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"sku":{"name":"S1","capacity":2},"kind":"Standard","location":"westus","tags":{},"properties":{"dataRetentionTime":"P8D","storageLimitExceededBehavior":"PurgeOldData","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"Thu,
-        23 Apr 2020 08:52:48 GMT","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"62ae24e5-6a5e-4752-945f-1dc74218f1fd","dataAccessFqdn":"62ae24e5-6a5e-4752-945f-1dc74218f1fd.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}'
+      string: '{"sku":{"name":"S1","capacity":2},"kind":"Standard","location":"westus","tags":{},"properties":{"dataRetentionTime":"P8D","storageLimitExceededBehavior":"PurgeOldData","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-05-18T07:05:43.4408437Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"04c71581-6f41-4b84-8068-5c68bc25a17b","dataAccessFqdn":"04c71581-6f41-4b84-8068-5c68bc25a17b.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '800'
+      - '799'
       content-type:
       - application/json
       date:
-      - Thu, 23 Apr 2020 08:54:06 GMT
+      - Mon, 18 May 2020 07:06:29 GMT
       expires:
       - '-1'
       pragma:
@@ -361,7 +308,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1196'
+      - '1188'
     status:
       code: 200
       message: OK
@@ -380,24 +327,23 @@ interactions:
       - --resource-group --name
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"sku":{"name":"S1","capacity":2},"kind":"Standard","location":"westus","tags":{},"properties":{"dataRetentionTime":"P8D","storageLimitExceededBehavior":"PurgeOldData","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"Thu,
-        23 Apr 2020 08:52:48 GMT","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"62ae24e5-6a5e-4752-945f-1dc74218f1fd","dataAccessFqdn":"62ae24e5-6a5e-4752-945f-1dc74218f1fd.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}'
+      string: '{"sku":{"name":"S1","capacity":2},"kind":"Standard","location":"westus","tags":{},"properties":{"dataRetentionTime":"P8D","storageLimitExceededBehavior":"PurgeOldData","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-05-18T07:05:43.4408437Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"04c71581-6f41-4b84-8068-5c68bc25a17b","dataAccessFqdn":"04c71581-6f41-4b84-8068-5c68bc25a17b.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '800'
+      - '799'
       content-type:
       - application/json
       date:
-      - Thu, 23 Apr 2020 08:54:08 GMT
+      - Mon, 18 May 2020 07:06:30 GMT
       expires:
       - '-1'
       pragma:
@@ -430,24 +376,23 @@ interactions:
       - --resource-group
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"value":[{"sku":{"name":"S1","capacity":2},"kind":"Standard","location":"westus","tags":{},"properties":{"dataRetentionTime":"P8D","storageLimitExceededBehavior":"PurgeOldData","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"Thu,
-        23 Apr 2020 08:52:48 GMT","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"62ae24e5-6a5e-4752-945f-1dc74218f1fd","dataAccessFqdn":"62ae24e5-6a5e-4752-945f-1dc74218f1fd.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}]}'
+      string: '{"value":[{"sku":{"name":"S1","capacity":2},"kind":"Standard","location":"westus","tags":{},"properties":{"dataRetentionTime":"P8D","storageLimitExceededBehavior":"PurgeOldData","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-05-18T07:05:43.4408437Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"04c71581-6f41-4b84-8068-5c68bc25a17b","dataAccessFqdn":"04c71581-6f41-4b84-8068-5c68bc25a17b.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '812'
+      - '811'
       content-type:
       - application/json
       date:
-      - Thu, 23 Apr 2020 08:54:10 GMT
+      - Mon, 18 May 2020 07:06:31 GMT
       expires:
       - '-1'
       pragma:
@@ -478,45 +423,37 @@ interactions:
       - keep-alive
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.TimeSeriesInsights/environments?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"value":[{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P31D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"Thu,
-        23 Apr 2020 08:52:42 GMT","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"c72de72b-1e7e-437a-b889-28db0873600b","dataAccessFqdn":"c72de72b-1e7e-437a-b889-28db0873600b.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights2oiftej3hx5342cijs7v7cjogck3zpitrefknndb425ds5ty/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-enve5dpsot4","name":"cli-test-tsi-enve5dpsot4","type":"Microsoft.TimeSeriesInsights/Environments"},{"sku":{"name":"L1","capacity":1},"kind":"LongTerm","location":"WestUs","tags":{},"properties":{"timeSeriesIdProperties":[{"name":"[''DeviceId1'']","type":"String"}],"storageConfiguration":{"accountName":"jlst0423"},"warmStoreConfiguration":{"dataRetention":"P12D"},"creationTime":"Thu,
-        23 Apr 2020 07:31:28 GMT","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"7edc94e2-0d50-45ec-87f0-8581f9fdb896","dataAccessFqdn":"7edc94e2-0d50-45ec-87f0-8581f9fdb896.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.TimeSeriesInsights/environments/env2","name":"env2","type":"Microsoft.TimeSeriesInsights/Environments"},{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P31D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"Thu,
-        23 Apr 2020 08:52:40 GMT","provisioningState":"Deleting","requestApiVersion":"2018-08-15-preview","dataAccessId":"def09b9c-9580-41a8-b1e1-d74e50d8d85a","dataAccessFqdn":"def09b9c-9580-41a8-b1e1-d74e50d8d85a.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsightsq2yvggz3wbrhaaimlkvs4pxaodgoxddp7xdsnv4c2ku5sc6x/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-enviwayt2td","name":"cli-test-tsi-enviwayt2td","type":"Microsoft.TimeSeriesInsights/Environments"},{"sku":{"name":"L1","capacity":1},"kind":"LongTerm","location":"westus","tags":null,"properties":{"timeSeriesIdProperties":[{"name":"[''DeviceId1'']","type":"String"}],"storageConfiguration":{"accountName":"clitesti77jqi5ajd6qf26ih"},"warmStoreConfiguration":{"dataRetention":"P7D"},"creationTime":"Thu,
-        23 Apr 2020 08:15:51 GMT","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"b7940864-a0c6-49f3-97f0-2f97a92029f1","dataAccessFqdn":"b7940864-a0c6-49f3-97f0-2f97a92029f1.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsightslqf77dpmzjutptzaamy3njmq2em5vzikcppxdp4xv3yzg52h/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-envkatcjyef","name":"cli-test-tsi-envkatcjyef","type":"Microsoft.TimeSeriesInsights/Environments"},{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P31D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"Thu,
-        23 Apr 2020 08:52:45 GMT","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"19d80b62-5ad8-413d-b006-9a81ba3dd670","dataAccessFqdn":"19d80b62-5ad8-413d-b006-9a81ba3dd670.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsightsykcxb7ztbepz3cbrz62whynq3mxbkltafzns3znlvb5q6v2e/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-envmy2ib4my","name":"cli-test-tsi-envmy2ib4my","type":"Microsoft.TimeSeriesInsights/Environments"},{"sku":{"name":"S1","capacity":2},"kind":"Standard","location":"westus","tags":{},"properties":{"dataRetentionTime":"P8D","storageLimitExceededBehavior":"PurgeOldData","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"Thu,
-        23 Apr 2020 08:52:48 GMT","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"62ae24e5-6a5e-4752-945f-1dc74218f1fd","dataAccessFqdn":"62ae24e5-6a5e-4752-945f-1dc74218f1fd.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"},{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P31D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"Thu,
-        23 Apr 2020 08:52:52 GMT","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"e366c607-9592-48f9-9f57-c274fd9787df","dataAccessFqdn":"e366c607-9592-48f9-9f57-c274fd9787df.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights6sqryqtjaivs76kpg4o4jrz7swfdygumzpyic7illekv6j5d/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-envkvpwo2pu","name":"cli-test-tsi-envkvpwo2pu","type":"Microsoft.TimeSeriesInsights/Environments"},{"sku":{"name":"L1","capacity":1},"kind":"LongTerm","location":"westus","tags":null,"properties":{"timeSeriesIdProperties":[{"name":"[''DeviceId1'']","type":"String"}],"storageConfiguration":{"accountName":"clitest7rfijel6fwut5i5pu"},"warmStoreConfiguration":{"dataRetention":"P7D"},"creationTime":"Thu,
-        23 Apr 2020 08:53:07 GMT","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"27230d72-77ee-4156-aa4a-43b545cc2504","dataAccessFqdn":"27230d72-77ee-4156-aa4a-43b545cc2504.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsightsq2vksngavqljrt5cw4eqq4kppsqha6q6co7anboikjdobqyl/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env6qb4o6ft","name":"cli-test-tsi-env6qb4o6ft","type":"Microsoft.TimeSeriesInsights/Environments"},{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus2","tags":null,"properties":{"dataRetentionTime":"P7D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"Thu,
-        23 Apr 2020 07:17:29 GMT","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"b5a60b17-e0a7-4e3a-87f7-cf48569e7eb9","dataAccessFqdn":"b5a60b17-e0a7-4e3a-87f7-cf48569e7eb9.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.TimeSeriesInsights/environments/env1","name":"env1","type":"Microsoft.TimeSeriesInsights/Environments"}]}'
+      string: '{"value":[{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P31D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-05-18T07:05:46.6439947Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"38c2b3bb-202d-409b-b6af-13165ba509ef","dataAccessFqdn":"38c2b3bb-202d-409b-b6af-13165ba509ef.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights3th7s5h3vkolxxhp4r7nndubsxczbjwc4ksdaaahmhy6yqni/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-envz4q5h5rp","name":"cli-test-tsi-envz4q5h5rp","type":"Microsoft.TimeSeriesInsights/Environments"},{"sku":{"name":"S1","capacity":2},"kind":"Standard","location":"westus","tags":{},"properties":{"dataRetentionTime":"P8D","storageLimitExceededBehavior":"PurgeOldData","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-05-18T07:05:43.4408437Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"04c71581-6f41-4b84-8068-5c68bc25a17b","dataAccessFqdn":"04c71581-6f41-4b84-8068-5c68bc25a17b.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"},{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P31D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-05-18T07:05:50.6704839Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"15e132bd-a526-4c9a-9ca7-5fb45d1ac184","dataAccessFqdn":"15e132bd-a526-4c9a-9ca7-5fb45d1ac184.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights4u7etlphuia5jroxjjxje63q6zzeabmhrna7ihbzgqgth2dq/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-envp64livwc","name":"cli-test-tsi-envp64livwc","type":"Microsoft.TimeSeriesInsights/Environments"},{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P31D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-05-18T07:05:41.1766404Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"a096910d-50b3-492e-a5f0-7e82868516c8","dataAccessFqdn":"a096910d-50b3-492e-a5f0-7e82868516c8.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsightsjul33xjtd7kg5jsdqokxkmcjiadch6wmu26sjd72bn5zaq7a/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-envzmk2u43r","name":"cli-test-tsi-envzmk2u43r","type":"Microsoft.TimeSeriesInsights/Environments"},{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P7D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-05-18T03:04:26.6065083Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"738c6b44-35d3-434a-a1e2-05a6c43f9b91","dataAccessFqdn":"738c6b44-35d3-434a-a1e2-05a6c43f9b91.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.TimeSeriesInsights/environments/env1","name":"env1","type":"Microsoft.TimeSeriesInsights/Environments"},{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P31D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-05-18T07:05:54.1394788Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"b229444b-d3fe-40b3-aa56-b1d0034ac955","dataAccessFqdn":"b229444b-d3fe-40b3-aa56-b1d0034ac955.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights3prg5bvmxghup6sde7wdyqilbskkj6e3eiui7pnwhmampwky/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-envbqzlrzpn","name":"cli-test-tsi-envbqzlrzpn","type":"Microsoft.TimeSeriesInsights/Environments"},{"sku":{"name":"L1","capacity":1},"kind":"LongTerm","location":"WestUs","tags":{},"properties":{"timeSeriesIdProperties":[{"name":"DeviceId1","type":"String"}],"storageConfiguration":{"accountName":"clitestjbmxigo3m3ojcr4xw"},"warmStoreConfiguration":{"dataRetention":"P8D"},"creationTime":"2020-05-18T06:55:29.1065897Z","provisioningState":"Deleting","requestApiVersion":"2018-08-15-preview","dataAccessId":"145f3b06-ac3a-41d4-9aea-f5f68d764402","dataAccessFqdn":"145f3b06-ac3a-41d4-9aea-f5f68d764402.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsightsmpyjuymosotkmjhrqb6mic34bmeefpwkf3swkto64mbwdg57/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-envtdlugpgl","name":"cli-test-tsi-envtdlugpgl","type":"Microsoft.TimeSeriesInsights/Environments"},{"sku":{"name":"L1","capacity":1},"kind":"LongTerm","location":"WestUs","tags":{},"properties":{"timeSeriesIdProperties":[{"name":"DeviceId1","type":"String"}],"storageConfiguration":{"accountName":"clitestqa73h5bnf7mngwfcy"},"warmStoreConfiguration":{"dataRetention":"P8D"},"creationTime":"2020-05-18T07:06:07.0622679Z","provisioningState":"Updating","requestApiVersion":"2018-08-15-preview","dataAccessId":"d6ad1bd9-084f-403c-bf5f-cab12ef5ad28","dataAccessFqdn":"d6ad1bd9-084f-403c-bf5f-cab12ef5ad28.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsightsiluqduqjjym4velhati7ko76mhzbldjiug2qzl5hrlb2dzph/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-envkvx2nuv5","name":"cli-test-tsi-envkvx2nuv5","type":"Microsoft.TimeSeriesInsights/Environments"}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '7140'
+      - '6397'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Thu, 23 Apr 2020 08:54:12 GMT
+      - Mon, 18 May 2020 07:06:33 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
       - nosniff
-      x-ms-original-request-ids:
-      - 4e81e23e-97dd-4478-82fd-9d5391fd2120
-      - 185cfc4a-c8f8-478c-8489-4856a1b327e8
     status:
       code: 200
       message: OK
@@ -534,10 +471,10 @@ interactions:
       Content-Length:
       - '0'
       ParameterSetName:
-      - --resource-group --name
+      - --resource-group --name --yes
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: DELETE
@@ -551,7 +488,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 23 Apr 2020 08:54:17 GMT
+      - Mon, 18 May 2020 07:06:38 GMT
       expires:
       - '-1'
       pragma:
@@ -563,7 +500,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-deletes:
-      - '14999'
+      - '14996'
     status:
       code: 200
       message: OK
@@ -582,7 +519,7 @@ interactions:
       - --resource-group
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: GET
@@ -598,7 +535,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 23 Apr 2020 08:54:18 GMT
+      - Mon, 18 May 2020 07:06:39 GMT
       expires:
       - '-1'
       pragma:

--- a/src/timeseriesinsights/azext_timeseriesinsights/tests/latest/recordings/test_timeseriesinsights_event_source_eventhub.yaml
+++ b/src/timeseriesinsights/azext_timeseriesinsights/tests/latest/recordings/test_timeseriesinsights_event_source_eventhub.yaml
@@ -15,14 +15,14 @@ interactions:
         --storage-limit-exceeded-behavior
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_timeseriesinsights000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001","name":"cli_test_timeseriesinsights000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-04-23T08:52:27Z","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001","name":"cli_test_timeseriesinsights000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-05-18T07:05:29Z","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -31,7 +31,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 23 Apr 2020 08:52:33 GMT
+      - Mon, 18 May 2020 07:05:34 GMT
       expires:
       - '-1'
       pragma:
@@ -67,23 +67,23 @@ interactions:
         --storage-limit-exceeded-behavior
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000005?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P31D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-04-23T08:52:42+00:00","provisioningState":"Accepted","dataAccessId":"c72de72b-1e7e-437a-b889-28db0873600b","dataAccessFqdn":"c72de72b-1e7e-437a-b889-28db0873600b.env.timeseries.azure.com","requestApiVersion":"2018-08-15-preview"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000005","name":"cli-test-tsi-env000005","type":"Microsoft.TimeSeriesInsights/Environments"}'
+      string: '{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P31D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-05-18T07:05:50.6704839+00:00","provisioningState":"Accepted","dataAccessId":"15e132bd-a526-4c9a-9ca7-5fb45d1ac184","dataAccessFqdn":"15e132bd-a526-4c9a-9ca7-5fb45d1ac184.env.timeseries.azure.com","requestApiVersion":"2018-08-15-preview"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000005","name":"cli-test-tsi-env000005","type":"Microsoft.TimeSeriesInsights/Environments"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '798'
+      - '806'
       content-type:
       - application/json
       date:
-      - Thu, 23 Apr 2020 08:52:47 GMT
+      - Mon, 18 May 2020 07:05:54 GMT
       expires:
       - '-1'
       pragma:
@@ -95,7 +95,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1194'
+      - '1191'
     status:
       code: 201
       message: Created
@@ -115,22 +115,21 @@ interactions:
         --storage-limit-exceeded-behavior
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000005?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P31D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"Thu,
-        23 Apr 2020 08:52:42 GMT","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"c72de72b-1e7e-437a-b889-28db0873600b","dataAccessFqdn":"c72de72b-1e7e-437a-b889-28db0873600b.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000005","name":"cli-test-tsi-env000005","type":"Microsoft.TimeSeriesInsights/Environments"}'
+      string: '{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P31D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-05-18T07:05:50.6704839Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"15e132bd-a526-4c9a-9ca7-5fb45d1ac184","dataAccessFqdn":"15e132bd-a526-4c9a-9ca7-5fb45d1ac184.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000005","name":"cli-test-tsi-env000005","type":"Microsoft.TimeSeriesInsights/Environments"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '803'
+      - '802'
       content-type:
       - application/json
       date:
-      - Thu, 23 Apr 2020 08:53:20 GMT
+      - Mon, 18 May 2020 07:06:25 GMT
       expires:
       - '-1'
       pragma:
@@ -163,14 +162,14 @@ interactions:
       - -g -n
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_timeseriesinsights000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001","name":"cli_test_timeseriesinsights000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-04-23T08:52:27Z","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001","name":"cli_test_timeseriesinsights000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-05-18T07:05:29Z","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -179,7 +178,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 23 Apr 2020 08:53:21 GMT
+      - Mon, 18 May 2020 07:06:26 GMT
       expires:
       - '-1'
       pragma:
@@ -212,7 +211,7 @@ interactions:
       - -g -n
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-eventhub/3.0.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-eventhub/3.0.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: PUT
@@ -220,16 +219,16 @@ interactions:
   response:
     body:
       string: '{"sku":{"name":"Standard","tier":"Standard","capacity":1},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.EventHub/namespaces/cli-test-tsi-ehns000003","name":"cli-test-tsi-ehns000003","type":"Microsoft.EventHub/Namespaces","location":"West
-        US","tags":{},"properties":{"isAutoInflateEnabled":false,"maximumThroughputUnits":0,"kafkaEnabled":true,"provisioningState":"Created","metricId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590:cli-test-tsi-ehns000003","createdAt":"2020-04-23T08:53:26.513Z","updatedAt":"2020-04-23T08:53:26.513Z","serviceBusEndpoint":"https://cli-test-tsi-ehns000003.servicebus.windows.net:443/","status":"Activating"}}'
+        US","tags":{},"properties":{"isAutoInflateEnabled":false,"maximumThroughputUnits":0,"kafkaEnabled":true,"provisioningState":"Created","metricId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590:cli-test-tsi-ehns000003","createdAt":"2020-05-18T07:06:32.01Z","updatedAt":"2020-05-18T07:06:32.01Z","serviceBusEndpoint":"https://cli-test-tsi-ehns000003.servicebus.windows.net:443/","status":"Activating"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '757'
+      - '755'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 23 Apr 2020 08:53:28 GMT
+      - Mon, 18 May 2020 07:06:33 GMT
       expires:
       - '-1'
       pragma:
@@ -267,64 +266,13 @@ interactions:
       - -g -n
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-eventhub/3.0.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-eventhub/3.0.0 Azure-SDK-For-Python AZURECLI/2.6.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.EventHub/namespaces/cli-test-tsi-ehns000003?api-version=2017-04-01
   response:
     body:
       string: '{"sku":{"name":"Standard","tier":"Standard","capacity":1},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.EventHub/namespaces/cli-test-tsi-ehns000003","name":"cli-test-tsi-ehns000003","type":"Microsoft.EventHub/Namespaces","location":"West
-        US","tags":{},"properties":{"isAutoInflateEnabled":false,"maximumThroughputUnits":0,"kafkaEnabled":true,"provisioningState":"Created","metricId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590:cli-test-tsi-ehns000003","createdAt":"2020-04-23T08:53:26.513Z","updatedAt":"2020-04-23T08:53:26.513Z","serviceBusEndpoint":"https://cli-test-tsi-ehns000003.servicebus.windows.net:443/","status":"Activating"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '757'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 23 Apr 2020 08:53:58 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Service-Bus-Resource-Provider/CH3
-      - Microsoft-HTTPAPI/2.0
-      server-sb:
-      - Service-Bus-Resource-Provider/CH3
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - eventhubs namespace create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n
-      User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-eventhub/3.0.0 Azure-SDK-For-Python AZURECLI/2.4.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.EventHub/namespaces/cli-test-tsi-ehns000003?api-version=2017-04-01
-  response:
-    body:
-      string: '{"sku":{"name":"Standard","tier":"Standard","capacity":1},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.EventHub/namespaces/cli-test-tsi-ehns000003","name":"cli-test-tsi-ehns000003","type":"Microsoft.EventHub/Namespaces","location":"West
-        US","tags":{},"properties":{"isAutoInflateEnabled":false,"maximumThroughputUnits":0,"kafkaEnabled":true,"provisioningState":"Succeeded","metricId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590:cli-test-tsi-ehns000003","createdAt":"2020-04-23T08:53:26.513Z","updatedAt":"2020-04-23T08:54:13.757Z","serviceBusEndpoint":"https://cli-test-tsi-ehns000003.servicebus.windows.net:443/","status":"Active"}}'
+        US","tags":{},"properties":{"isAutoInflateEnabled":false,"maximumThroughputUnits":0,"kafkaEnabled":true,"provisioningState":"Created","metricId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590:cli-test-tsi-ehns000003","createdAt":"2020-05-18T07:06:32.01Z","updatedAt":"2020-05-18T07:06:32.01Z","serviceBusEndpoint":"https://cli-test-tsi-ehns000003.servicebus.windows.net:443/","status":"Activating"}}'
     headers:
       cache-control:
       - no-cache
@@ -333,7 +281,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 23 Apr 2020 08:54:32 GMT
+      - Mon, 18 May 2020 07:07:04 GMT
       expires:
       - '-1'
       pragma:
@@ -369,7 +317,58 @@ interactions:
       - -g -n
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-eventhub/3.0.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-eventhub/3.0.0 Azure-SDK-For-Python AZURECLI/2.6.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.EventHub/namespaces/cli-test-tsi-ehns000003?api-version=2017-04-01
+  response:
+    body:
+      string: '{"sku":{"name":"Standard","tier":"Standard","capacity":1},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.EventHub/namespaces/cli-test-tsi-ehns000003","name":"cli-test-tsi-ehns000003","type":"Microsoft.EventHub/Namespaces","location":"West
+        US","tags":{},"properties":{"isAutoInflateEnabled":false,"maximumThroughputUnits":0,"kafkaEnabled":true,"provisioningState":"Succeeded","metricId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590:cli-test-tsi-ehns000003","createdAt":"2020-05-18T07:06:32.01Z","updatedAt":"2020-05-18T07:07:22.983Z","serviceBusEndpoint":"https://cli-test-tsi-ehns000003.servicebus.windows.net:443/","status":"Active"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '754'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 18 May 2020 07:07:34 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/CH3
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/CH3
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - eventhubs namespace create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
+        azure-mgmt-eventhub/3.0.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: GET
@@ -377,16 +376,16 @@ interactions:
   response:
     body:
       string: '{"sku":{"name":"Standard","tier":"Standard","capacity":1},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.EventHub/namespaces/cli-test-tsi-ehns000003","name":"cli-test-tsi-ehns000003","type":"Microsoft.EventHub/Namespaces","location":"West
-        US","tags":{},"properties":{"isAutoInflateEnabled":false,"maximumThroughputUnits":0,"kafkaEnabled":true,"provisioningState":"Succeeded","metricId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590:cli-test-tsi-ehns000003","createdAt":"2020-04-23T08:53:26.513Z","updatedAt":"2020-04-23T08:54:13.757Z","serviceBusEndpoint":"https://cli-test-tsi-ehns000003.servicebus.windows.net:443/","status":"Active"}}'
+        US","tags":{},"properties":{"isAutoInflateEnabled":false,"maximumThroughputUnits":0,"kafkaEnabled":true,"provisioningState":"Succeeded","metricId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590:cli-test-tsi-ehns000003","createdAt":"2020-05-18T07:06:32.01Z","updatedAt":"2020-05-18T07:07:22.983Z","serviceBusEndpoint":"https://cli-test-tsi-ehns000003.servicebus.windows.net:443/","status":"Active"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '755'
+      - '754'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 23 Apr 2020 08:54:40 GMT
+      - Mon, 18 May 2020 07:07:35 GMT
       expires:
       - '-1'
       pragma:
@@ -426,7 +425,7 @@ interactions:
       - -g -n --namespace-name
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-eventhub/3.0.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-eventhub/3.0.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: PUT
@@ -434,16 +433,16 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.EventHub/namespaces/cli-test-tsi-ehns000003/eventhubs/cli-test-tsi-eh000004","name":"cli-test-tsi-eh000004","type":"Microsoft.EventHub/Namespaces/EventHubs","location":"West
-        US","properties":{"messageRetentionInDays":7,"partitionCount":4,"status":"Active","createdAt":"2020-04-23T08:54:43.85Z","updatedAt":"2020-04-23T08:54:44.367Z","partitionIds":["0","1","2","3"]}}'
+        US","properties":{"messageRetentionInDays":7,"partitionCount":4,"status":"Active","createdAt":"2020-05-18T07:07:37.913Z","updatedAt":"2020-05-18T07:07:38.387Z","partitionIds":["0","1","2","3"]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '544'
+      - '545'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 23 Apr 2020 08:54:44 GMT
+      - Mon, 18 May 2020 07:07:38 GMT
       expires:
       - '-1'
       pragma:
@@ -462,7 +461,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1191'
+      - '1195'
     status:
       code: 200
       message: OK
@@ -483,14 +482,14 @@ interactions:
       - -g --namespace-name -n
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-eventhub/3.0.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-eventhub/3.0.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.EventHub/namespaces/cli-test-tsi-ehns000003/AuthorizationRules/RootManageSharedAccessKey/listKeys?api-version=2017-04-01
   response:
     body:
-      string: '{"primaryConnectionString":"Endpoint=sb://cli-test-tsi-ehns000003.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=EqhKj+SvaHDKWGT5sKKkAbofTWwoW1LBT1JOmBiveRM=","secondaryConnectionString":"Endpoint=sb://cli-test-tsi-ehns000003.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=A/3CAuapkQ9VWa+4a0Q9zDd3CCJ2k4YNWFBX2m+WCmQ=","primaryKey":"EqhKj+SvaHDKWGT5sKKkAbofTWwoW1LBT1JOmBiveRM=","secondaryKey":"A/3CAuapkQ9VWa+4a0Q9zDd3CCJ2k4YNWFBX2m+WCmQ=","keyName":"RootManageSharedAccessKey"}'
+      string: '{"primaryConnectionString":"Endpoint=sb://cli-test-tsi-ehns000003.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=rBZrT1glPpQjmzi070ftUjMWx41G/uIndxZL2vSMPbE=","secondaryConnectionString":"Endpoint=sb://cli-test-tsi-ehns000003.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=DjbuZUnzXbfHltWhmyx2tBcu0eTVW5VM0qxqtYZzlSw=","primaryKey":"rBZrT1glPpQjmzi070ftUjMWx41G/uIndxZL2vSMPbE=","secondaryKey":"DjbuZUnzXbfHltWhmyx2tBcu0eTVW5VM0qxqtYZzlSw=","keyName":"RootManageSharedAccessKey"}'
     headers:
       cache-control:
       - no-cache
@@ -499,284 +498,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 23 Apr 2020 08:54:46 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Service-Bus-Resource-Provider/CH3
-      - Microsoft-HTTPAPI/2.0
-      server-sb:
-      - Service-Bus-Resource-Provider/CH3
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - timeseriesinsights event-source eventhub create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --environment-name --name --key-name --shared-access-key --event-source-resource-id
-        --consumer-group-name --timestamp-property-name
-      User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.4.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_timeseriesinsights000001?api-version=2019-07-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001","name":"cli_test_timeseriesinsights000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-04-23T08:52:27Z","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '471'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 23 Apr 2020 08:54:47 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: 'b''{"location": "westus", "kind": "Microsoft.EventHub", "properties": {"timestampPropertyName":
-      "DeviceId", "eventSourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.EventHub/namespaces/cli-test-tsi-ehns000003/eventhubs/cli-test-tsi-eh000004",
-      "serviceBusNamespace": "cli-test-tsi-ehns000003", "eventHubName": "cli-test-tsi-eh000004",
-      "consumerGroupName": "$Default", "keyName": "RootManageSharedAccessKey", "sharedAccessKey":
-      "EqhKj+SvaHDKWGT5sKKkAbofTWwoW1LBT1JOmBiveRM="}}'''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - timeseriesinsights event-source eventhub create
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '611'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -g --environment-name --name --key-name --shared-access-key --event-source-resource-id
-        --consumer-group-name --timestamp-property-name
-      User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000005/eventSources/cli-test-tsi-es000002?api-version=2018-08-15-preview
-  response:
-    body:
-      string: '{"kind":"Microsoft.EventHub","location":"westus","tags":null,"properties":{"timestampPropertyName":"DeviceId","eventSourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.EventHub/namespaces/cli-test-tsi-ehns000003/eventhubs/cli-test-tsi-eh000004","serviceBusNamespace":"cli-test-tsi-ehns000003","eventHubName":"cli-test-tsi-eh000004","consumerGroupName":"$Default","keyName":"RootManageSharedAccessKey","creationTime":"Thu,
-        23 Apr 2020 08:54:53 GMT","provisioningState":"Succeeded"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000005/eventsources/cli-test-tsi-es000002","name":"cli-test-tsi-es000002","type":"Microsoft.TimeSeriesInsights/Environments/EventSources"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '982'
-      content-type:
-      - application/json
-      date:
-      - Thu, 23 Apr 2020 08:54:54 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"timestampPropertyName": "DeviceId1"}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - timeseriesinsights event-source eventhub update
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '54'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -g --environment-name --name --timestamp-property-name
-      User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
-      accept-language:
-      - en-US
-    method: PATCH
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000005/eventSources/cli-test-tsi-es000002?api-version=2018-08-15-preview
-  response:
-    body:
-      string: '{"kind":"Microsoft.EventHub","location":"westus","tags":null,"properties":{"timestampPropertyName":"DeviceId1","eventSourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.EventHub/namespaces/cli-test-tsi-ehns000003/eventhubs/cli-test-tsi-eh000004","serviceBusNamespace":"cli-test-tsi-ehns000003","eventHubName":"cli-test-tsi-eh000004","consumerGroupName":"$Default","keyName":"RootManageSharedAccessKey","creationTime":"Thu,
-        23 Apr 2020 08:54:53 GMT","provisioningState":"Succeeded"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000005/eventsources/cli-test-tsi-es000002","name":"cli-test-tsi-es000002","type":"Microsoft.TimeSeriesInsights/Environments/EventSources"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '983'
-      content-type:
-      - application/json
-      date:
-      - Thu, 23 Apr 2020 08:54:56 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1196'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"localTimestamp": {"format": "Embedded"}}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - timeseriesinsights event-source eventhub update
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '58'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -g --environment-name --name --local-timestamp-format
-      User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
-      accept-language:
-      - en-US
-    method: PATCH
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000005/eventSources/cli-test-tsi-es000002?api-version=2018-08-15-preview
-  response:
-    body:
-      string: '{"kind":"Microsoft.EventHub","location":"westus","tags":null,"properties":{"timestampPropertyName":"DeviceId1","eventSourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.EventHub/namespaces/cli-test-tsi-ehns000003/eventhubs/cli-test-tsi-eh000004","serviceBusNamespace":"cli-test-tsi-ehns000003","eventHubName":"cli-test-tsi-eh000004","consumerGroupName":"$Default","keyName":"RootManageSharedAccessKey","creationTime":"Thu,
-        23 Apr 2020 08:54:53 GMT","provisioningState":"Succeeded","localTimestamp":{"format":"Embedded","timezoneOffset":null}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000005/eventsources/cli-test-tsi-es000002","name":"cli-test-tsi-es000002","type":"Microsoft.TimeSeriesInsights/Environments/EventSources"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1044'
-      content-type:
-      - application/json
-      date:
-      - Thu, 23 Apr 2020 08:54:59 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1192'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"keyType": "PrimaryKey"}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - eventhubs namespace authorization-rule keys renew
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '25'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -g --namespace-name -n --key --query --output
-      User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-eventhub/3.0.0 Azure-SDK-For-Python AZURECLI/2.4.0
-      accept-language:
-      - en-US
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.EventHub/namespaces/cli-test-tsi-ehns000003/AuthorizationRules/RootManageSharedAccessKey/regenerateKeys?api-version=2017-04-01
-  response:
-    body:
-      string: '{"primaryConnectionString":"Endpoint=sb://cli-test-tsi-ehns000003.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=R7iSQjfokTcwmtsi2uqaxVO/8I6Br8wX8GrxFJ3NmqE=","secondaryConnectionString":"Endpoint=sb://cli-test-tsi-ehns000003.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=A/3CAuapkQ9VWa+4a0Q9zDd3CCJ2k4YNWFBX2m+WCmQ=","primaryKey":"R7iSQjfokTcwmtsi2uqaxVO/8I6Br8wX8GrxFJ3NmqE=","secondaryKey":"A/3CAuapkQ9VWa+4a0Q9zDd3CCJ2k4YNWFBX2m+WCmQ=","keyName":"RootManageSharedAccessKey"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '559'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 23 Apr 2020 08:55:08 GMT
+      - Mon, 18 May 2020 07:07:40 GMT
       expires:
       - '-1'
       pragma:
@@ -800,7 +522,219 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"properties": {"sharedAccessKey": "R7iSQjfokTcwmtsi2uqaxVO/8I6Br8wX8GrxFJ3NmqE="}}'
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - timeseriesinsights event-source eventhub create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --environment-name --name --key-name --shared-access-key --event-source-resource-id
+        --consumer-group-name
+      User-Agent:
+      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
+        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.6.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_timeseriesinsights000001?api-version=2019-07-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001","name":"cli_test_timeseriesinsights000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-05-18T07:05:29Z","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '471'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 18 May 2020 07:07:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: 'b''{"location": "westus", "kind": "Microsoft.EventHub", "properties": {"eventSourceResourceId":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.EventHub/namespaces/cli-test-tsi-ehns000003/eventhubs/cli-test-tsi-eh000004",
+      "serviceBusNamespace": "cli-test-tsi-ehns000003", "eventHubName": "cli-test-tsi-eh000004",
+      "consumerGroupName": "$Default", "keyName": "RootManageSharedAccessKey", "sharedAccessKey":
+      "rBZrT1glPpQjmzi070ftUjMWx41G/uIndxZL2vSMPbE="}}'''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - timeseriesinsights event-source eventhub create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '574'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g --environment-name --name --key-name --shared-access-key --event-source-resource-id
+        --consumer-group-name
+      User-Agent:
+      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000005/eventSources/cli-test-tsi-es000002?api-version=2018-08-15-preview
+  response:
+    body:
+      string: '{"kind":"Microsoft.EventHub","location":"westus","tags":null,"properties":{"eventSourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.EventHub/namespaces/cli-test-tsi-ehns000003/eventhubs/cli-test-tsi-eh000004","serviceBusNamespace":"cli-test-tsi-ehns000003","eventHubName":"cli-test-tsi-eh000004","consumerGroupName":"$Default","keyName":"RootManageSharedAccessKey","creationTime":"2020-05-18T07:07:46.6143524Z","provisioningState":"Succeeded"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000005/eventsources/cli-test-tsi-es000002","name":"cli-test-tsi-es000002","type":"Microsoft.TimeSeriesInsights/Environments/EventSources"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '946'
+      content-type:
+      - application/json
+      date:
+      - Mon, 18 May 2020 07:07:47 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1195'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - timeseriesinsights event-source eventhub create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --environment-name --name --key-name --shared-access-key --event-source-resource-id
+        --consumer-group-name --timestamp-property-name
+      User-Agent:
+      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
+        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.6.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_timeseriesinsights000001?api-version=2019-07-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001","name":"cli_test_timeseriesinsights000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-05-18T07:05:29Z","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '471'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 18 May 2020 07:07:48 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: 'b''{"location": "westus", "kind": "Microsoft.EventHub", "properties": {"timestampPropertyName":
+      "timestampProp", "eventSourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.EventHub/namespaces/cli-test-tsi-ehns000003/eventhubs/cli-test-tsi-eh000004",
+      "serviceBusNamespace": "cli-test-tsi-ehns000003", "eventHubName": "cli-test-tsi-eh000004",
+      "consumerGroupName": "$Default", "keyName": "RootManageSharedAccessKey", "sharedAccessKey":
+      "rBZrT1glPpQjmzi070ftUjMWx41G/uIndxZL2vSMPbE="}}'''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - timeseriesinsights event-source eventhub create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '616'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g --environment-name --name --key-name --shared-access-key --event-source-resource-id
+        --consumer-group-name --timestamp-property-name
+      User-Agent:
+      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000005/eventSources/cli-test-tsi-es000002?api-version=2018-08-15-preview
+  response:
+    body:
+      string: '{"kind":"Microsoft.EventHub","location":"westus","tags":null,"properties":{"timestampPropertyName":"timestampProp","eventSourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.EventHub/namespaces/cli-test-tsi-ehns000003/eventhubs/cli-test-tsi-eh000004","serviceBusNamespace":"cli-test-tsi-ehns000003","eventHubName":"cli-test-tsi-eh000004","consumerGroupName":"$Default","keyName":"RootManageSharedAccessKey","creationTime":"2020-05-18T07:07:46.6143524Z","provisioningState":"Succeeded"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000005/eventsources/cli-test-tsi-es000002","name":"cli-test-tsi-es000002","type":"Microsoft.TimeSeriesInsights/Environments/EventSources"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '986'
+      content-type:
+      - application/json
+      date:
+      - Mon, 18 May 2020 07:07:50 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1195'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"timestampPropertyName": "DeviceId1"}}'
     headers:
       Accept:
       - application/json
@@ -811,31 +745,30 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '83'
+      - '54'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
-      - -g --environment-name --name --shared-access-key
+      - -g --environment-name --name --timestamp-property-name
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000005/eventSources/cli-test-tsi-es000002?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"kind":"Microsoft.EventHub","location":"westus","tags":null,"properties":{"timestampPropertyName":"DeviceId1","eventSourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.EventHub/namespaces/cli-test-tsi-ehns000003/eventhubs/cli-test-tsi-eh000004","serviceBusNamespace":"cli-test-tsi-ehns000003","eventHubName":"cli-test-tsi-eh000004","consumerGroupName":"$Default","keyName":"RootManageSharedAccessKey","creationTime":"Thu,
-        23 Apr 2020 08:54:53 GMT","provisioningState":"Succeeded","localTimestamp":{"format":"Embedded","timezoneOffset":null}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000005/eventsources/cli-test-tsi-es000002","name":"cli-test-tsi-es000002","type":"Microsoft.TimeSeriesInsights/Environments/EventSources"}'
+      string: '{"kind":"Microsoft.EventHub","location":"westus","tags":null,"properties":{"timestampPropertyName":"DeviceId1","eventSourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.EventHub/namespaces/cli-test-tsi-ehns000003/eventhubs/cli-test-tsi-eh000004","serviceBusNamespace":"cli-test-tsi-ehns000003","eventHubName":"cli-test-tsi-eh000004","consumerGroupName":"$Default","keyName":"RootManageSharedAccessKey","creationTime":"2020-05-18T07:07:46.6143524Z","provisioningState":"Succeeded"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000005/eventsources/cli-test-tsi-es000002","name":"cli-test-tsi-es000002","type":"Microsoft.TimeSeriesInsights/Environments/EventSources"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1044'
+      - '982'
       content-type:
       - application/json
       date:
-      - Thu, 23 Apr 2020 08:55:10 GMT
+      - Mon, 18 May 2020 07:07:53 GMT
       expires:
       - '-1'
       pragma:
@@ -856,6 +789,174 @@ interactions:
       code: 200
       message: OK
 - request:
+    body: '{"properties": {"localTimestamp": {"format": "Embedded"}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - timeseriesinsights event-source eventhub update
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '58'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g --environment-name --name --local-timestamp-format
+      User-Agent:
+      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
+      accept-language:
+      - en-US
+    method: PATCH
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000005/eventSources/cli-test-tsi-es000002?api-version=2018-08-15-preview
+  response:
+    body:
+      string: '{"kind":"Microsoft.EventHub","location":"westus","tags":null,"properties":{"timestampPropertyName":"DeviceId1","eventSourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.EventHub/namespaces/cli-test-tsi-ehns000003/eventhubs/cli-test-tsi-eh000004","serviceBusNamespace":"cli-test-tsi-ehns000003","eventHubName":"cli-test-tsi-eh000004","consumerGroupName":"$Default","keyName":"RootManageSharedAccessKey","creationTime":"2020-05-18T07:07:46.6143524Z","provisioningState":"Succeeded","localTimestamp":{"format":"Embedded","timezoneOffset":null}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000005/eventsources/cli-test-tsi-es000002","name":"cli-test-tsi-es000002","type":"Microsoft.TimeSeriesInsights/Environments/EventSources"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1043'
+      content-type:
+      - application/json
+      date:
+      - Mon, 18 May 2020 07:07:55 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1187'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"keyType": "PrimaryKey"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - eventhubs namespace authorization-rule keys renew
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '25'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g --namespace-name -n --key --query --output
+      User-Agent:
+      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
+        azure-mgmt-eventhub/3.0.0 Azure-SDK-For-Python AZURECLI/2.6.0
+      accept-language:
+      - en-US
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.EventHub/namespaces/cli-test-tsi-ehns000003/AuthorizationRules/RootManageSharedAccessKey/regenerateKeys?api-version=2017-04-01
+  response:
+    body:
+      string: '{"primaryConnectionString":"Endpoint=sb://cli-test-tsi-ehns000003.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=zSsILFHvxn30c3RK6cwgrDSPzspiw56MGuKF8FpQrxs=","secondaryConnectionString":"Endpoint=sb://cli-test-tsi-ehns000003.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=DjbuZUnzXbfHltWhmyx2tBcu0eTVW5VM0qxqtYZzlSw=","primaryKey":"zSsILFHvxn30c3RK6cwgrDSPzspiw56MGuKF8FpQrxs=","secondaryKey":"DjbuZUnzXbfHltWhmyx2tBcu0eTVW5VM0qxqtYZzlSw=","keyName":"RootManageSharedAccessKey"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '559'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 18 May 2020 07:08:02 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Service-Bus-Resource-Provider/CH3
+      - Microsoft-HTTPAPI/2.0
+      server-sb:
+      - Service-Bus-Resource-Provider/CH3
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1197'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"sharedAccessKey": "zSsILFHvxn30c3RK6cwgrDSPzspiw56MGuKF8FpQrxs="}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - timeseriesinsights event-source eventhub update
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g --environment-name --name --shared-access-key
+      User-Agent:
+      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
+      accept-language:
+      - en-US
+    method: PATCH
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000005/eventSources/cli-test-tsi-es000002?api-version=2018-08-15-preview
+  response:
+    body:
+      string: '{"kind":"Microsoft.EventHub","location":"westus","tags":null,"properties":{"timestampPropertyName":"DeviceId1","eventSourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.EventHub/namespaces/cli-test-tsi-ehns000003/eventhubs/cli-test-tsi-eh000004","serviceBusNamespace":"cli-test-tsi-ehns000003","eventHubName":"cli-test-tsi-eh000004","consumerGroupName":"$Default","keyName":"RootManageSharedAccessKey","creationTime":"2020-05-18T07:07:46.6143524Z","provisioningState":"Succeeded","localTimestamp":{"format":"Embedded","timezoneOffset":null}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000005/eventsources/cli-test-tsi-es000002","name":"cli-test-tsi-es000002","type":"Microsoft.TimeSeriesInsights/Environments/EventSources"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1043'
+      content-type:
+      - application/json
+      date:
+      - Mon, 18 May 2020 07:08:04 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1194'
+    status:
+      code: 200
+      message: OK
+- request:
     body: null
     headers:
       Accept:
@@ -870,24 +971,23 @@ interactions:
       - -g --environment-name
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000005/eventSources?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"value":[{"kind":"Microsoft.EventHub","location":"westus","tags":null,"properties":{"timestampPropertyName":"DeviceId1","eventSourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.EventHub/namespaces/cli-test-tsi-ehns000003/eventhubs/cli-test-tsi-eh000004","serviceBusNamespace":"cli-test-tsi-ehns000003","eventHubName":"cli-test-tsi-eh000004","consumerGroupName":"$Default","keyName":"RootManageSharedAccessKey","creationTime":"Thu,
-        23 Apr 2020 08:54:53 GMT","provisioningState":"Succeeded","localTimestamp":{"format":"Embedded","timezoneOffset":null}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000005/eventsources/cli-test-tsi-es000002","name":"cli-test-tsi-es000002","type":"Microsoft.TimeSeriesInsights/Environments/EventSources"}]}'
+      string: '{"value":[{"kind":"Microsoft.EventHub","location":"westus","tags":null,"properties":{"timestampPropertyName":"DeviceId1","eventSourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.EventHub/namespaces/cli-test-tsi-ehns000003/eventhubs/cli-test-tsi-eh000004","serviceBusNamespace":"cli-test-tsi-ehns000003","eventHubName":"cli-test-tsi-eh000004","consumerGroupName":"$Default","keyName":"RootManageSharedAccessKey","creationTime":"2020-05-18T07:07:46.6143524Z","provisioningState":"Succeeded","localTimestamp":{"format":"Embedded","timezoneOffset":null}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000005/eventsources/cli-test-tsi-es000002","name":"cli-test-tsi-es000002","type":"Microsoft.TimeSeriesInsights/Environments/EventSources"}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1056'
+      - '1055'
       content-type:
       - application/json
       date:
-      - Thu, 23 Apr 2020 08:55:13 GMT
+      - Mon, 18 May 2020 07:08:06 GMT
       expires:
       - '-1'
       pragma:
@@ -920,24 +1020,23 @@ interactions:
       - -g --environment-name -n
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000005/eventSources/cli-test-tsi-es000002?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"kind":"Microsoft.EventHub","location":"westus","tags":null,"properties":{"timestampPropertyName":"DeviceId1","eventSourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.EventHub/namespaces/cli-test-tsi-ehns000003/eventhubs/cli-test-tsi-eh000004","serviceBusNamespace":"cli-test-tsi-ehns000003","eventHubName":"cli-test-tsi-eh000004","consumerGroupName":"$Default","keyName":"RootManageSharedAccessKey","creationTime":"Thu,
-        23 Apr 2020 08:54:53 GMT","provisioningState":"Succeeded","localTimestamp":{"format":"Embedded","timezoneOffset":null}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000005/eventsources/cli-test-tsi-es000002","name":"cli-test-tsi-es000002","type":"Microsoft.TimeSeriesInsights/Environments/EventSources"}'
+      string: '{"kind":"Microsoft.EventHub","location":"westus","tags":null,"properties":{"timestampPropertyName":"DeviceId1","eventSourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.EventHub/namespaces/cli-test-tsi-ehns000003/eventhubs/cli-test-tsi-eh000004","serviceBusNamespace":"cli-test-tsi-ehns000003","eventHubName":"cli-test-tsi-eh000004","consumerGroupName":"$Default","keyName":"RootManageSharedAccessKey","creationTime":"2020-05-18T07:07:46.6143524Z","provisioningState":"Succeeded","localTimestamp":{"format":"Embedded","timezoneOffset":null}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000005/eventsources/cli-test-tsi-es000002","name":"cli-test-tsi-es000002","type":"Microsoft.TimeSeriesInsights/Environments/EventSources"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1044'
+      - '1043'
       content-type:
       - application/json
       date:
-      - Thu, 23 Apr 2020 08:55:16 GMT
+      - Mon, 18 May 2020 07:08:07 GMT
       expires:
       - '-1'
       pragma:
@@ -969,10 +1068,10 @@ interactions:
       Content-Length:
       - '0'
       ParameterSetName:
-      - -g --environment-name -n
+      - -g --environment-name -n --yes
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: DELETE
@@ -986,7 +1085,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 23 Apr 2020 08:55:22 GMT
+      - Mon, 18 May 2020 07:08:12 GMT
       expires:
       - '-1'
       pragma:
@@ -998,7 +1097,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-deletes:
-      - '14998'
+      - '14994'
     status:
       code: 200
       message: OK

--- a/src/timeseriesinsights/azext_timeseriesinsights/tests/latest/recordings/test_timeseriesinsights_event_source_iothub.yaml
+++ b/src/timeseriesinsights/azext_timeseriesinsights/tests/latest/recordings/test_timeseriesinsights_event_source_iothub.yaml
@@ -15,14 +15,14 @@ interactions:
         --storage-limit-exceeded-behavior
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_timeseriesinsights000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001","name":"cli_test_timeseriesinsights000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-04-23T08:52:27Z","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001","name":"cli_test_timeseriesinsights000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-05-18T07:05:29Z","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -31,7 +31,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 23 Apr 2020 08:52:33 GMT
+      - Mon, 18 May 2020 07:05:34 GMT
       expires:
       - '-1'
       pragma:
@@ -67,23 +67,23 @@ interactions:
         --storage-limit-exceeded-behavior
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000004?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P31D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-04-23T08:52:52+00:00","provisioningState":"Accepted","dataAccessId":"e366c607-9592-48f9-9f57-c274fd9787df","dataAccessFqdn":"e366c607-9592-48f9-9f57-c274fd9787df.env.timeseries.azure.com","requestApiVersion":"2018-08-15-preview"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000004","name":"cli-test-tsi-env000004","type":"Microsoft.TimeSeriesInsights/Environments"}'
+      string: '{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P31D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-05-18T07:05:54.1394788+00:00","provisioningState":"Accepted","dataAccessId":"b229444b-d3fe-40b3-aa56-b1d0034ac955","dataAccessFqdn":"b229444b-d3fe-40b3-aa56-b1d0034ac955.env.timeseries.azure.com","requestApiVersion":"2018-08-15-preview"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000004","name":"cli-test-tsi-env000004","type":"Microsoft.TimeSeriesInsights/Environments"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '798'
+      - '806'
       content-type:
       - application/json
       date:
-      - Thu, 23 Apr 2020 08:52:54 GMT
+      - Mon, 18 May 2020 07:05:55 GMT
       expires:
       - '-1'
       pragma:
@@ -95,7 +95,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1191'
+      - '1196'
     status:
       code: 201
       message: Created
@@ -115,13 +115,12 @@ interactions:
         --storage-limit-exceeded-behavior
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000004?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P31D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"Thu,
-        23 Apr 2020 08:52:52 GMT","provisioningState":"Creating","requestApiVersion":"2018-08-15-preview","dataAccessId":"e366c607-9592-48f9-9f57-c274fd9787df","dataAccessFqdn":"e366c607-9592-48f9-9f57-c274fd9787df.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000004","name":"cli-test-tsi-env000004","type":"Microsoft.TimeSeriesInsights/Environments"}'
+      string: '{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P31D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-05-18T07:05:54.1394788Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"b229444b-d3fe-40b3-aa56-b1d0034ac955","dataAccessFqdn":"b229444b-d3fe-40b3-aa56-b1d0034ac955.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000004","name":"cli-test-tsi-env000004","type":"Microsoft.TimeSeriesInsights/Environments"}'
     headers:
       cache-control:
       - no-cache
@@ -130,56 +129,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 23 Apr 2020 08:53:26 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - timeseriesinsights environment standard create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --resource-group --name --sku-name --sku-capacity --data-retention-time --partition-key-properties
-        --storage-limit-exceeded-behavior
-      User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000004?api-version=2018-08-15-preview
-  response:
-    body:
-      string: '{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P31D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"Thu,
-        23 Apr 2020 08:52:52 GMT","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"e366c607-9592-48f9-9f57-c274fd9787df","dataAccessFqdn":"e366c607-9592-48f9-9f57-c274fd9787df.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000004","name":"cli-test-tsi-env000004","type":"Microsoft.TimeSeriesInsights/Environments"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '803'
-      content-type:
-      - application/json
-      date:
-      - Thu, 23 Apr 2020 08:53:57 GMT
+      - Mon, 18 May 2020 07:06:26 GMT
       expires:
       - '-1'
       pragma:
@@ -216,11 +166,11 @@ interactions:
       - -g -n
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-iothub/0.11.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-iothub/0.12.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/checkNameAvailability?api-version=2019-07-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/checkNameAvailability?api-version=2020-03-01
   response:
     body:
       string: '{"nameAvailable":true,"reason":"Invalid","message":null}'
@@ -232,7 +182,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 23 Apr 2020 08:53:59 GMT
+      - Mon, 18 May 2020 07:06:28 GMT
       expires:
       - '-1'
       pragma:
@@ -267,14 +217,14 @@ interactions:
       - -g -n
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_timeseriesinsights000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001","name":"cli_test_timeseriesinsights000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-04-23T08:52:27Z","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001","name":"cli_test_timeseriesinsights000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-05-18T07:05:29Z","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -283,7 +233,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 23 Apr 2020 08:54:00 GMT
+      - Mon, 18 May 2020 07:06:27 GMT
       expires:
       - '-1'
       pragma:
@@ -322,17 +272,17 @@ interactions:
       - -g -n
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-iothub/0.11.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-iothub/0.12.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Devices/IotHubs/cli-test-tsi-iothub000003?api-version=2019-07-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Devices/IotHubs/cli-test-tsi-iothub000003?api-version=2020-03-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Devices/IotHubs/cli-test-tsi-iothub000003","name":"cli-test-tsi-iothub000003","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"cli_test_timeseriesinsights000001","properties":{"state":"Activating","provisioningState":"Accepted","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT5S","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/operationResults/b3NfaWhfNzgwYTc0ZWItODMwZS00NmNmLThiMzEtYTEzNTE2ZjIwZDYw?api-version=2019-07-01-preview&operationSource=os_ih&asyncinfo
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/operationResults/b3NfaWhfZTAxZTgyZGQtMzc0Ny00ODY2LTlkNjktNjYwMmZkZjNjMDZh?api-version=2020-03-01&operationSource=os_ih&asyncinfo
       cache-control:
       - no-cache
       content-length:
@@ -340,7 +290,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 23 Apr 2020 08:54:09 GMT
+      - Mon, 18 May 2020 07:06:36 GMT
       expires:
       - '-1'
       pragma:
@@ -371,9 +321,9 @@ interactions:
       - -g -n
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-iothub/0.11.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-iothub/0.12.0 Azure-SDK-For-Python AZURECLI/2.6.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/operationResults/b3NfaWhfNzgwYTc0ZWItODMwZS00NmNmLThiMzEtYTEzNTE2ZjIwZDYw?api-version=2019-07-01-preview&operationSource=os_ih&asyncinfo
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/operationResults/b3NfaWhfZTAxZTgyZGQtMzc0Ny00ODY2LTlkNjktNjYwMmZkZjNjMDZh?api-version=2020-03-01&operationSource=os_ih&asyncinfo
   response:
     body:
       string: '{"status":"Running"}'
@@ -385,7 +335,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 23 Apr 2020 08:54:41 GMT
+      - Mon, 18 May 2020 07:07:07 GMT
       expires:
       - '-1'
       pragma:
@@ -418,9 +368,9 @@ interactions:
       - -g -n
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-iothub/0.11.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-iothub/0.12.0 Azure-SDK-For-Python AZURECLI/2.6.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/operationResults/b3NfaWhfNzgwYTc0ZWItODMwZS00NmNmLThiMzEtYTEzNTE2ZjIwZDYw?api-version=2019-07-01-preview&operationSource=os_ih&asyncinfo
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/operationResults/b3NfaWhfZTAxZTgyZGQtMzc0Ny00ODY2LTlkNjktNjYwMmZkZjNjMDZh?api-version=2020-03-01&operationSource=os_ih&asyncinfo
   response:
     body:
       string: '{"status":"Running"}'
@@ -432,7 +382,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 23 Apr 2020 08:55:11 GMT
+      - Mon, 18 May 2020 07:07:39 GMT
       expires:
       - '-1'
       pragma:
@@ -465,9 +415,9 @@ interactions:
       - -g -n
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-iothub/0.11.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-iothub/0.12.0 Azure-SDK-For-Python AZURECLI/2.6.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/operationResults/b3NfaWhfNzgwYTc0ZWItODMwZS00NmNmLThiMzEtYTEzNTE2ZjIwZDYw?api-version=2019-07-01-preview&operationSource=os_ih&asyncinfo
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/operationResults/b3NfaWhfZTAxZTgyZGQtMzc0Ny00ODY2LTlkNjktNjYwMmZkZjNjMDZh?api-version=2020-03-01&operationSource=os_ih&asyncinfo
   response:
     body:
       string: '{"status":"Running"}'
@@ -479,7 +429,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 23 Apr 2020 08:55:44 GMT
+      - Mon, 18 May 2020 07:08:10 GMT
       expires:
       - '-1'
       pragma:
@@ -512,9 +462,9 @@ interactions:
       - -g -n
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-iothub/0.11.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-iothub/0.12.0 Azure-SDK-For-Python AZURECLI/2.6.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/operationResults/b3NfaWhfNzgwYTc0ZWItODMwZS00NmNmLThiMzEtYTEzNTE2ZjIwZDYw?api-version=2019-07-01-preview&operationSource=os_ih&asyncinfo
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/operationResults/b3NfaWhfZTAxZTgyZGQtMzc0Ny00ODY2LTlkNjktNjYwMmZkZjNjMDZh?api-version=2020-03-01&operationSource=os_ih&asyncinfo
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -526,7 +476,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 23 Apr 2020 08:56:15 GMT
+      - Mon, 18 May 2020 07:08:41 GMT
       expires:
       - '-1'
       pragma:
@@ -559,13 +509,13 @@ interactions:
       - -g -n
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-iothub/0.11.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-iothub/0.12.0 Azure-SDK-For-Python AZURECLI/2.6.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Devices/IotHubs/cli-test-tsi-iothub000003?api-version=2019-07-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Devices/IotHubs/cli-test-tsi-iothub000003?api-version=2020-03-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Devices/IotHubs/cli-test-tsi-iothub000003","name":"cli-test-tsi-iothub000003","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"cli_test_timeseriesinsights000001","etag":"AAAAAA0HLQ8=","properties":{"locations":[{"location":"West
-        US","role":"primary"},{"location":"East US","role":"secondary"}],"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"cli-test-tsi-iothub000003.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"cli-test-tsi-iothub000003","endpoint":"sb://iothub-ns-cli-test-t-3301249-4bb741b8fe.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[],"storageContainers":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT5S","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Devices/IotHubs/cli-test-tsi-iothub000003","name":"cli-test-tsi-iothub000003","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"cli_test_timeseriesinsights000001","etag":"AAAAAA2+LAo=","properties":{"locations":[{"location":"West
+        US","role":"primary"},{"location":"East US","role":"secondary"}],"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"cli-test-tsi-iothub000003.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"cli-test-tsi-iothub000003","endpoint":"sb://iothub-ns-cli-test-t-3461315-188ebc2b20.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[],"storageContainers":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT5S","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}'
     headers:
       cache-control:
       - no-cache
@@ -574,7 +524,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 23 Apr 2020 08:56:16 GMT
+      - Mon, 18 May 2020 07:08:42 GMT
       expires:
       - '-1'
       pragma:
@@ -609,15 +559,15 @@ interactions:
       - -g --hub-name --query --output
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-iothub/0.11.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-iothub/0.12.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Devices/IotHubs/cli-test-tsi-iothub000003/listkeys?api-version=2019-07-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Devices/IotHubs/cli-test-tsi-iothub000003/listkeys?api-version=2020-03-01
   response:
     body:
-      string: '{"value":[{"keyName":"iothubowner","primaryKey":"TDulTUXa7mEtEL0wtQM6C4yKUJNwW6EB49ZjRMTHwnI=","secondaryKey":"PeBGGf/IiiQo23hAxASRJlJqQrqyJ1PXdpfdF+MMU9M=","rights":"RegistryWrite,
-        ServiceConnect, DeviceConnect"},{"keyName":"service","primaryKey":"dQLAouEOJHUz4KBBkmvhaWFEIkWZ4COrAR+NfVtD96U=","secondaryKey":"3JYW+ZuAtVmilPaqd/Vt/mTPW7yJatMpOidVbVuGWLk=","rights":"ServiceConnect"},{"keyName":"device","primaryKey":"qlEod871Un0IBPBYkljGGFCmSN/ntvc64tRyoVpdaIY=","secondaryKey":"c3BEZTAUoS8cypUbUSUjxCSFtJ9+lGdHqw1hNsZCAqs=","rights":"DeviceConnect"},{"keyName":"registryRead","primaryKey":"GywrLHwOJeigEL5K2h+2bZSk81NG8CsyigNy7durJzs=","secondaryKey":"eRPuE4ZLe4f27RgmKgaBcvP88rk2ipGw9Oohb4B4Ntk=","rights":"RegistryRead"},{"keyName":"registryReadWrite","primaryKey":"JiBa7tsVjJxH1s/WOdSDsGFpJ4xorALBZfHX1rPGtI0=","secondaryKey":"HH/9rpib42v1SwTURYc6mnS2fs3f+mU48ijF+oBgCKY=","rights":"RegistryWrite"}]}'
+      string: '{"value":[{"keyName":"iothubowner","primaryKey":"9BuhbHHHRDa9yuXwtOOZLiJhctrOUaAv4vTz0EYbNJo=","secondaryKey":"puZ4MtfWZRnaKZTx1xoMqMaHG1J9qCS+WXGXwO+bCEE=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"},{"keyName":"service","primaryKey":"bLELIemhnjk+Yw5CATypKmvJeMxXmtKLTmIprnecsOk=","secondaryKey":"WWn1SrcSLFbkhDGT+JLRNtw/gfbL3yV9ByqMeD5mjQk=","rights":"ServiceConnect"},{"keyName":"device","primaryKey":"7atGbzE4B15KmrvyjvqrrlxIF4INwkgcxPfalFTilG8=","secondaryKey":"zGzsr2rda9/CE4EWpLFgNpBOQMLyiwu8x3gCQ+yU4P4=","rights":"DeviceConnect"},{"keyName":"registryRead","primaryKey":"G0YTiX1faPxcr2C4zRUCJeCBbkOoXIZ8B7mm0pRMV0Y=","secondaryKey":"A3mwFrEFYoNncdQ44cJ+hav0HkqLw7AKmbbrLExVKM0=","rights":"RegistryRead"},{"keyName":"registryReadWrite","primaryKey":"W/rPthdImPD6OxY5Rufyxw9dv7fcaWIbZf2owIh7c/M=","secondaryKey":"CDqK+UyHFxpmhO5WuVvOddgbYMeeOhe7oVHz84rai3c=","rights":"RegistryWrite"}]}'
     headers:
       cache-control:
       - no-cache
@@ -626,7 +576,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 23 Apr 2020 08:56:19 GMT
+      - Mon, 18 May 2020 07:08:45 GMT
       expires:
       - '-1'
       pragma:
@@ -642,7 +592,112 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
+      - '1198'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - timeseriesinsights event-source iothub create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --environment-name --name --consumer-group-name --key-name --shared-access-key
+        --event-source-resource-id
+      User-Agent:
+      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
+        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.6.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_timeseriesinsights000001?api-version=2019-07-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001","name":"cli_test_timeseriesinsights000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-05-18T07:05:29Z","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '471'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 18 May 2020 07:08:45 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: 'b''{"location": "westus", "kind": "Microsoft.IoTHub", "properties": {"eventSourceResourceId":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Devices/IotHubs/cli-test-tsi-iothub000003",
+      "iotHubName": "cli-test-tsi-iothub000003", "consumerGroupName": "$Default",
+      "keyName": "iothubowner", "sharedAccessKey": "9BuhbHHHRDa9yuXwtOOZLiJhctrOUaAv4vTz0EYbNJo="}}'''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - timeseriesinsights event-source iothub create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '466'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g --environment-name --name --consumer-group-name --key-name --shared-access-key
+        --event-source-resource-id
+      User-Agent:
+      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000004/eventSources/cli-test-tsi-es000002?api-version=2018-08-15-preview
+  response:
+    body:
+      string: '{"kind":"Microsoft.IoTHub","location":"westus","tags":null,"properties":{"eventSourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Devices/IotHubs/cli-test-tsi-iothub000003","iotHubName":"cli-test-tsi-iothub000003","consumerGroupName":"$Default","keyName":"iothubowner","creationTime":"2020-05-18T07:08:52.3709605Z","provisioningState":"Succeeded"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000004/eventsources/cli-test-tsi-es000002","name":"cli-test-tsi-es000002","type":"Microsoft.TimeSeriesInsights/Environments/EventSources"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '840'
+      content-type:
+      - application/json
+      date:
+      - Mon, 18 May 2020 07:08:53 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1190'
     status:
       code: 200
       message: OK
@@ -662,14 +717,14 @@ interactions:
         --event-source-resource-id --timestamp-property-name
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_timeseriesinsights000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001","name":"cli_test_timeseriesinsights000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-04-23T08:52:27Z","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001","name":"cli_test_timeseriesinsights000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-05-18T07:05:29Z","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -678,7 +733,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 23 Apr 2020 08:56:20 GMT
+      - Mon, 18 May 2020 07:08:54 GMT
       expires:
       - '-1'
       pragma:
@@ -694,9 +749,9 @@ interactions:
       message: OK
 - request:
     body: 'b''{"location": "westus", "kind": "Microsoft.IoTHub", "properties": {"timestampPropertyName":
-      "DeviceId", "eventSourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Devices/IotHubs/cli-test-tsi-iothub000003",
+      "timestampProp", "eventSourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Devices/IotHubs/cli-test-tsi-iothub000003",
       "iotHubName": "cli-test-tsi-iothub000003", "consumerGroupName": "$Default",
-      "keyName": "iothubowner", "sharedAccessKey": "TDulTUXa7mEtEL0wtQM6C4yKUJNwW6EB49ZjRMTHwnI="}}'''
+      "keyName": "iothubowner", "sharedAccessKey": "9BuhbHHHRDa9yuXwtOOZLiJhctrOUaAv4vTz0EYbNJo="}}'''
     headers:
       Accept:
       - application/json
@@ -707,7 +762,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '503'
+      - '508'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
@@ -715,24 +770,23 @@ interactions:
         --event-source-resource-id --timestamp-property-name
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000004/eventSources/cli-test-tsi-es000002?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"kind":"Microsoft.IoTHub","location":"westus","tags":null,"properties":{"timestampPropertyName":"DeviceId","eventSourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Devices/IotHubs/cli-test-tsi-iothub000003","iotHubName":"cli-test-tsi-iothub000003","consumerGroupName":"$Default","keyName":"iothubowner","creationTime":"Thu,
-        23 Apr 2020 08:56:26 GMT","provisioningState":"Succeeded"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000004/eventsources/cli-test-tsi-es000002","name":"cli-test-tsi-es000002","type":"Microsoft.TimeSeriesInsights/Environments/EventSources"}'
+      string: '{"kind":"Microsoft.IoTHub","location":"westus","tags":null,"properties":{"timestampPropertyName":"timestampProp","eventSourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Devices/IotHubs/cli-test-tsi-iothub000003","iotHubName":"cli-test-tsi-iothub000003","consumerGroupName":"$Default","keyName":"iothubowner","creationTime":"2020-05-18T07:08:52.3709605Z","provisioningState":"Succeeded"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000004/eventsources/cli-test-tsi-es000002","name":"cli-test-tsi-es000002","type":"Microsoft.TimeSeriesInsights/Environments/EventSources"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '876'
+      - '880'
       content-type:
       - application/json
       date:
-      - Thu, 23 Apr 2020 08:56:27 GMT
+      - Mon, 18 May 2020 07:08:56 GMT
       expires:
       - '-1'
       pragma:
@@ -748,7 +802,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1191'
+      - '1190'
     status:
       code: 200
       message: OK
@@ -771,24 +825,23 @@ interactions:
       - -g --environment-name --name --timestamp-property-name
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000004/eventSources/cli-test-tsi-es000002?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"kind":"Microsoft.IoTHub","location":"westus","tags":null,"properties":{"timestampPropertyName":"DeviceId1","eventSourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Devices/IotHubs/cli-test-tsi-iothub000003","iotHubName":"cli-test-tsi-iothub000003","consumerGroupName":"$Default","keyName":"iothubowner","creationTime":"Thu,
-        23 Apr 2020 08:56:26 GMT","provisioningState":"Succeeded"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000004/eventsources/cli-test-tsi-es000002","name":"cli-test-tsi-es000002","type":"Microsoft.TimeSeriesInsights/Environments/EventSources"}'
+      string: '{"kind":"Microsoft.IoTHub","location":"westus","tags":null,"properties":{"timestampPropertyName":"DeviceId1","eventSourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Devices/IotHubs/cli-test-tsi-iothub000003","iotHubName":"cli-test-tsi-iothub000003","consumerGroupName":"$Default","keyName":"iothubowner","creationTime":"2020-05-18T07:08:52.3709605Z","provisioningState":"Succeeded"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000004/eventsources/cli-test-tsi-es000002","name":"cli-test-tsi-es000002","type":"Microsoft.TimeSeriesInsights/Environments/EventSources"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '877'
+      - '876'
       content-type:
       - application/json
       date:
-      - Thu, 23 Apr 2020 08:56:31 GMT
+      - Mon, 18 May 2020 07:08:58 GMT
       expires:
       - '-1'
       pragma:
@@ -804,7 +857,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1196'
+      - '1187'
     status:
       code: 200
       message: OK
@@ -827,24 +880,23 @@ interactions:
       - -g --environment-name --name --local-timestamp-format
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000004/eventSources/cli-test-tsi-es000002?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"kind":"Microsoft.IoTHub","location":"westus","tags":null,"properties":{"timestampPropertyName":"DeviceId1","eventSourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Devices/IotHubs/cli-test-tsi-iothub000003","iotHubName":"cli-test-tsi-iothub000003","consumerGroupName":"$Default","keyName":"iothubowner","creationTime":"Thu,
-        23 Apr 2020 08:56:26 GMT","provisioningState":"Succeeded","localTimestamp":{"format":"Embedded","timezoneOffset":null}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000004/eventsources/cli-test-tsi-es000002","name":"cli-test-tsi-es000002","type":"Microsoft.TimeSeriesInsights/Environments/EventSources"}'
+      string: '{"kind":"Microsoft.IoTHub","location":"westus","tags":null,"properties":{"timestampPropertyName":"DeviceId1","eventSourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Devices/IotHubs/cli-test-tsi-iothub000003","iotHubName":"cli-test-tsi-iothub000003","consumerGroupName":"$Default","keyName":"iothubowner","creationTime":"2020-05-18T07:08:52.3709605Z","provisioningState":"Succeeded","localTimestamp":{"format":"Embedded","timezoneOffset":null}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000004/eventsources/cli-test-tsi-es000002","name":"cli-test-tsi-es000002","type":"Microsoft.TimeSeriesInsights/Environments/EventSources"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '938'
+      - '937'
       content-type:
       - application/json
       date:
-      - Thu, 23 Apr 2020 08:56:34 GMT
+      - Mon, 18 May 2020 07:09:01 GMT
       expires:
       - '-1'
       pragma:
@@ -860,7 +912,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1193'
+      - '1194'
     status:
       code: 200
       message: OK
@@ -879,7 +931,7 @@ interactions:
       - -g --hub-name -n --renew-key --query --output
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: HEAD
@@ -893,7 +945,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 23 Apr 2020 08:56:35 GMT
+      - Mon, 18 May 2020 07:09:02 GMT
       expires:
       - '-1'
       pragma:
@@ -924,11 +976,11 @@ interactions:
       - -g --hub-name -n --renew-key --query --output
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-iothub/0.11.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-iothub/0.12.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/checkNameAvailability?api-version=2019-07-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/checkNameAvailability?api-version=2020-03-01
   response:
     body:
       string: '{"nameAvailable":false,"reason":"AlreadyExists","message":"IotHub name
@@ -941,7 +993,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 23 Apr 2020 08:56:36 GMT
+      - Mon, 18 May 2020 07:09:04 GMT
       expires:
       - '-1'
       pragma:
@@ -957,7 +1009,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
     status:
       code: 200
       message: OK
@@ -976,15 +1028,15 @@ interactions:
       - -g --hub-name -n --renew-key --query --output
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-iothub/0.11.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-iothub/0.12.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Devices/IotHubs/cli-test-tsi-iothub000003?api-version=2019-07-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Devices/IotHubs/cli-test-tsi-iothub000003?api-version=2020-03-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Devices/IotHubs/cli-test-tsi-iothub000003","name":"cli-test-tsi-iothub000003","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"cli_test_timeseriesinsights000001","etag":"AAAAAA0HLQ8=","properties":{"locations":[{"location":"West
-        US","role":"primary"},{"location":"East US","role":"secondary"}],"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"cli-test-tsi-iothub000003.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"cli-test-tsi-iothub000003","endpoint":"sb://iothub-ns-cli-test-t-3301249-4bb741b8fe.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[],"storageContainers":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT5S","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Devices/IotHubs/cli-test-tsi-iothub000003","name":"cli-test-tsi-iothub000003","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"cli_test_timeseriesinsights000001","etag":"AAAAAA2+LAo=","properties":{"locations":[{"location":"West
+        US","role":"primary"},{"location":"East US","role":"secondary"}],"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"cli-test-tsi-iothub000003.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"cli-test-tsi-iothub000003","endpoint":"sb://iothub-ns-cli-test-t-3461315-188ebc2b20.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[],"storageContainers":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT5S","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}'
     headers:
       cache-control:
       - no-cache
@@ -993,7 +1045,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 23 Apr 2020 08:56:37 GMT
+      - Mon, 18 May 2020 07:09:04 GMT
       expires:
       - '-1'
       pragma:
@@ -1028,15 +1080,15 @@ interactions:
       - -g --hub-name -n --renew-key --query --output
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-iothub/0.11.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-iothub/0.12.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Devices/IotHubs/cli-test-tsi-iothub000003/listkeys?api-version=2019-07-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Devices/IotHubs/cli-test-tsi-iothub000003/listkeys?api-version=2020-03-01
   response:
     body:
-      string: '{"value":[{"keyName":"iothubowner","primaryKey":"TDulTUXa7mEtEL0wtQM6C4yKUJNwW6EB49ZjRMTHwnI=","secondaryKey":"PeBGGf/IiiQo23hAxASRJlJqQrqyJ1PXdpfdF+MMU9M=","rights":"RegistryWrite,
-        ServiceConnect, DeviceConnect"},{"keyName":"service","primaryKey":"dQLAouEOJHUz4KBBkmvhaWFEIkWZ4COrAR+NfVtD96U=","secondaryKey":"3JYW+ZuAtVmilPaqd/Vt/mTPW7yJatMpOidVbVuGWLk=","rights":"ServiceConnect"},{"keyName":"device","primaryKey":"qlEod871Un0IBPBYkljGGFCmSN/ntvc64tRyoVpdaIY=","secondaryKey":"c3BEZTAUoS8cypUbUSUjxCSFtJ9+lGdHqw1hNsZCAqs=","rights":"DeviceConnect"},{"keyName":"registryRead","primaryKey":"GywrLHwOJeigEL5K2h+2bZSk81NG8CsyigNy7durJzs=","secondaryKey":"eRPuE4ZLe4f27RgmKgaBcvP88rk2ipGw9Oohb4B4Ntk=","rights":"RegistryRead"},{"keyName":"registryReadWrite","primaryKey":"JiBa7tsVjJxH1s/WOdSDsGFpJ4xorALBZfHX1rPGtI0=","secondaryKey":"HH/9rpib42v1SwTURYc6mnS2fs3f+mU48ijF+oBgCKY=","rights":"RegistryWrite"}]}'
+      string: '{"value":[{"keyName":"iothubowner","primaryKey":"9BuhbHHHRDa9yuXwtOOZLiJhctrOUaAv4vTz0EYbNJo=","secondaryKey":"puZ4MtfWZRnaKZTx1xoMqMaHG1J9qCS+WXGXwO+bCEE=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"},{"keyName":"service","primaryKey":"bLELIemhnjk+Yw5CATypKmvJeMxXmtKLTmIprnecsOk=","secondaryKey":"WWn1SrcSLFbkhDGT+JLRNtw/gfbL3yV9ByqMeD5mjQk=","rights":"ServiceConnect"},{"keyName":"device","primaryKey":"7atGbzE4B15KmrvyjvqrrlxIF4INwkgcxPfalFTilG8=","secondaryKey":"zGzsr2rda9/CE4EWpLFgNpBOQMLyiwu8x3gCQ+yU4P4=","rights":"DeviceConnect"},{"keyName":"registryRead","primaryKey":"G0YTiX1faPxcr2C4zRUCJeCBbkOoXIZ8B7mm0pRMV0Y=","secondaryKey":"A3mwFrEFYoNncdQ44cJ+hav0HkqLw7AKmbbrLExVKM0=","rights":"RegistryRead"},{"keyName":"registryReadWrite","primaryKey":"W/rPthdImPD6OxY5Rufyxw9dv7fcaWIbZf2owIh7c/M=","secondaryKey":"CDqK+UyHFxpmhO5WuVvOddgbYMeeOhe7oVHz84rai3c=","rights":"RegistryWrite"}]}'
     headers:
       cache-control:
       - no-cache
@@ -1045,7 +1097,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 23 Apr 2020 08:56:37 GMT
+      - Mon, 18 May 2020 07:09:05 GMT
       expires:
       - '-1'
       pragma:
@@ -1061,22 +1113,22 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
+      - '1198'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"location": "westus", "tags": {}, "etag": "AAAAAA0HLQ8=", "properties":
-      {"authorizationPolicies": [{"keyName": "service", "primaryKey": "dQLAouEOJHUz4KBBkmvhaWFEIkWZ4COrAR+NfVtD96U=",
-      "secondaryKey": "3JYW+ZuAtVmilPaqd/Vt/mTPW7yJatMpOidVbVuGWLk=", "rights": "ServiceConnect"},
-      {"keyName": "device", "primaryKey": "qlEod871Un0IBPBYkljGGFCmSN/ntvc64tRyoVpdaIY=",
-      "secondaryKey": "c3BEZTAUoS8cypUbUSUjxCSFtJ9+lGdHqw1hNsZCAqs=", "rights": "DeviceConnect"},
-      {"keyName": "registryRead", "primaryKey": "GywrLHwOJeigEL5K2h+2bZSk81NG8CsyigNy7durJzs=",
-      "secondaryKey": "eRPuE4ZLe4f27RgmKgaBcvP88rk2ipGw9Oohb4B4Ntk=", "rights": "RegistryRead"},
-      {"keyName": "registryReadWrite", "primaryKey": "JiBa7tsVjJxH1s/WOdSDsGFpJ4xorALBZfHX1rPGtI0=",
-      "secondaryKey": "HH/9rpib42v1SwTURYc6mnS2fs3f+mU48ijF+oBgCKY=", "rights": "RegistryWrite"},
-      {"keyName": "iothubowner", "primaryKey": "T1syLFUsG1NZG2hgVjkQZ28aLC4mbQ91HGpkdlRxeVc=",
-      "secondaryKey": "PeBGGf/IiiQo23hAxASRJlJqQrqyJ1PXdpfdF+MMU9M=", "rights": "RegistryWrite,
+    body: '{"location": "westus", "tags": {}, "etag": "AAAAAA2+LAo=", "properties":
+      {"authorizationPolicies": [{"keyName": "service", "primaryKey": "bLELIemhnjk+Yw5CATypKmvJeMxXmtKLTmIprnecsOk=",
+      "secondaryKey": "WWn1SrcSLFbkhDGT+JLRNtw/gfbL3yV9ByqMeD5mjQk=", "rights": "ServiceConnect"},
+      {"keyName": "device", "primaryKey": "7atGbzE4B15KmrvyjvqrrlxIF4INwkgcxPfalFTilG8=",
+      "secondaryKey": "zGzsr2rda9/CE4EWpLFgNpBOQMLyiwu8x3gCQ+yU4P4=", "rights": "DeviceConnect"},
+      {"keyName": "registryRead", "primaryKey": "G0YTiX1faPxcr2C4zRUCJeCBbkOoXIZ8B7mm0pRMV0Y=",
+      "secondaryKey": "A3mwFrEFYoNncdQ44cJ+hav0HkqLw7AKmbbrLExVKM0=", "rights": "RegistryRead"},
+      {"keyName": "registryReadWrite", "primaryKey": "W/rPthdImPD6OxY5Rufyxw9dv7fcaWIbZf2owIh7c/M=",
+      "secondaryKey": "CDqK+UyHFxpmhO5WuVvOddgbYMeeOhe7oVHz84rai3c=", "rights": "RegistryWrite"},
+      {"keyName": "iothubowner", "primaryKey": "LAVpWjRcU0xpam42amEzPhgCTx4eXFhcew8PcA5jG3c=",
+      "secondaryKey": "puZ4MtfWZRnaKZTx1xoMqMaHG1J9qCS+WXGXwO+bCEE=", "rights": "RegistryWrite,
       ServiceConnect, DeviceConnect"}], "ipFilterRules": [], "eventHubEndpoints":
       {"events": {"retentionTimeInDays": 1, "partitionCount": 4}}, "routing": {"endpoints":
       {"serviceBusQueues": [], "serviceBusTopics": [], "eventHubs": [], "storageContainers":
@@ -1102,27 +1154,27 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       If-Match:
-      - '{''IF-MATCH'': ''AAAAAA0HLQ8=''}'
+      - '{''IF-MATCH'': ''AAAAAA2+LAo=''}'
       ParameterSetName:
       - -g --hub-name -n --renew-key --query --output
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-iothub/0.11.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-iothub/0.12.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Devices/IotHubs/cli-test-tsi-iothub000003?api-version=2019-07-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Devices/IotHubs/cli-test-tsi-iothub000003?api-version=2020-03-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Devices/IotHubs/cli-test-tsi-iothub000003","name":"cli-test-tsi-iothub000003","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"cli_test_timeseriesinsights000001","etag":"AAAAAA0HLQ8=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"provisioningState":"Accepted","authorizationPolicies":[{"keyName":"service","primaryKey":"dQLAouEOJHUz4KBBkmvhaWFEIkWZ4COrAR+NfVtD96U=","secondaryKey":"3JYW+ZuAtVmilPaqd/Vt/mTPW7yJatMpOidVbVuGWLk=","rights":"ServiceConnect"},{"keyName":"device","primaryKey":"qlEod871Un0IBPBYkljGGFCmSN/ntvc64tRyoVpdaIY=","secondaryKey":"c3BEZTAUoS8cypUbUSUjxCSFtJ9+lGdHqw1hNsZCAqs=","rights":"DeviceConnect"},{"keyName":"registryRead","primaryKey":"GywrLHwOJeigEL5K2h+2bZSk81NG8CsyigNy7durJzs=","secondaryKey":"eRPuE4ZLe4f27RgmKgaBcvP88rk2ipGw9Oohb4B4Ntk=","rights":"RegistryRead"},{"keyName":"registryReadWrite","primaryKey":"JiBa7tsVjJxH1s/WOdSDsGFpJ4xorALBZfHX1rPGtI0=","secondaryKey":"HH/9rpib42v1SwTURYc6mnS2fs3f+mU48ijF+oBgCKY=","rights":"RegistryWrite"},{"keyName":"iothubowner","primaryKey":"T1syLFUsG1NZG2hgVjkQZ28aLC4mbQ91HGpkdlRxeVc=","secondaryKey":"PeBGGf/IiiQo23hAxASRJlJqQrqyJ1PXdpfdF+MMU9M=","rights":"RegistryWrite,
-        ServiceConnect, DeviceConnect"}],"ipFilterRules":[],"eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"cli-test-tsi-iothub000003-operationmonitoring","endpoint":"sb://iothub-ns-cli-test-t-3301249-4bb741b8fe.servicebus.windows.net/","internalAuthorizationPolicies":[{"KeyName":"scaleunitsend-14987bca-fb0e-40ec-bf21-84cfca6aa1b0-iothub","PrimaryKey":"wbPTKsgPj/vxNaqtZOPayqvOr0ohIgfTgN66If90t/M=","SecondaryKey":"FmtNTVqiTKH75wu2b1MTYjHQjjRANjvrcHmUw25bF+M=","ClaimType":"SharedAccessKey","ClaimValue":"None","Rights":["Send"],"CreatedTime":"Thu,
-        23 Apr 2020 08:56:08 GMT","ModifiedTime":"Thu, 23 Apr 2020 08:56:08 GMT"},{"KeyName":"owner-fb1dd4e5-3660-46a9-a75b-64426209f281-iothub","PrimaryKey":"srCLf/teUitR2iNzCFFE23+ueEIWdVmwjpFRHbnyZNY=","SecondaryKey":"69u1coU+p9T7PpzyciVJUIy6u2fbPC9iTciu6kVdMNk=","ClaimType":"SharedAccessKey","ClaimValue":"None","Rights":["Listen","Manage","Send"],"CreatedTime":"Thu,
-        23 Apr 2020 08:56:08 GMT","ModifiedTime":"Thu, 23 Apr 2020 08:56:08 GMT"}],"authorizationPolicies":[{"KeyName":"iothubowner","PrimaryKey":"TDulTUXa7mEtEL0wtQM6C4yKUJNwW6EB49ZjRMTHwnI=","SecondaryKey":"PeBGGf/IiiQo23hAxASRJlJqQrqyJ1PXdpfdF+MMU9M=","ClaimType":"SharedAccessKey","ClaimValue":"None","Rights":["Listen"],"CreatedTime":"Thu,
-        23 Apr 2020 08:56:08 GMT","ModifiedTime":"Thu, 23 Apr 2020 08:56:08 GMT"},{"KeyName":"service","PrimaryKey":"dQLAouEOJHUz4KBBkmvhaWFEIkWZ4COrAR+NfVtD96U=","SecondaryKey":"3JYW+ZuAtVmilPaqd/Vt/mTPW7yJatMpOidVbVuGWLk=","ClaimType":"SharedAccessKey","ClaimValue":"None","Rights":["Listen"],"CreatedTime":"Thu,
-        23 Apr 2020 08:56:08 GMT","ModifiedTime":"Thu, 23 Apr 2020 08:56:08 GMT"}]}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[],"storageContainers":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT5S","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Devices/IotHubs/cli-test-tsi-iothub000003","name":"cli-test-tsi-iothub000003","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"cli_test_timeseriesinsights000001","etag":"AAAAAA2+LAo=","properties":{"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"provisioningState":"Accepted","authorizationPolicies":[{"keyName":"service","primaryKey":"bLELIemhnjk+Yw5CATypKmvJeMxXmtKLTmIprnecsOk=","secondaryKey":"WWn1SrcSLFbkhDGT+JLRNtw/gfbL3yV9ByqMeD5mjQk=","rights":"ServiceConnect"},{"keyName":"device","primaryKey":"7atGbzE4B15KmrvyjvqrrlxIF4INwkgcxPfalFTilG8=","secondaryKey":"zGzsr2rda9/CE4EWpLFgNpBOQMLyiwu8x3gCQ+yU4P4=","rights":"DeviceConnect"},{"keyName":"registryRead","primaryKey":"G0YTiX1faPxcr2C4zRUCJeCBbkOoXIZ8B7mm0pRMV0Y=","secondaryKey":"A3mwFrEFYoNncdQ44cJ+hav0HkqLw7AKmbbrLExVKM0=","rights":"RegistryRead"},{"keyName":"registryReadWrite","primaryKey":"W/rPthdImPD6OxY5Rufyxw9dv7fcaWIbZf2owIh7c/M=","secondaryKey":"CDqK+UyHFxpmhO5WuVvOddgbYMeeOhe7oVHz84rai3c=","rights":"RegistryWrite"},{"keyName":"iothubowner","primaryKey":"LAVpWjRcU0xpam42amEzPhgCTx4eXFhcew8PcA5jG3c=","secondaryKey":"puZ4MtfWZRnaKZTx1xoMqMaHG1J9qCS+WXGXwO+bCEE=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"}],"ipFilterRules":[],"eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"cli-test-tsi-iothub000003-operationmonitoring","endpoint":"sb://iothub-ns-cli-test-t-3461315-188ebc2b20.servicebus.windows.net/","internalAuthorizationPolicies":[{"KeyName":"scaleunitsend-60b9a1f6-2453-4776-b1be-e83b09fa3b2d-iothub","PrimaryKey":"T9nRN7RE73qmfVEI4fqcoEPnaghcdXLgPw6yfvZ0vBY=","SecondaryKey":"197AOuWEIFth1vD0PH4cfDOajJo6OXKQdZSohvs9uLI=","ClaimType":"SharedAccessKey","ClaimValue":"None","Rights":["Send"],"CreatedTime":"Mon,
+        18 May 2020 07:08:09 GMT","ModifiedTime":"Mon, 18 May 2020 07:08:09 GMT"},{"KeyName":"owner-ec036545-b12b-41ec-9188-5f37fe31e3ee-iothub","PrimaryKey":"n6/7RJBry2XZNask8KflxpEjBA2bYxRNa/MExvd4xk8=","SecondaryKey":"n5mceCSM5hHQBKZUcDR8y0cWbicj+HVa8D6rrs0e2Go=","ClaimType":"SharedAccessKey","ClaimValue":"None","Rights":["Listen","Manage","Send"],"CreatedTime":"Mon,
+        18 May 2020 07:08:09 GMT","ModifiedTime":"Mon, 18 May 2020 07:08:09 GMT"}],"authorizationPolicies":[{"KeyName":"iothubowner","PrimaryKey":"9BuhbHHHRDa9yuXwtOOZLiJhctrOUaAv4vTz0EYbNJo=","SecondaryKey":"puZ4MtfWZRnaKZTx1xoMqMaHG1J9qCS+WXGXwO+bCEE=","ClaimType":"SharedAccessKey","ClaimValue":"None","Rights":["Listen"],"CreatedTime":"Mon,
+        18 May 2020 07:08:09 GMT","ModifiedTime":"Mon, 18 May 2020 07:08:09 GMT"},{"KeyName":"service","PrimaryKey":"bLELIemhnjk+Yw5CATypKmvJeMxXmtKLTmIprnecsOk=","SecondaryKey":"WWn1SrcSLFbkhDGT+JLRNtw/gfbL3yV9ByqMeD5mjQk=","ClaimType":"SharedAccessKey","ClaimValue":"None","Rights":["Listen"],"CreatedTime":"Mon,
+        18 May 2020 07:08:09 GMT","ModifiedTime":"Mon, 18 May 2020 07:08:09 GMT"}]}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[],"storageContainers":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT5S","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/operationResults/b3NfaWhfNWIzODBjNTctYjIzNy00N2EwLTg3NmYtMGZlMmEzN2E4OGJl?api-version=2019-07-01-preview&operationSource=os_ih&asyncinfo
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/operationResults/b3NfaWhfOWUxNzg4MzMtZDc4My00NjE5LWFmNTYtYTEwMGQ5ZDM0YjZi?api-version=2020-03-01&operationSource=os_ih&asyncinfo
       cache-control:
       - no-cache
       content-length:
@@ -1130,7 +1182,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 23 Apr 2020 08:56:44 GMT
+      - Mon, 18 May 2020 07:09:11 GMT
       expires:
       - '-1'
       pragma:
@@ -1161,9 +1213,9 @@ interactions:
       - -g --hub-name -n --renew-key --query --output
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-iothub/0.11.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-iothub/0.12.0 Azure-SDK-For-Python AZURECLI/2.6.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/operationResults/b3NfaWhfNWIzODBjNTctYjIzNy00N2EwLTg3NmYtMGZlMmEzN2E4OGJl?api-version=2019-07-01-preview&operationSource=os_ih&asyncinfo
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/operationResults/b3NfaWhfOWUxNzg4MzMtZDc4My00NjE5LWFmNTYtYTEwMGQ5ZDM0YjZi?api-version=2020-03-01&operationSource=os_ih&asyncinfo
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -1175,7 +1227,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 23 Apr 2020 08:57:16 GMT
+      - Mon, 18 May 2020 07:09:42 GMT
       expires:
       - '-1'
       pragma:
@@ -1208,22 +1260,22 @@ interactions:
       - -g --hub-name -n --renew-key --query --output
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-iothub/0.11.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-iothub/0.12.0 Azure-SDK-For-Python AZURECLI/2.6.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Devices/IotHubs/cli-test-tsi-iothub000003?api-version=2019-07-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Devices/IotHubs/cli-test-tsi-iothub000003?api-version=2020-03-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Devices/IotHubs/cli-test-tsi-iothub000003","name":"cli-test-tsi-iothub000003","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"cli_test_timeseriesinsights000001","etag":"AAAAAA0HLgM=","properties":{"locations":[{"location":"West
-        US","role":"primary"},{"location":"East US","role":"secondary"}],"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"cli-test-tsi-iothub000003.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"cli-test-tsi-iothub000003","endpoint":"sb://iothub-ns-cli-test-t-3301249-4bb741b8fe.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[],"storageContainers":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT5S","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Devices/IotHubs/cli-test-tsi-iothub000003","name":"cli-test-tsi-iothub000003","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"cli_test_timeseriesinsights000001","etag":"AAAAAA2+La0=","properties":{"locations":[{"location":"West
+        US","role":"primary"},{"location":"East US","role":"secondary"}],"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"cli-test-tsi-iothub000003.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"cli-test-tsi-iothub000003","endpoint":"sb://iothub-ns-cli-test-t-3461315-188ebc2b20.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[],"storageContainers":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT5S","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None"},"sku":{"name":"S1","tier":"Standard","capacity":1},"identity":{"principalId":null,"tenantId":null,"type":"None"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1673'
+      - '1735'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 23 Apr 2020 08:57:16 GMT
+      - Mon, 18 May 2020 07:09:43 GMT
       expires:
       - '-1'
       pragma:
@@ -1258,14 +1310,14 @@ interactions:
       - -g --hub-name -n --renew-key --query --output
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-iothub/0.11.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-iothub/0.12.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Devices/IotHubs/cli-test-tsi-iothub000003/IotHubKeys/iothubowner/listkeys?api-version=2019-07-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Devices/IotHubs/cli-test-tsi-iothub000003/IotHubKeys/iothubowner/listkeys?api-version=2020-03-01
   response:
     body:
-      string: '{"keyName":"iothubowner","primaryKey":"T1syLFUsG1NZG2hgVjkQZ28aLC4mbQ91HGpkdlRxeVc=","secondaryKey":"PeBGGf/IiiQo23hAxASRJlJqQrqyJ1PXdpfdF+MMU9M=","rights":"RegistryWrite,
+      string: '{"keyName":"iothubowner","primaryKey":"LAVpWjRcU0xpam42amEzPhgCTx4eXFhcew8PcA5jG3c=","secondaryKey":"puZ4MtfWZRnaKZTx1xoMqMaHG1J9qCS+WXGXwO+bCEE=","rights":"RegistryWrite,
         ServiceConnect, DeviceConnect"}'
     headers:
       cache-control:
@@ -1275,7 +1327,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 23 Apr 2020 08:57:17 GMT
+      - Mon, 18 May 2020 07:09:45 GMT
       expires:
       - '-1'
       pragma:
@@ -1291,12 +1343,12 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1196'
+      - '1197'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"properties": {"sharedAccessKey": "T1syLFUsG1NZG2hgVjkQZ28aLC4mbQ91HGpkdlRxeVc="}}'
+    body: '{"properties": {"sharedAccessKey": "LAVpWjRcU0xpam42amEzPhgCTx4eXFhcew8PcA5jG3c="}}'
     headers:
       Accept:
       - application/json
@@ -1314,24 +1366,23 @@ interactions:
       - -g --environment-name --name --shared-access-key
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000004/eventSources/cli-test-tsi-es000002?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"kind":"Microsoft.IoTHub","location":"westus","tags":null,"properties":{"timestampPropertyName":"DeviceId1","eventSourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Devices/IotHubs/cli-test-tsi-iothub000003","iotHubName":"cli-test-tsi-iothub000003","consumerGroupName":"$Default","keyName":"iothubowner","creationTime":"Thu,
-        23 Apr 2020 08:56:26 GMT","provisioningState":"Succeeded","localTimestamp":{"format":"Embedded","timezoneOffset":null}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000004/eventsources/cli-test-tsi-es000002","name":"cli-test-tsi-es000002","type":"Microsoft.TimeSeriesInsights/Environments/EventSources"}'
+      string: '{"kind":"Microsoft.IoTHub","location":"westus","tags":null,"properties":{"timestampPropertyName":"DeviceId1","eventSourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Devices/IotHubs/cli-test-tsi-iothub000003","iotHubName":"cli-test-tsi-iothub000003","consumerGroupName":"$Default","keyName":"iothubowner","creationTime":"2020-05-18T07:08:52.3709605Z","provisioningState":"Succeeded","localTimestamp":{"format":"Embedded","timezoneOffset":null}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000004/eventsources/cli-test-tsi-es000002","name":"cli-test-tsi-es000002","type":"Microsoft.TimeSeriesInsights/Environments/EventSources"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '938'
+      - '937'
       content-type:
       - application/json
       date:
-      - Thu, 23 Apr 2020 08:57:20 GMT
+      - Mon, 18 May 2020 07:09:47 GMT
       expires:
       - '-1'
       pragma:
@@ -1347,7 +1398,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1190'
+      - '1187'
     status:
       code: 200
       message: OK
@@ -1366,24 +1417,23 @@ interactions:
       - -g --environment-name
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000004/eventSources?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"value":[{"kind":"Microsoft.IoTHub","location":"westus","tags":null,"properties":{"timestampPropertyName":"DeviceId1","eventSourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Devices/IotHubs/cli-test-tsi-iothub000003","iotHubName":"cli-test-tsi-iothub000003","consumerGroupName":"$Default","keyName":"iothubowner","creationTime":"Thu,
-        23 Apr 2020 08:56:26 GMT","provisioningState":"Succeeded","localTimestamp":{"format":"Embedded","timezoneOffset":null}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000004/eventsources/cli-test-tsi-es000002","name":"cli-test-tsi-es000002","type":"Microsoft.TimeSeriesInsights/Environments/EventSources"}]}'
+      string: '{"value":[{"kind":"Microsoft.IoTHub","location":"westus","tags":null,"properties":{"timestampPropertyName":"DeviceId1","eventSourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Devices/IotHubs/cli-test-tsi-iothub000003","iotHubName":"cli-test-tsi-iothub000003","consumerGroupName":"$Default","keyName":"iothubowner","creationTime":"2020-05-18T07:08:52.3709605Z","provisioningState":"Succeeded","localTimestamp":{"format":"Embedded","timezoneOffset":null}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000004/eventsources/cli-test-tsi-es000002","name":"cli-test-tsi-es000002","type":"Microsoft.TimeSeriesInsights/Environments/EventSources"}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '950'
+      - '949'
       content-type:
       - application/json
       date:
-      - Thu, 23 Apr 2020 08:57:22 GMT
+      - Mon, 18 May 2020 07:09:50 GMT
       expires:
       - '-1'
       pragma:
@@ -1416,24 +1466,23 @@ interactions:
       - -g --environment-name -n
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000004/eventSources/cli-test-tsi-es000002?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"kind":"Microsoft.IoTHub","location":"westus","tags":null,"properties":{"timestampPropertyName":"DeviceId1","eventSourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Devices/IotHubs/cli-test-tsi-iothub000003","iotHubName":"cli-test-tsi-iothub000003","consumerGroupName":"$Default","keyName":"iothubowner","creationTime":"Thu,
-        23 Apr 2020 08:56:26 GMT","provisioningState":"Succeeded","localTimestamp":{"format":"Embedded","timezoneOffset":null}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000004/eventsources/cli-test-tsi-es000002","name":"cli-test-tsi-es000002","type":"Microsoft.TimeSeriesInsights/Environments/EventSources"}'
+      string: '{"kind":"Microsoft.IoTHub","location":"westus","tags":null,"properties":{"timestampPropertyName":"DeviceId1","eventSourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.Devices/IotHubs/cli-test-tsi-iothub000003","iotHubName":"cli-test-tsi-iothub000003","consumerGroupName":"$Default","keyName":"iothubowner","creationTime":"2020-05-18T07:08:52.3709605Z","provisioningState":"Succeeded","localTimestamp":{"format":"Embedded","timezoneOffset":null}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000004/eventsources/cli-test-tsi-es000002","name":"cli-test-tsi-es000002","type":"Microsoft.TimeSeriesInsights/Environments/EventSources"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '938'
+      - '937'
       content-type:
       - application/json
       date:
-      - Thu, 23 Apr 2020 08:57:26 GMT
+      - Mon, 18 May 2020 07:09:52 GMT
       expires:
       - '-1'
       pragma:
@@ -1465,10 +1514,10 @@ interactions:
       Content-Length:
       - '0'
       ParameterSetName:
-      - -g --environment-name -n
+      - -g --environment-name -n --yes
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: DELETE
@@ -1482,7 +1531,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 23 Apr 2020 08:57:31 GMT
+      - Mon, 18 May 2020 07:09:57 GMT
       expires:
       - '-1'
       pragma:
@@ -1494,7 +1543,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-deletes:
-      - '14998'
+      - '14997'
     status:
       code: 200
       message: OK

--- a/src/timeseriesinsights/azext_timeseriesinsights/tests/latest/recordings/test_timeseriesinsights_reference_data_set.yaml
+++ b/src/timeseriesinsights/azext_timeseriesinsights/tests/latest/recordings/test_timeseriesinsights_reference_data_set.yaml
@@ -15,14 +15,14 @@ interactions:
         --storage-limit-exceeded-behavior
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_timeseriesinsights000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001","name":"cli_test_timeseriesinsights000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-04-23T08:52:27Z","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001","name":"cli_test_timeseriesinsights000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-05-18T07:05:29Z","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -31,7 +31,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 23 Apr 2020 08:52:33 GMT
+      - Mon, 18 May 2020 07:05:34 GMT
       expires:
       - '-1'
       pragma:
@@ -67,23 +67,23 @@ interactions:
         --storage-limit-exceeded-behavior
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P31D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-04-23T08:52:45+00:00","provisioningState":"Accepted","dataAccessId":"19d80b62-5ad8-413d-b006-9a81ba3dd670","dataAccessFqdn":"19d80b62-5ad8-413d-b006-9a81ba3dd670.env.timeseries.azure.com","requestApiVersion":"2018-08-15-preview"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003","name":"cli-test-tsi-env000003","type":"Microsoft.TimeSeriesInsights/Environments"}'
+      string: '{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P31D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-05-18T07:05:41.1766404+00:00","provisioningState":"Accepted","dataAccessId":"a096910d-50b3-492e-a5f0-7e82868516c8","dataAccessFqdn":"a096910d-50b3-492e-a5f0-7e82868516c8.env.timeseries.azure.com","requestApiVersion":"2018-08-15-preview"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003","name":"cli-test-tsi-env000003","type":"Microsoft.TimeSeriesInsights/Environments"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '798'
+      - '806'
       content-type:
       - application/json
       date:
-      - Thu, 23 Apr 2020 08:52:59 GMT
+      - Mon, 18 May 2020 07:05:42 GMT
       expires:
       - '-1'
       pragma:
@@ -95,7 +95,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1192'
+      - '1190'
     status:
       code: 201
       message: Created
@@ -115,13 +115,12 @@ interactions:
         --storage-limit-exceeded-behavior
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P31D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"Thu,
-        23 Apr 2020 08:52:45 GMT","provisioningState":"Creating","requestApiVersion":"2018-08-15-preview","dataAccessId":"19d80b62-5ad8-413d-b006-9a81ba3dd670","dataAccessFqdn":"19d80b62-5ad8-413d-b006-9a81ba3dd670.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003","name":"cli-test-tsi-env000003","type":"Microsoft.TimeSeriesInsights/Environments"}'
+      string: '{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P31D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-05-18T07:05:41.1766404Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"a096910d-50b3-492e-a5f0-7e82868516c8","dataAccessFqdn":"a096910d-50b3-492e-a5f0-7e82868516c8.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003","name":"cli-test-tsi-env000003","type":"Microsoft.TimeSeriesInsights/Environments"}'
     headers:
       cache-control:
       - no-cache
@@ -130,56 +129,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 23 Apr 2020 08:53:30 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - timeseriesinsights environment standard create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --resource-group --name --sku-name --sku-capacity --data-retention-time --partition-key-properties
-        --storage-limit-exceeded-behavior
-      User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003?api-version=2018-08-15-preview
-  response:
-    body:
-      string: '{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P31D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"Thu,
-        23 Apr 2020 08:52:45 GMT","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"19d80b62-5ad8-413d-b006-9a81ba3dd670","dataAccessFqdn":"19d80b62-5ad8-413d-b006-9a81ba3dd670.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003","name":"cli-test-tsi-env000003","type":"Microsoft.TimeSeriesInsights/Environments"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '803'
-      content-type:
-      - application/json
-      date:
-      - Thu, 23 Apr 2020 08:54:01 GMT
+      - Mon, 18 May 2020 07:06:14 GMT
       expires:
       - '-1'
       pragma:
@@ -212,14 +162,14 @@ interactions:
       - -g --environment-name --name --key-properties --data-string-comparison-behavior
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_timeseriesinsights000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001","name":"cli_test_timeseriesinsights000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-04-23T08:52:27Z","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001","name":"cli_test_timeseriesinsights000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-05-18T07:05:29Z","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -228,7 +178,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 23 Apr 2020 08:54:03 GMT
+      - Mon, 18 May 2020 07:06:15 GMT
       expires:
       - '-1'
       pragma:
@@ -263,24 +213,23 @@ interactions:
       - -g --environment-name --name --key-properties --data-string-comparison-behavior
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003/referenceDataSets/clitesttsirds000002?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"location":"westus","tags":null,"properties":{"keyProperties":[{"name":"DeviceId1","type":"String"},{"name":"DeviceFloor","type":"Double"}],"dataStringComparisonBehavior":"Ordinal","creationTime":"Thu,
-        23 Apr 2020 08:54:10 GMT","provisioningState":"Succeeded"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003/referenceDataSets/clitesttsirds000002","name":"clitesttsirds000002","type":"Microsoft.TimeSeriesInsights/Environments/ReferenceDataSets"}'
+      string: '{"location":"westus","tags":null,"properties":{"keyProperties":[{"name":"DeviceId1","type":"String"},{"name":"DeviceFloor","type":"Double"}],"dataStringComparisonBehavior":"Ordinal","creationTime":"2020-05-18T07:06:18.4894874Z","provisioningState":"Succeeded"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003/referenceDataSets/clitesttsirds000002","name":"clitesttsirds000002","type":"Microsoft.TimeSeriesInsights/Environments/ReferenceDataSets"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '635'
+      - '634'
       content-type:
       - application/json
       date:
-      - Thu, 23 Apr 2020 08:54:11 GMT
+      - Mon, 18 May 2020 07:06:18 GMT
       expires:
       - '-1'
       pragma:
@@ -296,7 +245,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
+      - '1188'
     status:
       code: 200
       message: OK
@@ -319,24 +268,23 @@ interactions:
       - -g --environment-name --name --tags
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003/referenceDataSets/clitesttsirds000002?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"location":"westus","tags":{"mykey":"myvalue"},"properties":{"keyProperties":[{"name":"DeviceId1","type":"String"},{"name":"DeviceFloor","type":"Double"}],"dataStringComparisonBehavior":"Ordinal","creationTime":"Thu,
-        23 Apr 2020 08:54:10 GMT","provisioningState":"Succeeded"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003/referenceDataSets/clitesttsirds000002","name":"clitesttsirds000002","type":"Microsoft.TimeSeriesInsights/Environments/ReferenceDataSets"}'
+      string: '{"location":"westus","tags":{"mykey":"myvalue"},"properties":{"keyProperties":[{"name":"DeviceId1","type":"String"},{"name":"DeviceFloor","type":"Double"}],"dataStringComparisonBehavior":"Ordinal","creationTime":"2020-05-18T07:06:18.4894874Z","provisioningState":"Succeeded"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003/referenceDataSets/clitesttsirds000002","name":"clitesttsirds000002","type":"Microsoft.TimeSeriesInsights/Environments/ReferenceDataSets"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '650'
+      - '649'
       content-type:
       - application/json
       date:
-      - Thu, 23 Apr 2020 08:54:15 GMT
+      - Mon, 18 May 2020 07:06:36 GMT
       expires:
       - '-1'
       pragma:
@@ -352,7 +300,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1195'
+      - '1187'
     status:
       code: 200
       message: OK
@@ -371,24 +319,23 @@ interactions:
       - -g --environment-name
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003/referenceDataSets?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"value":[{"location":"westus","tags":{"mykey":"myvalue"},"properties":{"keyProperties":[{"name":"DeviceId1","type":"String"},{"name":"DeviceFloor","type":"Double"}],"dataStringComparisonBehavior":"Ordinal","creationTime":"Thu,
-        23 Apr 2020 08:54:10 GMT","provisioningState":"Succeeded"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003/referenceDataSets/clitesttsirds000002","name":"clitesttsirds000002","type":"Microsoft.TimeSeriesInsights/Environments/ReferenceDataSets"}]}'
+      string: '{"value":[{"location":"westus","tags":{"mykey":"myvalue"},"properties":{"keyProperties":[{"name":"DeviceId1","type":"String"},{"name":"DeviceFloor","type":"Double"}],"dataStringComparisonBehavior":"Ordinal","creationTime":"2020-05-18T07:06:18.4894874Z","provisioningState":"Succeeded"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003/referenceDataSets/clitesttsirds000002","name":"clitesttsirds000002","type":"Microsoft.TimeSeriesInsights/Environments/ReferenceDataSets"}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '662'
+      - '661'
       content-type:
       - application/json
       date:
-      - Thu, 23 Apr 2020 08:54:18 GMT
+      - Mon, 18 May 2020 07:06:38 GMT
       expires:
       - '-1'
       pragma:
@@ -421,24 +368,23 @@ interactions:
       - -g --environment-name -n
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003/referenceDataSets/clitesttsirds000002?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"location":"westus","tags":{"mykey":"myvalue"},"properties":{"keyProperties":[{"name":"DeviceId1","type":"String"},{"name":"DeviceFloor","type":"Double"}],"dataStringComparisonBehavior":"Ordinal","creationTime":"Thu,
-        23 Apr 2020 08:54:10 GMT","provisioningState":"Succeeded"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003/referenceDataSets/clitesttsirds000002","name":"clitesttsirds000002","type":"Microsoft.TimeSeriesInsights/Environments/ReferenceDataSets"}'
+      string: '{"location":"westus","tags":{"mykey":"myvalue"},"properties":{"keyProperties":[{"name":"DeviceId1","type":"String"},{"name":"DeviceFloor","type":"Double"}],"dataStringComparisonBehavior":"Ordinal","creationTime":"2020-05-18T07:06:18.4894874Z","provisioningState":"Succeeded"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003/referenceDataSets/clitesttsirds000002","name":"clitesttsirds000002","type":"Microsoft.TimeSeriesInsights/Environments/ReferenceDataSets"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '650'
+      - '649'
       content-type:
       - application/json
       date:
-      - Thu, 23 Apr 2020 08:54:20 GMT
+      - Mon, 18 May 2020 07:06:40 GMT
       expires:
       - '-1'
       pragma:
@@ -470,10 +416,10 @@ interactions:
       Content-Length:
       - '0'
       ParameterSetName:
-      - -g --environment-name -n
+      - -g --environment-name -n --yes
       User-Agent:
       - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
       accept-language:
       - en-US
     method: DELETE
@@ -487,7 +433,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 23 Apr 2020 08:54:28 GMT
+      - Mon, 18 May 2020 07:06:46 GMT
       expires:
       - '-1'
       pragma:
@@ -499,7 +445,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-deletes:
-      - '14999'
+      - '14995'
     status:
       code: 200
       message: OK

--- a/src/timeseriesinsights/azext_timeseriesinsights/tests/latest/test_timeseriesinsights_scenario.py
+++ b/src/timeseriesinsights/azext_timeseriesinsights/tests/latest/test_timeseriesinsights_scenario.py
@@ -127,11 +127,20 @@ class TimeSeriesInsightsClientScenarioTest(ScenarioTest):
         result = self.cmd('az eventhubs namespace authorization-rule keys list -g {rg} --namespace-name {ehns} -n RootManageSharedAccessKey').get_output_in_json()
         self.kwargs["shared_access_key"] = result["primaryKey"]
 
+        # Test --timestamp-property-name is not given
         self.cmd('az timeseriesinsights event-source eventhub create -g {rg} --environment-name {env} --name {es} '
                  '--key-name RootManageSharedAccessKey '
                  '--shared-access-key {shared_access_key} '
                  '--event-source-resource-id {es_resource_id} '
-                 '--consumer-group-name $Default --timestamp-property-name DeviceId')
+                 '--consumer-group-name $Default',
+                 checks=[self.check('timestampPropertyName', None)])
+
+        self.cmd('az timeseriesinsights event-source eventhub create -g {rg} --environment-name {env} --name {es} '
+                 '--key-name RootManageSharedAccessKey '
+                 '--shared-access-key {shared_access_key} '
+                 '--event-source-resource-id {es_resource_id} '
+                 '--consumer-group-name $Default --timestamp-property-name timestampProp',
+                 checks=[self.check('timestampPropertyName', 'timestampProp')])
 
         self.cmd('az timeseriesinsights event-source eventhub update -g {rg} --environment-name {env} --name {es} '
                  '--timestamp-property-name DeviceId1')
@@ -176,10 +185,18 @@ class TimeSeriesInsightsClientScenarioTest(ScenarioTest):
         self.kwargs["key_name"] = "iothubowner"
         self.kwargs["shared_access_key"] = self.cmd("az iot hub policy list -g {rg} --hub-name {iothub} --query \"[?keyName=='iothubowner']\".primaryKey --output tsv").output
 
+        # Test --timestamp-property-name is not given
         self.cmd('az timeseriesinsights event-source iothub create -g {rg} --environment-name {env} --name {es} '
                  '--consumer-group-name $Default '
                  '--key-name {key_name} --shared-access-key {shared_access_key} '
-                 '--event-source-resource-id {es_resource_id} --timestamp-property-name DeviceId')
+                 '--event-source-resource-id {es_resource_id}',
+                 checks=[self.check('timestampPropertyName', None)])
+
+        self.cmd('az timeseriesinsights event-source iothub create -g {rg} --environment-name {env} --name {es} '
+                 '--consumer-group-name $Default '
+                 '--key-name {key_name} --shared-access-key {shared_access_key} '
+                 '--event-source-resource-id {es_resource_id} --timestamp-property-name timestampProp',
+                 checks=[self.check('timestampPropertyName', 'timestampProp')])
 
         self.cmd('az timeseriesinsights event-source iothub update -g {rg} --environment-name {env} --name {es} '
                  '--timestamp-property-name DeviceId1')

--- a/src/timeseriesinsights/azext_timeseriesinsights/vendored_sdks/timeseriesinsights/models/_models_py3.py
+++ b/src/timeseriesinsights/azext_timeseriesinsights/vendored_sdks/timeseriesinsights/models/_models_py3.py
@@ -181,7 +181,7 @@ class ResourceProperties(Model):
 
     _attribute_map = {
         'provisioning_state': {'key': 'provisioningState', 'type': 'str'},
-        'creation_time': {'key': 'creationTime', 'type': 'rfc-1123'},
+        'creation_time': {'key': 'creationTime', 'type': 'iso-8601'},
     }
 
     def __init__(self, *, provisioning_state=None, **kwargs) -> None:
@@ -216,7 +216,7 @@ class EventSourceCommonProperties(ResourceProperties):
 
     _attribute_map = {
         'provisioning_state': {'key': 'provisioningState', 'type': 'str'},
-        'creation_time': {'key': 'creationTime', 'type': 'rfc-1123'},
+        'creation_time': {'key': 'creationTime', 'type': 'iso-8601'},
         'timestamp_property_name': {'key': 'timestampPropertyName', 'type': 'str'},
     }
 
@@ -258,7 +258,7 @@ class AzureEventSourceProperties(EventSourceCommonProperties):
 
     _attribute_map = {
         'provisioning_state': {'key': 'provisioningState', 'type': 'str'},
-        'creation_time': {'key': 'creationTime', 'type': 'rfc-1123'},
+        'creation_time': {'key': 'creationTime', 'type': 'iso-8601'},
         'timestamp_property_name': {'key': 'timestampPropertyName', 'type': 'str'},
         'event_source_resource_id': {'key': 'eventSourceResourceId', 'type': 'str'},
     }
@@ -555,7 +555,7 @@ class EnvironmentResourceProperties(ResourceProperties):
 
     _attribute_map = {
         'provisioning_state': {'key': 'provisioningState', 'type': 'str'},
-        'creation_time': {'key': 'creationTime', 'type': 'rfc-1123'},
+        'creation_time': {'key': 'creationTime', 'type': 'iso-8601'},
         'data_access_id': {'key': 'dataAccessId', 'type': 'str'},
         'data_access_fqdn': {'key': 'dataAccessFqdn', 'type': 'str'},
         'status': {'key': 'status', 'type': 'EnvironmentStatus'},
@@ -679,7 +679,7 @@ class EventHubEventSourceCommonProperties(AzureEventSourceProperties):
 
     _attribute_map = {
         'provisioning_state': {'key': 'provisioningState', 'type': 'str'},
-        'creation_time': {'key': 'creationTime', 'type': 'rfc-1123'},
+        'creation_time': {'key': 'creationTime', 'type': 'iso-8601'},
         'timestamp_property_name': {'key': 'timestampPropertyName', 'type': 'str'},
         'event_source_resource_id': {'key': 'eventSourceResourceId', 'type': 'str'},
         'service_bus_namespace': {'key': 'serviceBusNamespace', 'type': 'str'},
@@ -799,7 +799,7 @@ class EventHubEventSourceCreateOrUpdateParameters(EventSourceCreateOrUpdateParam
         'tags': {'key': 'tags', 'type': '{str}'},
         'kind': {'key': 'kind', 'type': 'str'},
         'provisioning_state': {'key': 'properties.provisioningState', 'type': 'str'},
-        'creation_time': {'key': 'properties.creationTime', 'type': 'rfc-1123'},
+        'creation_time': {'key': 'properties.creationTime', 'type': 'iso-8601'},
         'timestamp_property_name': {'key': 'properties.timestampPropertyName', 'type': 'str'},
         'event_source_resource_id': {'key': 'properties.eventSourceResourceId', 'type': 'str'},
         'service_bus_namespace': {'key': 'properties.serviceBusNamespace', 'type': 'str'},
@@ -868,7 +868,7 @@ class EventSourceResource(TrackedResource):
     }
 
     _subtype_map = {
-        'kind': {'Microsoft.EventHub': 'EventHubEventSourceResource', 'Microsoft.IotHub': 'IoTHubEventSourceResource'}
+        'kind': {'Microsoft.EventHub': 'EventHubEventSourceResource', 'Microsoft.IoTHub': 'IoTHubEventSourceResource'}
     }
 
     def __init__(self, *, location: str, tags=None, **kwargs) -> None:
@@ -948,7 +948,7 @@ class EventHubEventSourceResource(EventSourceResource):
         'tags': {'key': 'tags', 'type': '{str}'},
         'kind': {'key': 'kind', 'type': 'str'},
         'provisioning_state': {'key': 'properties.provisioningState', 'type': 'str'},
-        'creation_time': {'key': 'properties.creationTime', 'type': 'rfc-1123'},
+        'creation_time': {'key': 'properties.creationTime', 'type': 'iso-8601'},
         'timestamp_property_name': {'key': 'properties.timestampPropertyName', 'type': 'str'},
         'event_source_resource_id': {'key': 'properties.eventSourceResourceId', 'type': 'str'},
         'service_bus_namespace': {'key': 'properties.serviceBusNamespace', 'type': 'str'},
@@ -1141,7 +1141,7 @@ class IoTHubEventSourceCommonProperties(AzureEventSourceProperties):
 
     _attribute_map = {
         'provisioning_state': {'key': 'provisioningState', 'type': 'str'},
-        'creation_time': {'key': 'creationTime', 'type': 'rfc-1123'},
+        'creation_time': {'key': 'creationTime', 'type': 'iso-8601'},
         'timestamp_property_name': {'key': 'timestampPropertyName', 'type': 'str'},
         'event_source_resource_id': {'key': 'eventSourceResourceId', 'type': 'str'},
         'iot_hub_name': {'key': 'iotHubName', 'type': 'str'},
@@ -1217,7 +1217,7 @@ class IoTHubEventSourceCreateOrUpdateParameters(EventSourceCreateOrUpdateParamet
         'tags': {'key': 'tags', 'type': '{str}'},
         'kind': {'key': 'kind', 'type': 'str'},
         'provisioning_state': {'key': 'properties.provisioningState', 'type': 'str'},
-        'creation_time': {'key': 'properties.creationTime', 'type': 'rfc-1123'},
+        'creation_time': {'key': 'properties.creationTime', 'type': 'iso-8601'},
         'timestamp_property_name': {'key': 'properties.timestampPropertyName', 'type': 'str'},
         'event_source_resource_id': {'key': 'properties.eventSourceResourceId', 'type': 'str'},
         'iot_hub_name': {'key': 'properties.iotHubName', 'type': 'str'},
@@ -1306,7 +1306,7 @@ class IoTHubEventSourceResource(EventSourceResource):
         'tags': {'key': 'tags', 'type': '{str}'},
         'kind': {'key': 'kind', 'type': 'str'},
         'provisioning_state': {'key': 'properties.provisioningState', 'type': 'str'},
-        'creation_time': {'key': 'properties.creationTime', 'type': 'rfc-1123'},
+        'creation_time': {'key': 'properties.creationTime', 'type': 'iso-8601'},
         'timestamp_property_name': {'key': 'properties.timestampPropertyName', 'type': 'str'},
         'event_source_resource_id': {'key': 'properties.eventSourceResourceId', 'type': 'str'},
         'iot_hub_name': {'key': 'properties.iotHubName', 'type': 'str'},
@@ -1565,7 +1565,7 @@ class LongTermEnvironmentResource(EnvironmentResource):
         'data_access_fqdn': {'key': 'properties.dataAccessFqdn', 'type': 'str'},
         'status': {'key': 'properties.status', 'type': 'EnvironmentStatus'},
         'provisioning_state': {'key': 'properties.provisioningState', 'type': 'str'},
-        'creation_time': {'key': 'properties.creationTime', 'type': 'str'},
+        'creation_time': {'key': 'properties.creationTime', 'type': 'iso-8601'},
         'time_series_id_properties': {'key': 'properties.timeSeriesIdProperties', 'type': '[TimeSeriesIdProperty]'},
         'storage_configuration': {'key': 'properties.storageConfiguration', 'type': 'LongTermStorageConfigurationOutput'},
         'data_retention': {'key': 'properties.warmStoreConfiguration.dataRetention', 'type': 'duration'},
@@ -1909,7 +1909,7 @@ class ReferenceDataSetResource(TrackedResource):
         'key_properties': {'key': 'properties.keyProperties', 'type': '[ReferenceDataSetKeyProperty]'},
         'data_string_comparison_behavior': {'key': 'properties.dataStringComparisonBehavior', 'type': 'str'},
         'provisioning_state': {'key': 'properties.provisioningState', 'type': 'str'},
-        'creation_time': {'key': 'properties.creationTime', 'type': 'rfc-1123'},
+        'creation_time': {'key': 'properties.creationTime', 'type': 'iso-8601'},
     }
 
     def __init__(self, *, location: str, key_properties, tags=None, data_string_comparison_behavior=None, provisioning_state=None, **kwargs) -> None:
@@ -2122,7 +2122,7 @@ class StandardEnvironmentResource(EnvironmentResource):
         'data_access_fqdn': {'key': 'properties.dataAccessFqdn', 'type': 'str'},
         'status': {'key': 'properties.status', 'type': 'EnvironmentStatus'},
         'provisioning_state': {'key': 'properties.provisioningState', 'type': 'str'},
-        'creation_time': {'key': 'properties.creationTime', 'type': 'str'},
+        'creation_time': {'key': 'properties.creationTime', 'type': 'iso-8601'},
     }
 
     def __init__(self, *, location: str, sku, data_retention_time, tags=None, storage_limit_exceeded_behavior=None, partition_key_properties=None, status=None, provisioning_state=None, **kwargs) -> None:


### PR DESCRIPTION
- Fix https://github.com/Azure/azure-cli-extensions/issues/1712: `--timestamp-property-name` should be made optional
- Due to service change corresponding to https://github.com/Azure/azure-rest-api-specs/pull/8758, change all `creation_time`'s type to `iso-8601`
- Change `IotHub` to `IoTHub` corresponding to https://github.com/Azure/azure-rest-api-specs/pull/8758, so that `IoTHubEventSourceResource` can be deserialized correctly
- Add instructions for installing and uninstalling the extension 