### PR TITLE
wrap <xxx> in backticks for better documentation Part 2

### DIFF
--- a/src/spring-cloud/azext_spring_cloud/_help.py
+++ b/src/spring-cloud/azext_spring_cloud/_help.py
@@ -235,7 +235,7 @@ helps['spring-cloud app deployment delete'] = """
 
 helps['spring-cloud app deployment create'] = """
     type: command
-    short-summary: Create a staging deployment for the app. To deploy code or update setting to an existing deployment, use az spring-cloud app deploy/update --deployment <staging deployment>.
+    short-summary: Create a staging deployment for the app. To deploy code or update setting to an existing deployment, use `az spring-cloud app deploy/update --deployment <staging deployment>`.
     examples:
     - name: Deploy source code to a new deployment of an app. This will pack current directory, build binary with Pivotal Build Service and then deploy.
       text: az spring-cloud app deployment create -n green-deployment --app MyApp -s MyCluster -g MyResourceGroup

--- a/src/storage-preview/azext_storage_preview/vendored_sdks/azure_adls_storage_preview/v2019_02_02_preview/blob/baseblobservice.py
+++ b/src/storage-preview/azext_storage_preview/vendored_sdks/azure_adls_storage_preview/v2019_02_02_preview/blob/baseblobservice.py
@@ -3172,9 +3172,9 @@ class BaseBlobService(StorageClient):
             or must be authenticated via a shared access signature. If the source 
             is public, no authentication is required.
             Examples:
-            https://myaccount.blob.core.windows.net/mycontainer/myblob
-            https://myaccount.blob.core.windows.net/mycontainer/myblob?snapshot=<DateTime>
-            https://otheraccount.blob.core.windows.net/mycontainer/myblob?sastoken
+            `https://myaccount.blob.core.windows.net/mycontainer/myblob`
+            `https://myaccount.blob.core.windows.net/mycontainer/myblob?snapshot=<DateTime>`
+            `https://otheraccount.blob.core.windows.net/mycontainer/myblob?sastoken`
         :param metadata:
             Name-value pairs associated with the blob as metadata. If no name-value 
             pairs are specified, the operation will copy the metadata from the 

--- a/src/storage-preview/azext_storage_preview/vendored_sdks/azure_adls_storage_preview/v2019_02_02_preview/blob/blockblobservice.py
+++ b/src/storage-preview/azext_storage_preview/vendored_sdks/azure_adls_storage_preview/v2019_02_02_preview/blob/blockblobservice.py
@@ -1056,9 +1056,9 @@ class BlockBlobService(BaseBlobService):
         or must be authenticated via a shared access signature. If the source
         is public, no authentication is required.
         Examples:
-        https://myaccount.blob.core.windows.net/mycontainer/myblob
-        https://myaccount.blob.core.windows.net/mycontainer/myblob?snapshot=<DateTime>
-        https://otheraccount.blob.core.windows.net/mycontainer/myblob?sastoken
+        `https://myaccount.blob.core.windows.net/mycontainer/myblob`
+        `https://myaccount.blob.core.windows.net/mycontainer/myblob?snapshot=<DateTime>`
+        `https://otheraccount.blob.core.windows.net/mycontainer/myblob?sastoken`
         :param metadata:
         Name-value pairs associated with the blob as metadata. If no name-value
         pairs are specified, the operation will copy the metadata from the

--- a/src/storage-preview/azext_storage_preview/vendored_sdks/azure_adls_storage_preview/v2019_02_02_preview/blob/pageblobservice.py
+++ b/src/storage-preview/azext_storage_preview/vendored_sdks/azure_adls_storage_preview/v2019_02_02_preview/blob/pageblobservice.py
@@ -238,7 +238,7 @@ class PageBlobService(BaseBlobService):
             The value should be URL-encoded as it would appear in a request URI.
             The copy source must be a snapshot and include a valid SAS token or be public.
             Example:
-            https://myaccount.blob.core.windows.net/mycontainer/myblob?snapshot=<DateTime>&sastoken
+            `https://myaccount.blob.core.windows.net/mycontainer/myblob?snapshot=<DateTime>&sastoken`
         :param metadata:
             Name-value pairs associated with the blob as metadata. If no name-value
             pairs are specified, the operation will copy the metadata from the

