### PR TITLE
Increment webapp version from 0.3.0 -> 0.3.1

### DIFF
--- a/src/webapp/HISTORY.rst
+++ b/src/webapp/HISTORY.rst
@@ -1,0 +1,8 @@
+.. :changelog:
+
+Release History
+===============
+0.3.1 (2020-12-23)
+++++++++++++++++++
+
+* Add ``az webapp deploy`` to the CLI.

--- a/src/webapp/setup.py
+++ b/src/webapp/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup, find_packages
 
-VERSION = "0.3.0"
+VERSION = "0.3.1"
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',


### PR DESCRIPTION
- The 0.3.0 release didn't happen because of "azdev style webapp" errors
- Incrementing 0.3.0->0.3.1 to kick-off another release

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [x] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
