### PR TITLE
{Index} Remove useless AI extension version from index.json

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -1299,38 +1299,6 @@
         ],
         "application-insights": [
             {
-                "downloadUrl": "https://appinsightscli.blob.core.windows.net/controlplane-cli/application_insights-0.1.1-py2.py3-none-any.whl",
-                "filename": "application_insights-0.1.1-py2.py3-none-any.whl",
-                "metadata": {
-                    "azext.isPreview": true,
-                    "azext.minCliCoreVersion": "2.0.56",
-                    "extensions": {
-                        "python.details": {
-                            "contacts": [
-                                {
-                                    "email": "aleldeib@microsoft.com",
-                                    "name": "Ace Eldeib",
-                                    "role": "author"
-                                }
-                            ],
-                            "document_names": {
-                                "description": "DESCRIPTION.rst"
-                            },
-                            "project_urls": {
-                                "Home": "https://github.com/Azure/azure-cli-extensions/tree/master/src/application-insights"
-                            }
-                        }
-                    },
-                    "generator": "bdist_wheel (0.30.0)",
-                    "license": "MIT",
-                    "metadata_version": "2.0",
-                    "name": "application-insights",
-                    "summary": "Support for managing Application Insights components and querying metrics, events, and logs from such components.",
-                    "version": "0.1.1"
-                },
-                "sha256Digest": "6a03b2b1a78f44e096650870d02fc2d86ee30fb07a42656716f1ced9d8651831"
-            },
-            {
                 "downloadUrl": "https://azurecliprod.blob.core.windows.net/cli-extensions/application_insights-0.1.3-py2.py3-none-any.whl",
                 "filename": "application_insights-0.1.3-py2.py3-none-any.whl",
                 "metadata": {


### PR DESCRIPTION
Remove https://appinsightscli.blob.core.windows.net/controlplane-cli/application_insights-0.1.1-py2.py3-none-any.whl from index.json

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
