### PR TITLE
Do not include hidden deprecated command when building extension command tree

### DIFF
--- a/scripts/ci/update_ext_cmd_tree.py
+++ b/scripts/ci/update_ext_cmd_tree.py
@@ -49,7 +49,14 @@ def update_cmd_tree(ext_name):
     EXT_CMD_TREE_TO_UPLOAD = Session()
     EXT_CMD_TREE_TO_UPLOAD.load(os.path.expanduser(os.path.join('~', '.azure', file_name)))
     root = {}
-    for cmd_name, _ in extension_command_table.items():
+    for cmd_name, ext_cmd in extension_command_table.items():
+        try:
+            # do not include hidden deprecated command
+            if ext_cmd.deprecate_info.hide:
+                print(f"Skip hidden deprecated command: {cmd_name}")
+                continue
+        except AttributeError:
+            pass
         parts = cmd_name.split()
         parent = root
         for i, part in enumerate(parts):
@@ -88,4 +95,5 @@ def upload_cmd_tree():
 if __name__ == '__main__':
     for ext in sys.argv[1:]:
         update_cmd_tree(ext)
+        print()
     upload_cmd_tree()


### PR DESCRIPTION
We do not want users to use hidden deprecated command and should exclude them when building the extension command tree for dynamic install.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
