### PR TITLE
[SSH] Change scope so it can be used by both user account and service principal

### DIFF
--- a/src/ssh/azext_ssh/custom.py
+++ b/src/ssh/azext_ssh/custom.py
@@ -50,7 +50,7 @@ def _do_ssh_op(cmd, resource_group, vm_name, ssh_ip, public_key_file, private_ke
 
 
 def _get_and_write_certificate(cmd, public_key_file, cert_file):
-    scopes = ["https://pas.windows.net/CheckMyAccess/Linux/user_impersonation"]
+    scopes = ["https://pas.windows.net/CheckMyAccess/Linux/.default"]
     data = _prepare_jwk_data(public_key_file)
     from azure.cli.core._profile import Profile
     profile = Profile(cli_ctx=cmd.cli_ctx)


### PR DESCRIPTION
Change the scope so it can be used by both user account and service principal when getting ssh cert.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
