### PR TITLE
webapp: add support for using new OneDeploy API for deployments  in CLI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 
 /src/image-copy/ @tamirkamara
 
-/src/webapp/ @panchagnula
+/src/webapp/ @panchagnula @dannysongg
 
 /src/aem/ @qwordy
 

--- a/src/webapp/azext_webapp/__init__.py
+++ b/src/webapp/azext_webapp/__init__.py
@@ -25,6 +25,7 @@ class WebappExtCommandLoader(AzCommandsLoader):
         with self.command_group('webapp') as g:
             g.custom_command('container up', 'create_deploy_container_app', exception_handler=ex_handler_factory())
             g.custom_command('remote-connection create', 'create_tunnel')
+            g.custom_command('deploy', 'enable_one_deploy')
 
         with self.command_group('webapp scan') as g:
             g.custom_command('start', 'start_scan')

--- a/src/webapp/azext_webapp/__init__.py
+++ b/src/webapp/azext_webapp/__init__.py
@@ -52,14 +52,17 @@ class WebappExtCommandLoader(AzCommandsLoader):
             c.argument('dryrun', help="show summary of the create and deploy operation instead of executing it", default=False, action='store_true')
             c.argument('registry_rg', help="the resource group of the Azure Container Registry")
             c.argument('registry_name', help="the name of the Azure Container Registry")
+            c.argument('slot', help="the deployment slot")
         with self.argument_context('webapp remote-connection create') as c:
             c.argument('port', options_list=['--port', '-p'],
                        help='Port for the remote connection. Default: Random available port', type=int)
             c.argument('name', options_list=['--name', '-n'], help='Name of the webapp to connect to')
+            c.argument('slot', help="Name of the deployment slot to use")
         with self.argument_context('webapp scan') as c:
             c.argument('name', options_list=['--name', '-n'], help='Name of the webapp to connect to')
             c.argument('scan_id', options_list=['--scan-id'], help='Unique scan id')
             c.argument('timeout', options_list=['--timeout'], help='Timeout for operation in milliseconds')
+            c.argument('slot', help="Name of the deployment slot to use")
 
         with self.argument_context('webapp deploy') as c:
             c.argument('name', options_list=['--name'], help='Name of the webapp to connect to')
@@ -68,6 +71,7 @@ class WebappExtCommandLoader(AzCommandsLoader):
             c.argument('is_async', options_list=['--async'], help='Asynchronous deployment', type=bool)
             c.argument('target_path', options_list=['--target-path'], help='Target path to which the file will be deployed to.')
             c.argument('timeout', options_list=['--timeout'], help='Timeout for operation in milliseconds')
+            c.argument('slot', help="Name of the deployment slot to use")
 
 
 COMMAND_LOADER_CLS = WebappExtCommandLoader

--- a/src/webapp/azext_webapp/__init__.py
+++ b/src/webapp/azext_webapp/__init__.py
@@ -52,7 +52,7 @@ class WebappExtCommandLoader(AzCommandsLoader):
             c.argument('dryrun', help="show summary of the create and deploy operation instead of executing it", default=False, action='store_true')
             c.argument('registry_rg', help="the resource group of the Azure Container Registry")
             c.argument('registry_name', help="the name of the Azure Container Registry")
-            c.argument('slot', help="the deployment slot")
+            c.argument('slot', help="Name of the deployment slot to use")
         with self.argument_context('webapp remote-connection create') as c:
             c.argument('port', options_list=['--port', '-p'],
                        help='Port for the remote connection. Default: Random available port', type=int)

--- a/src/webapp/azext_webapp/__init__.py
+++ b/src/webapp/azext_webapp/__init__.py
@@ -69,7 +69,7 @@ class WebappExtCommandLoader(AzCommandsLoader):
             c.argument('src', options_list=['--src'], help='Path of the file to be deployed')
             c.argument('deploy_type', options_list=['--type'], help='Type of deployment requested')
             c.argument('is_async', options_list=['--async'], help='Asynchronous deployment', type=bool)
-            c.argument('target_path', options_list=['--target-path'], help='Target path to which the file will be deployed to.')
+            c.argument('target_path', options_list=['--target-path'], help='Target path relative to wwwroot to which the file will be deployed to.')
             c.argument('timeout', options_list=['--timeout'], help='Timeout for operation in milliseconds')
             c.argument('slot', help="Name of the deployment slot to use")
 

--- a/src/webapp/azext_webapp/__init__.py
+++ b/src/webapp/azext_webapp/__init__.py
@@ -61,5 +61,13 @@ class WebappExtCommandLoader(AzCommandsLoader):
             c.argument('scan_id', options_list=['--scan-id'], help='Unique scan id')
             c.argument('timeout', options_list=['--timeout'], help='Timeout for operation in milliseconds')
 
