### PR TITLE
[Imagecopy] Validation on resource group; Improve logging

### DIFF
--- a/src/image-copy/azext_imagecopy/__init__.py
+++ b/src/image-copy/azext_imagecopy/__init__.py
@@ -47,7 +47,7 @@ class ImageCopyCommandsLoader(AzCommandsLoader):
             c.argument('timeout', options_list=['--timeout'], type=int, default=3600,
                        help='Time in seconds for the copy operation to finish. Increase this time if '
                        'you are going to copy large images (disks) like 512GB or more.')
-            c.argument('temporary_resource_group_name', options_list=['--temporary_resource_group_name'],
+            c.argument('temporary_resource_group_name', options_list=['--temporary-resource-group-name'],
                        default='image-copy-rg',
                        help='Resource Group name where temporary storage account will be created.')
             c.argument('export_as_snapshot', options_list=['--export-as-snapshot'], action='store_true', default=False,

--- a/src/image-copy/azext_imagecopy/cli_utils.py
+++ b/src/image-copy/azext_imagecopy/cli_utils.py
@@ -91,6 +91,6 @@ def get_storage_account_id_from_blob_path(cmd, blob_path, resource_group, subscr
 
 
 def format_cmd(cmd: List[str]):
-    if len(cmd)
-    terms = cmd[3:]
-    return 'Running: az ' + ' '.join(cmd[3:])
+    if len(cmd) > 3:
+        return 'Running: az ' + ' '.join(cmd[3:])
+    return 'Running: ' + ' '.join(cmd)

--- a/src/image-copy/azext_imagecopy/cli_utils.py
+++ b/src/image-copy/azext_imagecopy/cli_utils.py
@@ -7,6 +7,8 @@ import sys
 import json
 
 from subprocess import check_output, STDOUT, CalledProcessError
+from typing import List
+
 from knack.util import CLIError
 
 from knack.log import get_logger
@@ -86,3 +88,9 @@ def get_storage_account_id_from_blob_path(cmd, blob_path, resource_group, subscr
         namespace='Microsoft.Storage', type='storageAccounts', name=storage_account_name)
 
     return storage_account_id
+
+
+def format_cmd(cmd: List[str]):
+    if len(cmd)
+    terms = cmd[3:]
+    return 'Running: az ' + ' '.join(cmd[3:])

--- a/src/image-copy/azext_imagecopy/create_target.py
+++ b/src/image-copy/azext_imagecopy/create_target.py
@@ -9,7 +9,9 @@ import time
 from knack.util import CLIError
 from knack.log import get_logger
 
-from azext_imagecopy.cli_utils import run_cli_command, prepare_cli_command, get_storage_account_id_from_blob_path
+from azext_imagecopy.cli_utils import (
+    run_cli_command, prepare_cli_command, get_storage_account_id_from_blob_path, format_cmd
+)
 
 logger = get_logger(__name__)
 
@@ -37,6 +39,7 @@ def create_target_image(cmd, location, transient_resource_group_name, source_typ
                                    '--sku', 'Standard_LRS'],
                                   subscription=target_subscription)
 
+    logger.warning(format_cmd(cli_cmd))
     json_output = run_cli_command(cli_cmd, return_as_json=True)
     target_blob_endpoint = json_output['primaryEndpoints']['blob']
 
@@ -46,6 +49,7 @@ def create_target_image(cmd, location, transient_resource_group_name, source_typ
                                    '--resource-group', transient_resource_group_name],
                                   subscription=target_subscription)
 
+    logger.warning(format_cmd(cli_cmd))
     json_output = run_cli_command(cli_cmd, return_as_json=True)
 
     target_storage_account_key = json_output[0]['value']
@@ -65,6 +69,7 @@ def create_target_image(cmd, location, transient_resource_group_name, source_typ
                                   output_as_json=False,
                                   subscription=target_subscription)
 
+    logger.warning(format_cmd(cli_cmd))
     sas_token = run_cli_command(cli_cmd)
     sas_token = sas_token.rstrip("\n\r")  # STRANGE
     logger.debug("sas token: %s", sas_token)
@@ -78,6 +83,7 @@ def create_target_image(cmd, location, transient_resource_group_name, source_typ
                                    '--account-name', target_storage_account_name],
                                   subscription=target_subscription)
 
+    logger.warning(format_cmd(cli_cmd))
     run_cli_command(cli_cmd)
 
     # Copy the snapshot to the target region using the SAS URL
@@ -92,6 +98,7 @@ def create_target_image(cmd, location, transient_resource_group_name, source_typ
                                    '--sas-token', sas_token],
                                   subscription=target_subscription)
 
+    logger.warning(format_cmd(cli_cmd))
     run_cli_command(cli_cmd)
 
     # Wait for the copy to complete
@@ -126,6 +133,7 @@ def create_target_image(cmd, location, transient_resource_group_name, source_typ
                                    '--source-storage-account-id', source_storage_account_id],
                                   subscription=target_subscription)
 
+    logger.warning(format_cmd(cli_cmd))
     json_output = run_cli_command(cli_cmd, return_as_json=True)
     target_snapshot_id = json_output['id']
 
@@ -150,7 +158,7 @@ def create_target_image(cmd, location, transient_resource_group_name, source_typ
                                        '--source', target_snapshot_id],
                                       tags=tags,
                                       subscription=target_subscription)
-
+        logger.warning(format_cmd(cli_cmd))
         run_cli_command(cli_cmd)
 
 


### PR DESCRIPTION
1.
Resolve https://github.com/Azure/azure-cli-extensions/issues/1584
`--cleanup` : Include this switch to delete temporary resources upon completion.
`--temporary-resource-group-name`    : Resource Group name where temporary storage account will be created.  Default: image-copy-rg.
If `--cleanup` is set and `--temporary-resource-group-name` is set an existing resource group, this resource group will be deleted, even the resources created by the user before.

Now it is forbidden to use existing resource group name is `--cleanup` is set.

2.
Add more logs. Print running commands.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
