### PR TITLE
[ai-examples] Send User ID hash for rate limiting

### DIFF
--- a/src/ai-examples/HISTORY.rst
+++ b/src/ai-examples/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.2.4
+++++++
+* Send User ID hash for rate limiting to prevent bad actors from slowing down the service for other users
+
 0.2.3
 ++++++
 * Add fallback to use built-in values if there is an issue with using the service

--- a/src/ai-examples/azext_ai_examples/custom.py
+++ b/src/ai-examples/azext_ai_examples/custom.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 
+import hashlib
 import json
 import re
 import requests
@@ -88,6 +89,10 @@ def call_aladdin_service(query):
     correlation_id = telemetry_core._session.correlation_id   # pylint: disable=protected-access
     subscription_id = telemetry_core._get_azure_subscription_id()  # pylint: disable=protected-access
 
+    # Used for DDOS protection and rate limiting
+    user_id = telemetry_core._get_user_azure_id()  # pylint: disable=protected-access
+    hashed_user_id = hashlib.sha256(user_id.encode('utf-8')).hexdigest()
+
     context = {
         "versionNumber": version,
     }
@@ -100,7 +105,10 @@ def call_aladdin_service(query):
         context['subscriptionId'] = subscription_id
 
     api_url = 'https://app.aladdin.microsoft.com/api/v1.0/examples'
-    headers = {'Content-Type': 'application/json'}
+    headers = {
+        'Content-Type': 'application/json',
+        'X-UserId': hashed_user_id
+    }
 
     response = requests.get(
         api_url,

--- a/src/ai-examples/setup.py
+++ b/src/ai-examples/setup.py
@@ -15,7 +15,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
 
 # HISTORY.rst entry.
-VERSION = '0.2.3'
+VERSION = '0.2.4'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
In order to better handle the increased traffic, the Aladdin service is adding hashed User IDs to the request header in order to accurately rate limit clients. These should not interfere with normal usage, just prevent bad actors (most likely run-a-way scripts) from slowing down or breaking the service for other users.

The hashed ID is only used for the rate limiting and is only stored in memory for a temporary amount of time. It is not stored in telemetry.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [X] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [X] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
