### PR TITLE
[Blueprint] Support removing depends_on in update

### DIFF
--- a/src/blueprint/HISTORY.rst
+++ b/src/blueprint/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.2.1
++++++
+* Support removing depends_on relationships for artifacts in update command
+
 0.2.0
 +++++
 * `az blueprint assignment create/update`: Support user assigned identity with `--user-assigned-identity`

--- a/src/blueprint/azext_blueprint/_params.py
+++ b/src/blueprint/azext_blueprint/_params.py
@@ -113,7 +113,7 @@ def load_arguments(self, _):
         c.argument('artifact_name', help='A unique name of this resource group artifact.')
         c.argument('display_name', help='Display name of this resource group artifact.')
         c.argument('description', help='Description of the blueprint artifact.')
-        c.argument('depends_on', nargs='*', help='Artifacts which need to be deployed before the specified artifact.')
+        c.argument('depends_on', nargs='*', help="Artifacts which need to be deployed before the specified artifact. Use '--depends-on' with no values to remove dependencies.")
         c.argument('tags', tags_type, arg_group='Resource Group', help='Tags to be assigned to this resource group.')
 
     with self.argument_context('blueprint resource-group remove') as c:
@@ -142,7 +142,7 @@ def load_arguments(self, _):
         c.argument('artifact_name', help='Name of the blueprint artifact.')
         c.argument('display_name', help='DisplayName of this artifact.')
         c.argument('description', help='Description of the blueprint artifact.')
-        c.argument('depends_on', nargs='*', help='Artifacts which need to be deployed before the specified artifact.')
+        c.argument('depends_on', nargs='*', help="Artifacts which need to be deployed before the specified artifact. Use '--depends-on' with no values to remove dependencies.")
         c.argument('resource_group_art', help='Name of the resource group artifact to which the policy will be assigned.')
         c.argument('parameters', arg_type=parameter_type, help='Parameters for policy assignment artifact. It can be a JSON string or JSON file path.')
 
@@ -161,7 +161,7 @@ def load_arguments(self, _):
         c.argument('artifact_name', help='Name of the blueprint artifact.')
         c.argument('display_name', help='DisplayName of this artifact.')
         c.argument('description', help='Description of the blueprint artifact.')
-        c.argument('depends_on', nargs='*', help='Artifacts which need to be deployed before the specified artifact.')
+        c.argument('depends_on', nargs='*', help="Artifacts which need to be deployed before the specified artifact. Use '--depends-on' with no values to remove dependencies.")
         c.argument('resource_group_art', help='Name of the resource group artifact to which the policy will be assigned.')
 
     with self.argument_context('blueprint artifact template create') as c:
@@ -179,7 +179,7 @@ def load_arguments(self, _):
         c.argument('artifact_name', help='Name of the blueprint artifact.')
         c.argument('display_name', help='DisplayName of this artifact.')
         c.argument('description', help='Description of the blueprint artifact.')
-        c.argument('depends_on', nargs='*', help='Artifacts which need to be deployed before the specified artifact.')
+        c.argument('depends_on', nargs='*', help="Artifacts which need to be deployed before the specified artifact. Use '--depends-on' with no values to remove dependencies.")
         c.argument('resource_group_art', help='Name of the resource group artifact to which the policy will be assigned.')
         c.argument('parameters', arg_type=parameter_type, help='Parameters for ARM template artifact. It can be a JSON string or JSON file path.')
         c.argument('template', arg_type=template_type)

--- a/src/blueprint/azext_blueprint/_params.py
+++ b/src/blueprint/azext_blueprint/_params.py
@@ -113,7 +113,7 @@ def load_arguments(self, _):
         c.argument('artifact_name', help='A unique name of this resource group artifact.')
         c.argument('display_name', help='Display name of this resource group artifact.')
         c.argument('description', help='Description of the blueprint artifact.')
-        c.argument('depends_on', nargs='+', help='Artifacts which need to be deployed before the specified artifact.')
+        c.argument('depends_on', nargs='*', help='Artifacts which need to be deployed before the specified artifact.')
         c.argument('tags', tags_type, arg_group='Resource Group', help='Tags to be assigned to this resource group.')
 
     with self.argument_context('blueprint resource-group remove') as c:
@@ -142,7 +142,7 @@ def load_arguments(self, _):
         c.argument('artifact_name', help='Name of the blueprint artifact.')
         c.argument('display_name', help='DisplayName of this artifact.')
         c.argument('description', help='Description of the blueprint artifact.')
