### PR TITLE
[aks-preview] Revert to use CLIError

### DIFF
--- a/src/aks-preview/HISTORY.md
+++ b/src/aks-preview/HISTORY.md
@@ -2,6 +2,10 @@
 
 Release History
 ===============
+0.4.70
+++++++
+* Revert to use CLIError to be compatible with azure cli versions < 2.15.0
+
 0.4.69
 +++++
 * Add argument 'subnetCIDR' to replace 'subnetPrefix' when using ingress-azure addon.

--- a/src/aks-preview/azext_aks_preview/_validators.py
+++ b/src/aks-preview/azext_aks_preview/_validators.py
@@ -14,7 +14,6 @@ from knack.log import get_logger
 
 from azure.cli.core.commands.validators import validate_tag
 from azure.cli.core.util import CLIError
-from azure.cli.core.azclierror import InvalidArgumentValueError
 import azure.cli.core.keys as keys
 
 from .vendored_sdks.azure_mgmt_preview_aks.v2020_11_01.models import ManagedClusterPropertiesAutoScalerProfile
@@ -247,7 +246,7 @@ def _validate_subnet_id(subnet_id, name):
         return
     from msrestazure.tools import is_valid_resource_id
     if not is_valid_resource_id(subnet_id):
-        raise InvalidArgumentValueError(name + " is not a valid Azure resource ID.")
+        raise CLIError(name + " is not a valid Azure resource ID.")
 
 
 def validate_load_balancer_outbound_ports(namespace):

--- a/src/aks-preview/setup.py
+++ b/src/aks-preview/setup.py
@@ -8,7 +8,7 @@
 from codecs import open as open1
 from setuptools import setup, find_packages
 
-VERSION = "0.4.69"
+VERSION = "0.4.70"
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',


### PR DESCRIPTION
The new error types require azure-cli versions >= 2.15.0. In order to make the extension compatible with older versions of azure-cli, this PR reverts the error type to be CLIError.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
