### PR TITLE
[ImageCopy] fix image copy failure when resource group location and disk location differ

### DIFF
--- a/src/image-copy/azext_imagecopy/custom.py
+++ b/src/image-copy/azext_imagecopy/custom.py
@@ -84,19 +84,21 @@ def imagecopy(cmd, source_resource_group_name, source_object_name, target_locati
     # TODO: skip creating another snapshot when the source is a snapshot
     logger.warning("Creating source snapshot")
     source_os_disk_snapshot_name = source_object_name + '_os_disk_snapshot'
-
+    snapshot_location = json_cmd_output['location']
     if source_os_disk_type == "BLOB":
         source_storage_account_id = get_storage_account_id_from_blob_path(cmd,
                                                                           source_os_disk_id,
                                                                           source_resource_group_name)
         cli_cmd = prepare_cli_command(['snapshot', 'create',
                                        '--name', source_os_disk_snapshot_name,
+                                       '--location', snapshot_location,
                                        '--resource-group', source_resource_group_name,
                                        '--source', source_os_disk_id,
                                        '--source-storage-account-id', source_storage_account_id])
     else:
         cli_cmd = prepare_cli_command(['snapshot', 'create',
                                        '--name', source_os_disk_snapshot_name,
+                                       '--location', snapshot_location,
                                        '--resource-group', source_resource_group_name,
                                        '--source', source_os_disk_id])
 


### PR DESCRIPTION
In `create_snapshot` function, there is a line
>location = location or _get_resource_group_location(cmd.cli_ctx, resource_group_name)

However service will use this location to retrieve the disk information. If the disk location differs with resource group location, service will throw "Resource disk_xxxxxxxx not found" error.

This makes the `az image copy` command fails.

This is a workaround solution from `image-copy` side for this case. The `snapshot` issue [az image copy failed create snapshot ](https://github.com/Azure/azure-cli/issues/14560)is recorded in azure-cli repo.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
