### PR TITLE
[TimeSeriesInsights] Fix #2003: --partition-key-properties should be optional

### DIFF
--- a/src/timeseriesinsights/HISTORY.rst
+++ b/src/timeseriesinsights/HISTORY.rst
@@ -3,10 +3,15 @@
 Release History
 ===============
 
+0.1.3
+++++++
+
+* Fix #2003: ``az timeseriesinsights environment standard create``: ``--partition-key-properties`` should be optional
+
 0.1.2
 ++++++
 
-* Fix #1712: ``--timestamp-property-name`` should be made optional
+* Fix #1712: ``az timeseriesinsights event-source eventhub/iothub create``: ``--timestamp-property-name`` should be optional
 
 0.1.1
 ++++++

--- a/src/timeseriesinsights/README.md
+++ b/src/timeseriesinsights/README.md
@@ -38,7 +38,7 @@ az group create --name $rg --location westus
 
 ```sh
 env={standard_environment_name}
-az timeseriesinsights environment standard create -g $rg --name $env --location westus --sku-name S1 --sku-capacity 1 --data-retention-time P31D --partition-key DeviceId1 --storage-limit-exceeded-behavior PauseIngress
+az timeseriesinsights environment standard create -g $rg --name $env --location westus --sku-name S1 --sku-capacity 1 --data-retention-time 31 --partition-key-properties DeviceId1 --storage-limit-exceeded-behavior PauseIngress
 ```
 
 ### Create a storage account and use it to create a long-term environment

--- a/src/timeseriesinsights/azext_timeseriesinsights/custom.py
+++ b/src/timeseriesinsights/azext_timeseriesinsights/custom.py
@@ -28,7 +28,7 @@ def create_timeseriesinsights_environment_standard(cmd, client,
         data_retention_time=data_retention_time,
         storage_limit_exceeded_behavior=storage_limit_exceeded_behavior,
         # Need to confirm whether multiple key properties are supported
-        partition_key_properties=[TimeSeriesIdProperty(name=id_property, type="String") for id_property in partition_key_properties]
+        partition_key_properties=[TimeSeriesIdProperty(name=id_property, type="String") for id_property in partition_key_properties] if partition_key_properties else None
     )
     return sdk_no_wait(no_wait, client.create_or_update, resource_group_name=resource_group_name, environment_name=environment_name, parameters=parameters)
 

--- a/src/timeseriesinsights/azext_timeseriesinsights/tests/latest/recordings/test_timeseriesinsights_environment_standard.yaml
+++ b/src/timeseriesinsights/azext_timeseriesinsights/tests/latest/recordings/test_timeseriesinsights_environment_standard.yaml
@@ -11,150 +11,6 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - --resource-group --name --sku-name --sku-capacity --data-retention-time
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_timeseriesinsights000001?api-version=2020-06-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001","name":"cli_test_timeseriesinsights000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-09-14T08:34:43Z"},"properties":{"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '428'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 14 Sep 2020 08:34:45 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"location": "westus", "sku": {"name": "S1", "capacity": 1}, "kind": "Standard",
-      "properties": {"dataRetentionTime": "P7D"}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - timeseriesinsights environment standard create
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '124'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - --resource-group --name --sku-name --sku-capacity --data-retention-time
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002?api-version=2018-08-15-preview
-  response:
-    body:
-      string: '{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P7D","creationTime":"2020-09-14T08:34:51.7969875+00:00","provisioningState":"Succeeded","dataAccessId":"9c25ef56-fb82-45f6-9ab6-ee09993e16f3","dataAccessFqdn":"9c25ef56-fb82-45f6-9ab6-ee09993e16f3.env.timeseries.azure.com","requestApiVersion":"2018-08-15-preview","storageLimitExceededBehavior":"PurgeOldData"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '742'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Sep 2020 08:35:05 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1188'
-    status:
-      code: 201
-      message: Created
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - timeseriesinsights environment delete
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      ParameterSetName:
-      - --resource-group --name --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
-      accept-language:
-      - en-US
-    method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002?api-version=2018-08-15-preview
-  response:
-    body:
-      string: ''
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Mon, 14 Sep 2020 08:35:10 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-deletes:
-      - '14999'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - timeseriesinsights environment standard create
-      Connection:
-      - keep-alive
-      ParameterSetName:
       - --resource-group --name --sku-name --sku-capacity --data-retention-time --partition-key-properties
         --storage-limit-exceeded-behavior
       User-Agent:
@@ -166,7 +22,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_timeseriesinsights000001?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001","name":"cli_test_timeseriesinsights000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-09-14T08:34:43Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001","name":"cli_test_timeseriesinsights000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-09-14T08:57:33Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -175,7 +31,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 14 Sep 2020 08:35:10 GMT
+      - Mon, 14 Sep 2020 08:57:35 GMT
       expires:
       - '-1'
       pragma:
