### PR TITLE
remove max-pods validation from CLI and let pre-flight handle it

### DIFF
--- a/src/aks-preview/azext_aks_preview/_params.py
+++ b/src/aks-preview/azext_aks_preview/_params.py
@@ -17,7 +17,7 @@ from ._completers import (
     get_vm_size_completion_list, get_k8s_versions_completion_list, get_k8s_upgrades_completion_list)
 from ._validators import (
     validate_cluster_autoscaler_profile, validate_create_parameters, validate_k8s_version, validate_linux_host_name,
-    validate_ssh_key, validate_max_pods, validate_nodes_count, validate_ip_ranges,
+    validate_ssh_key, validate_nodes_count, validate_ip_ranges,
     validate_nodepool_name, validate_vm_set_type, validate_load_balancer_sku,
     validate_load_balancer_outbound_ips, validate_load_balancer_outbound_ip_prefixes,
     validate_taints, validate_priority, validate_eviction_policy, validate_spot_max_price, validate_acr, validate_user,
@@ -76,7 +76,7 @@ def load_arguments(self, _):
         c.argument('disable_rbac', action='store_true')
         c.argument('enable_rbac', action='store_true', options_list=['--enable-rbac', '-r'],
                    deprecate_info=c.deprecate(redirect="--disable-rbac", hide="2.0.45"))
-        c.argument('max_pods', type=int, options_list=['--max-pods', '-m'], validator=validate_max_pods)
+        c.argument('max_pods', type=int, options_list=['--max-pods', '-m'])
         c.argument('network_plugin', arg_type=get_enum_type(['azure', 'kubenet']))
         c.argument('network_policy')
         c.argument('no_ssh_key', options_list=['--no-ssh-key', '-x'])
@@ -142,7 +142,7 @@ def load_arguments(self, _):
             c.argument('node_zones', zones_type, options_list=['--node-zones', '--zones', '-z'], help='(--node-zones will be deprecated) Space-separated list of availability zones where agent nodes will be placed.')
             c.argument('enable_node_public_ip', action='store_true', is_preview=True)
             c.argument('node_vm_size', options_list=['--node-vm-size', '-s'], completer=get_vm_size_completion_list)
-            c.argument('max_pods', type=int, options_list=['--max-pods', '-m'], validator=validate_max_pods)
+            c.argument('max_pods', type=int, options_list=['--max-pods', '-m'])
             c.argument('os_type', type=str)
             c.argument('enable_cluster_autoscaler', options_list=["--enable-cluster-autoscaler", "-e"], action='store_true')
             c.argument('node_taints', type=str, validator=validate_taints)

--- a/src/aks-preview/azext_aks_preview/_validators.py
+++ b/src/aks-preview/azext_aks_preview/_validators.py
@@ -88,16 +88,6 @@ def validate_linux_host_name(namespace):
                        'letters, numbers, or dashes (-).')
 
 
-def validate_max_pods(namespace):
-    """Validates that max_pods is set to a reasonable minimum number."""
-    # kube-proxy and kube-svc reside each nodes,
-    # 2 kube-proxy pods, 1 azureproxy/heapster/dashboard/tunnelfront are in kube-system
-    minimum_pods_required = ceil((namespace.node_count * 2 + 6 + 1) / namespace.node_count)
-    if namespace.max_pods != 0 and namespace.max_pods < minimum_pods_required:
-        raise CLIError('--max-pods must be at least {} for a managed Kubernetes cluster to function.'
-                       .format(minimum_pods_required))
-
-
 def validate_nodes_count(namespace):
     """Validate that min_count and max_count is set to 1-100"""
     if namespace.min_count is not None:


### PR DESCRIPTION
This check is somewhat updated and no longer relevant. It also doesn't play nicely with with 0 nodes nodepool. Remove this and let pre-flight validation handle it.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
