### PR TITLE
[ai-examples] Fix missing subscription or disabled telemetry bug

### DIFF
--- a/src/ai-examples/HISTORY.rst
+++ b/src/ai-examples/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.2.2
+++++++
+* Fix bug causing queries to fail when not logged in and when telemetry is disabled
+
 0.2.1
 ++++++
 * Change telemetry collection

--- a/src/ai-examples/azext_ai_examples/custom.py
+++ b/src/ai-examples/azext_ai_examples/custom.py
@@ -13,8 +13,6 @@ from azure.cli.core import telemetry as telemetry_core
 from azure.cli.core import __version__ as core_version
 from azure.cli.core._help import HelpExample
 
-DEFAULT_GUID = "00000000-0000-0000-0000-000000000000"
-
 
 # Commands
 def check_connection_aladdin():
@@ -81,18 +79,19 @@ def ping_aladdin_service():
 
 def call_aladdin_service(query):
     version = str(parse_version(core_version))
-
-    # Only pull in the contextual values if we have consent
-    telemetry_consent = telemetry_core.is_telemetry_enabled()
-    correlation_id = telemetry_core._session.correlation_id if telemetry_consent else DEFAULT_GUID  # pylint: disable=protected-access
-    subscription_id = telemetry_core._get_azure_subscription_id() if telemetry_consent else DEFAULT_GUID  # pylint: disable=protected-access
+    correlation_id = telemetry_core._session.correlation_id   # pylint: disable=protected-access
+    subscription_id = telemetry_core._get_azure_subscription_id()  # pylint: disable=protected-access
 
     context = {
         "versionNumber": version,
-        "correlationId": correlation_id,
-        # In case the user is not logged in
-        "subscriptionId": subscription_id if subscription_id is not None else DEFAULT_GUID
     }
+
+    # Only pull in the contextual values if we have consent
+    if telemetry_core.is_telemetry_enabled():
+        context['correlationId'] = correlation_id
+
+    if telemetry_core.is_telemetry_enabled() and subscription_id is not None:
+        context['subscriptionId'] = subscription_id
 
     api_url = 'https://app.aladdin.microsoft.com/api/v1.0/examples'
     headers = {'Content-Type': 'application/json'}

--- a/src/ai-examples/setup.py
+++ b/src/ai-examples/setup.py
@@ -15,7 +15,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
 
 # HISTORY.rst entry.
-VERSION = '0.2.1'
+VERSION = '0.2.2'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
The Aladdin service expects to receive a GUID for both the correlationId and subscriptionId if they are sent. If users were not logged in or had disabled their telemetry, this service would return a 400, since the values passed in were considered strings, not GUIDs.

I believe https://github.com/Azure/azure-cli/issues/14094 was caused by this issue in `az find`, though the user was unable to reproduce it, so there could be other factors at play. The PR to fix `az find` is https://github.com/Azure/azure-cli/pull/14243.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [X] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [X] Have you run `python scripts/ci/test_index.py -q` locally?


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