@@ -218,7 +74,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P7D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-09-14T08:35:16.4353186+00:00","provisioningState":"Succeeded","dataAccessId":"708bc83b-e9f6-44f3-a0c8-990906282d39","dataAccessFqdn":"708bc83b-e9f6-44f3-a0c8-990906282d39.env.timeseries.azure.com","requestApiVersion":"2018-08-15-preview"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}'
+      string: '{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P7D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-09-14T08:57:42.4150052+00:00","provisioningState":"Succeeded","dataAccessId":"0e2400dd-a9a7-4b22-bedf-145ecf8d8989","dataAccessFqdn":"0e2400dd-a9a7-4b22-bedf-145ecf8d8989.env.timeseries.azure.com","requestApiVersion":"2018-08-15-preview"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}'
     headers:
       cache-control:
       - no-cache
@@ -227,7 +83,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Sep 2020 08:35:28 GMT
+      - Mon, 14 Sep 2020 08:57:54 GMT
       expires:
       - '-1'
       pragma:
@@ -239,7 +95,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1193'
+      - '1158'
     status:
       code: 201
       message: Created
@@ -269,7 +125,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"sku":{"name":"S1","capacity":2},"kind":"Standard","location":"westus","tags":{},"properties":{"dataRetentionTime":"P7D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-09-14T08:35:16.4353186Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"708bc83b-e9f6-44f3-a0c8-990906282d39","dataAccessFqdn":"708bc83b-e9f6-44f3-a0c8-990906282d39.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}'
+      string: '{"sku":{"name":"S1","capacity":2},"kind":"Standard","location":"westus","tags":{},"properties":{"dataRetentionTime":"P7D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-09-14T08:57:42.4150052Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"0e2400dd-a9a7-4b22-bedf-145ecf8d8989","dataAccessFqdn":"0e2400dd-a9a7-4b22-bedf-145ecf8d8989.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}'
     headers:
       cache-control:
       - no-cache
@@ -278,7 +134,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Sep 2020 08:35:36 GMT
+      - Mon, 14 Sep 2020 08:58:01 GMT
       expires:
       - '-1'
       pragma:
@@ -294,7 +150,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1194'
+      - '1195'
     status:
       code: 200
       message: OK
@@ -324,7 +180,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"sku":{"name":"S1","capacity":2},"kind":"Standard","location":"westus","tags":{},"properties":{"dataRetentionTime":"P8D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-09-14T08:35:16.4353186Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"708bc83b-e9f6-44f3-a0c8-990906282d39","dataAccessFqdn":"708bc83b-e9f6-44f3-a0c8-990906282d39.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}'
+      string: '{"sku":{"name":"S1","capacity":2},"kind":"Standard","location":"westus","tags":{},"properties":{"dataRetentionTime":"P8D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-09-14T08:57:42.4150052Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"0e2400dd-a9a7-4b22-bedf-145ecf8d8989","dataAccessFqdn":"0e2400dd-a9a7-4b22-bedf-145ecf8d8989.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}'
     headers:
       cache-control:
       - no-cache
@@ -333,7 +189,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Sep 2020 08:35:37 GMT
+      - Mon, 14 Sep 2020 08:58:03 GMT
       expires:
       - '-1'
       pragma:
@@ -349,7 +205,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1193'
+      - '1194'
     status:
       code: 200
       message: OK
@@ -379,7 +235,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"sku":{"name":"S1","capacity":2},"kind":"Standard","location":"westus","tags":{},"properties":{"dataRetentionTime":"P8D","storageLimitExceededBehavior":"PurgeOldData","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-09-14T08:35:16.4353186Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"708bc83b-e9f6-44f3-a0c8-990906282d39","dataAccessFqdn":"708bc83b-e9f6-44f3-a0c8-990906282d39.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}'
+      string: '{"sku":{"name":"S1","capacity":2},"kind":"Standard","location":"westus","tags":{},"properties":{"dataRetentionTime":"P8D","storageLimitExceededBehavior":"PurgeOldData","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-09-14T08:57:42.4150052Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"0e2400dd-a9a7-4b22-bedf-145ecf8d8989","dataAccessFqdn":"0e2400dd-a9a7-4b22-bedf-145ecf8d8989.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}'
     headers:
       cache-control:
       - no-cache
@@ -388,7 +244,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Sep 2020 08:35:39 GMT
+      - Mon, 14 Sep 2020 08:58:04 GMT
       expires:
       - '-1'
       pragma:
@@ -430,7 +286,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"sku":{"name":"S1","capacity":2},"kind":"Standard","location":"westus","tags":{},"properties":{"dataRetentionTime":"P8D","storageLimitExceededBehavior":"PurgeOldData","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-09-14T08:35:16.4353186Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"708bc83b-e9f6-44f3-a0c8-990906282d39","dataAccessFqdn":"708bc83b-e9f6-44f3-a0c8-990906282d39.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}'
+      string: '{"sku":{"name":"S1","capacity":2},"kind":"Standard","location":"westus","tags":{},"properties":{"dataRetentionTime":"P8D","storageLimitExceededBehavior":"PurgeOldData","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-09-14T08:57:42.4150052Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"0e2400dd-a9a7-4b22-bedf-145ecf8d8989","dataAccessFqdn":"0e2400dd-a9a7-4b22-bedf-145ecf8d8989.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}'
     headers:
       cache-control:
       - no-cache