+        with self.argument_context('webapp deploy') as c:
+            c.argument('name', options_list=['--name'], help='Name of the webapp to connect to')
+            c.argument('src', options_list=['--src'], help='Path of the file to be deployed')
+            c.argument('deploy_type', options_list=['--type'], help='Type of deployment requested')
+            c.argument('is_async', options_list=['--async'], help='Asynchronous deployment', type=bool)
+            c.argument('target_path', options_list=['--target-path'], help='Target path to which the file will be deployed to.')
+            c.argument('timeout', options_list=['--timeout'], help='Timeout for operation in milliseconds')
+
 
 COMMAND_LOADER_CLS = WebappExtCommandLoader

--- a/src/webapp/azext_webapp/_help.py
+++ b/src/webapp/azext_webapp/_help.py
@@ -62,5 +62,5 @@ helps['webapp container up'] = """
 
 helps['webapp deploy'] = """
     type: command
-    short-summary: Deploys a given artifact to Azure Web Apps through OneDeploy.
+    short-summary: Deploys a provided artifact to Azure Web Apps.
 """

--- a/src/webapp/azext_webapp/_help.py
+++ b/src/webapp/azext_webapp/_help.py
@@ -59,3 +59,8 @@ helps['webapp container up'] = """
         - name: Upload files from the current directory to an Azure Container Registry, then build a container image and deploy it to a web app. The Azure Container Registry must already exist.
           text: az webapp container up -n AppName --registry-rg ContainerRegistryResourceGroup --registry-name ContainerRegistryName
 """
+
+helps['webapp deploy'] = """
+    type: command
+    short-summary: Deploys a given artifact to Azure Web Apps through OneDeploy.
+"""

--- a/src/webapp/azext_webapp/_help.py
+++ b/src/webapp/azext_webapp/_help.py
@@ -67,5 +67,5 @@ helps['webapp deploy'] = """
     - name: Deploy a war file asynchronously.
       text: az webapp deploy --resource-group ResouceGroup --name AppName --src SourcePath --type war --async IsAsync
     - name: Deploy a static text file to wwwroot/staticfiles/test.txt
-      text: az webapp deploy --resource-group ResouceGroup --name AppName --src SourcePath --type static --target-path staticfiles/test.txt 
+      text: az webapp deploy --resource-group ResouceGroup --name AppName --src SourcePath --type static --target-path staticfiles/test.txt
 """

--- a/src/webapp/azext_webapp/_help.py
+++ b/src/webapp/azext_webapp/_help.py
@@ -63,4 +63,9 @@ helps['webapp container up'] = """
 helps['webapp deploy'] = """
     type: command
     short-summary: Deploys a provided artifact to Azure Web Apps.
+    examples:
+    - name: Deploy a war file asynchronously.
+      text: az webapp deploy --resource-group ResouceGroup --name AppName --src SourcePath --type war --async IsAsync
+    - name: Deploy a static text file to wwwroot/staticfiles/test.txt
+      text: az webapp deploy --resource-group ResouceGroup --name AppName --src SourcePath --type static --target-path staticfiles/test.txt 
 """

--- a/src/webapp/azext_webapp/custom.py
+++ b/src/webapp/azext_webapp/custom.py
@@ -312,9 +312,9 @@ def _should_create_new_asp(cmd, rg_name, asp_name, location):
     return True
 
 
-def enable_one_deploy(cmd, resource_group_name, name, src, type=None, is_async=None, target_path=None, timeout=None, slot=None):
+def enable_one_deploy(cmd, resource_group_name, name, src, deploy_type=None, is_async=None, target_path=None, timeout=None, slot=None):
     import ntpath
-    logger.warning("Preparing for deployment through OneDeploy")
+    logger.warning("Preparing for deployment")
     user_name, password = _get_site_credential(cmd.cli_ctx, resource_group_name, name, slot)
 
     try:
@@ -323,18 +323,18 @@ def enable_one_deploy(cmd, resource_group_name, name, src, type=None, is_async=N
         raise CLIError('Failed to fetch scm url for function app')
 
     # Interpret deployment type from the file extension if the type parameter is not passed
-    if type is None:
+    if deploy_type is None:
         fileName = ntpath.basename(src)
         fileExtension = fileName.split(".", 1)[1]
         if fileExtension in ('war', 'jar', 'zip', 'ear'):
-            type = fileExtension
+            deploy_type = fileExtension
         elif fileExtension in ('sh', 'bat'):
-            type = 'startup'
+            deploy_type = 'startup'
         else:
-            type = 'static'
+            deploy_type = 'static'
 
-    logger.warning("Deployment type: %s. To override deloyment type, please specify the --type parameter. Possible values: static, zip, war, jar, ear, startup", type)
-    deploy_url = scm_url + '/api/onedeploy?type=' + type
+    logger.warning("Deployment type: %s. To override deloyment type, please specify the --type parameter. Possible values: static, zip, war, jar, ear, startup", deploy_type)
+    deploy_url = scm_url + '/api/publish?type=' + deploy_type
 
     if is_async is not None:
         deploy_url = deploy_url + '&async=true'

--- a/src/webapp/azext_webapp/custom.py
+++ b/src/webapp/azext_webapp/custom.py
@@ -13,8 +13,10 @@ from azure.cli.command_modules.appservice.custom import (
     _get_scm_url,
     list_publish_profiles,
     get_site_configs,
-    update_container_settings, create_webapp,
-    get_sku_name)
+    update_container_settings,
+    create_webapp,
+    get_sku_name,
+    _check_zip_deployment_status)
 from azure.cli.command_modules.appservice._appservice_utils import _generic_site_operation
 from azure.cli.command_modules.appservice._create_util import (
     should_create_new_rg,
@@ -308,3 +310,75 @@ def _should_create_new_asp(cmd, rg_name, asp_name, location):
                 item.location == location):
             return False
     return True
