### PR TITLE
Fix style warnings in the webapp extension

### DIFF
--- a/src/webapp/azext_webapp/__init__.py
+++ b/src/webapp/azext_webapp/__init__.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-# pylint: disable=unused-import,ungrouped-imports
+# pylint: disable=unused-import,ungrouped-imports,import-outside-toplevel,super-with-arguments
 from azure.cli.core import AzCommandsLoader
 from azure.cli.command_modules.appservice.commands import ex_handler_factory
 from knack.arguments import CLIArgumentType
@@ -68,12 +68,12 @@ class WebappExtCommandLoader(AzCommandsLoader):
             c.argument('name', options_list=['--name'], help='Name of the webapp to connect to')
             c.argument('src_path', options_list=['--src-path'], help='Path of the file to be deployed. Example: /mnt/apps/myapp.war')
             c.argument('src_url', options_list=['--src-url'], help='url to download the package from. Example: http://mysite.com/files/myapp.war?key=123')
-            c.argument('type', options_list=['--type'], help='Type of deployment requested')
-            c.argument('async', options_list=['--async'], help='Asynchronous deployment', type=bool)
             c.argument('target_path', options_list=['--target-path'], help='Target path relative to wwwroot to which the file will be deployed to.')
-            c.argument('restart', options_list=['--restart'], help='restart or not. default behavior is to restart.', type=bool)
-            c.argument('clean', options_list=['--clean'], help='clean or not. default is target-type specific.', type=bool)
-            c.argument('ignore_stack', options_list=['--ignore-stack'], help='should override the default stack check', type=bool)
+            c.argument('artifact_type', options_list=['--type'], help='Type of deployment requested')
+            c.argument('is_async', options_list=['--async'], help='Asynchronous deployment', choices=['true', 'false'])
+            c.argument('restart', options_list=['--restart'], help='restart or not. default behavior is to restart.', choices=['true', 'false'])
+            c.argument('clean', options_list=['--clean'], help='clean or not. default is target-type specific.', choices=['true', 'false'])
+            c.argument('ignore_stack', options_list=['--ignore-stack'], help='should override the default stack check', choices=['true', 'false'])
             c.argument('timeout', options_list=['--timeout'], help='Timeout for operation in milliseconds')
             c.argument('slot', help="Name of the deployment slot to use")
 

--- a/src/webapp/azext_webapp/acr_util.py
+++ b/src/webapp/azext_webapp/acr_util.py
@@ -19,6 +19,7 @@ logger = get_logger(__name__)
 VERSION_2019_06_01_PREVIEW = "2019-06-01-preview"
 
 
+# pylint:disable=import-outside-toplevel
 def queue_acr_build(cmd, registry_rg, registry_name, img_name, src_dir):
     import os
     client_registries = get_acr_service_client(cmd.cli_ctx, VERSION_2019_06_01_PREVIEW).registries
@@ -38,6 +39,7 @@ def queue_acr_build(cmd, registry_rg, registry_name, img_name, src_dir):
     tar_file_path = os.path.join(tempfile.gettempdir(), 'build_archive_{}.tar.gz'.format(uuid.uuid4().hex))
 
     source_location = upload_source_code(
+        cmd,
         client_registries, registry_name, registry_rg,
         src_dir, tar_file_path,
         docker_file_path, docker_file_in_tar)

--- a/src/webapp/azext_webapp/tunnel.py
+++ b/src/webapp/azext_webapp/tunnel.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-# pylint: disable=import-error,unused-import
+# pylint: disable=import-error,unused-import,import-outside-toplevel,super-with-arguments
 import sys
 import ssl
 import socket


### PR DESCRIPTION
- This commit primarily fixes the style warnings (azdev style webapp)
- upload_source_code parameter list was missing the command param. This commit fixes that.
- Another change to functionality is that OneDeploy async deployments don't poll for the operation completion now. This behavior can be toggled for development purposes using the poll_async_deployment_for_debugging flag in code

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [x] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