@@ -439,7 +295,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Sep 2020 08:35:40 GMT
+      - Mon, 14 Sep 2020 08:58:05 GMT
       expires:
       - '-1'
       pragma:
@@ -479,7 +335,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"value":[{"sku":{"name":"S1","capacity":2},"kind":"Standard","location":"westus","tags":{},"properties":{"dataRetentionTime":"P8D","storageLimitExceededBehavior":"PurgeOldData","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-09-14T08:35:16.4353186Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"708bc83b-e9f6-44f3-a0c8-990906282d39","dataAccessFqdn":"708bc83b-e9f6-44f3-a0c8-990906282d39.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}]}'
+      string: '{"value":[{"sku":{"name":"S1","capacity":2},"kind":"Standard","location":"westus","tags":{},"properties":{"dataRetentionTime":"P8D","storageLimitExceededBehavior":"PurgeOldData","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-09-14T08:57:42.4150052Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"0e2400dd-a9a7-4b22-bedf-145ecf8d8989","dataAccessFqdn":"0e2400dd-a9a7-4b22-bedf-145ecf8d8989.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}]}'
     headers:
       cache-control:
       - no-cache
@@ -488,7 +344,54 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Sep 2020 08:35:42 GMT
+      - Mon, 14 Sep 2020 08:58:06 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - timeseriesinsights environment list
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.TimeSeriesInsights/environments?api-version=2018-08-15-preview
+  response:
+    body:
+      string: '{"value":[{"sku":{"name":"S1","capacity":2},"kind":"Standard","location":"westus","tags":{},"properties":{"dataRetentionTime":"P8D","storageLimitExceededBehavior":"PurgeOldData","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-09-14T08:47:48.6136944Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"0d2e49a5-aafe-487f-a3f4-726fc119b567","dataAccessFqdn":"0d2e49a5-aafe-487f-a3f4-726fc119b567.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsightsshri4ciwopuz4f45undhb56vgq6pzxnf3deluxyd3z274jee/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-envd6s3xkly","name":"cli-test-tsi-envd6s3xkly","type":"Microsoft.TimeSeriesInsights/Environments"},{"sku":{"name":"S1","capacity":2},"kind":"Standard","location":"westus","tags":{},"properties":{"dataRetentionTime":"P8D","storageLimitExceededBehavior":"PurgeOldData","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-09-14T08:57:42.4150052Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"0e2400dd-a9a7-4b22-bedf-145ecf8d8989","dataAccessFqdn":"0e2400dd-a9a7-4b22-bedf-145ecf8d8989.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1611'
+      content-type:
+      - application/json
+      date:
+      - Mon, 14 Sep 2020 08:58:08 GMT
       expires:
       - '-1'
       pragma:
@@ -537,7 +440,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 14 Sep 2020 08:35:47 GMT
+      - Mon, 14 Sep 2020 08:58:12 GMT
       expires:
       - '-1'
       pragma:
@@ -549,7 +452,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-deletes:
-      - '14999'
+      - '14994'
     status:
       code: 200
       message: OK
@@ -584,7 +487,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 14 Sep 2020 08:35:47 GMT
+      - Mon, 14 Sep 2020 08:58:13 GMT
       expires:
       - '-1'
       pragma:
