### PR TITLE
{CI} Temporarily disable command index in CI

### DIFF
--- a/scripts/ci/test_source.py
+++ b/scripts/ci/test_source.py
@@ -68,6 +68,7 @@ class TestExtensionSourceMeta(type):
                 unittest_args = [sys.executable, '-m', 'unittest', 'discover', '-v', ext_path]
                 env = os.environ.copy()
                 env['PYTHONPATH'] = ext_install_dir
+                env['AZURE_CORE_USE_COMMAND_INDEX'] = 'false'
                 check_call(unittest_args, env=env)
             return test
 


### PR DESCRIPTION
CI in extension use `pip` to install `whl` package and command index cannot detect such changes. Disable command index first. We need to refine CI later.
![image](https://user-images.githubusercontent.com/49134743/87014366-a0b08b80-c1fe-11ea-96e4-ef43c2a18750.png)