-        c.argument('depends_on', nargs='+', help='Artifacts which need to be deployed before the specified artifact.')
+        c.argument('depends_on', nargs='*', help='Artifacts which need to be deployed before the specified artifact.')
         c.argument('resource_group_art', help='Name of the resource group artifact to which the policy will be assigned.')
         c.argument('parameters', arg_type=parameter_type, help='Parameters for policy assignment artifact. It can be a JSON string or JSON file path.')
 
@@ -161,7 +161,7 @@ def load_arguments(self, _):
         c.argument('artifact_name', help='Name of the blueprint artifact.')
         c.argument('display_name', help='DisplayName of this artifact.')
         c.argument('description', help='Description of the blueprint artifact.')
-        c.argument('depends_on', nargs='+', help='Artifacts which need to be deployed before the specified artifact.')
+        c.argument('depends_on', nargs='*', help='Artifacts which need to be deployed before the specified artifact.')
         c.argument('resource_group_art', help='Name of the resource group artifact to which the policy will be assigned.')
 
     with self.argument_context('blueprint artifact template create') as c:
@@ -179,7 +179,7 @@ def load_arguments(self, _):
         c.argument('artifact_name', help='Name of the blueprint artifact.')
         c.argument('display_name', help='DisplayName of this artifact.')
         c.argument('description', help='Description of the blueprint artifact.')
-        c.argument('depends_on', nargs='+', help='Artifacts which need to be deployed before the specified artifact.')
+        c.argument('depends_on', nargs='*', help='Artifacts which need to be deployed before the specified artifact.')
         c.argument('resource_group_art', help='Name of the resource group artifact to which the policy will be assigned.')
         c.argument('parameters', arg_type=parameter_type, help='Parameters for ARM template artifact. It can be a JSON string or JSON file path.')
         c.argument('template', arg_type=template_type)

--- a/src/blueprint/azext_blueprint/custom.py
+++ b/src/blueprint/azext_blueprint/custom.py
@@ -210,7 +210,7 @@ def update_blueprint_resource_group(cmd,
     if description is not None:
         resource_group['description'] = description  # str
     if depends_on is not None:
-        resource_group['depends_on'] = depends_on
+        resource_group['depends_on'] = _process_depends_on_for_update(depends_on)
     if tags is not None:
         resource_group['tags'] = tags
 
@@ -298,7 +298,7 @@ def update_blueprint_artifact_policy(cmd,
     if description is not None:
         body['description'] = description
     if depends_on is not None:
-        body['depends_on'] = depends_on
+        body['depends_on'] = _process_depends_on_for_update(depends_on)
 
     return client.create_or_update(scope=scope,
                                    blueprint_name=blueprint_name,
@@ -360,7 +360,7 @@ def update_blueprint_artifact_role(cmd,
     if description is not None:
         body['description'] = description
     if depends_on is not None:
-        body['depends_on'] = depends_on
+        body['depends_on'] = _process_depends_on_for_update(depends_on)
 
     return client.create_or_update(scope=scope,
                                    blueprint_name=blueprint_name,
@@ -424,7 +424,7 @@ def update_blueprint_artifact_template(cmd,
     if description is not None:
         body['description'] = description
     if depends_on is not None:
-        body['depends_on'] = depends_on
+        body['depends_on'] = _process_depends_on_for_update(depends_on)
 
     return client.create_or_update(scope=scope,
                                    blueprint_name=blueprint_name,
@@ -627,3 +627,11 @@ def wait_for_blueprint_assignment(cmd, client, assignment_name, management_group
 
 def who_is_blueprint_blueprint_assignment(cmd, client, assignment_name, management_group=None, subscription=None, scope=None):
     return client.who_is_blueprint(scope=scope, assignment_name=assignment_name)
+
+
+def _process_depends_on_for_update(depends_on):
+    if not depends_on:  # [] for case: --depends-on
+        return None
+    if not any(depends_on):  # [''] for case: --depends-on= /--depends-on ""
+        return None
+    return depends_on

--- a/src/blueprint/setup.py
+++ b/src/blueprint/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
-VERSION = '0.2.0'
+VERSION = '0.2.1'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Resolve #2594

To remove depends_on relationships between artifacts, you can use `--depends-on`, `--depends-on=` or `--depends-on ""` in artifact update commands.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