@@ -595,6 +498,150 @@ interactions:
       - Accept-Encoding
       x-content-type-options:
       - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - timeseriesinsights environment standard create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --sku-name --sku-capacity --data-retention-time
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_timeseriesinsights000001?api-version=2020-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001","name":"cli_test_timeseriesinsights000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-09-14T08:57:33Z"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '428'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 14 Sep 2020 08:58:13 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "westus", "sku": {"name": "S1", "capacity": 1}, "kind": "Standard",
+      "properties": {"dataRetentionTime": "P7D"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - timeseriesinsights environment standard create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '124'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --resource-group --name --sku-name --sku-capacity --data-retention-time
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003?api-version=2018-08-15-preview
+  response:
+    body:
+      string: '{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P7D","creationTime":"2020-09-14T08:58:20.0229426+00:00","provisioningState":"Succeeded","dataAccessId":"4d6cbba2-b744-4fab-b786-11a2e4198ab8","dataAccessFqdn":"4d6cbba2-b744-4fab-b786-11a2e4198ab8.env.timeseries.azure.com","requestApiVersion":"2018-08-15-preview","storageLimitExceededBehavior":"PurgeOldData"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003","name":"cli-test-tsi-env000003","type":"Microsoft.TimeSeriesInsights/Environments"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '742'
+      content-type:
+      - application/json
+      date:
+      - Mon, 14 Sep 2020 08:58:32 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1197'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - timeseriesinsights environment delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --resource-group --name --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      accept-language:
+      - en-US
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000003?api-version=2018-08-15-preview
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Mon, 14 Sep 2020 08:58:36 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14996'
     status:
       code: 200
       message: OK

--- a/src/timeseriesinsights/azext_timeseriesinsights/tests/latest/recordings/test_timeseriesinsights_environment_standard.yaml
+++ b/src/timeseriesinsights/azext_timeseriesinsights/tests/latest/recordings/test_timeseriesinsights_environment_standard.yaml
@@ -11,27 +11,171 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - --resource-group --name --sku-name --sku-capacity --data-retention-time --partition-key-properties
-        --storage-limit-exceeded-behavior
+      - --resource-group --name --sku-name --sku-capacity --data-retention-time
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.6.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_timeseriesinsights000001?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_timeseriesinsights000001?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001","name":"cli_test_timeseriesinsights000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-05-18T07:05:29Z","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001","name":"cli_test_timeseriesinsights000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-09-14T08:34:43Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '471'
+      - '428'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 18 May 2020 07:05:34 GMT
+      - Mon, 14 Sep 2020 08:34:45 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "westus", "sku": {"name": "S1", "capacity": 1}, "kind": "Standard",
+      "properties": {"dataRetentionTime": "P7D"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - timeseriesinsights environment standard create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '124'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --resource-group --name --sku-name --sku-capacity --data-retention-time
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002?api-version=2018-08-15-preview
+  response:
+    body:
+      string: '{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P7D","creationTime":"2020-09-14T08:34:51.7969875+00:00","provisioningState":"Succeeded","dataAccessId":"9c25ef56-fb82-45f6-9ab6-ee09993e16f3","dataAccessFqdn":"9c25ef56-fb82-45f6-9ab6-ee09993e16f3.env.timeseries.azure.com","requestApiVersion":"2018-08-15-preview","storageLimitExceededBehavior":"PurgeOldData"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '742'
+      content-type:
+      - application/json
+      date:
+      - Mon, 14 Sep 2020 08:35:05 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1188'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - timeseriesinsights environment delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --resource-group --name --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      accept-language:
+      - en-US
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002?api-version=2018-08-15-preview
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Mon, 14 Sep 2020 08:35:10 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14999'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - timeseriesinsights environment standard create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --sku-name --sku-capacity --data-retention-time --partition-key-properties
+        --storage-limit-exceeded-behavior
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_timeseriesinsights000001?api-version=2020-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001","name":"cli_test_timeseriesinsights000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-09-14T08:34:43Z"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '428'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 14 Sep 2020 08:35:10 GMT
       expires:
       - '-1'
       pragma:
@@ -66,24 +210,24 @@ interactions:
       - --resource-group --name --sku-name --sku-capacity --data-retention-time --partition-key-properties
         --storage-limit-exceeded-behavior
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P7D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-05-18T07:05:43.4408437+00:00","provisioningState":"Accepted","dataAccessId":"04c71581-6f41-4b84-8068-5c68bc25a17b","dataAccessFqdn":"04c71581-6f41-4b84-8068-5c68bc25a17b.env.timeseries.azure.com","requestApiVersion":"2018-08-15-preview"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}'
+      string: '{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P7D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-09-14T08:35:16.4353186+00:00","provisioningState":"Succeeded","dataAccessId":"708bc83b-e9f6-44f3-a0c8-990906282d39","dataAccessFqdn":"708bc83b-e9f6-44f3-a0c8-990906282d39.env.timeseries.azure.com","requestApiVersion":"2018-08-15-preview"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '805'
+      - '806'
       content-type:
       - application/json
       date:
-      - Mon, 18 May 2020 07:05:47 GMT
+      - Mon, 14 Sep 2020 08:35:28 GMT
       expires:
       - '-1'
       pragma:
@@ -95,58 +239,10 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1191'
+      - '1193'
     status:
       code: 201
       message: Created
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - timeseriesinsights environment standard create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --resource-group --name --sku-name --sku-capacity --data-retention-time --partition-key-properties
-        --storage-limit-exceeded-behavior
-      User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002?api-version=2018-08-15-preview
-  response:
-    body:
-      string: '{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P7D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-05-18T07:05:43.4408437Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"04c71581-6f41-4b84-8068-5c68bc25a17b","dataAccessFqdn":"04c71581-6f41-4b84-8068-5c68bc25a17b.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '801'
-      content-type:
-      - application/json
-      date:
-      - Mon, 18 May 2020 07:06:19 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
 - request:
     body: '{"sku": {"name": "S1", "capacity": 2}}'
     headers:
@@ -165,15 +261,15 @@ interactions:
       ParameterSetName:
       - --resource-group --name --sku-name --sku-capacity
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
       accept-language:
       - en-US
     method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"sku":{"name":"S1","capacity":2},"kind":"Standard","location":"westus","tags":{},"properties":{"dataRetentionTime":"P7D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-05-18T07:05:43.4408437Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"04c71581-6f41-4b84-8068-5c68bc25a17b","dataAccessFqdn":"04c71581-6f41-4b84-8068-5c68bc25a17b.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}'
+      string: '{"sku":{"name":"S1","capacity":2},"kind":"Standard","location":"westus","tags":{},"properties":{"dataRetentionTime":"P7D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-09-14T08:35:16.4353186Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"708bc83b-e9f6-44f3-a0c8-990906282d39","dataAccessFqdn":"708bc83b-e9f6-44f3-a0c8-990906282d39.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}'
     headers:
       cache-control:
       - no-cache
@@ -182,7 +278,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 18 May 2020 07:06:26 GMT
+      - Mon, 14 Sep 2020 08:35:36 GMT
       expires:
       - '-1'
       pragma:
@@ -198,7 +294,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1194'
     status:
       code: 200
       message: OK
@@ -220,15 +316,15 @@ interactions:
       ParameterSetName:
       - --resource-group --name --data-retention-time
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
       accept-language:
       - en-US
     method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"sku":{"name":"S1","capacity":2},"kind":"Standard","location":"westus","tags":{},"properties":{"dataRetentionTime":"P8D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-05-18T07:05:43.4408437Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"04c71581-6f41-4b84-8068-5c68bc25a17b","dataAccessFqdn":"04c71581-6f41-4b84-8068-5c68bc25a17b.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}'
+      string: '{"sku":{"name":"S1","capacity":2},"kind":"Standard","location":"westus","tags":{},"properties":{"dataRetentionTime":"P8D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-09-14T08:35:16.4353186Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"708bc83b-e9f6-44f3-a0c8-990906282d39","dataAccessFqdn":"708bc83b-e9f6-44f3-a0c8-990906282d39.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}'
     headers:
       cache-control:
       - no-cache
@@ -237,7 +333,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 18 May 2020 07:06:28 GMT
+      - Mon, 14 Sep 2020 08:35:37 GMT
       expires:
       - '-1'
       pragma:
@@ -253,7 +349,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1189'
+      - '1193'
     status:
       code: 200
       message: OK
@@ -275,15 +371,15 @@ interactions:
       ParameterSetName:
       - --resource-group --name --storage-limit-exceeded-behavior
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
       accept-language:
       - en-US
     method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"sku":{"name":"S1","capacity":2},"kind":"Standard","location":"westus","tags":{},"properties":{"dataRetentionTime":"P8D","storageLimitExceededBehavior":"PurgeOldData","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-05-18T07:05:43.4408437Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"04c71581-6f41-4b84-8068-5c68bc25a17b","dataAccessFqdn":"04c71581-6f41-4b84-8068-5c68bc25a17b.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}'
+      string: '{"sku":{"name":"S1","capacity":2},"kind":"Standard","location":"westus","tags":{},"properties":{"dataRetentionTime":"P8D","storageLimitExceededBehavior":"PurgeOldData","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-09-14T08:35:16.4353186Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"708bc83b-e9f6-44f3-a0c8-990906282d39","dataAccessFqdn":"708bc83b-e9f6-44f3-a0c8-990906282d39.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}'
     headers:
       cache-control:
       - no-cache
@@ -292,7 +388,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 18 May 2020 07:06:29 GMT
+      - Mon, 14 Sep 2020 08:35:39 GMT
       expires:
       - '-1'
       pragma:
@@ -308,7 +404,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1188'
+      - '1197'
     status:
       code: 200
       message: OK
@@ -326,15 +422,15 @@ interactions:
       ParameterSetName:
       - --resource-group --name
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"sku":{"name":"S1","capacity":2},"kind":"Standard","location":"westus","tags":{},"properties":{"dataRetentionTime":"P8D","storageLimitExceededBehavior":"PurgeOldData","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-05-18T07:05:43.4408437Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"04c71581-6f41-4b84-8068-5c68bc25a17b","dataAccessFqdn":"04c71581-6f41-4b84-8068-5c68bc25a17b.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}'
+      string: '{"sku":{"name":"S1","capacity":2},"kind":"Standard","location":"westus","tags":{},"properties":{"dataRetentionTime":"P8D","storageLimitExceededBehavior":"PurgeOldData","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-09-14T08:35:16.4353186Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"708bc83b-e9f6-44f3-a0c8-990906282d39","dataAccessFqdn":"708bc83b-e9f6-44f3-a0c8-990906282d39.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}'
     headers:
       cache-control:
       - no-cache
@@ -343,7 +439,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 18 May 2020 07:06:30 GMT
+      - Mon, 14 Sep 2020 08:35:40 GMT
       expires:
       - '-1'
       pragma:
@@ -375,15 +471,15 @@ interactions:
       ParameterSetName:
       - --resource-group
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments?api-version=2018-08-15-preview
   response:
     body:
-      string: '{"value":[{"sku":{"name":"S1","capacity":2},"kind":"Standard","location":"westus","tags":{},"properties":{"dataRetentionTime":"P8D","storageLimitExceededBehavior":"PurgeOldData","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-05-18T07:05:43.4408437Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"04c71581-6f41-4b84-8068-5c68bc25a17b","dataAccessFqdn":"04c71581-6f41-4b84-8068-5c68bc25a17b.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}]}'
+      string: '{"value":[{"sku":{"name":"S1","capacity":2},"kind":"Standard","location":"westus","tags":{},"properties":{"dataRetentionTime":"P8D","storageLimitExceededBehavior":"PurgeOldData","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-09-14T08:35:16.4353186Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"708bc83b-e9f6-44f3-a0c8-990906282d39","dataAccessFqdn":"708bc83b-e9f6-44f3-a0c8-990906282d39.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"}]}'
     headers:
       cache-control:
       - no-cache
@@ -392,54 +488,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 18 May 2020 07:06:31 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - timeseriesinsights environment list
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.TimeSeriesInsights/environments?api-version=2018-08-15-preview
-  response:
-    body:
-      string: '{"value":[{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P31D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-05-18T07:05:46.6439947Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"38c2b3bb-202d-409b-b6af-13165ba509ef","dataAccessFqdn":"38c2b3bb-202d-409b-b6af-13165ba509ef.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights3th7s5h3vkolxxhp4r7nndubsxczbjwc4ksdaaahmhy6yqni/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-envz4q5h5rp","name":"cli-test-tsi-envz4q5h5rp","type":"Microsoft.TimeSeriesInsights/Environments"},{"sku":{"name":"S1","capacity":2},"kind":"Standard","location":"westus","tags":{},"properties":{"dataRetentionTime":"P8D","storageLimitExceededBehavior":"PurgeOldData","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-05-18T07:05:43.4408437Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"04c71581-6f41-4b84-8068-5c68bc25a17b","dataAccessFqdn":"04c71581-6f41-4b84-8068-5c68bc25a17b.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights000001/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-env000002","name":"cli-test-tsi-env000002","type":"Microsoft.TimeSeriesInsights/Environments"},{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P31D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-05-18T07:05:50.6704839Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"15e132bd-a526-4c9a-9ca7-5fb45d1ac184","dataAccessFqdn":"15e132bd-a526-4c9a-9ca7-5fb45d1ac184.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights4u7etlphuia5jroxjjxje63q6zzeabmhrna7ihbzgqgth2dq/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-envp64livwc","name":"cli-test-tsi-envp64livwc","type":"Microsoft.TimeSeriesInsights/Environments"},{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P31D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-05-18T07:05:41.1766404Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"a096910d-50b3-492e-a5f0-7e82868516c8","dataAccessFqdn":"a096910d-50b3-492e-a5f0-7e82868516c8.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsightsjul33xjtd7kg5jsdqokxkmcjiadch6wmu26sjd72bn5zaq7a/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-envzmk2u43r","name":"cli-test-tsi-envzmk2u43r","type":"Microsoft.TimeSeriesInsights/Environments"},{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P7D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-05-18T03:04:26.6065083Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"738c6b44-35d3-434a-a1e2-05a6c43f9b91","dataAccessFqdn":"738c6b44-35d3-434a-a1e2-05a6c43f9b91.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.TimeSeriesInsights/environments/env1","name":"env1","type":"Microsoft.TimeSeriesInsights/Environments"},{"sku":{"name":"S1","capacity":1},"kind":"Standard","location":"westus","tags":null,"properties":{"dataRetentionTime":"P31D","storageLimitExceededBehavior":"PauseIngress","partitionKeyProperties":[{"name":"DeviceId1","type":"String"}],"creationTime":"2020-05-18T07:05:54.1394788Z","provisioningState":"Succeeded","requestApiVersion":"2018-08-15-preview","dataAccessId":"b229444b-d3fe-40b3-aa56-b1d0034ac955","dataAccessFqdn":"b229444b-d3fe-40b3-aa56-b1d0034ac955.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsights3prg5bvmxghup6sde7wdyqilbskkj6e3eiui7pnwhmampwky/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-envbqzlrzpn","name":"cli-test-tsi-envbqzlrzpn","type":"Microsoft.TimeSeriesInsights/Environments"},{"sku":{"name":"L1","capacity":1},"kind":"LongTerm","location":"WestUs","tags":{},"properties":{"timeSeriesIdProperties":[{"name":"DeviceId1","type":"String"}],"storageConfiguration":{"accountName":"clitestjbmxigo3m3ojcr4xw"},"warmStoreConfiguration":{"dataRetention":"P8D"},"creationTime":"2020-05-18T06:55:29.1065897Z","provisioningState":"Deleting","requestApiVersion":"2018-08-15-preview","dataAccessId":"145f3b06-ac3a-41d4-9aea-f5f68d764402","dataAccessFqdn":"145f3b06-ac3a-41d4-9aea-f5f68d764402.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsightsmpyjuymosotkmjhrqb6mic34bmeefpwkf3swkto64mbwdg57/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-envtdlugpgl","name":"cli-test-tsi-envtdlugpgl","type":"Microsoft.TimeSeriesInsights/Environments"},{"sku":{"name":"L1","capacity":1},"kind":"LongTerm","location":"WestUs","tags":{},"properties":{"timeSeriesIdProperties":[{"name":"DeviceId1","type":"String"}],"storageConfiguration":{"accountName":"clitestqa73h5bnf7mngwfcy"},"warmStoreConfiguration":{"dataRetention":"P8D"},"creationTime":"2020-05-18T07:06:07.0622679Z","provisioningState":"Updating","requestApiVersion":"2018-08-15-preview","dataAccessId":"d6ad1bd9-084f-403c-bf5f-cab12ef5ad28","dataAccessFqdn":"d6ad1bd9-084f-403c-bf5f-cab12ef5ad28.env.timeseries.azure.com"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_timeseriesinsightsiluqduqjjym4velhati7ko76mhzbldjiug2qzl5hrlb2dzph/providers/Microsoft.TimeSeriesInsights/environments/cli-test-tsi-envkvx2nuv5","name":"cli-test-tsi-envkvx2nuv5","type":"Microsoft.TimeSeriesInsights/Environments"}]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '6397'
-      content-type:
-      - application/json
-      date:
-      - Mon, 18 May 2020 07:06:33 GMT
+      - Mon, 14 Sep 2020 08:35:42 GMT
       expires:
       - '-1'
       pragma:
@@ -473,8 +522,8 @@ interactions:
       ParameterSetName:
       - --resource-group --name --yes
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
       accept-language:
       - en-US
     method: DELETE
@@ -488,7 +537,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 18 May 2020 07:06:38 GMT
+      - Mon, 14 Sep 2020 08:35:47 GMT
       expires:
       - '-1'
       pragma:
@@ -500,7 +549,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-deletes:
-      - '14996'
+      - '14999'
     status:
       code: 200
       message: OK
@@ -518,8 +567,8 @@ interactions:
       ParameterSetName:
       - --resource-group
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.6.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-timeseriesinsights/0.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
       accept-language:
       - en-US
     method: GET
@@ -535,7 +584,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 18 May 2020 07:06:39 GMT
+      - Mon, 14 Sep 2020 08:35:47 GMT
       expires:
       - '-1'
       pragma:

--- a/src/timeseriesinsights/azext_timeseriesinsights/tests/latest/test_timeseriesinsights_scenario.py
+++ b/src/timeseriesinsights/azext_timeseriesinsights/tests/latest/test_timeseriesinsights_scenario.py
@@ -44,7 +44,9 @@ class TimeSeriesInsightsClientScenarioTest(ScenarioTest):
                  '--data-retention-time 7 '
                  '--partition-key-properties DeviceId1 '
                  '--storage-limit-exceeded-behavior PauseIngress',
-                 checks=[self.check('name', '{env}')])
+                 checks=[self.check('name', '{env}'),
+                         self.check('partitionKeyProperties', [{"name": "DeviceId1", "type": "String"}]),
+                         self.check('storageLimitExceededBehavior', 'PauseIngress')])
 
         self.cmd('az timeseriesinsights environment standard update --resource-group {rg} --name {env} --sku-name S1 --sku-capacity 2',
                  checks=[self.check('sku.capacity', '2')])

