### PR TITLE
Improve collection arguments documentation for network rules

### DIFF
--- a/src/azure-firewall/HISTORY.rst
+++ b/src/azure-firewall/HISTORY.rst
@@ -2,6 +2,12 @@
 
 Release History
 ===============
+0.6.2
+++++++
+* `az network firewall create`: improve documentation of application and network rules options
+0.6.1
+++++++
+* `az network firewall create`: make Network.DNS.EnableProxy option value lowercase
 0.6.0
 ++++++
 * [Breaking Change] `az network firewall threat-intel-allowlist`: rename whitelist to allowlist

--- a/src/azure-firewall/azext_firewall/_params.py
+++ b/src/azure-firewall/azext_firewall/_params.py
@@ -106,7 +106,7 @@ def load_arguments(self, _):
 
         with self.argument_context('network firewall {} create'.format(item['name']), arg_group='Collection') as c:
             c.argument('collection_name', collection_name_type, help='Name of the collection to create the rule in. Will create the collection if it does not exist.')
-            c.argument('priority', help='Priority of the rule collection from 100 (high) to 65000 (low).', type=int)
+            c.argument('priority', help='Priority of the rule collection from 100 (high) to 65000 (low). Supply only if you want to create the collection.', type=int)
 
         with self.argument_context('network firewall {} collection'.format(item['name'])) as c:
             c.argument('item_name', collection_name_type)
@@ -118,10 +118,10 @@ def load_arguments(self, _):
 
     for scope in ['network-rule', 'application-rule']:
         with self.argument_context('network firewall {}'.format(scope), arg_group='Collection') as c:
-            c.argument('action', arg_type=get_enum_type(AzureFirewallRCActionType), help='The action to apply for the rule collection.')
+            c.argument('action', arg_type=get_enum_type(AzureFirewallRCActionType), help='The action to apply for the rule collection. Supply only if you want to create the collection.')
 
     with self.argument_context('network firewall nat-rule', arg_group='Collection') as c:
-        c.argument('action', arg_type=get_enum_type(AzureFirewallNatRCActionType), help='The action to apply for the rule collection.')
+        c.argument('action', arg_type=get_enum_type(AzureFirewallNatRCActionType), help='The action to apply for the rule collection. Supply only if you want to create the collection.')
 
     with self.argument_context('network firewall ip-config') as c:
         c.argument('item_name', options_list=['--name', '-n'], help='Name of the IP configuration.', id_part='child_name_2')

--- a/src/azure-firewall/setup.py
+++ b/src/azure-firewall/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup, find_packages
 
-VERSION = "0.6.1"
+VERSION = "0.6.2"
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',


### PR DESCRIPTION
If you specify `--priority` or `--action` in `az network firewall [network-rule|application-rule] create`, and the collection already exists, the operation will fail because it tries to recreate the collection. Make it more explicit in the documentation.
