### PR TITLE
[AKS] az aks browse: point to Azure Portal Kubernetes resources view if k8s >=1.19 or kube-dashboard not enabled

### DIFF
--- a/src/aks-preview/azext_aks_preview/custom.py
+++ b/src/aks-preview/azext_aks_preview/custom.py
@@ -624,7 +624,7 @@ def aks_browse(cmd,     # pylint: disable=too-many-statements,too-many-branches
             logger.warning('Kubernetes resources view on %s', dashboardURL)
 
         if not disable_browser:
-            wait_then_open_async(dashboardURL)
+            webbrowser.open_new_tab(dashboardURL)
         return
 
     # otherwise open the kube-dashboard addon

--- a/src/aks-preview/azext_aks_preview/custom.py
+++ b/src/aks-preview/azext_aks_preview/custom.py
@@ -14,7 +14,6 @@ import os
 import os.path
 import platform
 import re
-import semver
 import ssl
 import stat
 import subprocess
@@ -25,6 +24,7 @@ import time
 import uuid
 import base64
 import webbrowser
+from distutils.version import StrictVersion
 from math import isnan
 from six.moves.urllib.request import urlopen  # pylint: disable=import-error
 from six.moves.urllib.error import URLError  # pylint: disable=import-error
@@ -612,7 +612,7 @@ def aks_browse(cmd,     # pylint: disable=too-many-statements
                          ManagedClusterAddonProfile(enabled=False))
 
     # open portal view if addon is not enabled or k8s version >= 1.19.0
-    if semver.compare(instance.kubernetes_version, '1.19.0') >= 0 or (not addon_profile.enabled):
+    if StrictVersion(instance.kubernetes_version) >= StrictVersion('1.19.0') or (not addon_profile.enabled):
         subscription_id = get_subscription_id(cmd.cli_ctx)
         dashboardURL = (('https://portal.azure.com/#resource/subscriptions/{0}/resourceGroups/{1}/providers/'
                          'Microsoft.ContainerService/managedClusters/{2}/workloads')

--- a/src/aks-preview/azext_aks_preview/custom.py
+++ b/src/aks-preview/azext_aks_preview/custom.py
@@ -614,9 +614,11 @@ def aks_browse(cmd,     # pylint: disable=too-many-statements,too-many-branches
     # open portal view if addon is not enabled or k8s version >= 1.19.0
     if StrictVersion(instance.kubernetes_version) >= StrictVersion('1.19.0') or (not addon_profile.enabled):
         subscription_id = get_subscription_id(cmd.cli_ctx)
-        dashboardURL = (('https://portal.azure.com/#resource/subscriptions/{0}/resourceGroups/{1}/providers/'
-                         'Microsoft.ContainerService/managedClusters/{2}/workloads')
-                        .format(subscription_id, resource_group_name, name))
+        dashboardURL = (
+            cmd.cli_ctx.cloud.endpoints.portal +  # Azure Portal URL (https://portal.azure.com for public cloud)
+            ('/#resource/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.ContainerService'
+             '/managedClusters/{2}/workloads').format(subscription_id, resource_group_name, name)
+        )
 
         if in_cloud_console():
             logger.warning('To view the Kubernetes resources view, please open %s in a new tab', dashboardURL)

--- a/src/aks-preview/azext_aks_preview/custom.py
+++ b/src/aks-preview/azext_aks_preview/custom.py
@@ -596,7 +596,7 @@ def _update_dict(dict1, dict2):
     return cp
 
 
-def aks_browse(cmd,     # pylint: disable=too-many-statements
+def aks_browse(cmd,     # pylint: disable=too-many-statements,too-many-branches
                client,
                resource_group_name,
                name,
@@ -622,9 +622,9 @@ def aks_browse(cmd,     # pylint: disable=too-many-statements
             logger.warning('To view the Kubernetes resources view, please open %s in a new tab', dashboardURL)
         else:
             logger.warning('Kubernetes resources view on %s', dashboardURL)
-            if not disable_browser:
-                wait_then_open_async(dashboardURL)
 
+        if not disable_browser:
+            wait_then_open_async(dashboardURL)
         return
 
     # otherwise open the kube-dashboard addon


### PR DESCRIPTION
“az aks browse” command point to Azure Portal if Kubernetes version >= 1.19.0 or kube-dashboard addon is not enabled.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
