### PR TITLE
OneDeploy enhancements

### DIFF
--- a/src/webapp/azext_webapp/__init__.py
+++ b/src/webapp/azext_webapp/__init__.py
@@ -25,7 +25,7 @@ class WebappExtCommandLoader(AzCommandsLoader):
         with self.command_group('webapp') as g:
             g.custom_command('container up', 'create_deploy_container_app', exception_handler=ex_handler_factory())
             g.custom_command('remote-connection create', 'create_tunnel')
-            g.custom_command('deploy', 'enable_one_deploy')
+            g.custom_command('deploy', 'perform_onedeploy')
 
         with self.command_group('webapp scan') as g:
             g.custom_command('start', 'start_scan')
@@ -66,10 +66,14 @@ class WebappExtCommandLoader(AzCommandsLoader):
 
         with self.argument_context('webapp deploy') as c:
             c.argument('name', options_list=['--name'], help='Name of the webapp to connect to')
-            c.argument('src', options_list=['--src'], help='Path of the file to be deployed')
-            c.argument('deploy_type', options_list=['--type'], help='Type of deployment requested')
-            c.argument('is_async', options_list=['--async'], help='Asynchronous deployment', type=bool)
+            c.argument('src_path', options_list=['--src-path'], help='Path of the file to be deployed. Example: /mnt/apps/myapp.war')
+            c.argument('src_url', options_list=['--src-url'], help='url to download the package from. Example: http://mysite.com/files/myapp.war?key=123')
+            c.argument('type', options_list=['--type'], help='Type of deployment requested')
+            c.argument('async', options_list=['--async'], help='Asynchronous deployment', type=bool)
             c.argument('target_path', options_list=['--target-path'], help='Target path relative to wwwroot to which the file will be deployed to.')
+            c.argument('restart', options_list=['--restart'], help='restart or not. default behavior is to restart.', type=bool)
+            c.argument('clean', options_list=['--clean'], help='clean or not. default is target-type specific.', type=bool)
+            c.argument('ignore_stack', options_list=['--ignore-stack'], help='should override the default stack check', type=bool)
             c.argument('timeout', options_list=['--timeout'], help='Timeout for operation in milliseconds')
             c.argument('slot', help="Name of the deployment slot to use")
 

--- a/src/webapp/azext_webapp/_help.py
+++ b/src/webapp/azext_webapp/_help.py
@@ -65,7 +65,7 @@ helps['webapp deploy'] = """
     short-summary: Deploys a provided artifact to Azure Web Apps.
     examples:
     - name: Deploy a war file asynchronously.
-      text: az webapp deploy --resource-group ResouceGroup --name AppName --src SourcePath --type war --async IsAsync
+      text: az webapp deploy --resource-group ResouceGroup --name AppName --src-path SourcePath --type war --async IsAsync
     - name: Deploy a static text file to wwwroot/staticfiles/test.txt
-      text: az webapp deploy --resource-group ResouceGroup --name AppName --src SourcePath --type static --target-path staticfiles/test.txt
+      text: az webapp deploy --resource-group ResouceGroup --name AppName --src-path SourcePath --type static --target-path staticfiles/test.txt
 """

--- a/src/webapp/setup.py
+++ b/src/webapp/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup, find_packages
 
-VERSION = "0.2.24"
+VERSION = "0.3.0"
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',


### PR DESCRIPTION
- The previous onedeploy CLI implementation did not surface all functionality of the onedeploy API via the CLI. Example: restart, clean, etc
- This commit surfaces all functionality supported by the API via the CLI
- Additionally, refactored the enable_onedeploy function to make it readable (and also to address the Python function complexity limit)
- Also - bumping up the extension minor version as this is the first time we are introducing the onedeploy functionality in this extension

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [x] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
