### PR TITLE
Add information in command conflict exception message when building extension command tree

### DIFF
--- a/scripts/ci/update_ext_cmd_tree.py
+++ b/scripts/ci/update_ext_cmd_tree.py
@@ -24,7 +24,7 @@ file_name = 'extCmdTreeToUpload.json'
 def merge(data, key, value):
     if isinstance(value, str):
         if key in data:
-            raise Exception(f"Key: {key} already exists. 2 extensions cannot have the same command!")
+            raise Exception(f"Key: {key} already exists in {data[key]}. 2 extensions cannot have the same command!")
         data[key] = value
     else:
         data.setdefault(key, {})


### PR DESCRIPTION
Now the log will show messages like this in case of conflicts:

> Processing storage-blob-preview
> ...
> Exception: Key: show already exists in storage-preview. 2 extensions cannot have the same command!

Now we know that `storage-blob-preview` and `storage-preview` have the same command ending with `show`. By searching the log message, we are able to find the duplicate command is `az storage account management-policy show`.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
