### PR TITLE
[ApplicationInsights] Help shows api-keys in plural, should be singular

### DIFF
--- a/src/application-insights/azext_applicationinsights/_help.py
+++ b/src/application-insights/azext_applicationinsights/_help.py
@@ -122,7 +122,7 @@ helps['monitor app-insights api-key show'] = """
     parameters:
       - name: --api-key
         type: string
-        short-summary: name of the API key to fetch. Can be found using `api-keys show`.
+        short-summary: name of the API key to fetch. Can be found using `api-key show`.
     examples:
       - name: Fetch API Key.
         text: |
@@ -138,7 +138,7 @@ helps['monitor app-insights api-key delete'] = """
     parameters:
       - name: --api-key
         type: string
-        short-summary: Name of the API key to delete. Can be found using `api-keys show`.
+        short-summary: Name of the API key to delete. Can be found using `api-key show`.
     examples:
       - name: Delete API Key.
         text: |


### PR DESCRIPTION
I changed api-keys from plural to singular. I ran in to this "problem" because I tried to run 'api-keys show' and it suggested 'api-key show' since the plural version doesn't exist.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [no] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [no] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [n/a] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
