### PR TITLE
[subscription] Add azext_metadata.json

### DIFF
--- a/src/subscription/setup.py
+++ b/src/subscription/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup, find_packages
 
-VERSION = "0.1.3"
+VERSION = "0.1.4"
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
@@ -37,5 +37,10 @@ setup(
     url='https://github.com/Azure/azure-cli-extensions',
     classifiers=CLASSIFIERS,
     packages=find_packages(exclude=["tests"]),
-    install_requires=DEPENDENCIES
+    install_requires=DEPENDENCIES,
+    package_data={
+        'azext_subscription': [
+            'azext_metadata.json'
+        ]
+    }
 )


### PR DESCRIPTION
As it's going to on board #1842, we should fix the extension that miss azext_metadata.json

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
