### PR TITLE
vm-repair: Fix vm name bug when 8th character in a VM name is a hyphen

### DIFF
--- a/src/vm-repair/azext_vm_repair/_help.py
+++ b/src/vm-repair/azext_vm_repair/_help.py
@@ -9,7 +9,7 @@ helps['vm repair'] = """
     type: group
     short-summary: Auto repair commands to fix VMs.
     long-summary: |
-        VM repair scripts will enable Azure users to self-repair non-bootable VMs by copying the source VM's OS disk and attaching it to a newly created repair VM.
+        VM repair command will enable Azure users to self-repair non-bootable VMs by copying the source VM's OS disk and attaching it to a newly created repair VM.
 """
 
 helps['vm repair create'] = """

--- a/src/vm-repair/azext_vm_repair/_validators.py
+++ b/src/vm-repair/azext_vm_repair/_validators.py
@@ -41,7 +41,7 @@ def validate_create(cmd, namespace):
     if namespace.repair_vm_name:
         _validate_vm_name(namespace.repair_vm_name, is_linux)
     else:
-        namespace.repair_vm_name = ('repair-' + namespace.vm_name)[:15]
+        namespace.repair_vm_name = ('repair-' + namespace.vm_name)[:14] + '_'
 
     # Check copy disk name
     timestamp = datetime.utcnow().strftime('%Y%m%d%H%M%S.%f')

--- a/src/vm-repair/setup.py
+++ b/src/vm-repair/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup, find_packages
 
-VERSION = "0.3.1"
+VERSION = "0.3.2"
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
@@ -30,7 +30,7 @@ setup(
     name='vm-repair',
     version=VERSION,
     description='Auto repair commands to fix VMs.',
-    long_description='VM repair scripts will enable Azure users to self-repair non-connectable VMs by copying the source VM\'s OS disk and attaching it to a newly created repair VM.',
+    long_description='VM repair command will enable Azure users to self-repair non-bootable VMs by copying the source VM\'s OS disk and attaching it to a newly created repair VM.',
     license='MIT',
     author='Microsoft Corporation',
     author_email='caiddev@microsoft.com',


### PR DESCRIPTION
- Minor fixes to address bug reports. 
- Minor fixes to help text

The default name value for newly created repair vms will now have a '_' at the end. 