--- a/src/timeseriesinsights/azext_timeseriesinsights/tests/latest/test_timeseriesinsights_scenario.py
+++ b/src/timeseriesinsights/azext_timeseriesinsights/tests/latest/test_timeseriesinsights_scenario.py
@@ -32,21 +32,8 @@ class TimeSeriesInsightsClientScenarioTest(ScenarioTest):
     def test_timeseriesinsights_environment_standard(self, resource_group):
         self.kwargs.update({
             'env': self.create_random_name('cli-test-tsi-env', 24),
+            'env2': self.create_random_name('cli-test-tsi-env', 24),
         })
-
-        # Test `environment standard create` with required arguments
-        self.cmd('az timeseriesinsights environment standard create '
-                 '--resource-group {rg} '
-                 '--name {env} '
-                 '--sku-name S1 '
-                 '--sku-capacity 1 '
-                 '--data-retention-time 7',
-                 checks=[self.check('name', '{env}')])
-
-        self.cmd('az timeseriesinsights environment delete '
-                 '--resource-group {rg} '
-                 '--name {env} --yes',
-                 checks=[])
 
         # Test `environment standard create` with optional arguments
         self.cmd('az timeseriesinsights environment standard create '
@@ -77,9 +64,8 @@ class TimeSeriesInsightsClientScenarioTest(ScenarioTest):
                  '--resource-group {rg}',
                  checks=[self.check('length(@)', 1)])
 