+
+
+def enable_one_deploy(cmd, resource_group_name, name, src, type=None, is_async=None, target_path=None, timeout=None, slot=None):
+    import ntpath
+    logger.warning("Preparing for deployment through OneDeploy")
+    user_name, password = _get_site_credential(cmd.cli_ctx, resource_group_name, name, slot)
+
+    try:
+        scm_url = _get_scm_url(cmd, resource_group_name, name, slot)
+    except ValueError:
+        raise CLIError('Failed to fetch scm url for function app')
+
+    # Interpret deployment type from the file extension if the type parameter is not passed
+    if type is None:
+        fileName = ntpath.basename(src)
+        fileExtension = fileName.split(".", 1)[1]
+        if fileExtension in ('war', 'jar', 'zip', 'ear'):
+            type = fileExtension
+        elif fileExtension in ('sh', 'bat'):
+            type = 'startup'
+        else:
+            type = 'static'
+
+    logger.warning("Deployment type: %s. To override deloyment type, please specify the --type parameter. Possible values: static, zip, war, jar, ear, startup", type)
+    deploy_url = scm_url + '/api/onedeploy?type=' + type
+
+    if is_async is not None:
+        deploy_url = deploy_url + '&async=true'
+
+    if target_path is not None:
+        deploy_url = deploy_url + '&path=' + target_path
+
+    deployment_status_url = scm_url + '/api/deployments/latest'
+
+    from azure.cli.core.util import (
+        should_disable_connection_verify,
+        get_az_user_agent
+    )
+
+    import urllib3
+    authorization = urllib3.util.make_headers(basic_auth='{0}:{1}'.format(user_name, password))
+    headers = authorization
+    headers['Content-Type'] = 'application/octet-stream'
+    headers['Cache-Control'] = 'no-cache'
+    headers['User-Agent'] = get_az_user_agent()
+
+    import requests
+    import os
+
+    # Read file content
+    with open(os.path.realpath(os.path.expanduser(src)), 'rb') as fs:
+        artifact_content = fs.read()
+        logger.warning("Starting deployment...")
+        res = requests.post(deploy_url, data=artifact_content, headers=headers, verify=not should_disable_connection_verify())
+
+    # check if an error occured during deployment
+    if res.status_code == 400:
+        raise CLIError("An error occured durng deployment: {}".format(res.text))
+
+    # check if there's an ongoing process
+    if res.status_code == 409:
+        raise CLIError("There may be an ongoing deployment or your app setting has WEBSITE_RUN_FROM_PACKAGE. "
+                       "Please track your deployment in {} and ensure the WEBSITE_RUN_FROM_PACKAGE app setting "
+                       "is removed.".format(deployment_status_url))
+
+    # check the status of async deployment
+    if res.status_code == 202:
+        logger.warning("Asynchronous deployment request has been recieved")
+        response = _check_zip_deployment_status(cmd, resource_group_name, name, deployment_status_url, authorization, timeout)
+        return response
+
+    return logger.warning("Deployment has completed successfully")

--- a/src/webapp/azext_webapp/custom.py
+++ b/src/webapp/azext_webapp/custom.py
@@ -314,13 +314,13 @@ def _should_create_new_asp(cmd, rg_name, asp_name, location):
 
 def enable_one_deploy(cmd, resource_group_name, name, src, deploy_type=None, is_async=None, target_path=None, timeout=None, slot=None):
     import ntpath
-    logger.warning("Preparing for deployment")
+    logger.info("Preparing for deployment")
     user_name, password = _get_site_credential(cmd.cli_ctx, resource_group_name, name, slot)
 
     try:
         scm_url = _get_scm_url(cmd, resource_group_name, name, slot)
     except ValueError:
-        raise CLIError('Failed to fetch scm url for function app')
+        raise CLIError('Failed to fetch scm url for for app {}'.format(name))
 
     # Interpret deployment type from the file extension if the type parameter is not passed
     if deploy_type is None:


### PR DESCRIPTION
- Allows users to deploy various types of artifacts such as app.war, app.jar, static files, and zip files
- Supports asynchronous deployments, and deployments to a custom path.
- Deployment type is inferred from the extension of the file being deployed. This can be overridden using the --type parameter.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [X] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [X] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [X] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
