### PR TITLE
Fix issues of storage account name for az aks kollect

### DIFF
--- a/src/aks-preview/HISTORY.md
+++ b/src/aks-preview/HISTORY.md
@@ -2,6 +2,10 @@
 
 Release History
 ===============
+0.4.48
++++++
+* Fix issues of storage account name for az aks kollect
+
 0.4.47
 +++++
 * Add "--node-image-only" for "az aks nodepool upgrade" and "az aks upgrade"".

--- a/src/aks-preview/azext_aks_preview/_helpers.py
+++ b/src/aks-preview/azext_aks_preview/_helpers.py
@@ -90,5 +90,5 @@ def _trim_fqdn_name_containing_hcp(normalized_fqdn: str) -> str:
     """
     storage_name_without_hcp, _, _ = normalized_fqdn.partition('-hcp-')
     if len(storage_name_without_hcp) > CONST_CONTAINER_NAME_MAX_LENGTH:
-        return storage_name_without_hcp[:CONST_CONTAINER_NAME_MAX_LENGTH]
-    return storage_name_without_hcp
+        storage_name_without_hcp = storage_name_without_hcp[:CONST_CONTAINER_NAME_MAX_LENGTH]
+    return storage_name_without_hcp.rstrip('-')

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_helpers.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_helpers.py
@@ -53,6 +53,13 @@ class TestTrimContainerName(unittest.TestCase):
         trim_container_name = helpers._trim_fqdn_name_containing_hcp(container_name)
         self.assertEqual(expected_container_name, trim_container_name)
 
+    def test_trim_fqdn_name_trailing_dash(self):
+        container_name = 'dns-ed55ba6ad-e48fe2bd-b4bc-4aac-bc23-29bc44154fe1-privatelink-centralus-azmk8s-io'
+        expected_container_name = 'dns-ed55ba6ad-e48fe2bd-b4bc-4aac-bc23-29bc44154fe1-privatelink'
+        trim_container_name = helpers._trim_fqdn_name_containing_hcp(
+            container_name)
+        self.assertEqual(expected_container_name, trim_container_name)
+
     def test_trim_fqdn_name_not_containing_hcp(self):
         container_name = 'abcdef-dns-ed55ba6d-e48fe2bd-b4bc-4aac-bc23-29bc44154fe1-privatelink-centralus-azmk8s-io'
         expected_container_name = 'abcdef-dns-ed55ba6d-e48fe2bd-b4bc-4aac-bc23-29bc44154fe1-privat'

--- a/src/aks-preview/setup.py
+++ b/src/aks-preview/setup.py
@@ -8,7 +8,7 @@
 from codecs import open as open1
 from setuptools import setup, find_packages
 
-VERSION = "0.4.47"
+VERSION = "0.4.48"
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',


### PR DESCRIPTION
Refer https://github.com/Azure/aks-periscope/pull/21: trailing dash "-" is not allowed in storage name, hence this PR removes the trailing dash and aligned the logic with https://github.com/Azure/aks-periscope/pull/21.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