--- a/src/storage-preview/azext_storage_preview/vendored_sdks/azure_adls_storage_preview/v2019_02_02_preview/blob/pageblobservice.py
+++ b/src/storage-preview/azext_storage_preview/vendored_sdks/azure_adls_storage_preview/v2019_02_02_preview/blob/pageblobservice.py
@@ -1375,9 +1375,9 @@ class PageBlobService(BaseBlobService):
             or must be authenticated via a shared access signature. If the source
             is public, no authentication is required.
             Examples:
-            https://myaccount.blob.core.windows.net/mycontainer/myblob
-            https://myaccount.blob.core.windows.net/mycontainer/myblob?snapshot=<DateTime>
-            https://otheraccount.blob.core.windows.net/mycontainer/myblob?sastoken
+            `https://myaccount.blob.core.windows.net/mycontainer/myblob`
+            `https://myaccount.blob.core.windows.net/mycontainer/myblob?snapshot=<DateTime>`
+            `https://otheraccount.blob.core.windows.net/mycontainer/myblob?sastoken`
         :param metadata:
             Name-value pairs associated with the blob as metadata. If no name-value
             pairs are specified, the operation will copy the metadata from the

--- a/src/storage-preview/azext_storage_preview/vendored_sdks/azure_storage/v2018_03_28/blob/baseblobservice.py
+++ b/src/storage-preview/azext_storage_preview/vendored_sdks/azure_storage/v2018_03_28/blob/baseblobservice.py
@@ -2955,9 +2955,9 @@ class BaseBlobService(StorageClient):
             or must be authenticated via a shared access signature. If the source 
             is public, no authentication is required.
             Examples:
-            https://myaccount.blob.core.windows.net/mycontainer/myblob
-            https://myaccount.blob.core.windows.net/mycontainer/myblob?snapshot=<DateTime>
-            https://otheraccount.blob.core.windows.net/mycontainer/myblob?sastoken
+            `https://myaccount.blob.core.windows.net/mycontainer/myblob`
+            `https://myaccount.blob.core.windows.net/mycontainer/myblob?snapshot=<DateTime>`
+            `https://otheraccount.blob.core.windows.net/mycontainer/myblob?sastoken`
         :param metadata:
             Name-value pairs associated with the blob as metadata. If no name-value 
             pairs are specified, the operation will copy the metadata from the 

--- a/src/storage-preview/azext_storage_preview/vendored_sdks/azure_storage/v2018_03_28/blob/pageblobservice.py
+++ b/src/storage-preview/azext_storage_preview/vendored_sdks/azure_storage/v2018_03_28/blob/pageblobservice.py
@@ -230,7 +230,7 @@ class PageBlobService(BaseBlobService):
             The value should be URL-encoded as it would appear in a request URI.
             The copy source must be a snapshot and include a valid SAS token or be public.
             Example:
-            https://myaccount.blob.core.windows.net/mycontainer/myblob?snapshot=<DateTime>&sastoken
+            `https://myaccount.blob.core.windows.net/mycontainer/myblob?snapshot=<DateTime>&sastoken`
         :param metadata:
             Name-value pairs associated with the blob as metadata. If no name-value
             pairs are specified, the operation will copy the metadata from the

--- a/src/storage-preview/azext_storage_preview/vendored_sdks/azure_storage/v2018_03_28/blob/pageblobservice.py
+++ b/src/storage-preview/azext_storage_preview/vendored_sdks/azure_storage/v2018_03_28/blob/pageblobservice.py
@@ -1206,9 +1206,9 @@ class PageBlobService(BaseBlobService):
             or must be authenticated via a shared access signature. If the source
             is public, no authentication is required.
             Examples:
-            https://myaccount.blob.core.windows.net/mycontainer/myblob
-            https://myaccount.blob.core.windows.net/mycontainer/myblob?snapshot=<DateTime>
-            https://otheraccount.blob.core.windows.net/mycontainer/myblob?sastoken
+            `https://myaccount.blob.core.windows.net/mycontainer/myblob`
+            `https://myaccount.blob.core.windows.net/mycontainer/myblob?snapshot=<DateTime>`
+            `https://otheraccount.blob.core.windows.net/mycontainer/myblob?sastoken`
         :param metadata:
             Name-value pairs associated with the blob as metadata. If no name-value
             pairs are specified, the operation will copy the metadata from the


### PR DESCRIPTION
## Issue
Our documentation treats the summary as markdown. If it has <xxx> it could be rendered as an html tag.

similar to https://github.com/Azure/azure-cli-extensions/pull/2016

## Common solution
Common solution is wrap <xxx> in backticks, as the PR shows.