### PR TITLE
[ai-did-you-mean-this] Allow users to receive recommendations if they've opted out of telemetry.

### DIFF
--- a/src/ai-did-you-mean-this/azext_ai_did_you_mean_this/_const.py
+++ b/src/ai-did-you-mean-this/azext_ai_did_you_mean_this/_const.py
@@ -17,8 +17,12 @@ RECOMMENDATION_HEADER_FMT_STR = (
     '\nHere are the most common ways users succeeded after [{command}] failed:'
 )
 
-TELEMETRY_MUST_BE_ENABLED_STR = (
-    'User must agree to telemetry before failure recovery recommendations can be presented.'
+TELEMETRY_IS_DISABLED_STR = (
+    'User has not opted into telemetry.'
+)
+
+TELEMETRY_IS_ENABLED_STR = (
+    'User has opted into telemtry.'
 )
 
 TELEMETRY_MISSING_SUBSCRIPTION_ID_STR = (

--- a/src/ai-did-you-mean-this/azext_ai_did_you_mean_this/_const.py
+++ b/src/ai-did-you-mean-this/azext_ai_did_you_mean_this/_const.py
@@ -22,7 +22,7 @@ TELEMETRY_IS_DISABLED_STR = (
 )
 
 TELEMETRY_IS_ENABLED_STR = (
-    'User has opted into telemtry.'
+    'User has opted into telemetry.'
 )
 
 TELEMETRY_MISSING_SUBSCRIPTION_ID_STR = (

--- a/src/ai-did-you-mean-this/azext_ai_did_you_mean_this/custom.py
+++ b/src/ai-did-you-mean-this/azext_ai_did_you_mean_this/custom.py
@@ -19,7 +19,8 @@ from azext_ai_did_you_mean_this._style import style_message
 from azext_ai_did_you_mean_this._const import (
     RECOMMENDATION_HEADER_FMT_STR,
     UNABLE_TO_HELP_FMT_STR,
-    TELEMETRY_MUST_BE_ENABLED_STR,
+    TELEMETRY_IS_DISABLED_STR,
+    TELEMETRY_IS_ENABLED_STR,
     TELEMETRY_MISSING_SUBSCRIPTION_ID_STR,
     TELEMETRY_MISSING_CORRELATION_ID_STR,
     UNABLE_TO_CALL_SERVICE_STR
@@ -32,7 +33,7 @@ logger = get_logger(__name__)
 # Commands
 # note: at least one command is required in order for the CLI to load the extension.
 def show_extension_version():
-    print('Current version: 0.2.0')
+    print('Current version: 0.2.1')
 
 
 def _log_debug(msg, *args, **kwargs):
@@ -128,11 +129,6 @@ def recommend_recovery_options(version, command, parameters, extension):
     _log_debug('recommend_recovery_options: version: "%s", command: "%s", parameters: "%s", extension: "%s"',
                version, command, parameters, extension)
 
-    # if the user doesn't agree to telemetry...
-    if not telemetry.is_telemetry_enabled():
-        _log_debug(TELEMETRY_MUST_BE_ENABLED_STR)
-        return result
-
     # if the command is empty...
     if not command:
         # try to get the raw command field from telemetry.
@@ -204,39 +200,48 @@ def call_aladdin_service(command, parameters, version):
 
     correlation_id = telemetry._session.correlation_id  # pylint: disable=protected-access
     subscription_id = telemetry._get_azure_subscription_id()  # pylint: disable=protected-access
+    is_telemetry_enabled = telemetry.is_telemetry_enabled()
 
-    if subscription_id and correlation_id:
-        context = {
-            "correlationId": correlation_id,
-            "subscriptionId": subscription_id,
-            "versionNumber": version
-        }
+    telemetry_context = {
+        'correlationId': correlation_id,
+        'subscriptionId': subscription_id
+    }
 
-        query = {
-            "command": command,
-            "parameters": parameters
-        }
+    telemetry_context = {k: v for k, v in telemetry_context.items() if v is not None and is_telemetry_enabled}
 
-        api_url = 'https://app.aladdin.microsoft.com/api/v1.0/suggestions'
-        headers = {'Content-Type': 'application/json'}
-
-        try:
-            response = requests.get(
-                api_url,
-                params={
-                    'query': json.dumps(query),
-                    'clientType': 'AzureCli',
-                    'context': json.dumps(context)
-                },
-                headers=headers)
-        except RequestException as ex:
-            _log_debug('requests.get() exception: %s', ex)
+    if not is_telemetry_enabled:
+        _log_debug(TELEMETRY_IS_DISABLED_STR)
     else:
+        _log_debug(TELEMETRY_IS_ENABLED_STR)
+
         if subscription_id is None:
             _log_debug(TELEMETRY_MISSING_SUBSCRIPTION_ID_STR)
         if correlation_id is None:
             _log_debug(TELEMETRY_MISSING_CORRELATION_ID_STR)
 
-        _log_debug(UNABLE_TO_CALL_SERVICE_STR)
+    context = {
+        **telemetry_context,
+        "versionNumber": version
+    }
+
+    query = {
+        "command": command,
+        "parameters": parameters
+    }
+
+    api_url = 'https://app.aladdin.microsoft.com/api/v1.0/suggestions'
+    headers = {'Content-Type': 'application/json'}
+
+    try:
+        response = requests.get(
+            api_url,
+            params={
+                'query': json.dumps(query),
+                'clientType': 'AzureCli',
+                'context': json.dumps(context)
+            },
+            headers=headers)
+    except RequestException as ex:
+        _log_debug('requests.get() exception: %s', ex)
 
     return response

--- a/src/ai-did-you-mean-this/azext_ai_did_you_mean_this/custom.py
+++ b/src/ai-did-you-mean-this/azext_ai_did_you_mean_this/custom.py
@@ -22,8 +22,7 @@ from azext_ai_did_you_mean_this._const import (
     TELEMETRY_IS_DISABLED_STR,
     TELEMETRY_IS_ENABLED_STR,
     TELEMETRY_MISSING_SUBSCRIPTION_ID_STR,
-    TELEMETRY_MISSING_CORRELATION_ID_STR,
-    UNABLE_TO_CALL_SERVICE_STR
+    TELEMETRY_MISSING_CORRELATION_ID_STR
 )
 from azext_ai_did_you_mean_this._cmd_table import CommandTable
 

--- a/src/ai-did-you-mean-this/setup.py
+++ b/src/ai-did-you-mean-this/setup.py
@@ -44,8 +44,7 @@ setup(
     # TODO: Update author and email, if applicable
     author="Christopher O'Toole",
     author_email='chotool@microsoft.com',
-    # TODO: consider pointing directly to your source code instead of the generic repo
-    url='https://github.com/Azure/azure-cli-extensions/ai-did-you-mean-this',
+    url='https://github.com/Azure/azure-cli-extensions/tree/master/src/ai-did-you-mean-this',
     long_description=README + '\n\n' + HISTORY,
     license='MIT',
     classifiers=CLASSIFIERS,

--- a/src/ai-did-you-mean-this/setup.py
+++ b/src/ai-did-you-mean-this/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     from distutils import log as logger
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
 
-VERSION = '0.2.0'
+VERSION = '0.2.1'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Allow users who've not opted into telemetry to still receive recommendations. If the user opted out of telemetry, no user identifying data will be sent.

Related: #1975 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [X] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [X] Have you run `python scripts/ci/test_index.py -q` locally?
