### PR TITLE
[Account] Support sovereign clouds

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -114,7 +114,7 @@
 
 /src/import-export/ @arrownj
 
-/src/account/ @zikalino
+/src/account/ @arrownj @jiasli
 
 /src/datashare/ @fengzhou-msft
 

--- a/src/account/HISTORY.rst
+++ b/src/account/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.1.1
+++++++
+* Support sovereign clouds.
+
 0.1.0
 ++++++
 * Initial release.

--- a/src/account/azext_account/generated/_client_factory.py
+++ b/src/account/azext_account/generated/_client_factory.py
@@ -9,7 +9,7 @@ def cf_account(cli_ctx, *_):
     from ..vendored_sdks.subscription import SubscriptionClient
     return _get_mgmt_service_client(cli_ctx, SubscriptionClient,
                                     subscription_bound=False,
-                                    base_url_bound=False)[0]
+                                    base_url_bound=True)[0]
 
 
 def cf_subscription(cli_ctx, *_):

--- a/src/account/setup.py
+++ b/src/account/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
-VERSION = '0.1.0'
+VERSION = '0.1.1'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
As confirmed with @navysingla from service team. This extension now supports sovereign clouds.

Set `base_url_bound=True` so that the base URL for sovereign clouds' ARM endpoint is used. 