### PR TITLE
1797650: Remove '?view=' syntax

### DIFF
--- a/scripts/ci/avail-ext-doc/list-template.md
+++ b/scripts/ci/avail-ext-doc/list-template.md
@@ -15,7 +15,7 @@ ms.devlang: azure-cli
 
 This article is a complete list of the available extensions for the Azure CLI which are supported by Microsoft.
 
-The list of extensions is also available  from the CLI. To get it, run [az extension list-available](/cli/azure/extension?view=azure-cli-latest#az-extension-list-available):
+The list of extensions is also available  from the CLI. To get it, run [az extension list-available](/cli/azure/extension#az-extension-list-available):
 
 ```azurecli-interactive
 az extension list-available --output table

--- a/src/blockchain/README.md
+++ b/src/blockchain/README.md
@@ -4,7 +4,7 @@ Microsoft Azure CLI 'blockchain' Extension
 This package is for the 'blockchain' extension.
 i.e. 'az blockchain'
 #### Install:
-Install CLI first: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest
+Install CLI first: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli
 
 #### Install blockchain extension. (Pre-request)
 

--- a/src/vmware/README.md
+++ b/src/vmware/README.md
@@ -8,7 +8,7 @@ az extension add --name vmware
 ```
 
 ## Usage
-See the [extension reference documenation](https://docs.microsoft.com/en-us/cli/azure/ext/vmware/vmware?view=azure-cli-latest).
+See the [extension reference documenation](https://docs.microsoft.com/en-us/cli/azure/ext/vmware/vmware).
 
 ``` sh
 az vmware --help


### PR DESCRIPTION
No extension changes. Part of an effort to remove unnecessary versioning link syntax.

See user story [1797650](https://dev.azure.com/mseng/TechnicalContent/_workitems/edit/1797650) for more information. 