### PR TITLE
[SSH] Add support for getting the username from the certificate

### DIFF
--- a/src/ssh/HISTORY.md
+++ b/src/ssh/HISTORY.md
@@ -1,6 +1,11 @@
 Release History
 ===============
 
+0.1.4
+-----
+* Change to use the first in the list of validprincipals as the default username
+* Remove old paramiko dependency
+
 0.1.3
 -----
 * Add support for using private IPs

--- a/src/ssh/azext_ssh/ssh_utils.py
+++ b/src/ssh/azext_ssh/ssh_utils.py
@@ -27,6 +27,28 @@ def create_ssh_keyfile(private_key_file):
     subprocess.call(command, shell=platform.system() == 'Windows')
 
 
+def get_ssh_cert_info(cert_file):
+    command = [_get_ssh_path("ssh-keygen"), "-L", "-f", cert_file]
+    logger.debug("Running ssh-keygen command %s", ' '.join(command))
+    return subprocess.check_output(command, shell=platform.system() == 'Windows').decode().splitlines()
+
+
+def get_ssh_cert_principals(cert_file):
+    info = get_ssh_cert_info(cert_file)
+    principals = []
+    in_principal = False
+    for line in info:
+        if ":" in line:
+            in_principal = False
+        if "Principals:" in line:
+            in_principal = True
+            continue
+        if in_principal:
+            principals.append(line.strip())
+
+    return principals
+
+
 def write_ssh_config(config_path, resource_group, vm_name, overwrite,
                      ip, username, cert_file, private_key_file):
     file_utils.make_dirs_for_file(config_path)

--- a/src/ssh/azext_ssh/tests/latest/test_custom.py
+++ b/src/ssh/azext_ssh/tests/latest/test_custom.py
@@ -37,6 +37,7 @@ class SshCustomCommandTest(unittest.TestCase):
         mock_do_op.assert_called_once_with(
             cmd, "rg", "vm", "ip", "public", "private", False, mock.ANY)
 
+    @mock.patch('azext_ssh.ssh_utils.get_ssh_cert_principals')
     @mock.patch('os.path.join')
     @mock.patch('azext_ssh.custom._assert_args')
     @mock.patch('azext_ssh.custom._check_or_create_public_private_files')
@@ -45,10 +46,11 @@ class SshCustomCommandTest(unittest.TestCase):
     @mock.patch('azure.cli.core._profile.Profile.get_msal_token')
     @mock.patch('azext_ssh.custom._write_cert_file')
     def test_do_ssh_op(self, mock_write_cert, mock_ssh_creds, mock_get_mod_exp, mock_ip,
-                       mock_check_files, mock_assert, mock_join):
+                       mock_check_files, mock_assert, mock_join, mock_principal):
         cmd = mock.Mock()
         mock_op = mock.Mock()
         mock_check_files.return_value = "public", "private"
+        mock_principal.return_value = ["username"]
         mock_get_mod_exp.return_value = "modulus", "exponent"
         mock_ssh_creds.return_value = "username", "certificate"
         mock_join.return_value = "public-aadcert.pub"
@@ -61,7 +63,7 @@ class SshCustomCommandTest(unittest.TestCase):
         mock_get_mod_exp.assert_called_once_with("public")
         mock_write_cert.assert_called_once_with("certificate", "public-aadcert.pub")
         mock_op.assert_called_once_with(
-            "1.2.3.4", "username", mock_write_cert.return_value, "private")
+            "1.2.3.4", "username", "public-aadcert.pub", "private")
 
     @mock.patch('azext_ssh.custom._assert_args')
     @mock.patch('azext_ssh.custom._check_or_create_public_private_files')

--- a/src/ssh/setup.py
+++ b/src/ssh/setup.py
@@ -7,7 +7,7 @@
 
 from setuptools import setup, find_packages
 
-VERSION = "0.1.3"
+VERSION = "0.1.4"
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
@@ -22,7 +22,6 @@ CLASSIFIERS = [
 ]
 
 DEPENDENCIES = [
-    'paramiko==2.6.0',
     'cryptography==2.8.0'
 ]
 


### PR DESCRIPTION
* Change to use the first in the list of validprincipals as the default username
* Remove old paramiko dependency
This is an ugly hack with a real fix to come as part of a client and server side combined fix.  This will fix guest users who are using their mail (e.g. first.last@contso.com) but logged into az cli using a different UPN (e.g. flast@contso.com)

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
