### PR TITLE
[Codespaces] Add 60 minute auto-suspend timeout

### DIFF
--- a/src/codespaces/HISTORY.rst
+++ b/src/codespaces/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.2.1
+++++++
+* Added 60 minute auto-suspend timeout option
+
 0.2.0
 ++++++
 * Update to latest resource provider API version, 2020-05-26.

--- a/src/codespaces/azext_codespaces/_params.py
+++ b/src/codespaces/azext_codespaces/_params.py
@@ -22,7 +22,7 @@ def load_arguments(self, _):
                    validator=validate_codespace_name_or_id)
         c.argument('sku_name', options_list=['--instance-type'], help='Instance Type')
         c.argument('autoshutdown_delay', options_list=['--suspend-after'],
-                   arg_type=get_enum_type(['5', '30', '120']),
+                   arg_type=get_enum_type(['5', '30', '60', '120']),
                    help="Automatically suspend the inactive Codespace after this many minutes.")
 
     with self.argument_context('codespace plan') as c:
@@ -30,7 +30,7 @@ def load_arguments(self, _):
         c.argument('subnet_id', arg_group="Network", options_list=['--subnet'],
                    help="Resource ID of an existing subnet. If specified, all Codespaces in this plan will be created in this subnet. The subnet must be in the same region as the plan.")
         c.argument('default_autoshutdown_delay', arg_group="Plan Default", options_list=['--default-suspend-after'],
-                   arg_type=get_enum_type(['5', '30', '120']),
+                   arg_type=get_enum_type(['5', '30', '60', '120']),
                    help="Default minutes Codespaces in this plan should suspend after.")
         c.argument('default_sku_name', arg_group="Plan Default", options_list=['--default-instance-type'], help="Default Instance Type for Codespaces in this plan.")
 

--- a/src/codespaces/azext_codespaces/version.py
+++ b/src/codespaces/azext_codespaces/version.py
@@ -3,4 +3,4 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-VERSION = '0.2.0'
+VERSION = '0.2.1'


### PR DESCRIPTION
Update the Codespaces extension to add the option to specify a 60-minute auto-suspend delay. Tested locally and the option is available when creating a codespace through the CLI extension.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
