### PR TITLE
Fix UT for azure spring cloud

### DIFF
--- a/src/spring-cloud/azext_spring_cloud/tests/latest/test_asc_validator.py
+++ b/src/spring-cloud/azext_spring_cloud/tests/latest/test_asc_validator.py
@@ -121,14 +121,14 @@ class TestValidateIPRanges(unittest.TestCase):
                        reserved_cidr_range='10.0.0.0/14', sku=None, location='eastus')
         with self.assertRaises(CLIError) as context:
             validate_vnet_required_parameters(ns)
-            self.assertEqual('--app-subnet, --service-runtime-subnet must be set when deploying to VNet',
-                             str(context.exception))
+        self.assertEqual('--app-subnet, --service-runtime-subnet must be set when deploying to VNet',
+                         str(context.exception))
 
     def test_single_cidr(self):
         ns = Namespace(reserved_cidr_range='10.0.0.0/8')
         with self.assertRaises(CLIError) as context:
             _validate_cidr_range(ns)
-            self.assertEqual('--reserved-cidr-range should be 3 unused /16 IP ranges', str(context.exception))
+        self.assertEqual('--reserved-cidr-range should be 3 unused /16 IP ranges', str(context.exception))
 
     def test_multi_cidr(self):
         ns = Namespace(reserved_cidr_range='10.0.0.0/8,20.0.0.0/16,30.0.0.0/16')
@@ -144,9 +144,9 @@ class TestValidateIPRanges(unittest.TestCase):
         ns = Namespace(reserved_cidr_range='10.0.0.0/8,10.0.0.0/16,30.0.0.0/16')
         with self.assertRaises(CLIError) as context:
             _validate_cidr_range(ns)
-            self.assertEqual(
-                '--reserved-cidr-range should not overlap each other, but 10.0.0.0/8 and 10.0.0.0/16 overlapping.',
-                str(context.exception))
+        self.assertEqual(
+            '--reserved-cidr-range should not overlap each other, but 10.0.0.0/8 and 10.0.0.0/16 overlapping.',
+            str(context.exception))
 
     @mock.patch('azext_spring_cloud._validators._get_vnet', _mock_get_vnet)
     @mock.patch('azext_spring_cloud._validators._get_authorization_client', _mock_get_authorization_client)
@@ -167,14 +167,14 @@ class TestValidateIPRanges(unittest.TestCase):
                        app_subnet='app', service_runtime_subnet='svc', resource_group='test', sku=None)
         with self.assertRaises(CLIError) as context:
             validate_vnet(_get_test_cmd(), ns)
-            self.assertTrue('is not a valid VirtualNetwork resource ID' in str(context.exception))
+        self.assertTrue('is not a valid VirtualNetwork resource ID' in str(context.exception))
 
     def test_only_subnet_name(self):
         ns = Namespace(reserved_cidr_range='10.0.0.0/8,20.0.0.0/16,30.0.0.0/16', app_subnet='app',
                        service_runtime_subnet='svc', resource_group='test', vnet=None, sku=None)
         with self.assertRaises(CLIError) as context:
             validate_vnet(_get_test_cmd(), ns)
-            self.assertTrue('is not a valid subnet resource ID' in str(context.exception))
+        self.assertTrue('is not a valid subnet resource ID' in str(context.exception))
 
     @mock.patch('azext_spring_cloud._validators._get_vnet', _mock_get_vnet)
     @mock.patch('azext_spring_cloud._validators._get_authorization_client', _mock_get_authorization_client)
@@ -200,7 +200,7 @@ class TestValidateIPRanges(unittest.TestCase):
                        service_runtime_subnet='/subscriptions/22222222-0000-0000-0000-000000000000/resourceGroups/test/providers/Microsoft.Network/VirtualNetworks/test-vnet/subnets/svc')
         with self.assertRaises(CLIError) as context:
             validate_vnet(_get_test_cmd(), ns)
-            self.assertTrue('subnet should not associate with any route tables.' in str(context.exception))
+        self.assertTrue('app-subnet with existing route table is not supported. Please remove route table from the subnet, or select another subnet.' in str(context.exception))
 
     def test_subnets_same(self):
         ns = Namespace(reserved_cidr_range='10.0.0.0/8,20.0.0.0/16,30.0.0.0/16', resource_group='test', vnet=None, sku=None, location='eastus',
@@ -208,7 +208,7 @@ class TestValidateIPRanges(unittest.TestCase):
                        service_runtime_subnet='/subscriptions/11111111-0000-0000-0000-000000000000/resourceGroups/test/providers/Microsoft.Network/VirtualNetworks/test-vnet/subnets/app')
         with self.assertRaises(CLIError) as context:
             validate_vnet(_get_test_cmd(), ns)
-            self.assertEqual('--app-subnet and --service-runtime-subnet should not be same.', str(context.exception))
+        self.assertEqual('--app-subnet and --service-runtime-subnet should not be the same.', str(context.exception))
 
     def test_subnets_in_different_vnet(self):
         ns = Namespace(reserved_cidr_range='10.0.0.0/8,20.0.0.0/16,30.0.0.0/16', resource_group='test', vnet=None, sku=None, location='eastus',
@@ -216,8 +216,8 @@ class TestValidateIPRanges(unittest.TestCase):
                        service_runtime_subnet='/subscriptions/11111111-0000-0000-0000-000000000000/resourceGroups/test/providers/Microsoft.Network/VirtualNetworks/test-vnet1/subnets/svc')
         with self.assertRaises(CLIError) as context:
             validate_vnet(_get_test_cmd(), ns)
-            self.assertEqual('--app-subnet and --service-runtime-subnet should be in the same Virtual Networks.',
-                             str(context.exception))
+        self.assertEqual('--app-subnet and --service-runtime-subnet should be in the same Virtual Networks.',
+                         str(context.exception))
 
     def test_set_default_cidr_range(self):
         self.assertEqual('11.1.0.0/16,11.2.0.0/16,11.3.0.1/16', _set_default_cidr_range(['10.0.0.0/8', '11.0.2.0/16']))
@@ -230,13 +230,9 @@ class TestValidateIPRanges(unittest.TestCase):
             _set_default_cidr_range(
                 ['128.0.0.0/1', '0.0.0.0/2', '64.0.0.0/3', '96.0.0.0/4', '112.0.0.0/5', '120.0.0.0/6', '124.0.0.0/7',
                  '126.0.0.0/8'])
-            self.assertEqual(
-                'Cannot set "reserved-cidr-range" automatically.Please specify "--reserved-cidr-range" with 3 unused CIDR ranges in your network environment.',
-                str(context.exception))
-            _set_default_cidr_range(['0.0.0.0/1'])
-            self.assertEqual(
-                'Cannot set "reserved-cidr-range" automatically.Please specify "--reserved-cidr-range" with 3 unused CIDR ranges in your network environment.',
-                str(context.exception))
+        self.assertEqual(
+            'Cannot set "reserved-cidr-range" automatically.Please specify "--reserved-cidr-range" with 3 unused CIDR ranges in your network environment.',
+            str(context.exception))
 
     @mock.patch('azext_spring_cloud._validators._get_vnet', _mock_get_vnet)
     @mock.patch('azext_spring_cloud._validators._get_authorization_client', _mock_get_authorization_client)


### PR DESCRIPTION
---

For Python, we need assert raised exceptions out of `self.assertRaises()`, referring to [here](https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertRaises) for details. Currently lots of UT in Azure Spring Cloud misuses it, and this will lead regression someday since all these UT do not work as excepted today.

### General Guidelines

- [X] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [X] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [x] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
