### PR TITLE
wrap <xxx> in backticks for better documentation

### DIFF
--- a/src/spring-cloud/azext_spring_cloud/_help.py
+++ b/src/spring-cloud/azext_spring_cloud/_help.py
@@ -235,7 +235,7 @@ helps['spring-cloud app deployment delete'] = """
 
 helps['spring-cloud app deployment create'] = """
     type: command
-    short-summary: Create a staging deployment for the app. To deploy code or update setting to an existing deployment, use az spring-cloud app deploy/update --deployment <staging deployment>.
+    short-summary: Create a staging deployment for the app. To deploy code or update setting to an existing deployment, use `az spring-cloud app deploy/update --deployment <staging deployment>`.
     examples:
     - name: Deploy source code to a new deployment of an app. This will pack current directory, build binary with Pivotal Build Service and then deploy.
       text: az spring-cloud app deployment create -n green-deployment --app MyApp -s MyCluster -g MyResourceGroup


### PR DESCRIPTION
## Issue
Our documentation treats the summary as markdown. If it has <xxx> it could be rendered as an html tag.

For the page: https://docs.microsoft.com/en-us/cli/azure/ext/spring-cloud/spring-cloud/app/deployment?view=azure-cli-latest#ext-spring-cloud-az-spring-cloud-app-deployment-create
![image](https://user-images.githubusercontent.com/8327019/87396507-85ba8e80-c5e5-11ea-926d-2650ccacdc46.png)

## Common solution
Common solution is wrap <xxx> in backticks, as the PR shows.