### PR TITLE
Include the fzf extension in the index

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -5901,6 +5901,53 @@
                 "sha256Digest": "064aa0c647e0dd320fd1eba50257387fd27e125838a2cf5b58121cc1c5eefc45"
             }
         ],
+        "fzf": [
+            {
+                "downloadUrl": "https://pahealy.blob.core.windows.net/azext-fzf/fzf-1.0.2-py2.py3-none-any.whl",
+                "filename": "fzf-1.0.2-py2.py3-none-any.whl",
+                "metadata": {
+                    "azext.isExperimental": true,
+                    "azext.isPreview": false,
+                    "azext.maxCliCoreVersion": "2.99.0",
+                    "azext.minCliCoreVersion": "2.9.0",
+                    "classifiers": [
+                        "Development Status :: 4 - Beta",
+                        "Intended Audience :: Developers",
+                        "Intended Audience :: System Administrators",
+                        "Programming Language :: Python",
+                        "Programming Language :: Python :: 3",
+                        "Programming Language :: Python :: 3.6",
+                        "Programming Language :: Python :: 3.7",
+                        "Programming Language :: Python :: 3.8",
+                        "License :: OSI Approved :: MIT License"
+                    ],
+                    "extensions": {
+                        "python.details": {
+                            "contacts": [
+                                {
+                                    "email": "patrick.healy@microsoft.com",
+                                    "name": "Patrick W. Healy",
+                                    "role": "author"
+                                }
+                            ],
+                            "document_names": {
+                                "description": "DESCRIPTION.rst"
+                            },
+                            "project_urls": {
+                                "Home": "https://github.com/phealy/azure-cli-fzf"
+                            }
+                        }
+                    },
+                    "generator": "bdist_wheel (0.30.0)",
+                    "license": "MIT",
+                    "metadata_version": "2.0",
+                    "name": "fzf",
+                    "summary": "Microsoft Azure Command-Line Tools fzf Extension",
+                    "version": "1.0.2"
+                },
+                "sha256Digest": "87fc41624d52af36251c67f8f307e4e3b3789f8664e917d6d5bf4305fbb64e6d"
+            }
+        ],
         "guestconfig": [
             {
                 "downloadUrl": "https://azurecliprod.blob.core.windows.net/cli-extensions/guestconfig-0.1.0-py3-none-any.whl",


### PR DESCRIPTION
This is a new extension I've written to automate some of the tasks I find most repetitive with azure CLI: specifying my resource group, location, and subscription. It provides four new commands:

* `az fzf group` - select your default resource group
* `az fzf location` - select your default location
* `az fzf subscription` - select your current subscription
* `az fzf install` - download a copy of fzf if you don't have it

These commands make use of [FZF](https://github.com/junegunn/fzf), a command line fuzzy finder. When you install the extension and run them, they pop up a nice text interface that allows for searching and selecting from a list of objects via keyboard or mouse.

While I am a Microsoft employee, this is something I created on my off time and not something I did as a job duty. I will not be able to provide support during business hours, so I've marked it as experimental per Feng Zhou's guidance. I will answer issues as I can on the source repository: https://github.com/phealy/azure-cli-fzf/

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [x] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
