### PR TITLE
[Firewall] Fix AttributeError while hitting tap to automatically complete the name of network rule of a firewall

### DIFF
--- a/src/azure-firewall/azext_firewall/_completers.py
+++ b/src/azure-firewall/azext_firewall/_completers.py
@@ -17,7 +17,7 @@ def get_af_subresource_completion_list(prop):
         try:
             firewall_name = namespace.firewall_name
         except AttributeError:
-            firewall_name = namespace.resource_name
+            firewall_name = namespace.azure_firewall_name
         if namespace.resource_group_name and firewall_name:
             af = client.azure_firewalls.get(namespace.resource_group_name, firewall_name)
             return [r.name for r in getattr(af, prop)]


### PR DESCRIPTION
Fix the top 1 non-actionable bug (https://github.com/Azure/azure-cli/issues/14984) that completer throwing AttributeError while creating a firewall network-rule

![image](https://user-images.githubusercontent.com/14357159/98656976-4c6c1280-237c-11eb-83c1-314857a763d3.png)


### Bug Scenario Reproduce
1. set export _ARC_DEBUG=1
2. type `az network firewall network-rule create -g harold -f fw-1 --name` and hit tap
3. print out the `namespace` properties show there is no `resource_name` property (the desired property is collection_name)

```
{'_argument_validators': [],
 '_cmd': <azure.cli.core.commands.AzCliCommand object at 0x7f9e0d975b50>,
 '_command_package': 'network',
 '_command_validator': <function validate_af_network_rule at 0x7f9e0d96d290>,
 '_jmespath_query': None,
 '_log_verbosity_debug': False,
 '_log_verbosity_only_show_errors': False,
 '_log_verbosity_verbose': False,
 '_output_format': 'json',
 '_parser': MonkeyPatchedIntrospectiveArgumentParser(prog='az network firewall network-rule create', usage=None, description=None, formatter_class=<class 'argparse.HelpFormatter'>, conflict_handler='error', add_help=True),
 '_subcommand': 'create',
 '_subscription': None,
 'action': None,
 'azure_firewall_name': 'fw-1',
 'cmd': None,
 'collection_name': None,
 'command': 'network firewall network-rule create',
 'description': None,
 'destination_addresses': None,
 'destination_fqdns': None,
 'destination_ip_groups': None,
 'destination_ports': None,
 'func': <azure.cli.core.commands.AzCliCommand object at 0x7f9e0d975b50>,
 'item_name': None,
 'priority': None,
 'protocols': None,
 'resource_group_name': 'harold',
 'source_addresses': None,
 'source_ip_groups': None}
```

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
