### PR TITLE
fix format table for upgrade profile because agentPoolProfiles is nil

### DIFF
--- a/src/aks-preview/azext_aks_preview/_format.py
+++ b/src/aks-preview/azext_aks_preview/_format.py
@@ -69,14 +69,12 @@ def aks_upgrades_table_format(result):
             if upgrade.get('isPreview', False):
                 preview[upgrade['kubernetesVersion']] = True
     find_preview_versions(result.get('controlPlaneProfile', {}))
-    find_preview_versions(result.get('agentPoolProfiles', [{}])[0])
 
     # This expression assumes there is one node pool, and that the master and nodes upgrade in lockstep.
     parsed = compile_jmes("""{
         name: name,
         resourceGroup: resourceGroup,
-        masterVersion: controlPlaneProfile.kubernetesVersion || `unknown` | set_preview(@),
-        nodePoolVersion: agentPoolProfiles[0].kubernetesVersion || `unknown` | set_preview(@),
+        masterVersion: controlPlaneProfile.kubernetesVersion || `unknown`,
         upgrades: controlPlaneProfile.upgrades[].kubernetesVersion || [`None available`] | sort_versions(@) | set_preview_array(@) | join(`, `, @)
     }""")
     # use ordered dicts so headers are predictable


### PR DESCRIPTION
`agentPoolProfiles` is always nil in the upgrade so this fixes the `-o table` option to also match the core CLI one.

Closes #1866

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
