### PR TITLE
[CI] Add check that azext_metadata.json must exist

### DIFF
--- a/scripts/ci/test_index.py
+++ b/scripts/ci/test_index.py
@@ -15,7 +15,10 @@ import tempfile
 import unittest
 import hashlib
 import shutil
+
 from wheel.install import WHEEL_INFO_RE
+from pkg_resources import parse_version
+
 from util import get_ext_metadata, get_whl_from_url, get_index_data, verify_dependency
 
 
@@ -114,14 +117,36 @@ class TestIndex(unittest.TestCase):
 
     @unittest.skipUnless(os.getenv('CI'), 'Skipped as not running on CI')
     def test_metadata(self):
-        self.maxDiff = None
+        skipable_extension_thresholds = {
+            'ip-group': '0.1.2',
+            'vm-repair': '0.3.1',
+            'mixed-reality': '0.0.2',
+            'subscription': '0.1.4',
+            'managementpartner': '0.1.3',
+            'log-analytics': '0.2.1'
+        }
+
         extensions_dir = tempfile.mkdtemp()
         for ext_name, exts in self.index['extensions'].items():
             for item in exts:
                 ext_dir = tempfile.mkdtemp(dir=extensions_dir)
                 ext_file = get_whl_from_url(item['downloadUrl'], item['filename'],
                                             self.whl_cache_dir, self.whl_cache)
-                metadata = get_ext_metadata(ext_dir, ext_file, ext_name)
+
+                try:
+                    metadata = get_ext_metadata(ext_dir, ext_file, ext_name)
+                except ValueError as ex:
+                    if ext_name in skipable_extension_thresholds:
+                        ext_version = item['metadata']['version']
+                        threshold_version = skipable_extension_thresholds[ext_name]
+
+                        if parse_version(ext_version) < parse_version(threshold_version):
+                            continue
+                        else:
+                            raise ex
+                    else:
+                        raise ex
+
                 # Due to https://github.com/pypa/wheel/issues/195 we prevent whls built with 0.31.0 or greater.
                 # 0.29.0, 0.30.0 are the two previous versions before that release.
                 supported_generators = ['bdist_wheel (0.29.0)', 'bdist_wheel (0.30.0)']
@@ -144,6 +169,29 @@ class TestIndex(unittest.TestCase):
                         "Remove these dependencies: {}".format(item['filename'], deps))
         shutil.rmtree(extensions_dir)
 
+    def test_azext_metadata(self):
+
+        historical_extensios = [
+            'keyvault-preview',
+        ]
+
+        extensions_dir = tempfile.mkdtemp()
+
+        for ext_name, exts in self.index['extensions'].items():
+            latest = max(exts, key=lambda e: parse_version(e['metadata']['version']))
+
+            ext_dir = tempfile.mkdtemp(dir=extensions_dir)
+            ext_file = get_whl_from_url(latest['downloadUrl'], latest['filename'], self.whl_cache_dir, self.whl_cache)
+
+            metadata = get_ext_metadata(ext_dir, ext_file, ext_name)
+
+            try:
+                self.assertIn('azext.minCliCoreVersion', metadata)
+            except AssertionError as ex:
+                if ext_name in historical_extensios:
+                    pass
+                else:
+                    raise ex
 
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/ci/test_index.py
+++ b/scripts/ci/test_index.py
@@ -16,8 +16,8 @@ import unittest
 import hashlib
 import shutil
 
+from distutils.version import LooseVersion
 from wheel.install import WHEEL_INFO_RE
-from pkg_resources import parse_version
 
 from util import get_ext_metadata, get_whl_from_url, get_index_data, verify_dependency
 
@@ -133,6 +133,8 @@ class TestIndex(unittest.TestCase):
                 ext_file = get_whl_from_url(item['downloadUrl'], item['filename'],
                                             self.whl_cache_dir, self.whl_cache)
 
+                print(ext_file)
+
                 try:
                     metadata = get_ext_metadata(ext_dir, ext_file, ext_name)
                 except ValueError as ex:
@@ -140,7 +142,7 @@ class TestIndex(unittest.TestCase):
                         ext_version = item['metadata']['version']
                         threshold_version = skipable_extension_thresholds[ext_name]
 
-                        if parse_version(ext_version) < parse_version(threshold_version):
+                        if LooseVersion(ext_version) < LooseVersion(threshold_version):
                             continue
                         else:
                             raise ex
@@ -178,7 +180,7 @@ class TestIndex(unittest.TestCase):
         extensions_dir = tempfile.mkdtemp()
 
         for ext_name, exts in self.index['extensions'].items():
-            latest = max(exts, key=lambda e: parse_version(e['metadata']['version']))
+            latest = max(exts, key=lambda e: LooseVersion(e['metadata']['version']))
 
             ext_dir = tempfile.mkdtemp(dir=extensions_dir)
             ext_file = get_whl_from_url(latest['downloadUrl'], latest['filename'], self.whl_cache_dir, self.whl_cache)

