### PR TITLE
Explicit legacy iot extension deprecation.

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -2044,7 +2044,7 @@
         ],
         "azure-cli-iot-ext": [
             {
-                "downloadUrl": "https://github.com/Azure/azure-iot-cli-extension/releases/download/0.8.10/azure_cli_iot_ext-0.8.10-py2.py3-none-any.whl",
+                "downloadUrl": "https://github.com/Azure/azure-iot-cli-extension/releases/download/v0.8.10/azure_cli_iot_ext-0.8.10-py2.py3-none-any.whl",
                 "filename": "azure_cli_iot_ext-0.8.10-py2.py3-none-any.whl",
                 "metadata": {
                     "azext.minCliCoreVersion": "2.0.70",
@@ -2094,10 +2094,10 @@
                             ]
                         }
                     ],
-                    "summary": "[Deprecated: Use the 'azure-iot' extension instead.]",
+                    "summary": "Deprecated: please remove 'azure-cli-iot-ext' and install the 'azure-iot' extension instead. The legacy extension 'azure-cli-iot-ext' is scheduled for removal after 9/15/2020.",
                     "version": "0.8.10"
                 },
-                "sha256Digest": "631287889335faa4ba461a19b5af98af58f001377b9cf2c43c1bec959d598ae9"
+                "sha256Digest": "55178c5c9a975f27054764a4f2758815cdda55f73fdf11c432bd03f6ac2391fd"
             },
             {
                 "downloadUrl": "https://github.com/Azure/azure-iot-cli-extension/releases/download/v0.8.9/azure_cli_iot_ext-0.8.9-py2.py3-none-any.whl",

--- a/src/index.json
+++ b/src/index.json
@@ -2044,6 +2044,62 @@
         ],
         "azure-cli-iot-ext": [
             {
+                "downloadUrl": "https://github.com/Azure/azure-iot-cli-extension/releases/download/0.8.10/azure_cli_iot_ext-0.8.10-py2.py3-none-any.whl",
+                "filename": "azure_cli_iot_ext-0.8.10-py2.py3-none-any.whl",
+                "metadata": {
+                    "azext.minCliCoreVersion": "2.0.70",
+                    "classifiers": [
+                        "Development Status :: 4 - Beta",
+                        "Intended Audience :: Developers",
+                        "Intended Audience :: System Administrators",
+                        "Programming Language :: Python",
+                        "Programming Language :: Python :: 2",
+                        "Programming Language :: Python :: 2.7",
+                        "Programming Language :: Python :: 3",
+                        "Programming Language :: Python :: 3.4",
+                        "Programming Language :: Python :: 3.5",
+                        "Programming Language :: Python :: 3.6",
+                        "Programming Language :: Python :: 3.7",
+                        "Programming Language :: Python :: 3.8",
+                        "License :: OSI Approved :: MIT License"
+                    ],
+                    "extensions": {
+                        "python.details": {
+                            "contacts": [
+                                {
+                                    "email": "iotupx@microsoft.com",
+                                    "name": "Microsoft",
+                                    "role": "author"
+                                }
+                            ],
+                            "document_names": {
+                                "description": "DESCRIPTION.rst"
+                            },
+                            "project_urls": {
+                                "Home": "https://github.com/azure/azure-iot-cli-extension"
+                            }
+                        }
+                    },
+                    "extras": [],
+                    "generator": "bdist_wheel (0.30.0)",
+                    "license": "MIT",
+                    "metadata_version": "2.0",
+                    "name": "azure-cli-iot-ext",
+                    "run_requires": [
+                        {
+                            "requires": [
+                                "jsonschema (==3.0.2)",
+                                "paho-mqtt (==1.5.0)",
+                                "setuptools"
+                            ]
+                        }
+                    ],
+                    "summary": "[Deprecated: Use the 'azure-iot' extension instead.]",
+                    "version": "0.8.10"
+                },
+                "sha256Digest": "631287889335faa4ba461a19b5af98af58f001377b9cf2c43c1bec959d598ae9"
+            },
+            {
                 "downloadUrl": "https://github.com/Azure/azure-iot-cli-extension/releases/download/v0.8.9/azure_cli_iot_ext-0.8.9-py2.py3-none-any.whl",
                 "filename": "azure_cli_iot_ext-0.8.9-py2.py3-none-any.whl",
                 "metadata": {
@@ -2098,58 +2154,6 @@
                     "version": "0.8.9"
                 },
                 "sha256Digest": "080ea8af36c301bc2ed667eca5585f627c5a6f2de9a44eb903f83b156d2a2ee6"
-            },
-            {
-                "downloadUrl": "https://github.com/Azure/azure-iot-cli-extension/releases/download/v0.7.1/azure_cli_iot_ext-0.7.1-py2.py3-none-any.whl",
-                "filename": "azure_cli_iot_ext-0.7.1-py2.py3-none-any.whl",
-                "metadata": {
-                    "azext.minCliCoreVersion": "2.0.24",
-                    "classifiers": [
-                        "Development Status :: 4 - Beta",
-                        "Intended Audience :: Developers",
-                        "Intended Audience :: System Administrators",
-                        "Programming Language :: Python",
-                        "Programming Language :: Python :: 2",
-                        "Programming Language :: Python :: 2.7",
-                        "Programming Language :: Python :: 3",
-                        "Programming Language :: Python :: 3.4",
-                        "Programming Language :: Python :: 3.5",
-                        "Programming Language :: Python :: 3.6",
-                        "License :: OSI Approved :: MIT License"
-                    ],
-                    "extensions": {
-                        "python.details": {
-                            "contacts": [
-                                {
-                                    "email": "iotupx@microsoft.com",
-                                    "name": "Microsoft",
-                                    "role": "author"
-                                }
-                            ],
-                            "document_names": {
-                                "description": "DESCRIPTION.rst"
-                            },
-                            "project_urls": {
-                                "Home": "https://github.com/azure/azure-iot-cli-extension"
-                            }
-                        }
-                    },
-                    "extras": [],
-                    "generator": "bdist_wheel (0.30.0)",
-                    "license": "MIT",
-                    "metadata_version": "2.0",
-                    "name": "azure-cli-iot-ext",
-                    "run_requires": [
-                        {
-                            "requires": [
-                                "paho-mqtt (==1.3.1)"
-                            ]
-                        }
-                    ],
-                    "summary": "Provides the data plane command layer for Azure IoT Hub, IoT Edge and IoT Device Provisioning Service",
-                    "version": "0.7.1"
-                },
-                "sha256Digest": "0a8431db427db693ba6bcfe9572b4fceda6b20190be99990b1bb8c75a7c89405"
             }
         ],
         "azure-cli-ml": [


### PR DESCRIPTION
This update is to explicitly add deprecation information to command groups, commands and package description to make it obvious for users this extension should not be used anymore and to use 'azure-iot' instead.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