-        # Disable this test as it depends on environments in the subscription.
-        # self.cmd('az timeseriesinsights environment list',
-        #          checks=[self.check("length([?name=='{env}'])", 1)])
+        self.cmd('az timeseriesinsights environment list',
+                 checks=[self.check("length([?name=='{env}'])", 1)])
 
         self.cmd('az timeseriesinsights environment delete '
                  '--resource-group {rg} '
@@ -89,6 +75,20 @@ class TimeSeriesInsightsClientScenarioTest(ScenarioTest):
         self.cmd('az timeseriesinsights environment list '
                  '--resource-group {rg}',
                  checks=[self.check('length(@)', 0)])
+
+        # Test `environment standard create` with required arguments
+        self.cmd('az timeseriesinsights environment standard create '
+                 '--resource-group {rg} '
+                 '--name {env2} '
+                 '--sku-name S1 '
+                 '--sku-capacity 1 '
+                 '--data-retention-time 7',
+                 checks=[self.check('name', '{env2}')])
+
+        self.cmd('az timeseriesinsights environment delete '
+                 '--resource-group {rg} '
+                 '--name {env2} --yes',
+                 checks=[])
 
     @ResourceGroupPreparer(name_prefix='cli_test_timeseriesinsights')
     @StorageAccountPreparer()

--- a/src/timeseriesinsights/azext_timeseriesinsights/tests/latest/test_timeseriesinsights_scenario.py
+++ b/src/timeseriesinsights/azext_timeseriesinsights/tests/latest/test_timeseriesinsights_scenario.py
@@ -83,7 +83,9 @@ class TimeSeriesInsightsClientScenarioTest(ScenarioTest):
                  '--sku-name S1 '
                  '--sku-capacity 1 '
                  '--data-retention-time 7',
-                 checks=[self.check('name', '{env2}')])
+                 checks=[self.check('name', '{env2}'),
+                         self.check('partitionKeyProperties', None),
+                         self.check('storageLimitExceededBehavior', 'PurgeOldData')])
 
         self.cmd('az timeseriesinsights environment delete '
                  '--resource-group {rg} '

--- a/src/timeseriesinsights/azext_timeseriesinsights/tests/latest/test_timeseriesinsights_scenario.py
+++ b/src/timeseriesinsights/azext_timeseriesinsights/tests/latest/test_timeseriesinsights_scenario.py
@@ -34,7 +34,21 @@ class TimeSeriesInsightsClientScenarioTest(ScenarioTest):
             'env': self.create_random_name('cli-test-tsi-env', 24),
         })
 