--- a/scripts/ci/test_index.py
+++ b/scripts/ci/test_index.py
@@ -193,5 +193,6 @@ class TestIndex(unittest.TestCase):
                 else:
                     raise ex
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/ci/test_index.py
+++ b/scripts/ci/test_index.py
@@ -117,16 +117,17 @@ class TestIndex(unittest.TestCase):
 
     @unittest.skipUnless(os.getenv('CI'), 'Skipped as not running on CI')
     def test_metadata(self):
-        historical_extensios = [
-            'keyvault-preview',
-        ]
-
         skipable_extension_thresholds = {
             'ip-group': '0.1.2',
             'vm-repair': '0.3.1',
             'mixed-reality': '0.0.2',
             'subscription': '0.1.4',
             'managementpartner': '0.1.3',
+            'log-analytics': '0.2.1'
+        }
+
+        historical_extensios = {
+            'keyvault-preview': '0.1.3',
             'log-analytics': '0.2.1'
         }
 
@@ -139,14 +140,14 @@ class TestIndex(unittest.TestCase):
 
                 print(ext_file)
 
+                ext_version = item['metadata']['version']
                 try:
-                    metadata = get_ext_metadata(ext_dir, ext_file, ext_name)
+                    metadata = get_ext_metadata(ext_dir, ext_file, ext_name)    # check file exists
                 except ValueError as ex:
                     if ext_name in skipable_extension_thresholds:
-                        ext_version = item['metadata']['version']
                         threshold_version = skipable_extension_thresholds[ext_name]
 
-                        if LooseVersion(ext_version) < LooseVersion(threshold_version):
+                        if LooseVersion(ext_version) <= LooseVersion(threshold_version):
                             continue
                         else:
                             raise ex
@@ -154,10 +155,15 @@ class TestIndex(unittest.TestCase):
                         raise ex
 
                 try:
-                    self.assertIn('azext.minCliCoreVersion', metadata)
+                    self.assertIn('azext.minCliCoreVersion', metadata)  # check key properties exists
                 except AssertionError as ex:
                     if ext_name in historical_extensios:
-                        pass
+                        threshold_version = historical_extensios[ext_name]
+
+                        if LooseVersion(ext_version) <= LooseVersion(threshold_version):
+                            continue
+                        else:
+                            raise ex
                     else:
                         raise ex
 

--- a/scripts/ci/util.py
+++ b/scripts/ci/util.py
@@ -58,9 +58,14 @@ def get_ext_metadata(ext_dir, ext_file, ext_name):
     zip_ref.close()
     metadata = {}
     dist_info_dirs = [f for f in os.listdir(ext_dir) if f.endswith('.dist-info')]
+
     azext_metadata = _get_azext_metadata(ext_dir)
-    if azext_metadata:
-        metadata.update(azext_metadata)
+
+    if not azext_metadata:
+        raise ValueError('azext_metadata.json for Azure CLI Extension Metadata is missing')
+
+    metadata.update(azext_metadata)
+
     for dist_info_dirname in dist_info_dirs:
         parsed_dist_info_dir = WHEEL_INFO_RE(dist_info_dirname)
         if parsed_dist_info_dir and parsed_dist_info_dir.groupdict().get('name') == ext_name.replace('-', '_'):

--- a/scripts/ci/util.py
+++ b/scripts/ci/util.py
@@ -62,7 +62,7 @@ def get_ext_metadata(ext_dir, ext_file, ext_name):
     azext_metadata = _get_azext_metadata(ext_dir)
 
     if not azext_metadata:
-        raise ValueError('azext_metadata.json for Azure CLI Extension Metadata is missing')
+        raise ValueError('azext_metadata.json for Extension "{}" Metadata is missing'.format(ext_name))
 
     metadata.update(azext_metadata)
 


### PR DESCRIPTION
Fix https://github.com/Azure/azure-cli-extensions/issues/1052 via adding non-forgiveness assertion in CI to ensure azext_metadata.json must be existing.

### Test Guide:
1. This can detect error like **ip-group** successfully:
![image](https://user-images.githubusercontent.com/14357159/83999492-723c5800-a995-11ea-82b8-b2d249512244.png)
But with this PR https://github.com/Azure/azure-cli-extensions/pull/1843 merged, the error of ip-group would disappear.

2. With https://github.com/Azure/azure-cli-extensions/pull/1845 merged, error like **vm-repair** raise could be fixed.
![image](https://user-images.githubusercontent.com/14357159/84003485-b2530900-a99c-11ea-8dad-b8b19504f26f.png)

3. Fix mixed-reality https://github.com/Azure/azure-cli-extensions/pull/1847
4. Fix subscription https://github.com/Azure/azure-cli-extensions/pull/1848
5. Fix managementpartner https://github.com/Azure/azure-cli-extensions/pull/1851
6. Fix log-analytics https://github.com/Azure/azure-cli-extensions/pull/1857

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