-        # Test environment standard create
+        # Test `environment standard create` with required arguments
+        self.cmd('az timeseriesinsights environment standard create '
+                 '--resource-group {rg} '
+                 '--name {env} '
+                 '--sku-name S1 '
+                 '--sku-capacity 1 '
+                 '--data-retention-time 7',
+                 checks=[self.check('name', '{env}')])
+
+        self.cmd('az timeseriesinsights environment delete '
+                 '--resource-group {rg} '
+                 '--name {env} --yes',
+                 checks=[])
+
+        # Test `environment standard create` with optional arguments
         self.cmd('az timeseriesinsights environment standard create '
                  '--resource-group {rg} '
                  '--name {env} '
@@ -63,8 +77,9 @@ class TimeSeriesInsightsClientScenarioTest(ScenarioTest):
                  '--resource-group {rg}',
                  checks=[self.check('length(@)', 1)])
 
-        self.cmd('az timeseriesinsights environment list',
-                 checks=[self.check("length([?name=='{env}'])", 1)])
+        # Disable this test as it depends on environments in the subscription.
+        # self.cmd('az timeseriesinsights environment list',
+        #          checks=[self.check("length([?name=='{env}'])", 1)])
 
         self.cmd('az timeseriesinsights environment delete '
                  '--resource-group {rg} '

--- a/src/timeseriesinsights/setup.py
+++ b/src/timeseriesinsights/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     from distutils import log as logger
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
 
-VERSION = '0.1.2'
+VERSION = '0.1.3'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Fix #2003: `--partition-key-properties` should be optional

**Testing Guide**

```powershell
$env = 'env1'
$rg = 'rg1'
az timeseriesinsights environment standard create -g $rg --name $env --location westus --sku-name S1 --sku-capacity 1 --data-retention-time 31 --storage-limit-exceeded-behavior PauseIngress
az timeseriesinsights environment standard create -g $rg --name $env --location westus --sku-name S1 --sku-capacity 1 --data-retention-time 31 --partition-key-properties DeviceId1 --storage-limit-exceeded-behavior PauseIngress
```