### PR TITLE
Cosmosdb Add Role Definition and Role Assignment commands for Data Plane RBAC

### DIFF
--- a/src/cosmosdb-preview/HISTORY.rst
+++ b/src/cosmosdb-preview/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.3.0
+++++++
+* Create and manage Role Definitions and Role Assignments for enforcing data plane RBAC on Cosmos DB SQL accounts
+
 0.2.0
 ++++++
 * Utc is taken as the default timezone when the timezone is not specified in the restore timestamp

--- a/src/cosmosdb-preview/README.md
+++ b/src/cosmosdb-preview/README.md
@@ -7,6 +7,7 @@ This package provides commands to
 - List the different versions of databases and collections that were modified
 - Trigger a point in time restore on the Azure CosmosDB continuous mode backup accounts
 - Update the backup interval and backup retention of periodic mode backup accounts
+- Create and manage Role Definitions and Role Assignments for enforcing data plane RBAC on Cosmos DB SQL accounts
 
 ## How to use ##
 
@@ -107,4 +108,113 @@ az cosmosdb mongodb restorable-resource list \
     --location "westus" \
     --restore-location "westus" \
     --restore-timestamp "2020-07-20T16:09:53+0000"
+```
+
+#### Create a new Role Definition for a given Cosmos DB SQL account
+
+```sh
+az cosmosdb sql role definition create \
+    --resource-group "my-rg" \
+    --account-name "my-sql-account" \
+    --body "@role-definition-body.json"
+```
+
+#### List all Role Definitions for a given Cosmos DB SQL account
+
+```sh
+az cosmosdb sql role definition list \
+    --resource-group "my-rg" \
+    --account-name "my-sql-account"
+```
+
+#### Show a specific Role Definition for a given Cosmos DB SQL account
+
+```sh
+az cosmosdb sql role definition list \
+    --resource-group "my-rg" \
+    --account-name "my-sql-account" \
+    --id "my-role-def-id"
+```
+
+#### Delete a specific Role Definition for a given Cosmos DB SQL account
+
+```sh
+az cosmosdb sql role definition delete \
+    --resource-group "my-rg" \
+    --account-name "my-sql-account" \
+    --id "my-role-def-id"
+```
+
+#### Update an existing Role Definition for a given Cosmos DB SQL account
+
+```sh
+az cosmosdb sql role definition update \
+    --resource-group "my-rg" \
+    --account-name "my-sql-account" \
+    --body "@role-definition-body.json"
+```
+
+#### Check whether a specific Role Definition exists for a given Cosmos DB SQL account
+
+```sh
+az cosmosdb sql role definition exists \
+    --resource-group "my-rg" \
+    --account-name "my-sql-account" \
+    --id "my-role-def-id"
+```
+
+#### Create a new Role Assignment for a given Cosmos DB SQL account
+
+```sh
+az cosmosdb sql role assignment create \
+    --resource-group "my-rg" \
+    --account-name "my-sql-account" \
+    --role-definition-id "my-role-def-id" \
+    --scope "/" \
+    --principal-id "my-aad-principal-id" \
+```
+
+#### List all Role Assignments for a given Cosmos DB SQL account
+
+```sh
+az cosmosdb sql role assignment list \
+    --resource-group "my-rg" \
+    --account-name "my-sql-account"
+```
+
+#### Show a specific Role Assignment for a given Cosmos DB SQL account
+
+```sh
+az cosmosdb sql role assignment list \
+    --resource-group "my-rg" \
+    --account-name "my-sql-account" \
+    --role-assignment-id "my-role-assignment-id"
+```
+
+#### Delete a specific Role Assignment for a given Cosmos DB SQL account
+
+```sh
+az cosmosdb sql role assignment delete \
+    --resource-group "my-rg" \
+    --account-name "my-sql-account" \
+    --role-assignment-id "my-role-assignment-id"
+```
+
+#### Update an existing Role Assignment for a given Cosmos DB SQL account
+
+```sh
+az cosmosdb sql role assignment update \
+    --resource-group "my-rg" \
+    --account-name "my-sql-account" \
+    --role-assignment-id "my-role-assignment-id" \
+    --role-definition-id "my-role-def-id"
+```
+
+#### Check whether a specific Role Assignment exists for a given Cosmos DB SQL account
+
+```sh
+az cosmosdb sql role assignment exists \
+    --resource-group "my-rg" \
+    --account-name "my-sql-account" \
+    --role-assignment-id "my-role-def-id"
 ```

--- a/src/cosmosdb-preview/azext_cosmosdb_preview/_client_factory.py
+++ b/src/cosmosdb-preview/azext_cosmosdb_preview/_client_factory.py
@@ -40,3 +40,7 @@ def cf_restorable_mongodb_collections(cli_ctx, _):
 
 def cf_restorable_mongodb_resources(cli_ctx, _):
     return cf_cosmosdb_preview(cli_ctx).restorable_mongodb_resources
+
+
+def cf_sql_resources(cli_ctx, _):
+    return cf_cosmosdb_preview(cli_ctx).sql_resources

--- a/src/cosmosdb-preview/azext_cosmosdb_preview/_help.py
+++ b/src/cosmosdb-preview/azext_cosmosdb_preview/_help.py
@@ -160,8 +160,24 @@ helps['cosmosdb sql role definition create'] = """
 type: command
 short-summary: Create a SQL role definition under an Azure Cosmos DB account.
 examples:
-  - name: Create a SQL role definition under an Azure Cosmos DB account.
-    text: az cosmosdb sql role definition create -a MyAccount -g MyResourceGroup -b @role-definition.json
+  - name: Create a SQL role definition under an Azure Cosmos DB account using a JSON string.
+    text: |
+      az cosmosdb sql role definition create --account-name MyAccount --resource-group MyResourceGroup --body '{
+        "Id": "be79875a-2cc4-40d5-8958-566017875b39",
+        "RoleName": "My Read Only Role",
+        "Type": "CustomRole",
+        "AssignableScopes": ["/dbs/mydb/colls/mycontainer"],
+        "Permissions": [{
+          "DataActions": [
+            "Microsoft.DocumentDB/databaseAccounts/readMetadata",
+            "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/items/read",
+            "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/executeQuery",
+            "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/readChangeFeed"
+          ]
+        }]
+      }'
+  - name: Create a SQL role definition under an Azure Cosmos DB account using a JSON file.
+    text: az cosmosdb sql role definition create --account-name MyAccount --resource-group MyResourceGroup --body @role-definition.json
 """
 
 helps['cosmosdb sql role definition delete'] = """
@@ -169,7 +185,7 @@ type: command
 short-summary: Delete a SQL role definition under an Azure Cosmos DB account.
 examples:
   - name: Create a SQL role definition under an Azure Cosmos DB account.
-    text: az cosmosdb sql role definition delete -a MyAccount -g MyResourceGroup -i RoleDefinitionId
+    text: az cosmosdb sql role definition delete --account-name MyAccount --resource-group MyResourceGroup --id be79875a-2cc4-40d5-8958-566017875b39
 """
 
 helps['cosmosdb sql role definition exists'] = """
@@ -177,7 +193,7 @@ type: command
 short-summary: Check if an Azure Cosmos DB role definition exists.
 examples:
   - name: Check if an Azure Cosmos DB role definition exists.
-    text: az cosmosdb sql role definition exists -a MyAccount -g MyResourceGroup -i RoleDefinitionId
+    text: az cosmosdb sql role definition exists --account-name MyAccount --resource-group MyResourceGroup --id be79875a-2cc4-40d5-8958-566017875b39
 """
 
 helps['cosmosdb sql role definition list'] = """
@@ -185,7 +201,7 @@ type: command
 short-summary: List all SQL role definitions under an Azure Cosmos DB account.
 examples:
   - name: List all SQL role definitions under an Azure Cosmos DB account.
-    text: az cosmosdb sql role definition list -a MyAccount -g MyResourceGroup
+    text: az cosmosdb sql role definition list --account-name MyAccount --resource-group MyResourceGroup
 """
 
 helps['cosmosdb sql role definition show'] = """
@@ -193,7 +209,7 @@ type: command
 short-summary: Show the properties of a SQL role definition under an Azure Cosmos DB account.
 examples:
   - name: Show the properties of a SQL role definition under an Azure Cosmos DB account.
-    text: az cosmosdb sql role definition show -a MyAccount -g MyResourceGroup -i RoleDefinitionId
+    text: az cosmosdb sql role definition show --account-name MyAccount --resource-group MyResourceGroup --id be79875a-2cc4-40d5-8958-566017875b39
 """
 
 helps['cosmosdb sql role definition update'] = """
@@ -201,7 +217,7 @@ type: command
 short-summary: Update a SQL role definition under an Azure Cosmos DB account.
 examples:
   - name: Update a SQL role definition under an Azure Cosmos DB account.
-    text: az cosmosdb sql role definition update -a MyAccount -g MyResourceGroup -b @role-definition.json
+    text: az cosmosdb sql role definition update --account-name MyAccount --resource-group MyResourceGroup --body @role-definition.json
 """
 
 helps['cosmosdb sql role assignment'] = """
@@ -214,15 +230,20 @@ type: command
 short-summary: Create a SQL role assignment under an Azure Cosmos DB account.
 examples:
   - name: Create a SQL role assignment under an Azure Cosmos DB account.
-    text: az cosmosdb sql role assignment create -a MyAccount -g MyResourceGroup -s "/" -p MyPrincipalId -d RoleDefinitionId
+    text: |
+      az cosmosdb sql role assignment create --account-name MyAccount --resource-group MyResourceGroup \\
+        --role-assignment-id cb8ed2d7-2371-4e3c-bd31-6cc1560e84f8 \\
+        --role-definition-id be79875a-2cc4-40d5-8958-566017875b39 \\
+        --scope "/dbs/mydb/colls/mycontainer" \\
+        --principal-id 6328f5f7-dbf7-4244-bba8-fbb9d8066506
 """
 
 helps['cosmosdb sql role assignment delete'] = """
 type: command
 short-summary: Delete a SQL role assignment under an Azure Cosmos DB account.
 examples:
-  - name: Create a SQL role assignment under an Azure Cosmos DB account.
-    text: az cosmosdb sql role assignment delete -a MyAccount -g MyResourceGroup -i RoleAssignmentId
+  - name: Delete a SQL role assignment under an Azure Cosmos DB account.
+    text: az cosmosdb sql role assignment delete --account-name MyAccount --resource-group MyResourceGroup --role-assignment-id cb8ed2d7-2371-4e3c-bd31-6cc1560e84f8
 """
 
 helps['cosmosdb sql role assignment exists'] = """
@@ -230,7 +251,7 @@ type: command
 short-summary: Check if an Azure Cosmos DB role assignment exists.
 examples:
   - name: Check if an Azure Cosmos DB role assignment exists.
-    text: az cosmosdb sql role assignment exists -a MyAccount -g MyResourceGroup -i RoleAssignment
+    text: az cosmosdb sql role assignment exists --account-name MyAccount --resource-group MyResourceGroup --role-assignment-id cb8ed2d7-2371-4e3c-bd31-6cc1560e84f8
 """
 
 helps['cosmosdb sql role assignment list'] = """
@@ -238,7 +259,7 @@ type: command
 short-summary: List all SQL role assignments under an Azure Cosmos DB account.
 examples:
   - name: List all SQL role assignments under an Azure Cosmos DB account.
-    text: az cosmosdb sql role assignment list -a MyAccount -g MyResourceGroup
+    text: az cosmosdb sql role assignment list --account-name MyAccount --resource-group MyResourceGroup
 """
 
 helps['cosmosdb sql role assignment show'] = """
@@ -246,7 +267,7 @@ type: command
 short-summary: Show the properties of a SQL role assignment under an Azure Cosmos DB account.
 examples:
   - name: Show the properties of a SQL role assignment under an Azure Cosmos DB account.
-    text: az cosmosdb sql role assignment show -a MyAccount -g MyResourceGroup -i RoleAssignmentId
+    text: az cosmosdb sql role assignment show --account-name MyAccount --resource-group MyResourceGroup --role-assignment-id cb8ed2d7-2371-4e3c-bd31-6cc1560e84f8
 """
 
 helps['cosmosdb sql role assignment update'] = """
@@ -254,5 +275,8 @@ type: command
 short-summary: Update a SQL role assignment under an Azure Cosmos DB account.
 examples:
   - name: Update a SQL role assignment under an Azure Cosmos DB account.
-    text: az cosmosdb sql role assignment update -a MyAccount -g MyResourceGroup -i RoleAssignmentId -d RoleDefinitionId
+    text: |
+      az cosmosdb sql role assignment update --account-name MyAccount --resource-group MyResourceGroup \\
+        --role-assignment-id cb8ed2d7-2371-4e3c-bd31-6cc1560e84f8 \\
+        --role-definition-id updated-role-definition-id
 """

--- a/src/cosmosdb-preview/azext_cosmosdb_preview/_help.py
+++ b/src/cosmosdb-preview/azext_cosmosdb_preview/_help.py
@@ -145,3 +145,114 @@ helps['cosmosdb mongodb restorable-resource list'] = """
 type: command
 short-summary: List all the databases and its collections that can be restored in the given account at the given timesamp and region.
 """
+
+helps['cosmosdb sql role'] = """
+type: group
+short-summary: Manage Azure Cosmos DB SQL role resources.
+"""
+
+helps['cosmosdb sql role definition'] = """
+type: group
+short-summary: Manage Azure Cosmos DB SQL role definitions.
+"""
+
+helps['cosmosdb sql role definition create'] = """
+type: command
+short-summary: Create a SQL role definition under an Azure Cosmos DB account.
+examples:
+  - name: Create a SQL role definition under an Azure Cosmos DB account.
+    text: az cosmosdb sql role definition create -a MyAccount -g MyResourceGroup -b @role-definition.json
+"""
+
+helps['cosmosdb sql role definition delete'] = """
+type: command
+short-summary: Delete a SQL role definition under an Azure Cosmos DB account.
+examples:
+  - name: Create a SQL role definition under an Azure Cosmos DB account.
+    text: az cosmosdb sql role definition delete -a MyAccount -g MyResourceGroup -i RoleDefinitionId
+"""
+
+helps['cosmosdb sql role definition exists'] = """
+type: command
+short-summary: Check if an Azure Cosmos DB role definition exists.
+examples:
+  - name: Check if an Azure Cosmos DB role definition exists.
+    text: az cosmosdb sql role definition exists -a MyAccount -g MyResourceGroup -i RoleDefinitionId
+"""
+
+helps['cosmosdb sql role definition list'] = """
+type: command
+short-summary: List all SQL role definitions under an Azure Cosmos DB account.
+examples:
+  - name: List all SQL role definitions under an Azure Cosmos DB account.
+    text: az cosmosdb sql role definition list -a MyAccount -g MyResourceGroup
+"""
+
+helps['cosmosdb sql role definition show'] = """
+type: command
+short-summary: Show the properties of a SQL role definition under an Azure Cosmos DB account.
+examples:
+  - name: Show the properties of a SQL role definition under an Azure Cosmos DB account.
+    text: az cosmosdb sql role definition show -a MyAccount -g MyResourceGroup -i RoleDefinitionId
+"""
+
+helps['cosmosdb sql role definition update'] = """
+type: command
+short-summary: Update a SQL role definition under an Azure Cosmos DB account.
+examples:
+  - name: Update a SQL role definition under an Azure Cosmos DB account.
+    text: az cosmosdb sql role definition update -a MyAccount -g MyResourceGroup -b @role-definition.json
+"""
+
+helps['cosmosdb sql role assignment'] = """
+type: group
+short-summary: Manage Azure Cosmos DB SQL role assignments.
+"""
+
+helps['cosmosdb sql role assignment create'] = """
+type: command
+short-summary: Create a SQL role assignment under an Azure Cosmos DB account.
+examples:
+  - name: Create a SQL role assignment under an Azure Cosmos DB account.
+    text: az cosmosdb sql role assignment create -a MyAccount -g MyResourceGroup -s "/" -p MyPrincipalId -d RoleDefinitionId
+"""
+
+helps['cosmosdb sql role assignment delete'] = """
+type: command
+short-summary: Delete a SQL role assignment under an Azure Cosmos DB account.
+examples:
+  - name: Create a SQL role assignment under an Azure Cosmos DB account.
+    text: az cosmosdb sql role assignment delete -a MyAccount -g MyResourceGroup -i RoleAssignmentId
+"""
+
+helps['cosmosdb sql role assignment exists'] = """
+type: command
+short-summary: Check if an Azure Cosmos DB role assignment exists.
+examples:
+  - name: Check if an Azure Cosmos DB role assignment exists.
+    text: az cosmosdb sql role assignment exists -a MyAccount -g MyResourceGroup -i RoleAssignment
+"""
+
+helps['cosmosdb sql role assignment list'] = """
+type: command
+short-summary: List all SQL role assignments under an Azure Cosmos DB account.
+examples:
+  - name: List all SQL role assignments under an Azure Cosmos DB account.
+    text: az cosmosdb sql role assignment list -a MyAccount -g MyResourceGroup
+"""
+
+helps['cosmosdb sql role assignment show'] = """
+type: command
+short-summary: Show the properties of a SQL role assignment under an Azure Cosmos DB account.
+examples:
+  - name: Show the properties of a SQL role assignment under an Azure Cosmos DB account.
+    text: az cosmosdb sql role assignment show -a MyAccount -g MyResourceGroup -i RoleAssignmentId
+"""
+
+helps['cosmosdb sql role assignment update'] = """
+type: command
+short-summary: Update a SQL role assignment under an Azure Cosmos DB account.
+examples:
+  - name: Update a SQL role assignment under an Azure Cosmos DB account.
+    text: az cosmosdb sql role assignment update -a MyAccount -g MyResourceGroup -i RoleAssignmentId -d RoleDefinitionId
+"""

--- a/src/cosmosdb-preview/azext_cosmosdb_preview/_params.py
+++ b/src/cosmosdb-preview/azext_cosmosdb_preview/_params.py
@@ -6,11 +6,18 @@
 
 from enum import Enum
 
+from argcomplete.completers import FilesCompleter
+
 from azure.cli.core.commands.parameters import (
     get_resource_name_completion_list, name_type, get_enum_type, get_three_state_flag, get_location_type)
 
 from azext_cosmosdb_preview._validators import (
-    validate_capabilities, validate_virtual_network_rules, validate_ip_range_filter)
+    validate_capabilities, validate_virtual_network_rules, validate_ip_range_filter,
+    validate_role_definition_body,
+    validate_role_definition_id,
+    validate_fully_qualified_role_definition_id,
+    validate_role_assignment_id,
+    validate_scope)
 
 from azext_cosmosdb_preview.actions import (
     CreateLocation, CreateDatabaseRestoreResource, UtcDatetimeAction)
@@ -24,7 +31,7 @@ class BackupPolicyTypes(str, Enum):
 
 
 def load_arguments(self, _):
-
+    from knack.arguments import CLIArgumentType
     from azure.cli.core.commands.parameters import tags_type
 
     with self.argument_context('cosmosdb') as c:
@@ -114,3 +121,19 @@ def load_arguments(self, _):
         c.argument('instance_id', options_list=['--instance-id', '-i'], help="InstanceId of the Account", required=True)
         c.argument('restore_location', options_list=['--restore-location', '-r'], help="The region of the restore.", required=True)
         c.argument('restore_timestamp_in_utc', options_list=['--restore-timestamp', '-t'], help="The timestamp of the restore", required=True)
+
+    account_name_type = CLIArgumentType(options_list=['--account-name', '-a'], help="Cosmosdb account name.")
+
+    # SQL role definition
+    with self.argument_context('cosmosdb sql role definition') as c:
+        c.argument('account_name', account_name_type, id_part=None)
+        c.argument('role_definition_id', options_list=['--id', '-i'], validator=validate_role_definition_id, help="Role Definition Id")
+        c.argument('role_definition_body', options_list=['--body', '-b'], validator=validate_role_definition_body, completer=FilesCompleter(), help="Role Definition body with Id (Optional for create), DataActions or Permissions, Type (Default is CustomRole), and AssignableScopes.  You can enter it as a string or as a file, e.g., --body @rdbody-file.json")
+
+    # SQL role assignment
+    with self.argument_context('cosmosdb sql role assignment') as c:
+        c.argument('account_name', account_name_type, id_part=None)
+        c.argument('role_definition_id', options_list=['--role-definition-id', '-d'], validator=validate_fully_qualified_role_definition_id, help="Role Definition Id assigned in the Role Assignment")
+        c.argument('role_assignment_id', options_list=['--role-assignment-id', '-i'], validator=validate_role_assignment_id, help="Role Assignment Id")
+        c.argument('scope', validator=validate_scope, options_list=['--scope', '-s'], help="Scope assigned in the Role Assignment")
+        c.argument('principal_id', options_list=['--principal-id', '-p'], help="Principal Id assigned in the Role Assignment")

--- a/src/cosmosdb-preview/azext_cosmosdb_preview/_params.py
+++ b/src/cosmosdb-preview/azext_cosmosdb_preview/_params.py
@@ -30,6 +30,10 @@ class BackupPolicyTypes(str, Enum):
     continuous = "Continuous"
 
 
+SQL_ROLE_DEFINITION_EXAMPLE = """--body "{ \\"Id\\": \\"be79875a-2cc4-40d5-8958-566017875b39\\", \\"RoleName\\": \\"My Read Write Role\\", \\"Type\\": \\"CustomRole\\", \\"AssignableScopes\\": [ \\"/\\" ], \\"DataActions\\": [ \\"Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/items/create\\", \\"Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/items/read\\" ]}"
+"""
+
+
 def load_arguments(self, _):
     from knack.arguments import CLIArgumentType
     from azure.cli.core.commands.parameters import tags_type
@@ -127,13 +131,13 @@ def load_arguments(self, _):
     # SQL role definition
     with self.argument_context('cosmosdb sql role definition') as c:
         c.argument('account_name', account_name_type, id_part=None)
-        c.argument('role_definition_id', options_list=['--id', '-i'], validator=validate_role_definition_id, help="Role Definition Id")
-        c.argument('role_definition_body', options_list=['--body', '-b'], validator=validate_role_definition_body, completer=FilesCompleter(), help="Role Definition body with Id (Optional for create), DataActions or Permissions, Type (Default is CustomRole), and AssignableScopes.  You can enter it as a string or as a file, e.g., --body @rdbody-file.json")
+        c.argument('role_definition_id', options_list=['--id', '-i'], validator=validate_role_definition_id, help="Unique ID for the Role Definition.")
+        c.argument('role_definition_body', options_list=['--body', '-b'], validator=validate_role_definition_body, completer=FilesCompleter(), help="Role Definition body with Id (Optional for create), DataActions or Permissions, Type (Default is CustomRole), and AssignableScopes.  You can enter it as a string or as a file, e.g., --body @rdbody-file.json or " + SQL_ROLE_DEFINITION_EXAMPLE)
 
     # SQL role assignment
     with self.argument_context('cosmosdb sql role assignment') as c:
         c.argument('account_name', account_name_type, id_part=None)
-        c.argument('role_definition_id', options_list=['--role-definition-id', '-d'], validator=validate_fully_qualified_role_definition_id, help="Role Definition Id assigned in the Role Assignment")
-        c.argument('role_assignment_id', options_list=['--role-assignment-id', '-i'], validator=validate_role_assignment_id, help="Role Assignment Id")
-        c.argument('scope', validator=validate_scope, options_list=['--scope', '-s'], help="Scope assigned in the Role Assignment")
-        c.argument('principal_id', options_list=['--principal-id', '-p'], help="Principal Id assigned in the Role Assignment")
+        c.argument('role_assignment_id', options_list=['--role-assignment-id', '-i'], validator=validate_role_assignment_id, help="Optional for Create. Unique ID for the Role Assignment. If not provided, a new GUID will be used.")
+        c.argument('role_definition_id', options_list=['--role-definition-id', '-d'], validator=validate_fully_qualified_role_definition_id, help="Unique ID of the Role Definition that this Role Assignment refers to.")
+        c.argument('scope', validator=validate_scope, options_list=['--scope', '-s'], help="Data plane resource path at which this Role Assignment is being granted.")
+        c.argument('principal_id', options_list=['--principal-id', '-p'], help="AAD Object ID of the principal to which this Role Assignment is being granted.")

--- a/src/cosmosdb-preview/azext_cosmosdb_preview/_validators.py
+++ b/src/cosmosdb-preview/azext_cosmosdb_preview/_validators.py
@@ -65,7 +65,7 @@ def validate_virtual_network_rules(ns):
 
 def validate_role_definition_body(cmd, ns):
     """ Extracts role definition body """
-    from azext_cosmosdb_preview.vendored_sdks.azure_mgmt_cosmosdb.models import Permission
+    from azext_cosmosdb_preview.vendored_sdks.azure_mgmt_cosmosdb.models import Permission, RoleDefinitionType
     from azure.cli.core.util import get_file_json, shell_safe_json_parse
     import os
     if ns.role_definition_body is not None:
@@ -76,7 +76,7 @@ def validate_role_definition_body(cmd, ns):
 
         if not isinstance(role_definition, dict):
             raise InvalidArgumentValueError(
-                'Invalid role defintion. A valid dictionary JSON representation is expected.')
+                'Invalid role definition. A valid dictionary JSON representation is expected.')
 
         if 'Id' in role_definition:
             role_definition['Id'] = _parse_resource_path(role_definition['Id'], False, "sqlRoleDefinitions")
@@ -89,10 +89,8 @@ def validate_role_definition_body(cmd, ns):
             role_definition['Permissions'] = [Permission(data_actions=p['DataActions'])
                                               for p in role_definition['Permissions']]
 
-        if 'Type' in role_definition:
-            role_definition['Type'] = role_definition['Type']
-        else:
-            role_definition['Type'] = "CustomRole"
+        if 'Type' not in role_definition:
+            role_definition['Type'] = RoleDefinitionType.custom_role
 
         role_definition['AssignableScopes'] = [_parse_resource_path(
             scope,

--- a/src/cosmosdb-preview/azext_cosmosdb_preview/_validators.py
+++ b/src/cosmosdb-preview/azext_cosmosdb_preview/_validators.py
@@ -4,6 +4,8 @@
 # --------------------------------------------------------------------------------------------
 
 from knack.util import CLIError
+from azure.cli.core.commands.client_factory import get_subscription_id
+from azure.cli.core.azclierror import InvalidArgumentValueError
 
 
 def validate_failover_policies(ns):
@@ -59,3 +61,117 @@ def validate_virtual_network_rules(ns):
         for item in ns.virtual_network_rules:
             virtual_network_rules_list.append(VirtualNetworkRule(id=item))
         ns.virtual_network_rules = virtual_network_rules_list
+
+
+def validate_role_definition_body(cmd, ns):
+    """ Extracts role definition body """
+    from azext_cosmosdb_preview.vendored_sdks.azure_mgmt_cosmosdb.models import Permission
+    from azure.cli.core.util import get_file_json, shell_safe_json_parse
+    import os
+    if ns.role_definition_body is not None:
+        if os.path.exists(ns.role_definition_body):
+            role_definition = get_file_json(ns.role_definition_body)
+        else:
+            role_definition = shell_safe_json_parse(ns.role_definition_body)
+
+        if not isinstance(role_definition, dict):
+            raise InvalidArgumentValueError(
+                'Invalid role defintion. A valid dictionary JSON representation is expected.')
+
+        if 'Id' in role_definition:
+            role_definition['Id'] = _parse_resource_path(role_definition['Id'], False, "sqlRoleDefinitions")
+        else:
+            role_definition['Id'] = _gen_guid()
+
+        if 'DataActions' in role_definition:
+            role_definition['Permissions'] = [Permission(data_actions=role_definition['DataActions'])]
+        else:
+            role_definition['Permissions'] = [Permission(data_actions=p['DataActions'])
+                                              for p in role_definition['Permissions']]
+
+        if 'Type' in role_definition:
+            role_definition['Type'] = role_definition['Type']
+        else:
+            role_definition['Type'] = "CustomRole"
+
+        role_definition['AssignableScopes'] = [_parse_resource_path(
+            scope,
+            True,
+            None,
+            get_subscription_id(cmd.cli_ctx),
+            ns.resource_group_name, ns.account_name) for scope in role_definition['AssignableScopes']]
+
+        ns.role_definition_body = role_definition
+
+
+def validate_role_definition_id(ns):
+    """ Extracts Guid role definition Id """
+    if ns.role_definition_id is not None:
+        ns.role_definition_id = _parse_resource_path(ns.role_definition_id, False, "sqlRoleDefinitions")
+
+
+def validate_fully_qualified_role_definition_id(cmd, ns):
+    """ Extracts fully qualified role definition Id """
+    if ns.role_definition_id is not None:
+        ns.role_definition_id = _parse_resource_path(ns.role_definition_id,
+                                                     True,
+                                                     "sqlRoleDefinitions",
+                                                     get_subscription_id(cmd.cli_ctx),
+                                                     ns.resource_group_name,
+                                                     ns.account_name)
+
+
+def validate_role_assignment_id(ns):
+    """ Extracts Guid role assignment Id """
+    if ns.role_assignment_id is not None:
+        ns.role_assignment_id = _parse_resource_path(ns.role_assignment_id, False, "sqlRoleAssignments")
+    else:
+        ns.role_assignment_id = _gen_guid()
+
+
+def validate_scope(cmd, ns):
+    """ Extracts fully qualified scope """
+    if ns.scope is not None:
+        ns.scope = _parse_resource_path(ns.scope,
+                                        True,
+                                        None,
+                                        get_subscription_id(cmd.cli_ctx),
+                                        ns.resource_group_name,
+                                        ns.account_name)
+
+
+def _parse_resource_path(resource,
+                         to_fully_qualified,
+                         resource_type=None,
+                         subscription_id=None,
+                         resource_group_name=None,
+                         account_name=None):
+    """Returns a properly formatted role definition or assignment id or scope. If scope, type=None."""
+    import re
+    regex = "/subscriptions/(?P<subscription>.*)/resourceGroups/(?P<resource_group>.*)/providers/" \
+            "Microsoft.DocumentDB/databaseAccounts/(?P<database_account>.*)"
+    formatted = "/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.DocumentDB/databaseAccounts/{2}"
+
+    if resource_type is not None:
+        regex += "/" + resource_type + "/(?P<resource_id>.*)"
+        formatted += "/" + resource_type + "/"
+
+    formatted += "{3}"
+
+    if to_fully_qualified:
+        result = re.match(regex, resource)
+        if result is not None:
+            return resource
+
+        return formatted.format(subscription_id, resource_group_name, account_name, resource)
+
+    result = re.match(regex, resource)
+    if result is None:
+        return resource
+
+    return result['resource_id']
+
+
+def _gen_guid():
+    import uuid
+    return uuid.uuid4()

--- a/src/cosmosdb-preview/azext_cosmosdb_preview/commands.py
+++ b/src/cosmosdb-preview/azext_cosmosdb_preview/commands.py
@@ -14,7 +14,8 @@ from azext_cosmosdb_preview._client_factory import (
     cf_restorable_sql_resources,
     cf_restorable_mongodb_databases,
     cf_restorable_mongodb_collections,
-    cf_restorable_mongodb_resources
+    cf_restorable_mongodb_resources,
+    cf_sql_resources
 )
 
 
@@ -51,6 +52,10 @@ def load_command_table(self, _):
         operations_tmpl='azext_cosmosdb_preview.vendored_sdks.azure_mgmt_cosmosdb.operations#RestorableMongodbResourcesOperations.{}',
         client_factory=cf_restorable_mongodb_resources)
 
+    cosmosdb_rbac_sql_sdk = CliCommandType(
+        operations_tmpl='azext_cosmosdb_preview.vendored_sdks.azure_mgmt_cosmosdb.operations#SqlResourcesOperations.{}',
+        client_factory=cf_sql_resources)
+
     with self.command_group('cosmosdb restorable-database-account', cosmosdb_restorable_database_accounts_sdk, client_factory=cf_restorable_database_accounts, is_preview=True) as g:
         g.show_command('show', 'get_by_location')
         g.custom_command('list', 'cli_cosmosdb_restorable_database_account_list')
@@ -79,3 +84,19 @@ def load_command_table(self, _):
 
     with self.command_group('cosmosdb mongodb restorable-resource', cosmosdb_restorable_mongodb_resources_sdk, client_factory=cf_restorable_mongodb_resources, is_preview=True) as g:
         g.command('list', 'list')
+
+    with self.command_group('cosmosdb sql role definition', cosmosdb_rbac_sql_sdk, client_factory=cf_sql_resources) as g:
+        g.custom_command('create', 'cli_cosmosdb_sql_role_definition_create')
+        g.custom_command('update', 'cli_cosmosdb_sql_role_definition_update')
+        g.custom_command('exists', 'cli_cosmosdb_sql_role_definition_exists')
+        g.command('list', 'list_sql_role_definitions')
+        g.show_command('show', 'get_sql_role_definition')
+        g.command('delete', 'delete_sql_role_definition', confirmation=True)
+
+    with self.command_group('cosmosdb sql role assignment', cosmosdb_rbac_sql_sdk, client_factory=cf_sql_resources) as g:
+        g.custom_command('create', 'cli_cosmosdb_sql_role_assignment_create')
+        g.custom_command('update', 'cli_cosmosdb_sql_role_assignment_update')
+        g.custom_command('exists', 'cli_cosmosdb_sql_role_assignment_exists')
+        g.command('list', 'list_sql_role_assignments')
+        g.show_command('show', 'get_sql_role_assignment')
+        g.command('delete', 'delete_sql_role_assignment', confirmation=True)

--- a/src/cosmosdb-preview/azext_cosmosdb_preview/tests/latest/recordings/test_cosmosdb_mongodb_restorable_commands.yaml
+++ b/src/cosmosdb-preview/azext_cosmosdb_preview/tests/latest/recordings/test_cosmosdb_mongodb_restorable_commands.yaml
@@ -13,15 +13,15 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations --kind
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-resource/12.0.0 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cosmosdb_mongodb_restorable_commands000001?api-version=2020-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cosmosdb_mongodb_restorable_commands000001?api-version=2020-10-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_mongodb_restorable_commands000001","name":"cli_test_cosmosdb_mongodb_restorable_commands000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-12-10T21:59:24Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_mongodb_restorable_commands000001","name":"cli_test_cosmosdb_mongodb_restorable_commands000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2021-01-28T22:57:14Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -30,7 +30,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 10 Dec 2020 21:59:27 GMT
+      - Thu, 28 Jan 2021 22:57:15 GMT
       expires:
       - '-1'
       pragma:
@@ -65,8 +65,8 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations --kind
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: PUT
@@ -74,14 +74,14 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_mongodb_restorable_commands000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004","name":"cli000004","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"MongoDB","tags":{},"systemData":{"createdAt":"2020-12-10T21:59:29.7972222Z"},"properties":{"provisioningState":"Creating","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"MongoDB","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"7f6eb33c-2b17-44f5-a956-0acd1bd9437d","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"apiProperties":{"serverVersion":"3.6"},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"MongoDB","tags":{},"systemData":{"createdAt":"2021-01-28T22:57:19.4505829Z"},"properties":{"provisioningState":"Creating","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"MongoDB","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"f46ed918-cadc-48cd-9381-386376eceec1","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"apiProperties":{"serverVersion":"3.6"},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
         US","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000004-westus","locationName":"West
         US","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000004-westus","locationName":"West
         US","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000004-westus","locationName":"West
         US","failoverPriority":0}],"cors":[],"capabilities":[{"name":"EnableMongo"}],"ipRules":[],"backupPolicy":{"type":"Continuous"}},"identity":{"type":"None"}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/55cc055f-efac-4cb5-a05f-19ef9350bd28?api-version=2020-06-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/c94f177f-fb17-442b-a019-ea3d2284d2c8?api-version=2020-06-01-preview
       cache-control:
       - no-store, no-cache
       content-length:
@@ -89,9 +89,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 21:59:30 GMT
+      - Thu, 28 Jan 2021 22:57:19 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_mongodb_restorable_commands000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004/operationResults/55cc055f-efac-4cb5-a05f-19ef9350bd28?api-version=2020-06-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_mongodb_restorable_commands000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004/operationResults/c94f177f-fb17-442b-a019-ea3d2284d2c8?api-version=2020-06-01-preview
       pragma:
       - no-cache
       server:
@@ -107,7 +107,7 @@ interactions:
       x-ms-gatewayversion:
       - version=2.11.0
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1197'
     status:
       code: 200
       message: Ok
@@ -125,10 +125,10 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations --kind
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/55cc055f-efac-4cb5-a05f-19ef9350bd28?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/c94f177f-fb17-442b-a019-ea3d2284d2c8?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -140,7 +140,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:00:00 GMT
+      - Thu, 28 Jan 2021 22:57:50 GMT
       pragma:
       - no-cache
       server:
@@ -172,10 +172,10 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations --kind
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/55cc055f-efac-4cb5-a05f-19ef9350bd28?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/c94f177f-fb17-442b-a019-ea3d2284d2c8?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -187,7 +187,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:00:31 GMT
+      - Thu, 28 Jan 2021 22:58:20 GMT
       pragma:
       - no-cache
       server:
@@ -219,10 +219,10 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations --kind
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/55cc055f-efac-4cb5-a05f-19ef9350bd28?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/c94f177f-fb17-442b-a019-ea3d2284d2c8?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -234,7 +234,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:01:01 GMT
+      - Thu, 28 Jan 2021 22:58:51 GMT
       pragma:
       - no-cache
       server:
@@ -266,10 +266,10 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations --kind
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/55cc055f-efac-4cb5-a05f-19ef9350bd28?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/c94f177f-fb17-442b-a019-ea3d2284d2c8?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -281,7 +281,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:01:32 GMT
+      - Thu, 28 Jan 2021 22:59:21 GMT
       pragma:
       - no-cache
       server:
@@ -313,10 +313,10 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations --kind
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/55cc055f-efac-4cb5-a05f-19ef9350bd28?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/c94f177f-fb17-442b-a019-ea3d2284d2c8?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -328,7 +328,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:02:03 GMT
+      - Thu, 28 Jan 2021 22:59:51 GMT
       pragma:
       - no-cache
       server:
@@ -360,668 +360,10 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations --kind
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/55cc055f-efac-4cb5-a05f-19ef9350bd28?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:02:33 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations --kind
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/55cc055f-efac-4cb5-a05f-19ef9350bd28?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:03:04 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations --kind
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/55cc055f-efac-4cb5-a05f-19ef9350bd28?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:03:34 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations --kind
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/55cc055f-efac-4cb5-a05f-19ef9350bd28?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:04:04 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations --kind
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/55cc055f-efac-4cb5-a05f-19ef9350bd28?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:04:35 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations --kind
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/55cc055f-efac-4cb5-a05f-19ef9350bd28?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:05:06 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations --kind
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/55cc055f-efac-4cb5-a05f-19ef9350bd28?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:05:36 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations --kind
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/55cc055f-efac-4cb5-a05f-19ef9350bd28?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:06:06 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations --kind
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/55cc055f-efac-4cb5-a05f-19ef9350bd28?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:06:37 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations --kind
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/55cc055f-efac-4cb5-a05f-19ef9350bd28?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:07:07 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations --kind
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/55cc055f-efac-4cb5-a05f-19ef9350bd28?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:07:38 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations --kind
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/55cc055f-efac-4cb5-a05f-19ef9350bd28?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:08:08 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations --kind
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/55cc055f-efac-4cb5-a05f-19ef9350bd28?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:08:39 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations --kind
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/55cc055f-efac-4cb5-a05f-19ef9350bd28?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:09:09 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations --kind
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/55cc055f-efac-4cb5-a05f-19ef9350bd28?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/c94f177f-fb17-442b-a019-ea3d2284d2c8?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -1033,7 +375,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:09:40 GMT
+      - Thu, 28 Jan 2021 23:00:22 GMT
       pragma:
       - no-cache
       server:
@@ -1065,14 +407,14 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations --kind
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_mongodb_restorable_commands000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004?api-version=2020-06-01-preview
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_mongodb_restorable_commands000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004","name":"cli000004","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"MongoDB","tags":{},"systemData":{"createdAt":"2020-12-10T22:08:58.6534483Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","mongoEndpoint":"https://cli000004.mongo.cosmos.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"MongoDB","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"7f6eb33c-2b17-44f5-a956-0acd1bd9437d","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"apiProperties":{"serverVersion":"3.6"},"configurationOverrides":{"EnableBsonSchema":"True"},"writeLocations":[{"id":"cli000004-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"MongoDB","tags":{},"systemData":{"createdAt":"2021-01-28T22:59:21.7713933Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","mongoEndpoint":"https://cli000004.mongo.cosmos.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"MongoDB","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"f46ed918-cadc-48cd-9381-386376eceec1","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"apiProperties":{"serverVersion":"3.6"},"configurationOverrides":{"EnableBsonSchema":"True"},"writeLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000004-westus","locationName":"West
@@ -1085,7 +427,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:09:41 GMT
+      - Thu, 28 Jan 2021 23:00:22 GMT
       pragma:
       - no-cache
       server:
@@ -1117,8 +459,8 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations --kind
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: GET
@@ -1126,7 +468,7 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_mongodb_restorable_commands000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004","name":"cli000004","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"MongoDB","tags":{},"systemData":{"createdAt":"2020-12-10T22:08:58.6534483Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","mongoEndpoint":"https://cli000004.mongo.cosmos.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"MongoDB","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"7f6eb33c-2b17-44f5-a956-0acd1bd9437d","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"apiProperties":{"serverVersion":"3.6"},"configurationOverrides":{"EnableBsonSchema":"True"},"writeLocations":[{"id":"cli000004-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"MongoDB","tags":{},"systemData":{"createdAt":"2021-01-28T22:59:21.7713933Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","mongoEndpoint":"https://cli000004.mongo.cosmos.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"MongoDB","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"f46ed918-cadc-48cd-9381-386376eceec1","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"apiProperties":{"serverVersion":"3.6"},"configurationOverrides":{"EnableBsonSchema":"True"},"writeLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000004-westus","locationName":"West
@@ -1139,7 +481,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:09:41 GMT
+      - Thu, 28 Jan 2021 23:00:22 GMT
       pragma:
       - no-cache
       server:
@@ -1171,8 +513,8 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: GET
@@ -1180,7 +522,7 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_mongodb_restorable_commands000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004","name":"cli000004","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"MongoDB","tags":{},"systemData":{"createdAt":"2020-12-10T22:08:58.6534483Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","mongoEndpoint":"https://cli000004.mongo.cosmos.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"MongoDB","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"7f6eb33c-2b17-44f5-a956-0acd1bd9437d","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"apiProperties":{"serverVersion":"3.6"},"configurationOverrides":{"EnableBsonSchema":"True"},"writeLocations":[{"id":"cli000004-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"MongoDB","tags":{},"systemData":{"createdAt":"2021-01-28T22:59:21.7713933Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","mongoEndpoint":"https://cli000004.mongo.cosmos.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"MongoDB","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"f46ed918-cadc-48cd-9381-386376eceec1","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"apiProperties":{"serverVersion":"3.6"},"configurationOverrides":{"EnableBsonSchema":"True"},"writeLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000004-westus","locationName":"West
@@ -1193,7 +535,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:09:41 GMT
+      - Thu, 28 Jan 2021 23:00:23 GMT
       pragma:
       - no-cache
       server:
@@ -1229,8 +571,8 @@ interactions:
       ParameterSetName:
       - -g -a -n
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: PUT
@@ -1240,7 +582,7 @@ interactions:
       string: '{"status":"Enqueued"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/46bb9086-d3d6-403f-82f8-a8c3e25d6eff?api-version=2020-04-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/790faac0-efe2-489e-be79-a279dfbcb972?api-version=2020-04-01
       cache-control:
       - no-store, no-cache
       content-length:
@@ -1248,9 +590,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:09:43 GMT
+      - Thu, 28 Jan 2021 23:00:25 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_mongodb_restorable_commands000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004/mongodbDatabases/cli000003/operationResults/46bb9086-d3d6-403f-82f8-a8c3e25d6eff?api-version=2020-04-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_mongodb_restorable_commands000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004/mongodbDatabases/cli000003/operationResults/790faac0-efe2-489e-be79-a279dfbcb972?api-version=2020-04-01
       pragma:
       - no-cache
       server:
@@ -1280,10 +622,10 @@ interactions:
       ParameterSetName:
       - -g -a -n
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/46bb9086-d3d6-403f-82f8-a8c3e25d6eff?api-version=2020-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/790faac0-efe2-489e-be79-a279dfbcb972?api-version=2020-04-01
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -1295,7 +637,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:10:14 GMT
+      - Thu, 28 Jan 2021 23:00:54 GMT
       pragma:
       - no-cache
       server:
@@ -1327,8 +669,8 @@ interactions:
       ParameterSetName:
       - -g -a -n
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_mongodb_restorable_commands000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004/mongodbDatabases/cli000003?api-version=2020-04-01
   response:
@@ -1342,7 +684,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:10:15 GMT
+      - Thu, 28 Jan 2021 23:00:56 GMT
       pragma:
       - no-cache
       server:
@@ -1379,8 +721,8 @@ interactions:
       ParameterSetName:
       - -g -a -d -n --shard --throughput
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: PUT
@@ -1390,7 +732,7 @@ interactions:
       string: '{"status":"Enqueued"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/fd65fb8a-8261-40e6-8a72-bd663f4ec715?api-version=2020-04-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/3d70905d-0574-40dc-837a-08e1a104dd74?api-version=2020-04-01
       cache-control:
       - no-store, no-cache
       content-length:
@@ -1398,9 +740,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:10:16 GMT
+      - Thu, 28 Jan 2021 23:00:57 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_mongodb_restorable_commands000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004/mongodbDatabases/cli000003/collections/cli000002/operationResults/fd65fb8a-8261-40e6-8a72-bd663f4ec715?api-version=2020-04-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_mongodb_restorable_commands000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004/mongodbDatabases/cli000003/collections/cli000002/operationResults/3d70905d-0574-40dc-837a-08e1a104dd74?api-version=2020-04-01
       pragma:
       - no-cache
       server:
@@ -1430,10 +772,10 @@ interactions:
       ParameterSetName:
       - -g -a -d -n --shard --throughput
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/fd65fb8a-8261-40e6-8a72-bd663f4ec715?api-version=2020-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/3d70905d-0574-40dc-837a-08e1a104dd74?api-version=2020-04-01
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -1445,7 +787,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:10:47 GMT
+      - Thu, 28 Jan 2021 23:01:28 GMT
       pragma:
       - no-cache
       server:
@@ -1477,8 +819,8 @@ interactions:
       ParameterSetName:
       - -g -a -d -n --shard --throughput
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_mongodb_restorable_commands000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004/mongodbDatabases/cli000003/collections/cli000002?api-version=2020-04-01
   response:
@@ -1492,7 +834,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:10:48 GMT
+      - Thu, 28 Jan 2021 23:01:29 GMT
       pragma:
       - no-cache
       server:
@@ -1524,25 +866,25 @@ interactions:
       ParameterSetName:
       - --location --instance-id
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/7f6eb33c-2b17-44f5-a956-0acd1bd9437d?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/f46ed918-cadc-48cd-9381-386376eceec1?api-version=2020-06-01-preview
   response:
     body:
-      string: '{"name":"7f6eb33c-2b17-44f5-a956-0acd1bd9437d","location":"West US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/7f6eb33c-2b17-44f5-a956-0acd1bd9437d","properties":{"accountName":"cli000004","creationTime":"2020-12-10T22:08:58.6534483Z","apiType":"MongoDB","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-12-10T22:08:59.5384495Z","regionalDatabaseAccountInstanceId":"3ff2c3f0-9ee9-4010-980b-2e5f48066f75"}]}}'
+      string: '{"name":"f46ed918-cadc-48cd-9381-386376eceec1","location":"West US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/f46ed918-cadc-48cd-9381-386376eceec1","properties":{"accountName":"cli000004","apiType":"MongoDB","creationTime":"2021-01-28T22:59:22Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"63a7ae8b-329a-492a-8fbf-99ab5a901730","creationTime":"2021-01-28T22:59:23Z"}]}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '591'
+      - '575'
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:10:50 GMT
+      - Thu, 28 Jan 2021 23:01:33 GMT
       pragma:
       - no-cache
       server:
@@ -1574,15 +916,15 @@ interactions:
       ParameterSetName:
       - --location --instance-id
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/7f6eb33c-2b17-44f5-a956-0acd1bd9437d/restorableMongodbDatabases?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/f46ed918-cadc-48cd-9381-386376eceec1/restorableMongodbDatabases?api-version=2020-06-01-preview
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/7f6eb33c-2b17-44f5-a956-0acd1bd9437d/restorableMongodbDatabases/7dd70401-7424-48b1-9de4-4f93d6e29f35","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts/restorableMongodbDatabases","name":"7dd70401-7424-48b1-9de4-4f93d6e29f35","properties":{"resource":{"_rid":"SvitWgAAAA==","eventTimestamp":"2020-12-10T22:09:48Z","ownerId":"cli000003","ownerResourceId":"NJIhAA==","operationType":"Create"}}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/f46ed918-cadc-48cd-9381-386376eceec1/restorableMongodbDatabases/173d0f2c-f1c5-406f-9c3c-f19e47ba3f49","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts/restorableMongodbDatabases","name":"173d0f2c-f1c5-406f-9c3c-f19e47ba3f49","properties":{"resource":{"_rid":"01zVHQAAAA==","eventTimestamp":"2021-01-28T23:00:29Z","ownerId":"cli000003","ownerResourceId":"mZZ6AA==","operationType":"Create"}}}]}'
     headers:
       cache-control:
       - no-store, no-cache
@@ -1591,7 +933,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:10:52 GMT
+      - Thu, 28 Jan 2021 23:01:37 GMT
       pragma:
       - no-cache
       server:
@@ -1623,15 +965,15 @@ interactions:
       ParameterSetName:
       - --location --instance-id --database-rid
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/7f6eb33c-2b17-44f5-a956-0acd1bd9437d/restorableMongodbCollections?api-version=2020-06-01-preview&restorableMongodbDatabaseRid=NJIhAA%3D%3D
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/f46ed918-cadc-48cd-9381-386376eceec1/restorableMongodbCollections?api-version=2020-06-01-preview&restorableMongodbDatabaseRid=mZZ6AA%3D%3D
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/7f6eb33c-2b17-44f5-a956-0acd1bd9437d/restorableMongodbCollections/93cc5dad-7ad9-4947-bab8-65f78573158e","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts/restorableMongodbCollections","name":"93cc5dad-7ad9-4947-bab8-65f78573158e","properties":{"resource":{"_rid":"PnqzegAAAA==","eventTimestamp":"2020-12-10T22:10:23Z","ownerId":"cli000002","ownerResourceId":"NJIhAOBQ4Tg=","operationType":"Create"}}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/f46ed918-cadc-48cd-9381-386376eceec1/restorableMongodbCollections/77aa11c3-d8c6-43a0-b730-749cdd0c02be","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts/restorableMongodbCollections","name":"77aa11c3-d8c6-43a0-b730-749cdd0c02be","properties":{"resource":{"_rid":"oFyNXgAAAA==","eventTimestamp":"2021-01-28T23:01:03Z","ownerId":"cli000002","ownerResourceId":"mZZ6AIfwxGg=","operationType":"Create"}}}]}'
     headers:
       cache-control:
       - no-store, no-cache
@@ -1640,7 +982,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:10:54 GMT
+      - Thu, 28 Jan 2021 23:01:42 GMT
       pragma:
       - no-cache
       server:
@@ -1672,12 +1014,12 @@ interactions:
       ParameterSetName:
       - --restore-location -l --instance-id --restore-timestamp
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/7f6eb33c-2b17-44f5-a956-0acd1bd9437d/restorableMongodbResources?api-version=2020-06-01-preview&restoreLocation=westus&restoreTimestampInUtc=2020-12-10T22%3A10%3A58.653448%2B00%3A00
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/f46ed918-cadc-48cd-9381-386376eceec1/restorableMongodbResources?api-version=2020-06-01-preview&restoreLocation=westus&restoreTimestampInUtc=2021-01-28T23%3A01%3A22%2B00%3A00
   response:
     body:
       string: '{"value":[{"databaseName":"cli000003","collectionNames":["cli000002"]}]}'
@@ -1689,7 +1031,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:12:55 GMT
+      - Thu, 28 Jan 2021 23:03:45 GMT
       pragma:
       - no-cache
       server:

--- a/src/cosmosdb-preview/azext_cosmosdb_preview/tests/latest/recordings/test_cosmosdb_restore_command.yaml
+++ b/src/cosmosdb-preview/azext_cosmosdb_preview/tests/latest/recordings/test_cosmosdb_restore_command.yaml
@@ -13,15 +13,15 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-resource/12.0.0 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cosmosdb_restore_command000001?api-version=2020-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cosmosdb_restore_command000001?api-version=2020-10-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001","name":"cli_test_cosmosdb_restore_command000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-12-14T03:45:56Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001","name":"cli_test_cosmosdb_restore_command000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2021-01-28T22:57:14Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -30,7 +30,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 14 Dec 2020 03:46:00 GMT
+      - Thu, 28 Jan 2021 22:57:16 GMT
       expires:
       - '-1'
       pragma:
@@ -65,8 +65,8 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: PUT
@@ -74,14 +74,14 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2020-12-14T03:46:02.9759509Z"},"properties":{"provisioningState":"Creating","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"5c8a5401-1159-40cc-9e1d-99af7c7bc289","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-28T22:57:18.9032601Z"},"properties":{"provisioningState":"Creating","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"dad19ede-1592-4d87-95ff-4e20c8a09de5","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
         US","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000003-westus","locationName":"West
         US","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000003-westus","locationName":"West
         US","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000003-westus","locationName":"West
         US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"}},"identity":{"type":"None"}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/52f49a82-d772-4e39-a576-a7b0dbb7ac8a?api-version=2020-06-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/f819b3b3-eedd-40db-9718-a11c32691211?api-version=2020-06-01-preview
       cache-control:
       - no-store, no-cache
       content-length:
@@ -89,9 +89,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 03:46:03 GMT
+      - Thu, 28 Jan 2021 22:57:19 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/operationResults/52f49a82-d772-4e39-a576-a7b0dbb7ac8a?api-version=2020-06-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/operationResults/f819b3b3-eedd-40db-9718-a11c32691211?api-version=2020-06-01-preview
       pragma:
       - no-cache
       server:
@@ -107,7 +107,7 @@ interactions:
       x-ms-gatewayversion:
       - version=2.11.0
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1197'
     status:
       code: 200
       message: Ok
@@ -125,10 +125,10 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/52f49a82-d772-4e39-a576-a7b0dbb7ac8a?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/f819b3b3-eedd-40db-9718-a11c32691211?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -140,7 +140,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 03:46:34 GMT
+      - Thu, 28 Jan 2021 22:57:49 GMT
       pragma:
       - no-cache
       server:
@@ -172,10 +172,10 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/52f49a82-d772-4e39-a576-a7b0dbb7ac8a?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/f819b3b3-eedd-40db-9718-a11c32691211?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -187,7 +187,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 03:47:04 GMT
+      - Thu, 28 Jan 2021 22:58:19 GMT
       pragma:
       - no-cache
       server:
@@ -219,574 +219,10 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/52f49a82-d772-4e39-a576-a7b0dbb7ac8a?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 03:47:34 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/52f49a82-d772-4e39-a576-a7b0dbb7ac8a?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 03:48:05 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/52f49a82-d772-4e39-a576-a7b0dbb7ac8a?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 03:48:35 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/52f49a82-d772-4e39-a576-a7b0dbb7ac8a?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 03:49:07 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/52f49a82-d772-4e39-a576-a7b0dbb7ac8a?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 03:49:37 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/52f49a82-d772-4e39-a576-a7b0dbb7ac8a?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 03:50:07 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/52f49a82-d772-4e39-a576-a7b0dbb7ac8a?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 03:50:38 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/52f49a82-d772-4e39-a576-a7b0dbb7ac8a?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 03:51:08 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/52f49a82-d772-4e39-a576-a7b0dbb7ac8a?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 03:51:39 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/52f49a82-d772-4e39-a576-a7b0dbb7ac8a?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 03:52:09 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/52f49a82-d772-4e39-a576-a7b0dbb7ac8a?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 03:52:40 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/52f49a82-d772-4e39-a576-a7b0dbb7ac8a?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 03:53:10 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/52f49a82-d772-4e39-a576-a7b0dbb7ac8a?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/f819b3b3-eedd-40db-9718-a11c32691211?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -798,7 +234,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 03:53:41 GMT
+      - Thu, 28 Jan 2021 22:58:50 GMT
       pragma:
       - no-cache
       server:
@@ -830,14 +266,14 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2020-06-01-preview
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2020-12-14T03:53:12.2321417Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"5c8a5401-1159-40cc-9e1d-99af7c7bc289","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-28T22:58:05.0291967Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"dad19ede-1592-4d87-95ff-4e20c8a09de5","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000003-westus","locationName":"West
@@ -850,7 +286,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 03:53:41 GMT
+      - Thu, 28 Jan 2021 22:58:51 GMT
       pragma:
       - no-cache
       server:
@@ -882,8 +318,8 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: GET
@@ -891,7 +327,7 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2020-12-14T03:53:12.2321417Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"5c8a5401-1159-40cc-9e1d-99af7c7bc289","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-28T22:58:05.0291967Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"dad19ede-1592-4d87-95ff-4e20c8a09de5","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000003-westus","locationName":"West
@@ -904,7 +340,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 03:53:41 GMT
+      - Thu, 28 Jan 2021 22:58:51 GMT
       pragma:
       - no-cache
       server:
@@ -936,8 +372,8 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: GET
@@ -945,7 +381,7 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2020-12-14T03:53:12.2321417Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"5c8a5401-1159-40cc-9e1d-99af7c7bc289","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-28T22:58:05.0291967Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"dad19ede-1592-4d87-95ff-4e20c8a09de5","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000003-westus","locationName":"West
@@ -958,7 +394,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 03:53:42 GMT
+      - Thu, 28 Jan 2021 22:58:51 GMT
       pragma:
       - no-cache
       server:
@@ -994,8 +430,8 @@ interactions:
       ParameterSetName:
       - -g -a -n
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: PUT
@@ -1005,7 +441,7 @@ interactions:
       string: '{"status":"Enqueued"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/6590aedd-0361-49b0-b5ea-c23b0563a41e?api-version=2020-04-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/b6a1e96b-6aa8-477b-92b6-69c85c278c01?api-version=2020-04-01
       cache-control:
       - no-store, no-cache
       content-length:
@@ -1013,9 +449,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 03:53:44 GMT
+      - Thu, 28 Jan 2021 22:58:52 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/operationResults/6590aedd-0361-49b0-b5ea-c23b0563a41e?api-version=2020-04-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/operationResults/b6a1e96b-6aa8-477b-92b6-69c85c278c01?api-version=2020-04-01
       pragma:
       - no-cache
       server:
@@ -1027,7 +463,7 @@ interactions:
       x-ms-gatewayversion:
       - version=2.11.0
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1196'
     status:
       code: 202
       message: Accepted
@@ -1045,10 +481,10 @@ interactions:
       ParameterSetName:
       - -g -a -n
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/6590aedd-0361-49b0-b5ea-c23b0563a41e?api-version=2020-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/b6a1e96b-6aa8-477b-92b6-69c85c278c01?api-version=2020-04-01
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -1060,7 +496,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 03:54:14 GMT
+      - Thu, 28 Jan 2021 22:59:23 GMT
       pragma:
       - no-cache
       server:
@@ -1092,13 +528,13 @@ interactions:
       ParameterSetName:
       - -g -a -n
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005?api-version=2020-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005","type":"Microsoft.DocumentDB/databaseAccounts/sqlDatabases","name":"cli000005","properties":{"resource":{"id":"cli000005","_rid":"Q+NzAA==","_self":"dbs/Q+NzAA==/","_etag":"\"0000e601-0000-0700-0000-5fd6e1ce0000\"","_colls":"colls/","_users":"users/","_ts":1607918030}}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005","type":"Microsoft.DocumentDB/databaseAccounts/sqlDatabases","name":"cli000005","properties":{"resource":{"id":"cli000005","_rid":"mfBsAA==","_self":"dbs/mfBsAA==/","_etag":"\"00003401-0000-0700-0000-601341b00000\"","_colls":"colls/","_users":"users/","_ts":1611874736}}}'
     headers:
       cache-control:
       - no-store, no-cache
@@ -1107,7 +543,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 03:54:14 GMT
+      - Thu, 28 Jan 2021 22:59:24 GMT
       pragma:
       - no-cache
       server:
@@ -1146,8 +582,8 @@ interactions:
       ParameterSetName:
       - -g -a -d -n -p
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: PUT
@@ -1157,7 +593,7 @@ interactions:
       string: '{"status":"Enqueued"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/5d09e3b7-5a55-4858-beac-cbe762ac7569?api-version=2020-04-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/53bcd9c8-4b16-46a7-a260-ea19b66d3da7?api-version=2020-04-01
       cache-control:
       - no-store, no-cache
       content-length:
@@ -1165,9 +601,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 03:54:15 GMT
+      - Thu, 28 Jan 2021 22:59:25 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/containers/cli000002/operationResults/5d09e3b7-5a55-4858-beac-cbe762ac7569?api-version=2020-04-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/containers/cli000002/operationResults/53bcd9c8-4b16-46a7-a260-ea19b66d3da7?api-version=2020-04-01
       pragma:
       - no-cache
       server:
@@ -1179,7 +615,7 @@ interactions:
       x-ms-gatewayversion:
       - version=2.11.0
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1195'
     status:
       code: 202
       message: Accepted
@@ -1197,10 +633,10 @@ interactions:
       ParameterSetName:
       - -g -a -d -n -p
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/5d09e3b7-5a55-4858-beac-cbe762ac7569?api-version=2020-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/53bcd9c8-4b16-46a7-a260-ea19b66d3da7?api-version=2020-04-01
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -1212,7 +648,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 03:54:47 GMT
+      - Thu, 28 Jan 2021 22:59:55 GMT
       pragma:
       - no-cache
       server:
@@ -1244,13 +680,13 @@ interactions:
       ParameterSetName:
       - -g -a -d -n -p
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/containers/cli000002?api-version=2020-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/containers/cli000002","type":"Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers","name":"cli000002","properties":{"resource":{"id":"cli000002","indexingPolicy":{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"/*"}],"excludedPaths":[{"path":"/\"_etag\"/?"}]},"partitionKey":{"paths":["/pk"],"kind":"Hash"},"uniqueKeyPolicy":{"uniqueKeys":[]},"conflictResolutionPolicy":{"mode":"LastWriterWins","conflictResolutionPath":"/_ts","conflictResolutionProcedure":""},"backupPolicy":{"type":1},"allowMaterializedViews":false,"geospatialConfig":{"type":"Geography"},"_rid":"Q+NzAJQ8vS4=","_ts":1607918060,"_self":"dbs/Q+NzAA==/colls/Q+NzAJQ8vS4=/","_etag":"\"0000e901-0000-0700-0000-5fd6e1ec0000\"","_docs":"docs/","_sprocs":"sprocs/","_triggers":"triggers/","_udfs":"udfs/","_conflicts":"conflicts/","statistics":[{"id":"0","sizeInKB":0,"documentCount":0,"partitionKeys":[]}]}}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/containers/cli000002","type":"Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers","name":"cli000002","properties":{"resource":{"id":"cli000002","indexingPolicy":{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"/*"}],"excludedPaths":[{"path":"/\"_etag\"/?"}]},"partitionKey":{"paths":["/pk"],"kind":"Hash"},"uniqueKeyPolicy":{"uniqueKeys":[]},"conflictResolutionPolicy":{"mode":"LastWriterWins","conflictResolutionPath":"/_ts","conflictResolutionProcedure":""},"backupPolicy":{"type":1},"allowMaterializedViews":false,"geospatialConfig":{"type":"Geography"},"_rid":"mfBsAKtWvfE=","_ts":1611874769,"_self":"dbs/mfBsAA==/colls/mfBsAKtWvfE=/","_etag":"\"00003701-0000-0700-0000-601341d10000\"","_docs":"docs/","_sprocs":"sprocs/","_triggers":"triggers/","_udfs":"udfs/","_conflicts":"conflicts/","statistics":[{"id":"0","sizeInKB":0,"documentCount":0,"partitionKeys":[]}]}}}'
     headers:
       cache-control:
       - no-store, no-cache
@@ -1259,7 +695,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 03:54:47 GMT
+      - Thu, 28 Jan 2021 22:59:56 GMT
       pragma:
       - no-cache
       server:
@@ -1291,25 +727,25 @@ interactions:
       ParameterSetName:
       - --location --instance-id
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/5c8a5401-1159-40cc-9e1d-99af7c7bc289?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/dad19ede-1592-4d87-95ff-4e20c8a09de5?api-version=2020-06-01-preview
   response:
     body:
-      string: '{"name":"5c8a5401-1159-40cc-9e1d-99af7c7bc289","location":"West US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/5c8a5401-1159-40cc-9e1d-99af7c7bc289","properties":{"accountName":"cli000003","creationTime":"2020-12-14T03:53:12.2321417Z","apiType":"Sql","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-12-14T03:53:12.9771426Z","regionalDatabaseAccountInstanceId":"63446e97-a8fb-4373-b0fd-57bd2d700bfa"}]}}'
+      string: '{"name":"dad19ede-1592-4d87-95ff-4e20c8a09de5","location":"West US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/dad19ede-1592-4d87-95ff-4e20c8a09de5","properties":{"accountName":"cli000003","apiType":"Sql","creationTime":"2021-01-28T22:58:06Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"a2c2b55a-9cda-4aad-b75a-bfd34647818f","creationTime":"2021-01-28T22:58:06Z"}]}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '587'
+      - '571'
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 03:54:49 GMT
+      - Thu, 28 Jan 2021 23:00:01 GMT
       pragma:
       - no-cache
       server:
@@ -1341,98 +777,220 @@ interactions:
       ParameterSetName:
       - -n -g -a --restore-timestamp --location
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/restorableDatabaseAccounts?api-version=2020-06-01-preview
   response:
     body:
-      string: '{"value":[{"name":"5c8a5401-1159-40cc-9e1d-99af7c7bc289","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/5c8a5401-1159-40cc-9e1d-99af7c7bc289","properties":{"accountName":"cli000003","creationTime":"2020-12-14T03:53:12.2321417Z","apiType":"Sql","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-12-14T03:53:12.9771426Z","regionalDatabaseAccountInstanceId":"63446e97-a8fb-4373-b0fd-57bd2d700bfa"}]}},{"name":"651acce6-dd9b-4cb0-a236-444fa0760775","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/651acce6-dd9b-4cb0-a236-444fa0760775","properties":{"accountName":"continuous-db2121","creationTime":"2020-08-06T21:04:15.6720984Z","apiType":"Sql","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-08-06T21:04:16.5626858Z","regionalDatabaseAccountInstanceId":"7119a7d0-aab2-4dac-90d2-68880d3fa967"}]}},{"name":"b27cbd07-72f0-4769-9bc7-8cfbe0523d29","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b27cbd07-72f0-4769-9bc7-8cfbe0523d29","properties":{"accountName":"continuous-db2121-r1","creationTime":"2020-09-03T17:58:33.3003917Z","apiType":"Sql","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-09-03T17:58:33.3003917Z","regionalDatabaseAccountInstanceId":"c800c27e-ec05-4656-9391-6e31f28e3e8b"}]}},{"name":"780425ec-5b37-4661-ab56-bdeac3ca2763","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/780425ec-5b37-4661-ab56-bdeac3ca2763","properties":{"accountName":"continuous-db2332","creationTime":"2020-08-06T22:43:00.3153258Z","apiType":"Sql","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-08-06T22:43:01.1889467Z","regionalDatabaseAccountInstanceId":"4d097971-9228-459b-8687-e6016e34599e"}]}},{"name":"d92d948a-afb9-4bb3-9a4c-d6b8fcf8d204","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d92d948a-afb9-4bb3-9a4c-d6b8fcf8d204","properties":{"accountName":"kal-continuous","creationTime":"2020-08-05T01:00:24.1857393Z","apiType":"Sql","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-08-05T01:00:25.0607285Z","regionalDatabaseAccountInstanceId":"c28cc815-caba-4bd3-9402-6c8ec362efe6"},{"locationName":"East
-        US","creationTime":"2020-08-05T01:12:02.3818516Z","regionalDatabaseAccountInstanceId":"cc0bacf7-91d0-4c4b-95ff-2479327f0866"},{"locationName":"South
-        Central US","creationTime":"2020-08-23T01:34:10.8844144Z","regionalDatabaseAccountInstanceId":"6fc9f211-8f76-4c29-9edc-f82ee8c5211a"}]}},{"name":"11d8ee78-2502-4ad6-becd-291aef9ac258","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/11d8ee78-2502-4ad6-becd-291aef9ac258","properties":{"accountName":"kal-continuous-dedicated-test","creationTime":"2020-10-05T23:45:25.9865024Z","apiType":"Sql","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-10-05T23:45:26.9395959Z","regionalDatabaseAccountInstanceId":"543c99f9-7bc2-4b55-9732-9733b981341f"}]}},{"name":"ed1b5536-d225-4af9-bf33-71ff5fc8ef4b","location":"South
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/southcentralus/restorableDatabaseAccounts/ed1b5536-d225-4af9-bf33-71ff5fc8ef4b","properties":{"accountName":"kal-dedicated-test","creationTime":"2020-10-05T23:57:44.8347861Z","apiType":"Sql","restorableLocations":[{"locationName":"South
-        Central US","creationTime":"2020-10-05T23:57:45.381672Z","regionalDatabaseAccountInstanceId":"ff8bf7b0-f9c3-461c-8c13-26e94ac4c2bc"}]}},{"name":"3325eb2c-3a59-4ebb-882f-27fe519f2253","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3325eb2c-3a59-4ebb-882f-27fe519f2253","properties":{"accountName":"pitracc","creationTime":"2020-10-15T00:44:15.224607Z","apiType":"Sql","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-10-15T00:44:16.8339914Z","regionalDatabaseAccountInstanceId":"b7cb54bc-b620-4d34-a004-11bda0dab218"},{"locationName":"East
-        US 2","creationTime":"2020-10-15T06:41:51.7956227Z","regionalDatabaseAccountInstanceId":"9b2e4539-1898-4f11-b568-5b72c913eb53"}]}},{"name":"1e2bec8e-adcc-4c5a-aa5b-82091d6c8a37","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1e2bec8e-adcc-4c5a-aa5b-82091d6c8a37","properties":{"accountName":"pitracctdemo2","creationTime":"2020-08-11T02:34:22.7041021Z","apiType":"Sql","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-08-11T02:34:23.4228904Z","regionalDatabaseAccountInstanceId":"7419408f-e6af-4596-a76b-c31ca62a54ca"}]}},{"name":"6fd844b3-71af-4e89-9b9d-f829945272bf","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6fd844b3-71af-4e89-9b9d-f829945272bf","properties":{"accountName":"pitrdemo1015","creationTime":"2020-10-15T17:28:58.4349667Z","apiType":"Sql","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-10-15T17:28:59.3099929Z","regionalDatabaseAccountInstanceId":"af26f717-b6ff-4eac-864c-17e759891ae8"}]}},{"name":"3f392004-9f83-4ae9-ac1c-fa5f6542f245","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3f392004-9f83-4ae9-ac1c-fa5f6542f245","properties":{"accountName":"pitrdemorestored1015","creationTime":"2020-10-15T17:37:19.7445957Z","apiType":"Sql","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-10-15T17:37:19.7445957Z","regionalDatabaseAccountInstanceId":"2f4857ad-25c3-4e2f-883a-abe35c5f5e0c"}]}},{"name":"74ebfb99-1914-4ea9-b802-736b5bda12a7","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/74ebfb99-1914-4ea9-b802-736b5bda12a7","properties":{"accountName":"pitrmongotest","creationTime":"2020-10-01T17:27:21.7773462Z","apiType":"MongoDB","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-10-01T17:27:22.8398227Z","regionalDatabaseAccountInstanceId":"73ef95f2-a338-4afc-8bb2-6fc3b0071d58"}]}},{"name":"9905e7ca-6f2d-4b24-a4c5-8e7529036a74","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/9905e7ca-6f2d-4b24-a4c5-8e7529036a74","properties":{"accountName":"pitrmongotest-restore","creationTime":"2020-10-01T21:24:44.2340464Z","apiType":"MongoDB","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-10-01T21:24:44.2340464Z","regionalDatabaseAccountInstanceId":"75c41286-d7f2-4594-b9f2-87f6c9843cf8"}]}},{"name":"eeb45f7f-4c05-4b52-9f42-6807d8eb8703","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/eeb45f7f-4c05-4b52-9f42-6807d8eb8703","properties":{"accountName":"powershell-restore","creationTime":"2020-08-10T19:20:13.1359094Z","apiType":"Sql","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-08-10T19:20:13.1359094Z","regionalDatabaseAccountInstanceId":"3cd8b081-4b95-47d8-86f5-a17da18e3b88"}]}},{"name":"f780ef6c-1fea-4a6a-9c33-784bf8a52edd","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/f780ef6c-1fea-4a6a-9c33-784bf8a52edd","properties":{"accountName":"restored-continuous-db2121-1","creationTime":"2020-08-07T17:55:44.1250519Z","apiType":"Sql","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-08-07T17:55:44.1250519Z","regionalDatabaseAccountInstanceId":"ce739365-8e46-4e12-81e5-9ba7f7ee5ff9"}]}},{"name":"d412cde0-dcee-4e6c-9e8f-69770224be1a","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d412cde0-dcee-4e6c-9e8f-69770224be1a","properties":{"accountName":"restored2-continuous-db2121-2","creationTime":"2020-08-07T18:16:29.8946196Z","apiType":"Sql","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-08-07T18:16:29.8946196Z","regionalDatabaseAccountInstanceId":"a52cc373-6f32-4feb-b28b-15c0bb9842c3"}]}},{"name":"23e99a35-cd36-4df4-9614-f767a03b9995","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/23e99a35-cd36-4df4-9614-f767a03b9995","properties":{"accountName":"subbannageeta","creationTime":"2020-08-08T01:04:52.0701907Z","apiType":"Sql","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-08-08T01:04:52.9451855Z","regionalDatabaseAccountInstanceId":"30701557-ecf8-43ce-8810-2c8be01dccf9"},{"locationName":"East
-        US","creationTime":"2020-08-08T01:15:43.5077951Z","regionalDatabaseAccountInstanceId":"8283b088-b67d-4975-bfbe-0705e3e7a599"}]}},{"name":"2cfb9266-6837-4c5c-b7ae-ec8e72913cd1","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/2cfb9266-6837-4c5c-b7ae-ec8e72913cd1","properties":{"accountName":"test-bk-cont-restore1","creationTime":"2020-10-15T23:55:02.6142219Z","apiType":"Sql","restorableLocations":[{"locationName":"South
-        Central US","creationTime":"2020-10-15T23:55:02.6142219Z","regionalDatabaseAccountInstanceId":"a1893351-8aa8-4ff0-8457-47ce4e6c2790"}]}},{"name":"6f7de73f-d3aa-4b35-9bab-f4359a8415a5","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6f7de73f-d3aa-4b35-9bab-f4359a8415a5","properties":{"accountName":"vinhpitrrestored1015","creationTime":"2020-10-15T16:08:38.1731104Z","apiType":"Sql","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-10-15T16:08:38.1731104Z","regionalDatabaseAccountInstanceId":"2d731560-b500-49c7-ad88-acba387c072c"}]}},{"name":"c0291614-213c-4629-a26a-12802ca1b761","location":"West
+      string: '{"value":[{"name":"70f3ea16-d3bc-46f6-98e8-576fc201eabf","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/70f3ea16-d3bc-46f6-98e8-576fc201eabf","properties":{"accountName":"balaksrestorebug","apiType":"Sql","creationTime":"2021-01-09T01:08:25Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"94244165-49de-46f8-bb1a-2e0956694168","creationTime":"2021-01-09T01:08:27Z"}]}},{"name":"5f95bef8-07b9-400b-aac2-4e09efbc47c2","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/5f95bef8-07b9-400b-aac2-4e09efbc47c2","properties":{"accountName":"cli56zv275qols2","apiType":"MongoDB","creationTime":"2021-01-28T22:28:28Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"0eed5071-4e89-480f-ac03-d245d57bd6a0","creationTime":"2021-01-28T22:28:29Z"}]}},{"name":"f46ed918-cadc-48cd-9381-386376eceec1","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/f46ed918-cadc-48cd-9381-386376eceec1","properties":{"accountName":"clib5bw3s76u6yq","apiType":"MongoDB","creationTime":"2021-01-28T22:59:22Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"63a7ae8b-329a-492a-8fbf-99ab5a901730","creationTime":"2021-01-28T22:59:23Z"}]}},{"name":"1cea11b1-c170-4ffe-993d-63da1bff9a94","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1cea11b1-c170-4ffe-993d-63da1bff9a94","properties":{"accountName":"clid4bvkfsumrnr-restore","apiType":"MongoDB","creationTime":"2021-01-08T20:25:49Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"d36f7f5b-7d0f-4e35-8a05-a253eaaad55b","creationTime":"2021-01-08T20:25:49Z"}]}},{"name":"dad19ede-1592-4d87-95ff-4e20c8a09de5","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/dad19ede-1592-4d87-95ff-4e20c8a09de5","properties":{"accountName":"cli000003","apiType":"Sql","creationTime":"2021-01-28T22:58:06Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"a2c2b55a-9cda-4aad-b75a-bfd34647818f","creationTime":"2021-01-28T22:58:06Z"}]}},{"name":"16e57fca-6555-4c92-bb57-1afa38d69371","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/16e57fca-6555-4c92-bb57-1afa38d69371","properties":{"accountName":"clikbicro7ly5p2","apiType":"MongoDB","creationTime":"2021-01-16T01:25:45Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"9688f6b2-7410-4ae1-bd8b-1de6a0edcdca","creationTime":"2021-01-16T01:25:46Z"}]}},{"name":"28bc2837-a17f-4038-8569-7ffb33794333","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/28bc2837-a17f-4038-8569-7ffb33794333","properties":{"accountName":"cliweraslfbdxmi","apiType":"MongoDB","creationTime":"2021-01-28T22:55:58Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"8614d5c7-d9bf-4e5b-9d0c-62731c7d45c4","creationTime":"2021-01-28T22:55:59Z"}]}},{"name":"7346d3b4-8657-441b-8661-c1eb1071b700","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/7346d3b4-8657-441b-8661-c1eb1071b700","properties":{"accountName":"cliwqgrqdlkgt5b","apiType":"Sql","creationTime":"2021-01-28T22:58:07Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"767353e5-3784-43ee-ba9c-76e7e83db6e7","creationTime":"2021-01-28T22:58:08Z"}]}},{"name":"31869788-6f92-47f9-8f8b-6619582d2381","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/31869788-6f92-47f9-8f8b-6619582d2381","properties":{"accountName":"cosmosdb-1212","apiType":"Sql","creationTime":"2021-01-08T02:05:37Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"62ff38d6-4f2d-4c43-8c9d-17258a38ad81","creationTime":"2021-01-08T02:05:37Z"}]}},{"name":"5c84891d-ee24-4dc7-aa2b-d8968baf7936","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/5c84891d-ee24-4dc7-aa2b-d8968baf7936","properties":{"accountName":"gskcssdemo","apiType":"Sql","creationTime":"2020-12-14T21:53:52Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"21f8bb0a-9b6d-4d79-b305-82f555946c5f","creationTime":"2020-12-14T21:53:53Z"}]}},{"name":"cc9b5676-f21b-4bd4-b3d9-26ded6884aaa","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/cc9b5676-f21b-4bd4-b3d9-26ded6884aaa","properties":{"accountName":"gskcssdemo-r1","apiType":"Sql","creationTime":"2021-01-15T05:24:40Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"11da6634-3b4d-4b81-99ef-04d8b4d7410d","creationTime":"2021-01-15T05:24:40Z"}]}},{"name":"d92d948a-afb9-4bb3-9a4c-d6b8fcf8d204","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d92d948a-afb9-4bb3-9a4c-d6b8fcf8d204","properties":{"accountName":"kal-continuous","apiType":"Sql","creationTime":"2020-08-05T01:00:25Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"c28cc815-caba-4bd3-9402-6c8ec362efe6","creationTime":"2020-08-05T01:00:26Z"},{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"cc0bacf7-91d0-4c4b-95ff-2479327f0866","creationTime":"2020-08-05T01:12:03Z"},{"locationName":"South
+        Central US","regionalDatabaseAccountInstanceId":"6fc9f211-8f76-4c29-9edc-f82ee8c5211a","creationTime":"2020-08-23T01:34:11Z"}]}},{"name":"11d8ee78-2502-4ad6-becd-291aef9ac258","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/11d8ee78-2502-4ad6-becd-291aef9ac258","properties":{"accountName":"kal-continuous-dedicated-test","apiType":"Sql","creationTime":"2020-10-05T23:45:26Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"543c99f9-7bc2-4b55-9732-9733b981341f","creationTime":"2020-10-05T23:45:27Z"}]}},{"name":"ed1b5536-d225-4af9-bf33-71ff5fc8ef4b","location":"South
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/southcentralus/restorableDatabaseAccounts/ed1b5536-d225-4af9-bf33-71ff5fc8ef4b","properties":{"accountName":"kal-dedicated-test","apiType":"Sql","creationTime":"2020-10-05T23:57:45Z","restorableLocations":[{"locationName":"South
+        Central US","regionalDatabaseAccountInstanceId":"ff8bf7b0-f9c3-461c-8c13-26e94ac4c2bc","creationTime":"2020-10-05T23:57:46Z"}]}},{"name":"15ba6ca5-a356-4e90-b17e-71b9226d3566","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/15ba6ca5-a356-4e90-b17e-71b9226d3566","properties":{"accountName":"lisarestore1","apiType":"Sql","creationTime":"2021-01-08T22:12:16Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"3e848a1c-29b9-4627-889f-37c12a3c56fd","creationTime":"2021-01-08T22:12:16Z"}]}},{"name":"bbff0620-ef73-4071-9554-15e460f25e84","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/bbff0620-ef73-4071-9554-15e460f25e84","properties":{"accountName":"lisarestore2","apiType":"Sql","creationTime":"2021-01-08T22:23:52Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"8d3f47b6-7337-43c4-aaf3-59b0fa3720fd","creationTime":"2021-01-08T22:23:52Z"}]}},{"name":"47e6f98d-41c0-44f7-b0db-62ec4f1eec01","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/47e6f98d-41c0-44f7-b0db-62ec4f1eec01","properties":{"accountName":"lisarestore3","apiType":"Sql","creationTime":"2021-01-08T22:25:55Z","restorableLocations":[{"locationName":"Australia
+        Southeast","regionalDatabaseAccountInstanceId":"d62f91a9-8177-4cfb-88bb-647538637100","creationTime":"2021-01-08T22:25:55Z"}]}},{"name":"098565ea-96cc-45f8-a0fb-efecf4517ba0","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/098565ea-96cc-45f8-a0fb-efecf4517ba0","properties":{"accountName":"lisarestore4","apiType":"Sql","creationTime":"2021-01-08T22:30:27Z","restorableLocations":[{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"a88f7ab5-2623-4ca5-b962-c22b7027c647","creationTime":"2021-01-08T22:30:27Z"}]}},{"name":"421f2916-5405-47a0-bbb8-398672c8b539","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/421f2916-5405-47a0-bbb8-398672c8b539","properties":{"accountName":"lisarestore5","apiType":"Sql","creationTime":"2021-01-08T22:39:29Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"8989da63-0d67-4fa6-bf5d-caaa4961445b","creationTime":"2021-01-08T22:39:29Z"}]}},{"name":"e24fd3a7-20ed-48ac-a50e-6284402a72b9","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/e24fd3a7-20ed-48ac-a50e-6284402a72b9","properties":{"accountName":"lisarestore6","apiType":"Sql","creationTime":"2021-01-08T22:41:21Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"c2d1bb47-6e39-4ad6-9b82-9717f8feac85","creationTime":"2021-01-08T22:41:21Z"}]}},{"name":"5ed72f8f-00db-484a-8b7a-c90d9874431d","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/5ed72f8f-00db-484a-8b7a-c90d9874431d","properties":{"accountName":"lisarestore7","apiType":"Sql","creationTime":"2021-01-08T22:44:37Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"9e111575-7289-463d-9368-a89d76d9dc6b","creationTime":"2021-01-08T22:44:37Z"}]}},{"name":"90e99bc6-8031-4f65-886e-32628f7af45a","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/90e99bc6-8031-4f65-886e-32628f7af45a","properties":{"accountName":"lisarestore8b","apiType":"Sql","creationTime":"2021-01-08T23:17:40Z","restorableLocations":[{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"2ad74ba2-c366-461c-940b-02e0c5017422","creationTime":"2021-01-08T23:17:40Z"}]}},{"name":"1e2bec8e-adcc-4c5a-aa5b-82091d6c8a37","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1e2bec8e-adcc-4c5a-aa5b-82091d6c8a37","properties":{"accountName":"pitracctdemo2","apiType":"Sql","creationTime":"2020-08-11T02:34:23Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"7419408f-e6af-4596-a76b-c31ca62a54ca","creationTime":"2020-08-11T02:34:24Z"}]}},{"name":"38562595-c786-4560-a297-370226ed1450","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/38562595-c786-4560-a297-370226ed1450","properties":{"accountName":"pitrb-subbanna","apiType":"Sql","creationTime":"2021-01-18T06:12:43Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"0a2f53ac-1920-4f18-aae4-19c496a7e923","creationTime":"2021-01-18T06:12:43Z"}]}},{"name":"7133a59a-d1c0-4645-a699-6e296d6ac865","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/7133a59a-d1c0-4645-a699-6e296d6ac865","properties":{"accountName":"pitrbb-ankshah-ps-1","apiType":"Sql","creationTime":"2021-01-08T23:34:12Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"f02df26b-c0ec-4829-8bef-3482d36e6230","creationTime":"2021-01-08T23:34:12Z"}]}},{"name":"d6f96f0e-4b4e-4823-8a95-e59c688a00e2","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d6f96f0e-4b4e-4823-8a95-e59c688a00e2","properties":{"accountName":"pitrbb-ankshah-ps-6","apiType":"Sql","creationTime":"2021-01-08T23:58:46Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"6148981d-a65f-45b1-80f9-a26302e5214b","creationTime":"2021-01-08T23:58:46Z"}]}},{"name":"fcade1ce-4758-4d39-bbf8-8be7e9de50b2","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/fcade1ce-4758-4d39-bbf8-8be7e9de50b2","properties":{"accountName":"pitrbb-ankshah-ps-6-fixutc","apiType":"Sql","creationTime":"2021-01-09T00:26:43Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"5ac2a361-da75-47de-a13b-e4d9f0579e0c","creationTime":"2021-01-09T00:26:43Z"}]}},{"name":"0b32523b-4268-474d-a369-6888565ff043","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0b32523b-4268-474d-a369-6888565ff043","properties":{"accountName":"pitrbb-dech-sql-1","apiType":"Sql","creationTime":"2021-01-08T22:48:20Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"4d5edac2-df25-4a27-9bf4-e75a0b78af86","creationTime":"2021-01-08T22:48:20Z"}]}},{"name":"79659b7d-1049-4c79-9ba4-4fad8110181a","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/79659b7d-1049-4c79-9ba4-4fad8110181a","properties":{"accountName":"pitrbb-dech-sql-2","apiType":"Sql","creationTime":"2021-01-08T23:26:15Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"b5d55b81-59cf-4b14-9717-247a45438d45","creationTime":"2021-01-08T23:26:15Z"}]}},{"name":"5b213b47-99da-4b75-9eb2-4307e54ac28b","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/5b213b47-99da-4b75-9eb2-4307e54ac28b","properties":{"accountName":"pitrbb-dech-sql-3","apiType":"Sql","creationTime":"2021-01-08T23:32:11Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"0187813e-8bf5-43bd-a16f-e344c3d251fd","creationTime":"2021-01-08T23:32:11Z"}]}},{"name":"7a3b8026-9d25-4933-aa8f-726c63a0b9fd","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/7a3b8026-9d25-4933-aa8f-726c63a0b9fd","properties":{"accountName":"pitrbb-dech-sql-4","apiType":"Sql","creationTime":"2021-01-08T23:37:21Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"e57af9d0-1b1f-435f-b2c7-12199949b4a1","creationTime":"2021-01-08T23:37:21Z"}]}},{"name":"fc3ea677-0377-4004-923e-49f7e650cd0f","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/fc3ea677-0377-4004-923e-49f7e650cd0f","properties":{"accountName":"pitrbb-dech-sql-5","apiType":"Sql","creationTime":"2021-01-08T23:43:10Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"ae59cbb3-a365-405e-bd06-906bd01f3e16","creationTime":"2021-01-08T23:43:10Z"}]}},{"name":"3838563c-0364-4951-9728-4bb1a17266f8","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3838563c-0364-4951-9728-4bb1a17266f8","properties":{"accountName":"pitrbb-dech-sql-6","apiType":"Sql","creationTime":"2021-01-08T23:46:57Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"d75fc007-5da7-4d00-8811-6920ece49a33","creationTime":"2021-01-08T23:46:57Z"}]}},{"name":"7486c373-649e-4627-ad96-2d087ec06be1","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/7486c373-649e-4627-ad96-2d087ec06be1","properties":{"accountName":"pitrbb-dech-sql-7","apiType":"Sql","creationTime":"2021-01-08T23:53:32Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"a9a529c6-5ce1-49e9-9410-57be267c41c6","creationTime":"2021-01-08T23:53:32Z"}]}},{"name":"6fd844b3-71af-4e89-9b9d-f829945272bf","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6fd844b3-71af-4e89-9b9d-f829945272bf","properties":{"accountName":"pitrdemo1015","apiType":"Sql","creationTime":"2020-10-15T17:28:59Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"af26f717-b6ff-4eac-864c-17e759891ae8","creationTime":"2020-10-15T17:29:00Z"}]}},{"name":"3f392004-9f83-4ae9-ac1c-fa5f6542f245","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3f392004-9f83-4ae9-ac1c-fa5f6542f245","properties":{"accountName":"pitrdemorestored1015","apiType":"Sql","creationTime":"2020-10-15T17:37:20Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"2f4857ad-25c3-4e2f-883a-abe35c5f5e0c","creationTime":"2020-10-15T17:37:20Z"}]}},{"name":"74ebfb99-1914-4ea9-b802-736b5bda12a7","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/74ebfb99-1914-4ea9-b802-736b5bda12a7","properties":{"accountName":"pitrmongotest","apiType":"MongoDB","creationTime":"2020-10-01T17:27:22Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"73ef95f2-a338-4afc-8bb2-6fc3b0071d58","creationTime":"2020-10-01T17:27:23Z"}]}},{"name":"9905e7ca-6f2d-4b24-a4c5-8e7529036a74","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/9905e7ca-6f2d-4b24-a4c5-8e7529036a74","properties":{"accountName":"pitrmongotest-restore","apiType":"MongoDB","creationTime":"2020-10-01T21:24:45Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"75c41286-d7f2-4594-b9f2-87f6c9843cf8","creationTime":"2020-10-01T21:24:45Z"}]}},{"name":"a081024d-5e38-45c1-b1cb-9c99552d42b3","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a081024d-5e38-45c1-b1cb-9c99552d42b3","properties":{"accountName":"pitrmongowithsnapshots","apiType":"MongoDB","creationTime":"2021-01-07T19:45:07Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"cef7a5af-c690-49cd-b661-53f9241552bf","creationTime":"2021-01-07T19:45:07Z"}]}},{"name":"b4c688c1-2ea7-477e-b994-4affe5d3ea35","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b4c688c1-2ea7-477e-b994-4affe5d3ea35","properties":{"accountName":"ptr-target","apiType":"Sql","creationTime":"2021-01-05T22:25:24Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"1f68340e-49a4-45df-9a2a-804cd8ab1795","creationTime":"2021-01-05T22:25:24Z"}]}},{"name":"013b30aa-cf27-451a-b2b7-c8da950167c0","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/013b30aa-cf27-451a-b2b7-c8da950167c0","properties":{"accountName":"restored-cosmosdb-1212","apiType":"Sql","creationTime":"2021-01-08T08:12:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"84e252b7-8fe2-4976-bc64-bccc19511e44","creationTime":"2021-01-08T08:12:56Z"}]}},{"name":"eae0599c-2b32-4126-95f2-598dc4bf4ab9","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/eae0599c-2b32-4126-95f2-598dc4bf4ab9","properties":{"accountName":"restoredeleted","apiType":"Sql","creationTime":"2021-01-27T16:25:59Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"f1c5bdbf-77bb-4a9a-a4ff-39938c662029","creationTime":"2021-01-27T16:25:59Z"}]}},{"name":"0034883d-1a13-418f-9eaf-5dbbaabdd901","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0034883d-1a13-418f-9eaf-5dbbaabdd901","properties":{"accountName":"restoredeletedacct","apiType":"Sql","creationTime":"2021-01-08T22:46:18Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"514f853c-9454-44e7-a568-63823c7d25f0","creationTime":"2021-01-08T22:46:18Z"}]}},{"name":"1e9c8685-1f15-4b3b-ab1c-0ad505f0cd24","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1e9c8685-1f15-4b3b-ab1c-0ad505f0cd24","properties":{"accountName":"sivarv-test","apiType":"Sql","creationTime":"2021-01-05T23:13:23Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"83791770-489f-4272-9816-4d66377703c5","creationTime":"2021-01-05T23:13:23Z"}]}},{"name":"cc78ddc0-94a1-499d-8820-3b97ead9329d","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/cc78ddc0-94a1-499d-8820-3b97ead9329d","properties":{"accountName":"source-mongo36","apiType":"MongoDB","creationTime":"2021-01-05T21:12:59Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"c253e611-4c39-472e-b5fa-db7a7b5e1f0f","creationTime":"2021-01-05T21:12:59Z"},{"locationName":"North
+        Europe","regionalDatabaseAccountInstanceId":"1f4747a7-0698-4970-b81d-90257264f650","creationTime":"2021-01-05T22:35:50Z"},{"locationName":"Southeast
+        Asia","regionalDatabaseAccountInstanceId":"d5fab2ed-1caa-454c-a40a-98baba42f761","creationTime":"2021-01-05T22:49:00Z"}]}},{"name":"f37b13fb-cd2e-44da-929f-7db3ec82472f","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/f37b13fb-cd2e-44da-929f-7db3ec82472f","properties":{"accountName":"source-sql","apiType":"Sql","creationTime":"2021-01-05T21:27:08Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"c43022bd-9262-4421-a550-3566dda0191f","creationTime":"2021-01-05T21:27:09Z"},{"locationName":"Australia
+        Southeast","regionalDatabaseAccountInstanceId":"45e72c23-3fc3-45fa-8c05-444717f61eed","creationTime":"2021-01-05T22:14:59Z"},{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"bc1e9044-6d2f-4943-8a7f-1a0e345913ee","creationTime":"2021-01-05T21:38:36Z","deletionTime":"2021-01-05T22:25:59Z"}]}},{"name":"8ab61be5-bc16-408b-b33b-90a341eb00f8","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/8ab61be5-bc16-408b-b33b-90a341eb00f8","properties":{"accountName":"source-sql-cli0108-r1","apiType":"Sql","creationTime":"2021-01-08T23:00:22Z","restorableLocations":[{"locationName":"Australia
+        Southeast","regionalDatabaseAccountInstanceId":"18d3b111-3091-4c7b-9494-38d55cf6b591","creationTime":"2021-01-08T23:00:22Z"}]}},{"name":"97aecfb1-60ea-47eb-8ba6-b18a9d63d5ea","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/97aecfb1-60ea-47eb-8ba6-b18a9d63d5ea","properties":{"accountName":"source-sql-cli0108-r4","apiType":"Sql","creationTime":"2021-01-08T23:42:23Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"204031a3-e50f-4357-9e30-e0ed40d2edfe","creationTime":"2021-01-08T23:42:23Z"}]}},{"name":"44fd125a-9c78-43ec-a408-7bde337284d7","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/44fd125a-9c78-43ec-a408-7bde337284d7","properties":{"accountName":"source-sql-cli0108-r5","apiType":"Sql","creationTime":"2021-01-08T23:48:38Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"bcdbe26c-e95e-4d13-8ed2-65ed87835440","creationTime":"2021-01-08T23:48:38Z"}]}},{"name":"28c894c1-564c-4751-a581-0899fe982fb2","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/28c894c1-564c-4751-a581-0899fe982fb2","properties":{"accountName":"source-sql-cli0108-r6","apiType":"Sql","creationTime":"2021-01-09T00:10:01Z","restorableLocations":[{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"04fc930f-e6f4-4247-909b-a019fca6d3c3","creationTime":"2021-01-09T00:10:01Z"}]}},{"name":"e5d37ca0-4cad-4f68-8b01-798ab80d4e29","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/e5d37ca0-4cad-4f68-8b01-798ab80d4e29","properties":{"accountName":"source-sql-r1-all-dr1","apiType":"Sql","creationTime":"2021-01-06T00:38:07Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"b025ecf9-c5cb-4dd8-8808-ff91d5a3585d","creationTime":"2021-01-06T00:38:07Z"}]}},{"name":"c2725545-e90d-46e1-b952-3de18e28229d","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c2725545-e90d-46e1-b952-3de18e28229d","properties":{"accountName":"source-sql-r1-procol1","apiType":"Sql","creationTime":"2021-01-05T22:57:00Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"1a218afa-4d6e-4a9e-8dcb-c50e811b921d","creationTime":"2021-01-05T22:57:00Z"}]}},{"name":"360f37cf-0874-4d58-9cf8-fd5f3fc87d07","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/360f37cf-0874-4d58-9cf8-fd5f3fc87d07","properties":{"accountName":"source-sql-restored-kal-1","apiType":"Sql","creationTime":"2021-01-25T22:47:07Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"6e9003ca-f7f7-482a-8bcc-e7ecb383cce7","creationTime":"2021-01-25T22:47:07Z"}]}},{"name":"23e99a35-cd36-4df4-9614-f767a03b9995","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/23e99a35-cd36-4df4-9614-f767a03b9995","properties":{"accountName":"subbannageeta","apiType":"Sql","creationTime":"2020-08-08T01:04:53Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"30701557-ecf8-43ce-8810-2c8be01dccf9","creationTime":"2020-08-08T01:04:53Z"},{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"8283b088-b67d-4975-bfbe-0705e3e7a599","creationTime":"2020-08-08T01:15:44Z"}]}},{"name":"a97044b4-5be9-4f17-acc5-05bd58f0156e","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a97044b4-5be9-4f17-acc5-05bd58f0156e","properties":{"accountName":"target-mongo36-beforecolla","apiType":"MongoDB","creationTime":"2021-01-06T00:06:55Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"4af906ad-1a4a-4eb7-8453-f6cd8c795e91","creationTime":"2021-01-06T00:06:55Z"}]}},{"name":"1e88cc09-a8d1-4c02-b3bc-45621aa14532","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1e88cc09-a8d1-4c02-b3bc-45621aa14532","properties":{"accountName":"targetacct","apiType":"Sql","creationTime":"2021-01-27T16:27:39Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"a6b133b0-11d9-49c6-b747-7e81b8ca91d0","creationTime":"2021-01-27T16:27:39Z"}]}},{"name":"2cfb9266-6837-4c5c-b7ae-ec8e72913cd1","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/2cfb9266-6837-4c5c-b7ae-ec8e72913cd1","properties":{"accountName":"test-bk-cont-restore1","apiType":"Sql","creationTime":"2020-10-15T23:55:03Z","restorableLocations":[{"locationName":"South
+        Central US","regionalDatabaseAccountInstanceId":"a1893351-8aa8-4ff0-8457-47ce4e6c2790","creationTime":"2020-10-15T23:55:03Z"}]}},{"name":"05640131-c5c8-4d30-adec-aa623e28866b","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/05640131-c5c8-4d30-adec-aa623e28866b","properties":{"accountName":"test-cli2loqd5ro7y4w-restore-del","apiType":"Sql","creationTime":"2021-01-08T01:37:39Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"d137f5e4-3154-43fd-9f16-179b6c9bb8fa","creationTime":"2021-01-08T01:37:39Z"}]}},{"name":"c51d3c61-fa49-426f-96d0-77dd6c8592f4","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c51d3c61-fa49-426f-96d0-77dd6c8592f4","properties":{"accountName":"test-pitr-restore3","apiType":"Sql","creationTime":"2021-01-06T09:26:15Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"a9153da9-30fe-44bf-beaf-6ad266823926","creationTime":"2021-01-06T09:26:15Z"}]}},{"name":"329aedaa-1997-4c0d-b3c9-40e890c3dc08","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/329aedaa-1997-4c0d-b3c9-40e890c3dc08","properties":{"accountName":"test-restore-pitr1","apiType":"Sql","creationTime":"2021-01-06T09:20:17Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"20d74db9-927d-4e1c-9944-5386a9ce1eda","creationTime":"2021-01-06T09:20:17Z"}]}},{"name":"c914554e-5881-4048-b427-240d3c9ffda6","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c914554e-5881-4048-b427-240d3c9ffda6","properties":{"accountName":"test-restore-pitr2","apiType":"Sql","creationTime":"2021-01-06T09:23:25Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"7f2f80b7-20ec-47ce-a2eb-f9143781908b","creationTime":"2021-01-06T09:23:25Z"}]}},{"name":"7ccb546f-804d-4fe3-902f-bdb162d2ca51","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/7ccb546f-804d-4fe3-902f-bdb162d2ca51","properties":{"accountName":"virangai-test-pitr-restore-del","apiType":"Sql","creationTime":"2020-12-10T02:06:22Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"fbbdcce1-e4cc-4fb9-8a5c-64f96438e722","creationTime":"2020-12-10T02:06:22Z"}]}},{"name":"26c6c802-2477-422f-b3a0-9da58299b82e","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/26c6c802-2477-422f-b3a0-9da58299b82e","properties":{"accountName":"virangai-test-pitr-restore-del-restore","apiType":"Sql","creationTime":"2021-01-08T00:50:35Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"9eaed152-86f9-4576-b201-2301ea9e9719","creationTime":"2021-01-08T00:50:35Z"}]}},{"name":"e89306b9-137a-4293-b692-263bb3406366","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/e89306b9-137a-4293-b692-263bb3406366","properties":{"accountName":"virangai-test-pitr-restore-del-restore1","apiType":"Sql","creationTime":"2021-01-08T01:07:16Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"2e16165a-c3f1-44c5-99a7-bef5e8a2311f","creationTime":"2021-01-08T01:07:16Z"}]}},{"name":"adc221c8-8826-4d48-8c8d-af48be84b678","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/adc221c8-8826-4d48-8c8d-af48be84b678","properties":{"accountName":"virangai-test-pitr-restore-del-restore2","apiType":"Sql","creationTime":"2021-01-08T01:12:07Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"e6c2237b-56a2-4e27-9ba5-d3da7d136504","creationTime":"2021-01-08T01:12:07Z"}]}},{"name":"b2bcdd92-0b33-4574-ba6e-56f1b3e346e4","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b2bcdd92-0b33-4574-ba6e-56f1b3e346e4","properties":{"accountName":"virangai-test-pitr-restore-del-restore3","apiType":"Sql","creationTime":"2021-01-08T01:15:26Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"75d75dd1-21da-47d0-bc25-fa01c0e3ed3e","creationTime":"2021-01-08T01:15:26Z"}]}},{"name":"e96a653a-cc5e-49f0-a3ae-36a4d461cf07","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/e96a653a-cc5e-49f0-a3ae-36a4d461cf07","properties":{"accountName":"virangai-test-pitr-restore-del-restore4","apiType":"Sql","creationTime":"2021-01-08T01:36:22Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"e59deecb-9222-4a80-b5d4-09af4a886f55","creationTime":"2021-01-08T01:36:22Z"}]}},{"name":"bb466093-aad0-4e58-8ae5-94c4b48caa3d","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/bb466093-aad0-4e58-8ae5-94c4b48caa3d","properties":{"accountName":"virangai-test-pitr-restore-del1","apiType":"Sql","creationTime":"2021-01-08T20:19:57Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"f14d0c9e-ac38-4809-b5f3-f7c37d712012","creationTime":"2021-01-08T20:19:57Z"}]}},{"name":"86db30d3-1725-4ece-b2f5-591ea37e14f9","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/86db30d3-1725-4ece-b2f5-591ea37e14f9","properties":{"accountName":"virangai-test-pitr-restore-del2","apiType":"Sql","creationTime":"2021-01-08T20:20:20Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"36f57e91-674e-49d0-891a-f4be394b8e3a","creationTime":"2021-01-08T20:20:20Z"}]}},{"name":"baf212fa-867f-4979-a007-4db919a87868","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/baf212fa-867f-4979-a007-4db919a87868","properties":{"accountName":"virangai-test-pitr-restore-del5","apiType":"Sql","creationTime":"2021-01-08T20:23:32Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"76ee28bb-12d9-4829-a473-cb5e29ad9a55","creationTime":"2021-01-08T20:23:32Z"}]}},{"name":"0278f25e-74d3-432c-9bef-8af67bb0d2c0","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0278f25e-74d3-432c-9bef-8af67bb0d2c0","properties":{"accountName":"clizv5pcgzbsl7a","apiType":"Sql","creationTime":"2021-01-28T22:28:06Z","deletionTime":"2021-01-28T22:29:41Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"4f5f85bb-a229-472f-89dc-33115193e985","creationTime":"2021-01-28T22:28:06Z","deletionTime":"2021-01-28T22:29:41Z"}]}},{"name":"0651d578-4267-432f-9b14-e829f7b55ca8","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0651d578-4267-432f-9b14-e829f7b55ca8","properties":{"accountName":"cliemi42xntjcpg","apiType":"Sql","creationTime":"2021-01-28T22:55:24Z","deletionTime":"2021-01-28T22:56:59Z","restorableLocations":[]}},{"name":"08f8360d-830d-4e8b-ab58-c4bdefe180a1","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/08f8360d-830d-4e8b-ab58-c4bdefe180a1","properties":{"accountName":"clij264u6pvpgg5","apiType":"Sql","creationTime":"2021-01-28T22:55:23Z","deletionTime":"2021-01-28T22:56:58Z","restorableLocations":[]}},{"name":"1ac1ade1-7f87-4764-81d4-61e2bf271d1c","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1ac1ade1-7f87-4764-81d4-61e2bf271d1c","properties":{"accountName":"restored-cosmosdb-1212","apiType":"Sql","creationTime":"2021-01-07T02:45:14Z","deletionTime":"2021-01-07T06:37:29Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"8cad4147-b0e8-43d0-bb4c-2562d435daf0","creationTime":"2021-01-07T02:45:14Z","deletionTime":"2021-01-07T06:37:29Z"}]}},{"name":"20e131eb-6e59-403d-afe6-5cd5687b06f3","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/20e131eb-6e59-403d-afe6-5cd5687b06f3","properties":{"accountName":"clicjskuodwwh4y","apiType":"Sql","creationTime":"2021-01-28T22:55:30Z","deletionTime":"2021-01-28T22:56:57Z","restorableLocations":[]}},{"name":"2e57506a-6aa1-4a3a-8a2b-b46d1be47d3a","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/2e57506a-6aa1-4a3a-8a2b-b46d1be47d3a","properties":{"accountName":"clilet52fhyl5fe","apiType":"MongoDB","creationTime":"2021-01-16T01:19:20Z","deletionTime":"2021-01-16T01:20:03Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"3df175b1-d106-42c3-89e6-716bdfab208f","creationTime":"2021-01-16T01:19:21Z","deletionTime":"2021-01-16T01:20:03Z"}]}},{"name":"3183f258-d6c7-42da-9260-0345d7a5775d","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3183f258-d6c7-42da-9260-0345d7a5775d","properties":{"accountName":"mongo-continuous-1212","apiType":"MongoDB","creationTime":"2021-01-06T22:54:49Z","deletionTime":"2021-01-07T06:37:29Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"baf545cb-b632-4a1b-b9a8-8fec4a019c02","creationTime":"2021-01-06T22:54:49Z","deletionTime":"2021-01-07T06:37:29Z"}]}},{"name":"3325eb2c-3a59-4ebb-882f-27fe519f2253","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3325eb2c-3a59-4ebb-882f-27fe519f2253","properties":{"accountName":"pitracc","apiType":"Sql","creationTime":"2020-10-15T00:44:16Z","deletionTime":"2021-01-08T05:31:20Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"9b2e4539-1898-4f11-b568-5b72c913eb53","creationTime":"2020-10-15T06:41:52Z","deletionTime":"2021-01-08T05:31:20Z"},{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"b7cb54bc-b620-4d34-a004-11bda0dab218","creationTime":"2020-10-15T00:44:17Z","deletionTime":"2021-01-08T05:31:20Z"}]}},{"name":"651acce6-dd9b-4cb0-a236-444fa0760775","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/651acce6-dd9b-4cb0-a236-444fa0760775","properties":{"accountName":"continuous-db2121","apiType":"Sql","creationTime":"2020-08-06T21:04:16Z","deletionTime":"2021-01-07T06:37:29Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"7119a7d0-aab2-4dac-90d2-68880d3fa967","creationTime":"2020-08-06T21:04:17Z","deletionTime":"2021-01-07T06:37:29Z"}]}},{"name":"68592cbb-6b1d-45d5-92c4-5e768127801d","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/68592cbb-6b1d-45d5-92c4-5e768127801d","properties":{"accountName":"cliwgffp7vsxcnn","apiType":"MongoDB","creationTime":"2021-01-16T01:46:25Z","deletionTime":"2021-01-16T01:51:06Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"1ab48938-70a0-4233-9270-266ede1c697f","creationTime":"2021-01-16T01:46:26Z","deletionTime":"2021-01-16T01:51:06Z"}]}},{"name":"6a0b5950-99b7-4684-b296-8e1525b6a38f","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6a0b5950-99b7-4684-b296-8e1525b6a38f","properties":{"accountName":"sivarv-restored-sdb","apiType":"Sql","creationTime":"2021-01-05T23:29:51Z","deletionTime":"2021-01-06T00:16:23Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"cb909054-6a6f-4e06-811c-363bb5acd7d3","creationTime":"2021-01-05T23:29:51Z","deletionTime":"2021-01-06T00:16:23Z"}]}},{"name":"6f7de73f-d3aa-4b35-9bab-f4359a8415a5","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6f7de73f-d3aa-4b35-9bab-f4359a8415a5","properties":{"accountName":"vinhpitrrestored1015","apiType":"Sql","creationTime":"2020-10-15T16:08:39Z","deletionTime":"2021-01-08T05:31:30Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"2d731560-b500-49c7-ad88-acba387c072c","creationTime":"2020-10-15T16:08:39Z","deletionTime":"2021-01-08T05:31:30Z"}]}},{"name":"7781ad7c-a95f-4b8a-9a65-5b7e20292263","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/7781ad7c-a95f-4b8a-9a65-5b7e20292263","properties":{"accountName":"clirvbpeuorjlez","apiType":"Sql","creationTime":"2021-01-28T22:28:07Z","deletionTime":"2021-01-28T22:29:42Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"d04575bb-6713-48ed-9e2d-9d5d1d945dc1","creationTime":"2021-01-28T22:28:07Z","deletionTime":"2021-01-28T22:29:42Z"}]}},{"name":"780425ec-5b37-4661-ab56-bdeac3ca2763","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/780425ec-5b37-4661-ab56-bdeac3ca2763","properties":{"accountName":"continuous-db2332","apiType":"Sql","creationTime":"2020-08-06T22:43:01Z","deletionTime":"2021-01-07T06:37:29Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"4d097971-9228-459b-8687-e6016e34599e","creationTime":"2020-08-06T22:43:02Z","deletionTime":"2021-01-07T06:37:29Z"}]}},{"name":"8e9595e6-628e-4583-bbcb-e79b7594be6e","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/8e9595e6-628e-4583-bbcb-e79b7594be6e","properties":{"accountName":"source-sql-r1-all","apiType":"Sql","creationTime":"2021-01-05T23:53:13Z","deletionTime":"2021-01-06T00:12:22Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"0384eed4-096c-425d-b2c1-a081f254cf02","creationTime":"2021-01-05T23:53:13Z","deletionTime":"2021-01-06T00:12:22Z"}]}},{"name":"a18feb1f-15a9-4000-ade0-ffc81a16309c","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a18feb1f-15a9-4000-ade0-ffc81a16309c","properties":{"accountName":"restored2-cosmosdb-1212-1","apiType":"Sql","creationTime":"2021-01-07T01:55:14Z","deletionTime":"2021-01-07T06:37:29Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"3ab440db-4ae7-4ff2-8da1-dfdad6853a08","creationTime":"2021-01-07T01:55:14Z","deletionTime":"2021-01-07T06:37:29Z"}]}},{"name":"b27cbd07-72f0-4769-9bc7-8cfbe0523d29","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b27cbd07-72f0-4769-9bc7-8cfbe0523d29","properties":{"accountName":"continuous-db2121-r1","apiType":"Sql","creationTime":"2020-09-03T17:58:34Z","deletionTime":"2021-01-07T06:37:29Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"c800c27e-ec05-4656-9391-6e31f28e3e8b","creationTime":"2020-09-03T17:58:34Z","deletionTime":"2021-01-07T06:37:29Z"}]}},{"name":"bed4f838-b8ea-4998-a373-d71b28ae239d","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/bed4f838-b8ea-4998-a373-d71b28ae239d","properties":{"accountName":"cliwvj2gl4plqwc","apiType":"Sql","creationTime":"2021-01-28T22:28:07Z","deletionTime":"2021-01-28T22:29:42Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"84e00b11-921a-4bee-bfa7-bcabbb63759c","creationTime":"2021-01-28T22:28:07Z","deletionTime":"2021-01-28T22:29:42Z"}]}},{"name":"d412cde0-dcee-4e6c-9e8f-69770224be1a","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d412cde0-dcee-4e6c-9e8f-69770224be1a","properties":{"accountName":"restored2-continuous-db2121-2","apiType":"Sql","creationTime":"2020-08-07T18:16:30Z","deletionTime":"2021-01-07T06:37:29Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"a52cc373-6f32-4feb-b28b-15c0bb9842c3","creationTime":"2020-08-07T18:16:30Z","deletionTime":"2021-01-07T06:37:29Z"}]}},{"name":"e27e7197-8a10-4082-808f-bdd67fc65d93","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/e27e7197-8a10-4082-808f-bdd67fc65d93","properties":{"accountName":"sivarv-pitr-test","apiType":"Sql","creationTime":"2021-01-05T21:32:38Z","deletionTime":"2021-01-05T22:26:13Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"a948a101-396b-4c50-83a3-73b01d1c52db","creationTime":"2021-01-05T21:32:38Z","deletionTime":"2021-01-05T22:26:13Z"}]}},{"name":"e333d05f-7c78-41cb-842f-a543f2eb9116","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/e333d05f-7c78-41cb-842f-a543f2eb9116","properties":{"accountName":"cosmosdb-1212","apiType":"Sql","creationTime":"2021-01-06T22:26:11Z","deletionTime":"2021-01-07T06:37:29Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"4a41012e-3313-4825-8064-da2a6f6da7fb","creationTime":"2021-01-06T22:26:11Z","deletionTime":"2021-01-07T06:37:29Z"}]}},{"name":"edf13eb4-5bcd-443c-802c-099edcb9b1c7","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/edf13eb4-5bcd-443c-802c-099edcb9b1c7","properties":{"accountName":"cli7qiaf5atxtbg","apiType":"Sql","creationTime":"2021-01-28T22:58:07Z","deletionTime":"2021-01-28T23:02:56Z","restorableLocations":[]}},{"name":"eeb45f7f-4c05-4b52-9f42-6807d8eb8703","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/eeb45f7f-4c05-4b52-9f42-6807d8eb8703","properties":{"accountName":"powershell-restore","apiType":"Sql","creationTime":"2020-08-10T19:20:14Z","deletionTime":"2021-01-07T06:37:29Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"3cd8b081-4b95-47d8-86f5-a17da18e3b88","creationTime":"2020-08-10T19:20:14Z","deletionTime":"2021-01-07T06:37:29Z"}]}},{"name":"f780ef6c-1fea-4a6a-9c33-784bf8a52edd","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/f780ef6c-1fea-4a6a-9c33-784bf8a52edd","properties":{"accountName":"restored-continuous-db2121-1","apiType":"Sql","creationTime":"2020-08-07T17:55:45Z","deletionTime":"2021-01-07T06:37:29Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"ce739365-8e46-4e12-81e5-9ba7f7ee5ff9","creationTime":"2020-08-07T17:55:45Z","deletionTime":"2021-01-07T06:37:29Z"}]}},{"name":"c0291614-213c-4629-a26a-12802ca1b761","location":"West
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/c0291614-213c-4629-a26a-12802ca1b761","properties":{"accountName":"virangai-test-mongo-pitr","creationTime":"2020-11-24T21:46:06.459782Z","apiType":"MongoDB","restorableLocations":[{"locationName":"West
-        US 2","creationTime":"2020-11-24T21:46:07.1249476Z","regionalDatabaseAccountInstanceId":"12e12ed9-5da1-4a35-9ecf-09dff1515d58"}]}},{"name":"7ccb546f-804d-4fe3-902f-bdb162d2ca51","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/7ccb546f-804d-4fe3-902f-bdb162d2ca51","properties":{"accountName":"virangai-test-pitr-restore-del","creationTime":"2020-12-10T02:06:21.2690247Z","apiType":"Sql","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-12-10T02:06:21.2690247Z","regionalDatabaseAccountInstanceId":"fbbdcce1-e4cc-4fb9-8a5c-64f96438e722"}]}},{"name":"02cf4c6e-8c16-48ed-9626-e135a1e3fc01","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/02cf4c6e-8c16-48ed-9626-e135a1e3fc01","properties":{"accountName":"cli6sjyklw2shv5","creationTime":"2020-12-10T22:11:55.0479455Z","apiType":"Sql","deletionTime":"2020-12-10T22:16:27.9464018Z","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-12-10T22:11:55.8079602Z","deletionTime":"2020-12-10T22:16:27.9464018Z","regionalDatabaseAccountInstanceId":"244e1781-aead-45ba-b987-06d7cf9d9016"}]}},{"name":"0f15c95d-762e-465d-a31c-a66b9d880bfc","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0f15c95d-762e-465d-a31c-a66b9d880bfc","properties":{"accountName":"virangai-test-pitr-restore1","creationTime":"2020-11-17T23:20:50.6676642Z","apiType":"Sql","deletionTime":"2020-11-19T07:21:17.9581005Z","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-11-17T23:20:50.6676642Z","deletionTime":"2020-11-19T07:21:17.9581005Z","regionalDatabaseAccountInstanceId":"718a2356-4556-4d54-90fb-b8c65b065d38"}]}},{"name":"1d16299c-e79e-4130-9647-1fa47f738892","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1d16299c-e79e-4130-9647-1fa47f738892","properties":{"accountName":"clid4bvkfsumrnr","creationTime":"2020-12-10T21:41:44.7967591Z","apiType":"MongoDB","deletionTime":"2020-12-10T21:46:01.404794Z","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-12-10T21:41:45.8387477Z","deletionTime":"2020-12-10T21:46:01.404794Z","regionalDatabaseAccountInstanceId":"0583b6dc-1c55-4786-be03-8a5ecc6ff7b1"}]}},{"name":"4fae7f97-17a8-4e16-b1ec-c403112381e1","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/4fae7f97-17a8-4e16-b1ec-c403112381e1","properties":{"accountName":"virangai-test-pitr","creationTime":"2020-11-17T05:43:36.9551156Z","apiType":"Sql","deletionTime":"2020-11-19T07:24:27.2721258Z","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-11-17T05:43:37.7451168Z","deletionTime":"2020-11-19T07:24:27.2721258Z","regionalDatabaseAccountInstanceId":"09b126d6-b6f2-490f-8ab9-71fab19bde3a"}]}},{"name":"5fdb9f12-f0ec-4600-85c2-bc747a65a794","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/5fdb9f12-f0ec-4600-85c2-bc747a65a794","properties":{"accountName":"cliddnyz7svsjkw","creationTime":"2020-12-10T20:04:05.7748719Z","apiType":"MongoDB","deletionTime":"2020-12-10T20:06:37.8091556Z","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-12-10T20:04:06.5848765Z","deletionTime":"2020-12-10T20:06:37.8091556Z","regionalDatabaseAccountInstanceId":"15115e15-54a6-4798-9492-9021583f9449"}]}},{"name":"7f6eb33c-2b17-44f5-a956-0acd1bd9437d","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/7f6eb33c-2b17-44f5-a956-0acd1bd9437d","properties":{"accountName":"clie4ftgf4chlgo","creationTime":"2020-12-10T22:08:58.6534483Z","apiType":"MongoDB","deletionTime":"2020-12-10T22:13:41.7778806Z","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-12-10T22:08:59.5384495Z","deletionTime":"2020-12-10T22:13:41.7778806Z","regionalDatabaseAccountInstanceId":"3ff2c3f0-9ee9-4010-980b-2e5f48066f75"}]}},{"name":"8547cf42-c6b3-40c4-8803-5f9028ebf8b9","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/8547cf42-c6b3-40c4-8803-5f9028ebf8b9","properties":{"accountName":"cliv27tkdmumnms","creationTime":"2020-12-09T23:55:23.3285739Z","apiType":"MongoDB","deletionTime":"2020-12-09T23:56:36.6896944Z","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-12-09T23:55:25.0086107Z","deletionTime":"2020-12-09T23:56:36.6896944Z","regionalDatabaseAccountInstanceId":"50ba6bf9-62df-42c0-b86e-7d2e5f7e1dcf"}]}},{"name":"9b2e1fd4-16b5-42c6-b1a7-106d5854e6bb","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/9b2e1fd4-16b5-42c6-b1a7-106d5854e6bb","properties":{"accountName":"clia4mcsvr7ks4h","creationTime":"2020-12-09T23:34:23.0830227Z","apiType":"Sql","deletionTime":"2020-12-09T23:35:35.022734Z","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-12-09T23:34:24.16302Z","deletionTime":"2020-12-09T23:35:35.022734Z","regionalDatabaseAccountInstanceId":"d7cc4411-8e9a-4e5d-a013-7e7add065426"}]}},{"name":"9df51477-54dc-4b4f-905f-1ed43537317f","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/9df51477-54dc-4b4f-905f-1ed43537317f","properties":{"accountName":"clibqfjknjmazv2","creationTime":"2020-12-10T21:05:11.5937687Z","apiType":"MongoDB","deletionTime":"2020-12-10T21:09:42.3504596Z","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-12-10T21:05:12.7519752Z","deletionTime":"2020-12-10T21:09:42.3504596Z","regionalDatabaseAccountInstanceId":"491d82d1-4212-4dcd-b96e-a8eda0082222"}]}},{"name":"b4069826-61d2-4e50-aa0d-2cd03d81642c","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b4069826-61d2-4e50-aa0d-2cd03d81642c","properties":{"accountName":"clipfj35yw42xny","creationTime":"2020-12-10T00:45:43.8449527Z","apiType":"MongoDB","deletionTime":"2020-12-10T00:47:06.4394815Z","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-12-10T00:45:44.6499584Z","deletionTime":"2020-12-10T00:47:06.4394815Z","regionalDatabaseAccountInstanceId":"9da90b42-f7b3-48bb-8512-66be68306d10"}]}},{"name":"c05c602b-ab23-4a18-84e9-290d58baacbf","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c05c602b-ab23-4a18-84e9-290d58baacbf","properties":{"accountName":"clipop7ki4e6xqj","creationTime":"2020-12-10T21:44:27.2688628Z","apiType":"Sql","deletionTime":"2020-12-10T21:48:55.2953289Z","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-12-10T21:44:28.1288929Z","deletionTime":"2020-12-10T21:48:55.2953289Z","regionalDatabaseAccountInstanceId":"f0c11f0f-89cc-4b0d-b752-ea0077244dfc"}]}},{"name":"c4b9598a-0ebc-4f67-8fac-2b21a77155a7","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c4b9598a-0ebc-4f67-8fac-2b21a77155a7","properties":{"accountName":"viragai-test-pitr-restore","creationTime":"2020-11-17T08:02:02.2299935Z","apiType":"Sql","deletionTime":"2020-11-17T23:08:08.3790553Z","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-11-17T08:02:02.2299935Z","deletionTime":"2020-11-17T23:08:08.3790553Z","regionalDatabaseAccountInstanceId":"63ec2eb9-1037-4785-8aee-fc7bcc71b2ea"}]}},{"name":"d3f80d92-65bc-4c29-9441-a9a048d304d7","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d3f80d92-65bc-4c29-9441-a9a048d304d7","properties":{"accountName":"cli2loqd5ro7y4w","creationTime":"2020-12-10T06:23:42.3337138Z","apiType":"Sql","deletionTime":"2020-12-10T06:30:25.9454783Z","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-12-10T06:23:43.6317337Z","deletionTime":"2020-12-10T06:30:25.9454783Z","regionalDatabaseAccountInstanceId":"c23c9314-e31d-47c5-a735-ba2b1b200adc"}]}},{"name":"dd81c490-1c9f-46e7-941c-4bc466d1aa57","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/dd81c490-1c9f-46e7-941c-4bc466d1aa57","properties":{"accountName":"clipvtgubbsmtym","creationTime":"2020-12-10T19:35:40.4977301Z","apiType":"MongoDB","deletionTime":"2020-12-10T19:37:24.8071209Z","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-12-10T19:35:41.337723Z","deletionTime":"2020-12-10T19:37:24.8071209Z","regionalDatabaseAccountInstanceId":"3ecbb255-c516-4620-868c-c05e49dc5fe1"}]}}]}'
+        US 2","creationTime":"2020-11-24T21:46:07.1249476Z","regionalDatabaseAccountInstanceId":"12e12ed9-5da1-4a35-9ecf-09dff1515d58"}]}},{"name":"c484bb25-9a8e-4c3e-9359-df5dd84c7f16","location":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/c484bb25-9a8e-4c3e-9359-df5dd84c7f16","properties":{"accountName":"virangai-test-pitr-sql","creationTime":"2021-01-16T01:05:59.1231999Z","apiType":"Sql","restorableLocations":[{"locationName":"West
+        US 2","creationTime":"2021-01-16T01:05:59.7287705Z","regionalDatabaseAccountInstanceId":"2f0ca6dc-a022-438e-9451-384c8ebdf50b"}]}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '22661'
+      - '57800'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 14 Dec 2020 03:58:51 GMT
+      - Thu, 28 Jan 2021 23:04:14 GMT
       expires:
       - '-1'
       pragma:
@@ -1447,6 +1005,11 @@ interactions:
       - ''
       - ''
       - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
     status:
       code: 200
       message: OK
@@ -1454,8 +1017,8 @@ interactions:
     body: '{"location": "West US", "kind": "GlobalDocumentDB", "properties": {"locations":
       [{"locationName": "westus", "failoverPriority": 0}], "databaseAccountOfferType":
       "Standard", "apiProperties": {}, "createMode": "Restore", "restoreParameters":
-      {"restoreMode": "PointInTime", "restoreSource": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/5c8a5401-1159-40cc-9e1d-99af7c7bc289",
-      "restoreTimestampInUtc": "2020-12-14T03:57:12.232141Z"}}}'
+      {"restoreMode": "PointInTime", "restoreSource": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/dad19ede-1592-4d87-95ff-4e20c8a09de5",
+      "restoreTimestampInUtc": "2021-01-28T23:02:06.000Z"}}}'
     headers:
       Accept:
       - application/json
@@ -1466,14 +1029,14 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '512'
+      - '509'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
       - -n -g -a --restore-timestamp --location
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: PUT
@@ -1481,24 +1044,24 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004","name":"cli000004","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2020-12-14T03:59:00.5204584Z"},"properties":{"provisioningState":"Creating","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"352dffff-44ea-4189-91e3-56ecc28ab6f3","createMode":"Restore","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-28T23:04:21.7475946Z"},"properties":{"provisioningState":"Creating","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"d4e35274-db6f-4c2c-8d3b-19de793aef37","createMode":"Restore","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000004-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/5c8a5401-1159-40cc-9e1d-99af7c7bc289","restoreTimestampInUtc":"2020-12-14T03:57:12.232141Z","databasesToRestore":[]}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/dad19ede-1592-4d87-95ff-4e20c8a09de5","restoreTimestampInUtc":"2021-01-28T23:02:06Z","databasesToRestore":[]}},"identity":{"type":"None"}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/eb2701d8-52ac-44ba-9607-2e7b62137212?api-version=2020-06-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/753b3374-df17-4dfb-8b59-13c063a84535?api-version=2020-06-01-preview
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2212'
+      - '2205'
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 03:59:01 GMT
+      - Thu, 28 Jan 2021 23:04:22 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004/operationResults/eb2701d8-52ac-44ba-9607-2e7b62137212?api-version=2020-06-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004/operationResults/753b3374-df17-4dfb-8b59-13c063a84535?api-version=2020-06-01-preview
       pragma:
       - no-cache
       server:
@@ -1514,7 +1077,7 @@ interactions:
       x-ms-gatewayversion:
       - version=2.11.0
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
     status:
       code: 200
       message: Ok
@@ -1532,10 +1095,10 @@ interactions:
       ParameterSetName:
       - -n -g -a --restore-timestamp --location
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/eb2701d8-52ac-44ba-9607-2e7b62137212?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/753b3374-df17-4dfb-8b59-13c063a84535?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1547,7 +1110,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 03:59:31 GMT
+      - Thu, 28 Jan 2021 23:04:53 GMT
       pragma:
       - no-cache
       server:
@@ -1579,10 +1142,10 @@ interactions:
       ParameterSetName:
       - -n -g -a --restore-timestamp --location
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/eb2701d8-52ac-44ba-9607-2e7b62137212?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/753b3374-df17-4dfb-8b59-13c063a84535?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1594,7 +1157,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:00:01 GMT
+      - Thu, 28 Jan 2021 23:05:23 GMT
       pragma:
       - no-cache
       server:
@@ -1626,10 +1189,10 @@ interactions:
       ParameterSetName:
       - -n -g -a --restore-timestamp --location
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/eb2701d8-52ac-44ba-9607-2e7b62137212?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/753b3374-df17-4dfb-8b59-13c063a84535?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1641,7 +1204,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:00:32 GMT
+      - Thu, 28 Jan 2021 23:05:54 GMT
       pragma:
       - no-cache
       server:
@@ -1673,10 +1236,10 @@ interactions:
       ParameterSetName:
       - -n -g -a --restore-timestamp --location
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/eb2701d8-52ac-44ba-9607-2e7b62137212?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/753b3374-df17-4dfb-8b59-13c063a84535?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1688,7 +1251,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:01:02 GMT
+      - Thu, 28 Jan 2021 23:06:24 GMT
       pragma:
       - no-cache
       server:
@@ -1720,10 +1283,10 @@ interactions:
       ParameterSetName:
       - -n -g -a --restore-timestamp --location
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/eb2701d8-52ac-44ba-9607-2e7b62137212?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/753b3374-df17-4dfb-8b59-13c063a84535?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1735,7 +1298,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:01:33 GMT
+      - Thu, 28 Jan 2021 23:06:54 GMT
       pragma:
       - no-cache
       server:
@@ -1767,10 +1330,10 @@ interactions:
       ParameterSetName:
       - -n -g -a --restore-timestamp --location
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/eb2701d8-52ac-44ba-9607-2e7b62137212?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/753b3374-df17-4dfb-8b59-13c063a84535?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1782,7 +1345,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:02:03 GMT
+      - Thu, 28 Jan 2021 23:07:25 GMT
       pragma:
       - no-cache
       server:
@@ -1814,10 +1377,10 @@ interactions:
       ParameterSetName:
       - -n -g -a --restore-timestamp --location
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/eb2701d8-52ac-44ba-9607-2e7b62137212?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/753b3374-df17-4dfb-8b59-13c063a84535?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1829,7 +1392,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:02:34 GMT
+      - Thu, 28 Jan 2021 23:07:55 GMT
       pragma:
       - no-cache
       server:
@@ -1861,10 +1424,10 @@ interactions:
       ParameterSetName:
       - -n -g -a --restore-timestamp --location
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/eb2701d8-52ac-44ba-9607-2e7b62137212?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/753b3374-df17-4dfb-8b59-13c063a84535?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1876,7 +1439,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:03:04 GMT
+      - Thu, 28 Jan 2021 23:08:25 GMT
       pragma:
       - no-cache
       server:
@@ -1908,10 +1471,10 @@ interactions:
       ParameterSetName:
       - -n -g -a --restore-timestamp --location
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/eb2701d8-52ac-44ba-9607-2e7b62137212?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/753b3374-df17-4dfb-8b59-13c063a84535?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1923,7 +1486,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:03:35 GMT
+      - Thu, 28 Jan 2021 23:08:55 GMT
       pragma:
       - no-cache
       server:
@@ -1955,10 +1518,10 @@ interactions:
       ParameterSetName:
       - -n -g -a --restore-timestamp --location
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/eb2701d8-52ac-44ba-9607-2e7b62137212?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/753b3374-df17-4dfb-8b59-13c063a84535?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1970,7 +1533,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:04:05 GMT
+      - Thu, 28 Jan 2021 23:09:26 GMT
       pragma:
       - no-cache
       server:
@@ -2002,10 +1565,10 @@ interactions:
       ParameterSetName:
       - -n -g -a --restore-timestamp --location
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/eb2701d8-52ac-44ba-9607-2e7b62137212?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/753b3374-df17-4dfb-8b59-13c063a84535?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2017,7 +1580,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:04:35 GMT
+      - Thu, 28 Jan 2021 23:09:56 GMT
       pragma:
       - no-cache
       server:
@@ -2049,10 +1612,10 @@ interactions:
       ParameterSetName:
       - -n -g -a --restore-timestamp --location
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/eb2701d8-52ac-44ba-9607-2e7b62137212?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/753b3374-df17-4dfb-8b59-13c063a84535?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2064,7 +1627,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:05:06 GMT
+      - Thu, 28 Jan 2021 23:10:26 GMT
       pragma:
       - no-cache
       server:
@@ -2096,10 +1659,10 @@ interactions:
       ParameterSetName:
       - -n -g -a --restore-timestamp --location
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/eb2701d8-52ac-44ba-9607-2e7b62137212?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/753b3374-df17-4dfb-8b59-13c063a84535?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2111,7 +1674,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:05:37 GMT
+      - Thu, 28 Jan 2021 23:10:56 GMT
       pragma:
       - no-cache
       server:
@@ -2143,10 +1706,10 @@ interactions:
       ParameterSetName:
       - -n -g -a --restore-timestamp --location
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/eb2701d8-52ac-44ba-9607-2e7b62137212?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/753b3374-df17-4dfb-8b59-13c063a84535?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2158,7 +1721,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:06:07 GMT
+      - Thu, 28 Jan 2021 23:11:27 GMT
       pragma:
       - no-cache
       server:
@@ -2190,10 +1753,10 @@ interactions:
       ParameterSetName:
       - -n -g -a --restore-timestamp --location
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/eb2701d8-52ac-44ba-9607-2e7b62137212?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/753b3374-df17-4dfb-8b59-13c063a84535?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2205,7 +1768,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:06:37 GMT
+      - Thu, 28 Jan 2021 23:11:57 GMT
       pragma:
       - no-cache
       server:
@@ -2237,10 +1800,10 @@ interactions:
       ParameterSetName:
       - -n -g -a --restore-timestamp --location
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/eb2701d8-52ac-44ba-9607-2e7b62137212?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/753b3374-df17-4dfb-8b59-13c063a84535?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2252,7 +1815,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:07:08 GMT
+      - Thu, 28 Jan 2021 23:12:27 GMT
       pragma:
       - no-cache
       server:
@@ -2284,10 +1847,10 @@ interactions:
       ParameterSetName:
       - -n -g -a --restore-timestamp --location
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/eb2701d8-52ac-44ba-9607-2e7b62137212?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/753b3374-df17-4dfb-8b59-13c063a84535?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2299,7 +1862,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:07:38 GMT
+      - Thu, 28 Jan 2021 23:12:58 GMT
       pragma:
       - no-cache
       server:
@@ -2331,10 +1894,10 @@ interactions:
       ParameterSetName:
       - -n -g -a --restore-timestamp --location
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/eb2701d8-52ac-44ba-9607-2e7b62137212?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/753b3374-df17-4dfb-8b59-13c063a84535?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2346,7 +1909,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:08:09 GMT
+      - Thu, 28 Jan 2021 23:13:28 GMT
       pragma:
       - no-cache
       server:
@@ -2378,10 +1941,10 @@ interactions:
       ParameterSetName:
       - -n -g -a --restore-timestamp --location
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/eb2701d8-52ac-44ba-9607-2e7b62137212?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/753b3374-df17-4dfb-8b59-13c063a84535?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2393,7 +1956,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:08:40 GMT
+      - Thu, 28 Jan 2021 23:13:58 GMT
       pragma:
       - no-cache
       server:
@@ -2425,527 +1988,10 @@ interactions:
       ParameterSetName:
       - -n -g -a --restore-timestamp --location
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/eb2701d8-52ac-44ba-9607-2e7b62137212?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 04:09:09 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb restore
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g -a --restore-timestamp --location
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/eb2701d8-52ac-44ba-9607-2e7b62137212?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 04:09:40 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb restore
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g -a --restore-timestamp --location
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/eb2701d8-52ac-44ba-9607-2e7b62137212?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 04:10:10 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb restore
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g -a --restore-timestamp --location
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/eb2701d8-52ac-44ba-9607-2e7b62137212?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 04:10:41 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb restore
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g -a --restore-timestamp --location
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/eb2701d8-52ac-44ba-9607-2e7b62137212?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 04:11:11 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb restore
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g -a --restore-timestamp --location
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/eb2701d8-52ac-44ba-9607-2e7b62137212?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 04:11:42 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb restore
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g -a --restore-timestamp --location
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/eb2701d8-52ac-44ba-9607-2e7b62137212?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 04:12:13 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb restore
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g -a --restore-timestamp --location
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/eb2701d8-52ac-44ba-9607-2e7b62137212?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 04:12:43 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb restore
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g -a --restore-timestamp --location
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/eb2701d8-52ac-44ba-9607-2e7b62137212?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 04:13:14 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb restore
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g -a --restore-timestamp --location
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/eb2701d8-52ac-44ba-9607-2e7b62137212?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 04:13:44 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb restore
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g -a --restore-timestamp --location
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/eb2701d8-52ac-44ba-9607-2e7b62137212?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 04:14:14 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb restore
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g -a --restore-timestamp --location
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/eb2701d8-52ac-44ba-9607-2e7b62137212?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/753b3374-df17-4dfb-8b59-13c063a84535?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -2957,7 +2003,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:14:45 GMT
+      - Thu, 28 Jan 2021 23:14:29 GMT
       pragma:
       - no-cache
       server:
@@ -2989,27 +2035,27 @@ interactions:
       ParameterSetName:
       - -n -g -a --restore-timestamp --location
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004?api-version=2020-06-01-preview
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004","name":"cli000004","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2020-12-14T04:14:26.6871551Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"352dffff-44ea-4189-91e3-56ecc28ab6f3","createMode":"Restore","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-28T23:14:23.8553697Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"d4e35274-db6f-4c2c-8d3b-19de793aef37","createMode":"Restore","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000004-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/5c8a5401-1159-40cc-9e1d-99af7c7bc289","restoreTimestampInUtc":"2020-12-14T03:57:12.232141Z","databasesToRestore":[]}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/dad19ede-1592-4d87-95ff-4e20c8a09de5","restoreTimestampInUtc":"2021-01-28T23:02:06Z","databasesToRestore":[]}},"identity":{"type":"None"}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2286'
+      - '2279'
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:14:46 GMT
+      - Thu, 28 Jan 2021 23:14:29 GMT
       pragma:
       - no-cache
       server:
@@ -3041,8 +2087,8 @@ interactions:
       ParameterSetName:
       - -n -g -a --restore-timestamp --location
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: GET
@@ -3050,20 +2096,20 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004","name":"cli000004","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2020-12-14T04:14:26.6871551Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"352dffff-44ea-4189-91e3-56ecc28ab6f3","createMode":"Restore","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-28T23:14:23.8553697Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"d4e35274-db6f-4c2c-8d3b-19de793aef37","createMode":"Restore","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000004-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/5c8a5401-1159-40cc-9e1d-99af7c7bc289","restoreTimestampInUtc":"2020-12-14T03:57:12.232141Z","databasesToRestore":[]}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/dad19ede-1592-4d87-95ff-4e20c8a09de5","restoreTimestampInUtc":"2021-01-28T23:02:06Z","databasesToRestore":[]}},"identity":{"type":"None"}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2286'
+      - '2279'
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:14:47 GMT
+      - Thu, 28 Jan 2021 23:14:30 GMT
       pragma:
       - no-cache
       server:
@@ -3095,8 +2141,8 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: GET
@@ -3104,20 +2150,20 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004","name":"cli000004","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2020-12-14T04:14:26.6871551Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"352dffff-44ea-4189-91e3-56ecc28ab6f3","createMode":"Restore","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-28T23:14:23.8553697Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"d4e35274-db6f-4c2c-8d3b-19de793aef37","createMode":"Restore","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000004-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/5c8a5401-1159-40cc-9e1d-99af7c7bc289","restoreTimestampInUtc":"2020-12-14T03:57:12.232141Z","databasesToRestore":[]}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/dad19ede-1592-4d87-95ff-4e20c8a09de5","restoreTimestampInUtc":"2021-01-28T23:02:06Z","databasesToRestore":[]}},"identity":{"type":"None"}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2286'
+      - '2279'
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:14:47 GMT
+      - Thu, 28 Jan 2021 23:14:30 GMT
       pragma:
       - no-cache
       server:

--- a/src/cosmosdb-preview/azext_cosmosdb_preview/tests/latest/recordings/test_cosmosdb_restore_using_create.yaml
+++ b/src/cosmosdb-preview/azext_cosmosdb_preview/tests/latest/recordings/test_cosmosdb_restore_using_create.yaml
@@ -13,15 +13,15 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-resource/12.0.0 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cosmosdb_restore_using_create000001?api-version=2020-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cosmosdb_restore_using_create000001?api-version=2020-10-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_using_create000001","name":"cli_test_cosmosdb_restore_using_create000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-12-14T04:39:23Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_using_create000001","name":"cli_test_cosmosdb_restore_using_create000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2021-01-28T22:57:14Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -30,7 +30,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 14 Dec 2020 04:39:26 GMT
+      - Thu, 28 Jan 2021 22:57:15 GMT
       expires:
       - '-1'
       pragma:
@@ -65,8 +65,8 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: PUT
@@ -74,14 +74,14 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_using_create000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2020-12-14T04:39:29.0529195Z"},"properties":{"provisioningState":"Creating","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"e794d811-cb33-4f8c-a039-0409dfa6a840","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-28T22:57:19.3879028Z"},"properties":{"provisioningState":"Creating","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"7346d3b4-8657-441b-8661-c1eb1071b700","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
         US","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000003-westus","locationName":"West
         US","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000003-westus","locationName":"West
         US","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000003-westus","locationName":"West
         US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"}},"identity":{"type":"None"}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/db54f8b3-2936-4b01-9563-0d7c291d2797?api-version=2020-06-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e3f849c8-2426-4559-a885-678230b87cb9?api-version=2020-06-01-preview
       cache-control:
       - no-store, no-cache
       content-length:
@@ -89,9 +89,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:39:29 GMT
+      - Thu, 28 Jan 2021 22:57:20 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_using_create000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/operationResults/db54f8b3-2936-4b01-9563-0d7c291d2797?api-version=2020-06-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_using_create000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/operationResults/e3f849c8-2426-4559-a885-678230b87cb9?api-version=2020-06-01-preview
       pragma:
       - no-cache
       server:
@@ -107,7 +107,7 @@ interactions:
       x-ms-gatewayversion:
       - version=2.11.0
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1196'
     status:
       code: 200
       message: Ok
@@ -125,10 +125,10 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/db54f8b3-2936-4b01-9563-0d7c291d2797?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e3f849c8-2426-4559-a885-678230b87cb9?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -140,7 +140,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:40:01 GMT
+      - Thu, 28 Jan 2021 22:57:50 GMT
       pragma:
       - no-cache
       server:
@@ -172,10 +172,10 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/db54f8b3-2936-4b01-9563-0d7c291d2797?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e3f849c8-2426-4559-a885-678230b87cb9?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -187,7 +187,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:40:32 GMT
+      - Thu, 28 Jan 2021 22:58:20 GMT
       pragma:
       - no-cache
       server:
@@ -219,621 +219,10 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/db54f8b3-2936-4b01-9563-0d7c291d2797?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 04:41:03 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/db54f8b3-2936-4b01-9563-0d7c291d2797?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 04:41:33 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/db54f8b3-2936-4b01-9563-0d7c291d2797?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 04:42:03 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/db54f8b3-2936-4b01-9563-0d7c291d2797?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 04:42:33 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/db54f8b3-2936-4b01-9563-0d7c291d2797?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 04:43:03 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/db54f8b3-2936-4b01-9563-0d7c291d2797?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 04:43:35 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/db54f8b3-2936-4b01-9563-0d7c291d2797?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 04:44:05 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/db54f8b3-2936-4b01-9563-0d7c291d2797?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 04:44:35 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/db54f8b3-2936-4b01-9563-0d7c291d2797?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 04:45:06 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/db54f8b3-2936-4b01-9563-0d7c291d2797?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 04:45:37 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/db54f8b3-2936-4b01-9563-0d7c291d2797?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 04:46:07 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/db54f8b3-2936-4b01-9563-0d7c291d2797?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 04:46:37 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/db54f8b3-2936-4b01-9563-0d7c291d2797?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 04:47:08 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/db54f8b3-2936-4b01-9563-0d7c291d2797?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e3f849c8-2426-4559-a885-678230b87cb9?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -845,7 +234,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:47:39 GMT
+      - Thu, 28 Jan 2021 22:58:50 GMT
       pragma:
       - no-cache
       server:
@@ -877,14 +266,14 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_using_create000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2020-06-01-preview
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_using_create000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2020-12-14T04:47:04.7308289Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"e794d811-cb33-4f8c-a039-0409dfa6a840","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-28T22:58:06.9755118Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"7346d3b4-8657-441b-8661-c1eb1071b700","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000003-westus","locationName":"West
@@ -897,7 +286,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:47:40 GMT
+      - Thu, 28 Jan 2021 22:58:50 GMT
       pragma:
       - no-cache
       server:
@@ -929,8 +318,8 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: GET
@@ -938,7 +327,7 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_using_create000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2020-12-14T04:47:04.7308289Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"e794d811-cb33-4f8c-a039-0409dfa6a840","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-28T22:58:06.9755118Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"7346d3b4-8657-441b-8661-c1eb1071b700","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000003-westus","locationName":"West
@@ -951,7 +340,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:47:40 GMT
+      - Thu, 28 Jan 2021 22:58:51 GMT
       pragma:
       - no-cache
       server:
@@ -983,8 +372,8 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: GET
@@ -992,7 +381,7 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_using_create000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2020-12-14T04:47:04.7308289Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"e794d811-cb33-4f8c-a039-0409dfa6a840","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-28T22:58:06.9755118Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"7346d3b4-8657-441b-8661-c1eb1071b700","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000003-westus","locationName":"West
@@ -1005,7 +394,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:47:41 GMT
+      - Thu, 28 Jan 2021 22:58:52 GMT
       pragma:
       - no-cache
       server:
@@ -1041,8 +430,8 @@ interactions:
       ParameterSetName:
       - -g -a -n
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: PUT
@@ -1052,7 +441,7 @@ interactions:
       string: '{"status":"Enqueued"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/3d7f58e7-5453-47da-80b7-622832c9285d?api-version=2020-04-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/3d8699c0-9070-4c6b-864d-000c25edda4a?api-version=2020-04-01
       cache-control:
       - no-store, no-cache
       content-length:
@@ -1060,9 +449,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:47:41 GMT
+      - Thu, 28 Jan 2021 22:58:53 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_using_create000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/operationResults/3d7f58e7-5453-47da-80b7-622832c9285d?api-version=2020-04-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_using_create000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/operationResults/3d8699c0-9070-4c6b-864d-000c25edda4a?api-version=2020-04-01
       pragma:
       - no-cache
       server:
@@ -1074,7 +463,7 @@ interactions:
       x-ms-gatewayversion:
       - version=2.11.0
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
     status:
       code: 202
       message: Accepted
@@ -1092,10 +481,10 @@ interactions:
       ParameterSetName:
       - -g -a -n
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/3d7f58e7-5453-47da-80b7-622832c9285d?api-version=2020-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/3d8699c0-9070-4c6b-864d-000c25edda4a?api-version=2020-04-01
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -1107,7 +496,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:48:12 GMT
+      - Thu, 28 Jan 2021 22:59:23 GMT
       pragma:
       - no-cache
       server:
@@ -1139,13 +528,13 @@ interactions:
       ParameterSetName:
       - -g -a -n
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_using_create000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005?api-version=2020-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_using_create000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005","type":"Microsoft.DocumentDB/databaseAccounts/sqlDatabases","name":"cli000005","properties":{"resource":{"id":"cli000005","_rid":"JS4vAA==","_self":"dbs/JS4vAA==/","_etag":"\"00001a00-0000-0700-0000-5fd6ee730000\"","_colls":"colls/","_users":"users/","_ts":1607921267}}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_using_create000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005","type":"Microsoft.DocumentDB/databaseAccounts/sqlDatabases","name":"cli000005","properties":{"resource":{"id":"cli000005","_rid":"DCdYAA==","_self":"dbs/DCdYAA==/","_etag":"\"00008001-0000-0700-0000-601341b10000\"","_colls":"colls/","_users":"users/","_ts":1611874737}}}'
     headers:
       cache-control:
       - no-store, no-cache
@@ -1154,7 +543,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:48:13 GMT
+      - Thu, 28 Jan 2021 22:59:24 GMT
       pragma:
       - no-cache
       server:
@@ -1193,8 +582,8 @@ interactions:
       ParameterSetName:
       - -g -a -d -n -p
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: PUT
@@ -1204,7 +593,7 @@ interactions:
       string: '{"status":"Enqueued"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/1068db93-ee4d-441f-b6fa-2b34a9abcbab?api-version=2020-04-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/b553302b-0ace-43f0-acf6-c5a518f61da8?api-version=2020-04-01
       cache-control:
       - no-store, no-cache
       content-length:
@@ -1212,9 +601,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:48:15 GMT
+      - Thu, 28 Jan 2021 22:59:25 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_using_create000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/containers/cli000002/operationResults/1068db93-ee4d-441f-b6fa-2b34a9abcbab?api-version=2020-04-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_using_create000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/containers/cli000002/operationResults/b553302b-0ace-43f0-acf6-c5a518f61da8?api-version=2020-04-01
       pragma:
       - no-cache
       server:
@@ -1226,7 +615,7 @@ interactions:
       x-ms-gatewayversion:
       - version=2.11.0
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1196'
     status:
       code: 202
       message: Accepted
@@ -1244,10 +633,10 @@ interactions:
       ParameterSetName:
       - -g -a -d -n -p
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/1068db93-ee4d-441f-b6fa-2b34a9abcbab?api-version=2020-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/b553302b-0ace-43f0-acf6-c5a518f61da8?api-version=2020-04-01
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -1259,7 +648,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:48:45 GMT
+      - Thu, 28 Jan 2021 22:59:55 GMT
       pragma:
       - no-cache
       server:
@@ -1291,13 +680,13 @@ interactions:
       ParameterSetName:
       - -g -a -d -n -p
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_using_create000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/containers/cli000002?api-version=2020-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_using_create000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/containers/cli000002","type":"Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers","name":"cli000002","properties":{"resource":{"id":"cli000002","indexingPolicy":{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"/*"}],"excludedPaths":[{"path":"/\"_etag\"/?"}]},"partitionKey":{"paths":["/pk"],"kind":"Hash"},"uniqueKeyPolicy":{"uniqueKeys":[]},"conflictResolutionPolicy":{"mode":"LastWriterWins","conflictResolutionPath":"/_ts","conflictResolutionProcedure":""},"backupPolicy":{"type":1},"allowMaterializedViews":false,"geospatialConfig":{"type":"Geography"},"_rid":"JS4vAOhbWbY=","_ts":1607921300,"_self":"dbs/JS4vAA==/colls/JS4vAOhbWbY=/","_etag":"\"00001d00-0000-0700-0000-5fd6ee940000\"","_docs":"docs/","_sprocs":"sprocs/","_triggers":"triggers/","_udfs":"udfs/","_conflicts":"conflicts/","statistics":[{"id":"0","sizeInKB":0,"documentCount":0,"partitionKeys":[]}]}}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_using_create000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/containers/cli000002","type":"Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers","name":"cli000002","properties":{"resource":{"id":"cli000002","indexingPolicy":{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"/*"}],"excludedPaths":[{"path":"/\"_etag\"/?"}]},"partitionKey":{"paths":["/pk"],"kind":"Hash"},"uniqueKeyPolicy":{"uniqueKeys":[]},"conflictResolutionPolicy":{"mode":"LastWriterWins","conflictResolutionPath":"/_ts","conflictResolutionProcedure":""},"backupPolicy":{"type":1},"allowMaterializedViews":false,"geospatialConfig":{"type":"Geography"},"_rid":"DCdYALZS+Ko=","_ts":1611874770,"_self":"dbs/DCdYAA==/colls/DCdYALZS+Ko=/","_etag":"\"00008301-0000-0700-0000-601341d20000\"","_docs":"docs/","_sprocs":"sprocs/","_triggers":"triggers/","_udfs":"udfs/","_conflicts":"conflicts/","statistics":[{"id":"0","sizeInKB":0,"documentCount":0,"partitionKeys":[]}]}}}'
     headers:
       cache-control:
       - no-store, no-cache
@@ -1306,7 +695,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:48:46 GMT
+      - Thu, 28 Jan 2021 22:59:56 GMT
       pragma:
       - no-cache
       server:
@@ -1336,102 +725,221 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/restorableDatabaseAccounts?api-version=2020-06-01-preview
   response:
     body:
-      string: '{"value":[{"name":"e794d811-cb33-4f8c-a039-0409dfa6a840","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/e794d811-cb33-4f8c-a039-0409dfa6a840","properties":{"accountName":"cli000003","creationTime":"2020-12-14T04:47:04.7308289Z","apiType":"Sql","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-12-14T04:47:05.5208386Z","regionalDatabaseAccountInstanceId":"4dff6e0d-4487-44fd-8dd3-6bf9cbbe7056"}]}},{"name":"651acce6-dd9b-4cb0-a236-444fa0760775","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/651acce6-dd9b-4cb0-a236-444fa0760775","properties":{"accountName":"continuous-db2121","creationTime":"2020-08-06T21:04:15.6720984Z","apiType":"Sql","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-08-06T21:04:16.5626858Z","regionalDatabaseAccountInstanceId":"7119a7d0-aab2-4dac-90d2-68880d3fa967"}]}},{"name":"b27cbd07-72f0-4769-9bc7-8cfbe0523d29","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b27cbd07-72f0-4769-9bc7-8cfbe0523d29","properties":{"accountName":"continuous-db2121-r1","creationTime":"2020-09-03T17:58:33.3003917Z","apiType":"Sql","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-09-03T17:58:33.3003917Z","regionalDatabaseAccountInstanceId":"c800c27e-ec05-4656-9391-6e31f28e3e8b"}]}},{"name":"780425ec-5b37-4661-ab56-bdeac3ca2763","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/780425ec-5b37-4661-ab56-bdeac3ca2763","properties":{"accountName":"continuous-db2332","creationTime":"2020-08-06T22:43:00.3153258Z","apiType":"Sql","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-08-06T22:43:01.1889467Z","regionalDatabaseAccountInstanceId":"4d097971-9228-459b-8687-e6016e34599e"}]}},{"name":"d92d948a-afb9-4bb3-9a4c-d6b8fcf8d204","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d92d948a-afb9-4bb3-9a4c-d6b8fcf8d204","properties":{"accountName":"kal-continuous","creationTime":"2020-08-05T01:00:24.1857393Z","apiType":"Sql","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-08-05T01:00:25.0607285Z","regionalDatabaseAccountInstanceId":"c28cc815-caba-4bd3-9402-6c8ec362efe6"},{"locationName":"East
-        US","creationTime":"2020-08-05T01:12:02.3818516Z","regionalDatabaseAccountInstanceId":"cc0bacf7-91d0-4c4b-95ff-2479327f0866"},{"locationName":"South
-        Central US","creationTime":"2020-08-23T01:34:10.8844144Z","regionalDatabaseAccountInstanceId":"6fc9f211-8f76-4c29-9edc-f82ee8c5211a"}]}},{"name":"11d8ee78-2502-4ad6-becd-291aef9ac258","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/11d8ee78-2502-4ad6-becd-291aef9ac258","properties":{"accountName":"kal-continuous-dedicated-test","creationTime":"2020-10-05T23:45:25.9865024Z","apiType":"Sql","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-10-05T23:45:26.9395959Z","regionalDatabaseAccountInstanceId":"543c99f9-7bc2-4b55-9732-9733b981341f"}]}},{"name":"ed1b5536-d225-4af9-bf33-71ff5fc8ef4b","location":"South
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/southcentralus/restorableDatabaseAccounts/ed1b5536-d225-4af9-bf33-71ff5fc8ef4b","properties":{"accountName":"kal-dedicated-test","creationTime":"2020-10-05T23:57:44.8347861Z","apiType":"Sql","restorableLocations":[{"locationName":"South
-        Central US","creationTime":"2020-10-05T23:57:45.381672Z","regionalDatabaseAccountInstanceId":"ff8bf7b0-f9c3-461c-8c13-26e94ac4c2bc"}]}},{"name":"3325eb2c-3a59-4ebb-882f-27fe519f2253","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3325eb2c-3a59-4ebb-882f-27fe519f2253","properties":{"accountName":"pitracc","creationTime":"2020-10-15T00:44:15.224607Z","apiType":"Sql","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-10-15T00:44:16.8339914Z","regionalDatabaseAccountInstanceId":"b7cb54bc-b620-4d34-a004-11bda0dab218"},{"locationName":"East
-        US 2","creationTime":"2020-10-15T06:41:51.7956227Z","regionalDatabaseAccountInstanceId":"9b2e4539-1898-4f11-b568-5b72c913eb53"}]}},{"name":"1e2bec8e-adcc-4c5a-aa5b-82091d6c8a37","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1e2bec8e-adcc-4c5a-aa5b-82091d6c8a37","properties":{"accountName":"pitracctdemo2","creationTime":"2020-08-11T02:34:22.7041021Z","apiType":"Sql","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-08-11T02:34:23.4228904Z","regionalDatabaseAccountInstanceId":"7419408f-e6af-4596-a76b-c31ca62a54ca"}]}},{"name":"6fd844b3-71af-4e89-9b9d-f829945272bf","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6fd844b3-71af-4e89-9b9d-f829945272bf","properties":{"accountName":"pitrdemo1015","creationTime":"2020-10-15T17:28:58.4349667Z","apiType":"Sql","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-10-15T17:28:59.3099929Z","regionalDatabaseAccountInstanceId":"af26f717-b6ff-4eac-864c-17e759891ae8"}]}},{"name":"3f392004-9f83-4ae9-ac1c-fa5f6542f245","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3f392004-9f83-4ae9-ac1c-fa5f6542f245","properties":{"accountName":"pitrdemorestored1015","creationTime":"2020-10-15T17:37:19.7445957Z","apiType":"Sql","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-10-15T17:37:19.7445957Z","regionalDatabaseAccountInstanceId":"2f4857ad-25c3-4e2f-883a-abe35c5f5e0c"}]}},{"name":"74ebfb99-1914-4ea9-b802-736b5bda12a7","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/74ebfb99-1914-4ea9-b802-736b5bda12a7","properties":{"accountName":"pitrmongotest","creationTime":"2020-10-01T17:27:21.7773462Z","apiType":"MongoDB","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-10-01T17:27:22.8398227Z","regionalDatabaseAccountInstanceId":"73ef95f2-a338-4afc-8bb2-6fc3b0071d58"}]}},{"name":"9905e7ca-6f2d-4b24-a4c5-8e7529036a74","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/9905e7ca-6f2d-4b24-a4c5-8e7529036a74","properties":{"accountName":"pitrmongotest-restore","creationTime":"2020-10-01T21:24:44.2340464Z","apiType":"MongoDB","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-10-01T21:24:44.2340464Z","regionalDatabaseAccountInstanceId":"75c41286-d7f2-4594-b9f2-87f6c9843cf8"}]}},{"name":"eeb45f7f-4c05-4b52-9f42-6807d8eb8703","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/eeb45f7f-4c05-4b52-9f42-6807d8eb8703","properties":{"accountName":"powershell-restore","creationTime":"2020-08-10T19:20:13.1359094Z","apiType":"Sql","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-08-10T19:20:13.1359094Z","regionalDatabaseAccountInstanceId":"3cd8b081-4b95-47d8-86f5-a17da18e3b88"}]}},{"name":"f780ef6c-1fea-4a6a-9c33-784bf8a52edd","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/f780ef6c-1fea-4a6a-9c33-784bf8a52edd","properties":{"accountName":"restored-continuous-db2121-1","creationTime":"2020-08-07T17:55:44.1250519Z","apiType":"Sql","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-08-07T17:55:44.1250519Z","regionalDatabaseAccountInstanceId":"ce739365-8e46-4e12-81e5-9ba7f7ee5ff9"}]}},{"name":"d412cde0-dcee-4e6c-9e8f-69770224be1a","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d412cde0-dcee-4e6c-9e8f-69770224be1a","properties":{"accountName":"restored2-continuous-db2121-2","creationTime":"2020-08-07T18:16:29.8946196Z","apiType":"Sql","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-08-07T18:16:29.8946196Z","regionalDatabaseAccountInstanceId":"a52cc373-6f32-4feb-b28b-15c0bb9842c3"}]}},{"name":"23e99a35-cd36-4df4-9614-f767a03b9995","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/23e99a35-cd36-4df4-9614-f767a03b9995","properties":{"accountName":"subbannageeta","creationTime":"2020-08-08T01:04:52.0701907Z","apiType":"Sql","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-08-08T01:04:52.9451855Z","regionalDatabaseAccountInstanceId":"30701557-ecf8-43ce-8810-2c8be01dccf9"},{"locationName":"East
-        US","creationTime":"2020-08-08T01:15:43.5077951Z","regionalDatabaseAccountInstanceId":"8283b088-b67d-4975-bfbe-0705e3e7a599"}]}},{"name":"2cfb9266-6837-4c5c-b7ae-ec8e72913cd1","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/2cfb9266-6837-4c5c-b7ae-ec8e72913cd1","properties":{"accountName":"test-bk-cont-restore1","creationTime":"2020-10-15T23:55:02.6142219Z","apiType":"Sql","restorableLocations":[{"locationName":"South
-        Central US","creationTime":"2020-10-15T23:55:02.6142219Z","regionalDatabaseAccountInstanceId":"a1893351-8aa8-4ff0-8457-47ce4e6c2790"}]}},{"name":"6f7de73f-d3aa-4b35-9bab-f4359a8415a5","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6f7de73f-d3aa-4b35-9bab-f4359a8415a5","properties":{"accountName":"vinhpitrrestored1015","creationTime":"2020-10-15T16:08:38.1731104Z","apiType":"Sql","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-10-15T16:08:38.1731104Z","regionalDatabaseAccountInstanceId":"2d731560-b500-49c7-ad88-acba387c072c"}]}},{"name":"c0291614-213c-4629-a26a-12802ca1b761","location":"West
+      string: '{"value":[{"name":"70f3ea16-d3bc-46f6-98e8-576fc201eabf","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/70f3ea16-d3bc-46f6-98e8-576fc201eabf","properties":{"accountName":"balaksrestorebug","apiType":"Sql","creationTime":"2021-01-09T01:08:25Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"94244165-49de-46f8-bb1a-2e0956694168","creationTime":"2021-01-09T01:08:27Z"}]}},{"name":"5f95bef8-07b9-400b-aac2-4e09efbc47c2","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/5f95bef8-07b9-400b-aac2-4e09efbc47c2","properties":{"accountName":"cli56zv275qols2","apiType":"MongoDB","creationTime":"2021-01-28T22:28:28Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"0eed5071-4e89-480f-ac03-d245d57bd6a0","creationTime":"2021-01-28T22:28:29Z"}]}},{"name":"edf13eb4-5bcd-443c-802c-099edcb9b1c7","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/edf13eb4-5bcd-443c-802c-099edcb9b1c7","properties":{"accountName":"cli7qiaf5atxtbg","apiType":"Sql","creationTime":"2021-01-28T22:58:07Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"fc9b8e20-570c-44ba-927b-22e9e1c3124f","creationTime":"2021-01-28T22:58:08Z"}]}},{"name":"f46ed918-cadc-48cd-9381-386376eceec1","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/f46ed918-cadc-48cd-9381-386376eceec1","properties":{"accountName":"clib5bw3s76u6yq","apiType":"MongoDB","creationTime":"2021-01-28T22:59:22Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"63a7ae8b-329a-492a-8fbf-99ab5a901730","creationTime":"2021-01-28T22:59:23Z"}]}},{"name":"1cea11b1-c170-4ffe-993d-63da1bff9a94","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1cea11b1-c170-4ffe-993d-63da1bff9a94","properties":{"accountName":"clid4bvkfsumrnr-restore","apiType":"MongoDB","creationTime":"2021-01-08T20:25:49Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"d36f7f5b-7d0f-4e35-8a05-a253eaaad55b","creationTime":"2021-01-08T20:25:49Z"}]}},{"name":"dad19ede-1592-4d87-95ff-4e20c8a09de5","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/dad19ede-1592-4d87-95ff-4e20c8a09de5","properties":{"accountName":"clihzexbhh7tkjz","apiType":"Sql","creationTime":"2021-01-28T22:58:06Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"a2c2b55a-9cda-4aad-b75a-bfd34647818f","creationTime":"2021-01-28T22:58:06Z"}]}},{"name":"16e57fca-6555-4c92-bb57-1afa38d69371","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/16e57fca-6555-4c92-bb57-1afa38d69371","properties":{"accountName":"clikbicro7ly5p2","apiType":"MongoDB","creationTime":"2021-01-16T01:25:45Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"9688f6b2-7410-4ae1-bd8b-1de6a0edcdca","creationTime":"2021-01-16T01:25:46Z"}]}},{"name":"28bc2837-a17f-4038-8569-7ffb33794333","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/28bc2837-a17f-4038-8569-7ffb33794333","properties":{"accountName":"cliweraslfbdxmi","apiType":"MongoDB","creationTime":"2021-01-28T22:55:58Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"8614d5c7-d9bf-4e5b-9d0c-62731c7d45c4","creationTime":"2021-01-28T22:55:59Z"}]}},{"name":"7346d3b4-8657-441b-8661-c1eb1071b700","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/7346d3b4-8657-441b-8661-c1eb1071b700","properties":{"accountName":"cli000003","apiType":"Sql","creationTime":"2021-01-28T22:58:07Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"767353e5-3784-43ee-ba9c-76e7e83db6e7","creationTime":"2021-01-28T22:58:08Z"}]}},{"name":"31869788-6f92-47f9-8f8b-6619582d2381","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/31869788-6f92-47f9-8f8b-6619582d2381","properties":{"accountName":"cosmosdb-1212","apiType":"Sql","creationTime":"2021-01-08T02:05:37Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"62ff38d6-4f2d-4c43-8c9d-17258a38ad81","creationTime":"2021-01-08T02:05:37Z"}]}},{"name":"5c84891d-ee24-4dc7-aa2b-d8968baf7936","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/5c84891d-ee24-4dc7-aa2b-d8968baf7936","properties":{"accountName":"gskcssdemo","apiType":"Sql","creationTime":"2020-12-14T21:53:52Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"21f8bb0a-9b6d-4d79-b305-82f555946c5f","creationTime":"2020-12-14T21:53:53Z"}]}},{"name":"cc9b5676-f21b-4bd4-b3d9-26ded6884aaa","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/cc9b5676-f21b-4bd4-b3d9-26ded6884aaa","properties":{"accountName":"gskcssdemo-r1","apiType":"Sql","creationTime":"2021-01-15T05:24:40Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"11da6634-3b4d-4b81-99ef-04d8b4d7410d","creationTime":"2021-01-15T05:24:40Z"}]}},{"name":"d92d948a-afb9-4bb3-9a4c-d6b8fcf8d204","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d92d948a-afb9-4bb3-9a4c-d6b8fcf8d204","properties":{"accountName":"kal-continuous","apiType":"Sql","creationTime":"2020-08-05T01:00:25Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"c28cc815-caba-4bd3-9402-6c8ec362efe6","creationTime":"2020-08-05T01:00:26Z"},{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"cc0bacf7-91d0-4c4b-95ff-2479327f0866","creationTime":"2020-08-05T01:12:03Z"},{"locationName":"South
+        Central US","regionalDatabaseAccountInstanceId":"6fc9f211-8f76-4c29-9edc-f82ee8c5211a","creationTime":"2020-08-23T01:34:11Z"}]}},{"name":"11d8ee78-2502-4ad6-becd-291aef9ac258","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/11d8ee78-2502-4ad6-becd-291aef9ac258","properties":{"accountName":"kal-continuous-dedicated-test","apiType":"Sql","creationTime":"2020-10-05T23:45:26Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"543c99f9-7bc2-4b55-9732-9733b981341f","creationTime":"2020-10-05T23:45:27Z"}]}},{"name":"ed1b5536-d225-4af9-bf33-71ff5fc8ef4b","location":"South
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/southcentralus/restorableDatabaseAccounts/ed1b5536-d225-4af9-bf33-71ff5fc8ef4b","properties":{"accountName":"kal-dedicated-test","apiType":"Sql","creationTime":"2020-10-05T23:57:45Z","restorableLocations":[{"locationName":"South
+        Central US","regionalDatabaseAccountInstanceId":"ff8bf7b0-f9c3-461c-8c13-26e94ac4c2bc","creationTime":"2020-10-05T23:57:46Z"}]}},{"name":"15ba6ca5-a356-4e90-b17e-71b9226d3566","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/15ba6ca5-a356-4e90-b17e-71b9226d3566","properties":{"accountName":"lisarestore1","apiType":"Sql","creationTime":"2021-01-08T22:12:16Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"3e848a1c-29b9-4627-889f-37c12a3c56fd","creationTime":"2021-01-08T22:12:16Z"}]}},{"name":"bbff0620-ef73-4071-9554-15e460f25e84","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/bbff0620-ef73-4071-9554-15e460f25e84","properties":{"accountName":"lisarestore2","apiType":"Sql","creationTime":"2021-01-08T22:23:52Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"8d3f47b6-7337-43c4-aaf3-59b0fa3720fd","creationTime":"2021-01-08T22:23:52Z"}]}},{"name":"47e6f98d-41c0-44f7-b0db-62ec4f1eec01","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/47e6f98d-41c0-44f7-b0db-62ec4f1eec01","properties":{"accountName":"lisarestore3","apiType":"Sql","creationTime":"2021-01-08T22:25:55Z","restorableLocations":[{"locationName":"Australia
+        Southeast","regionalDatabaseAccountInstanceId":"d62f91a9-8177-4cfb-88bb-647538637100","creationTime":"2021-01-08T22:25:55Z"}]}},{"name":"098565ea-96cc-45f8-a0fb-efecf4517ba0","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/098565ea-96cc-45f8-a0fb-efecf4517ba0","properties":{"accountName":"lisarestore4","apiType":"Sql","creationTime":"2021-01-08T22:30:27Z","restorableLocations":[{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"a88f7ab5-2623-4ca5-b962-c22b7027c647","creationTime":"2021-01-08T22:30:27Z"}]}},{"name":"421f2916-5405-47a0-bbb8-398672c8b539","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/421f2916-5405-47a0-bbb8-398672c8b539","properties":{"accountName":"lisarestore5","apiType":"Sql","creationTime":"2021-01-08T22:39:29Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"8989da63-0d67-4fa6-bf5d-caaa4961445b","creationTime":"2021-01-08T22:39:29Z"}]}},{"name":"e24fd3a7-20ed-48ac-a50e-6284402a72b9","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/e24fd3a7-20ed-48ac-a50e-6284402a72b9","properties":{"accountName":"lisarestore6","apiType":"Sql","creationTime":"2021-01-08T22:41:21Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"c2d1bb47-6e39-4ad6-9b82-9717f8feac85","creationTime":"2021-01-08T22:41:21Z"}]}},{"name":"5ed72f8f-00db-484a-8b7a-c90d9874431d","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/5ed72f8f-00db-484a-8b7a-c90d9874431d","properties":{"accountName":"lisarestore7","apiType":"Sql","creationTime":"2021-01-08T22:44:37Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"9e111575-7289-463d-9368-a89d76d9dc6b","creationTime":"2021-01-08T22:44:37Z"}]}},{"name":"90e99bc6-8031-4f65-886e-32628f7af45a","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/90e99bc6-8031-4f65-886e-32628f7af45a","properties":{"accountName":"lisarestore8b","apiType":"Sql","creationTime":"2021-01-08T23:17:40Z","restorableLocations":[{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"2ad74ba2-c366-461c-940b-02e0c5017422","creationTime":"2021-01-08T23:17:40Z"}]}},{"name":"1e2bec8e-adcc-4c5a-aa5b-82091d6c8a37","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1e2bec8e-adcc-4c5a-aa5b-82091d6c8a37","properties":{"accountName":"pitracctdemo2","apiType":"Sql","creationTime":"2020-08-11T02:34:23Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"7419408f-e6af-4596-a76b-c31ca62a54ca","creationTime":"2020-08-11T02:34:24Z"}]}},{"name":"38562595-c786-4560-a297-370226ed1450","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/38562595-c786-4560-a297-370226ed1450","properties":{"accountName":"pitrb-subbanna","apiType":"Sql","creationTime":"2021-01-18T06:12:43Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"0a2f53ac-1920-4f18-aae4-19c496a7e923","creationTime":"2021-01-18T06:12:43Z"}]}},{"name":"7133a59a-d1c0-4645-a699-6e296d6ac865","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/7133a59a-d1c0-4645-a699-6e296d6ac865","properties":{"accountName":"pitrbb-ankshah-ps-1","apiType":"Sql","creationTime":"2021-01-08T23:34:12Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"f02df26b-c0ec-4829-8bef-3482d36e6230","creationTime":"2021-01-08T23:34:12Z"}]}},{"name":"d6f96f0e-4b4e-4823-8a95-e59c688a00e2","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d6f96f0e-4b4e-4823-8a95-e59c688a00e2","properties":{"accountName":"pitrbb-ankshah-ps-6","apiType":"Sql","creationTime":"2021-01-08T23:58:46Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"6148981d-a65f-45b1-80f9-a26302e5214b","creationTime":"2021-01-08T23:58:46Z"}]}},{"name":"fcade1ce-4758-4d39-bbf8-8be7e9de50b2","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/fcade1ce-4758-4d39-bbf8-8be7e9de50b2","properties":{"accountName":"pitrbb-ankshah-ps-6-fixutc","apiType":"Sql","creationTime":"2021-01-09T00:26:43Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"5ac2a361-da75-47de-a13b-e4d9f0579e0c","creationTime":"2021-01-09T00:26:43Z"}]}},{"name":"0b32523b-4268-474d-a369-6888565ff043","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0b32523b-4268-474d-a369-6888565ff043","properties":{"accountName":"pitrbb-dech-sql-1","apiType":"Sql","creationTime":"2021-01-08T22:48:20Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"4d5edac2-df25-4a27-9bf4-e75a0b78af86","creationTime":"2021-01-08T22:48:20Z"}]}},{"name":"79659b7d-1049-4c79-9ba4-4fad8110181a","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/79659b7d-1049-4c79-9ba4-4fad8110181a","properties":{"accountName":"pitrbb-dech-sql-2","apiType":"Sql","creationTime":"2021-01-08T23:26:15Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"b5d55b81-59cf-4b14-9717-247a45438d45","creationTime":"2021-01-08T23:26:15Z"}]}},{"name":"5b213b47-99da-4b75-9eb2-4307e54ac28b","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/5b213b47-99da-4b75-9eb2-4307e54ac28b","properties":{"accountName":"pitrbb-dech-sql-3","apiType":"Sql","creationTime":"2021-01-08T23:32:11Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"0187813e-8bf5-43bd-a16f-e344c3d251fd","creationTime":"2021-01-08T23:32:11Z"}]}},{"name":"7a3b8026-9d25-4933-aa8f-726c63a0b9fd","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/7a3b8026-9d25-4933-aa8f-726c63a0b9fd","properties":{"accountName":"pitrbb-dech-sql-4","apiType":"Sql","creationTime":"2021-01-08T23:37:21Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"e57af9d0-1b1f-435f-b2c7-12199949b4a1","creationTime":"2021-01-08T23:37:21Z"}]}},{"name":"fc3ea677-0377-4004-923e-49f7e650cd0f","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/fc3ea677-0377-4004-923e-49f7e650cd0f","properties":{"accountName":"pitrbb-dech-sql-5","apiType":"Sql","creationTime":"2021-01-08T23:43:10Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"ae59cbb3-a365-405e-bd06-906bd01f3e16","creationTime":"2021-01-08T23:43:10Z"}]}},{"name":"3838563c-0364-4951-9728-4bb1a17266f8","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3838563c-0364-4951-9728-4bb1a17266f8","properties":{"accountName":"pitrbb-dech-sql-6","apiType":"Sql","creationTime":"2021-01-08T23:46:57Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"d75fc007-5da7-4d00-8811-6920ece49a33","creationTime":"2021-01-08T23:46:57Z"}]}},{"name":"7486c373-649e-4627-ad96-2d087ec06be1","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/7486c373-649e-4627-ad96-2d087ec06be1","properties":{"accountName":"pitrbb-dech-sql-7","apiType":"Sql","creationTime":"2021-01-08T23:53:32Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"a9a529c6-5ce1-49e9-9410-57be267c41c6","creationTime":"2021-01-08T23:53:32Z"}]}},{"name":"6fd844b3-71af-4e89-9b9d-f829945272bf","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6fd844b3-71af-4e89-9b9d-f829945272bf","properties":{"accountName":"pitrdemo1015","apiType":"Sql","creationTime":"2020-10-15T17:28:59Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"af26f717-b6ff-4eac-864c-17e759891ae8","creationTime":"2020-10-15T17:29:00Z"}]}},{"name":"3f392004-9f83-4ae9-ac1c-fa5f6542f245","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3f392004-9f83-4ae9-ac1c-fa5f6542f245","properties":{"accountName":"pitrdemorestored1015","apiType":"Sql","creationTime":"2020-10-15T17:37:20Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"2f4857ad-25c3-4e2f-883a-abe35c5f5e0c","creationTime":"2020-10-15T17:37:20Z"}]}},{"name":"74ebfb99-1914-4ea9-b802-736b5bda12a7","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/74ebfb99-1914-4ea9-b802-736b5bda12a7","properties":{"accountName":"pitrmongotest","apiType":"MongoDB","creationTime":"2020-10-01T17:27:22Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"73ef95f2-a338-4afc-8bb2-6fc3b0071d58","creationTime":"2020-10-01T17:27:23Z"}]}},{"name":"9905e7ca-6f2d-4b24-a4c5-8e7529036a74","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/9905e7ca-6f2d-4b24-a4c5-8e7529036a74","properties":{"accountName":"pitrmongotest-restore","apiType":"MongoDB","creationTime":"2020-10-01T21:24:45Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"75c41286-d7f2-4594-b9f2-87f6c9843cf8","creationTime":"2020-10-01T21:24:45Z"}]}},{"name":"a081024d-5e38-45c1-b1cb-9c99552d42b3","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a081024d-5e38-45c1-b1cb-9c99552d42b3","properties":{"accountName":"pitrmongowithsnapshots","apiType":"MongoDB","creationTime":"2021-01-07T19:45:07Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"cef7a5af-c690-49cd-b661-53f9241552bf","creationTime":"2021-01-07T19:45:07Z"}]}},{"name":"b4c688c1-2ea7-477e-b994-4affe5d3ea35","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b4c688c1-2ea7-477e-b994-4affe5d3ea35","properties":{"accountName":"ptr-target","apiType":"Sql","creationTime":"2021-01-05T22:25:24Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"1f68340e-49a4-45df-9a2a-804cd8ab1795","creationTime":"2021-01-05T22:25:24Z"}]}},{"name":"013b30aa-cf27-451a-b2b7-c8da950167c0","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/013b30aa-cf27-451a-b2b7-c8da950167c0","properties":{"accountName":"restored-cosmosdb-1212","apiType":"Sql","creationTime":"2021-01-08T08:12:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"84e252b7-8fe2-4976-bc64-bccc19511e44","creationTime":"2021-01-08T08:12:56Z"}]}},{"name":"eae0599c-2b32-4126-95f2-598dc4bf4ab9","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/eae0599c-2b32-4126-95f2-598dc4bf4ab9","properties":{"accountName":"restoredeleted","apiType":"Sql","creationTime":"2021-01-27T16:25:59Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"f1c5bdbf-77bb-4a9a-a4ff-39938c662029","creationTime":"2021-01-27T16:25:59Z"}]}},{"name":"0034883d-1a13-418f-9eaf-5dbbaabdd901","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0034883d-1a13-418f-9eaf-5dbbaabdd901","properties":{"accountName":"restoredeletedacct","apiType":"Sql","creationTime":"2021-01-08T22:46:18Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"514f853c-9454-44e7-a568-63823c7d25f0","creationTime":"2021-01-08T22:46:18Z"}]}},{"name":"1e9c8685-1f15-4b3b-ab1c-0ad505f0cd24","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1e9c8685-1f15-4b3b-ab1c-0ad505f0cd24","properties":{"accountName":"sivarv-test","apiType":"Sql","creationTime":"2021-01-05T23:13:23Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"83791770-489f-4272-9816-4d66377703c5","creationTime":"2021-01-05T23:13:23Z"}]}},{"name":"cc78ddc0-94a1-499d-8820-3b97ead9329d","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/cc78ddc0-94a1-499d-8820-3b97ead9329d","properties":{"accountName":"source-mongo36","apiType":"MongoDB","creationTime":"2021-01-05T21:12:59Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"c253e611-4c39-472e-b5fa-db7a7b5e1f0f","creationTime":"2021-01-05T21:12:59Z"},{"locationName":"North
+        Europe","regionalDatabaseAccountInstanceId":"1f4747a7-0698-4970-b81d-90257264f650","creationTime":"2021-01-05T22:35:50Z"},{"locationName":"Southeast
+        Asia","regionalDatabaseAccountInstanceId":"d5fab2ed-1caa-454c-a40a-98baba42f761","creationTime":"2021-01-05T22:49:00Z"}]}},{"name":"f37b13fb-cd2e-44da-929f-7db3ec82472f","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/f37b13fb-cd2e-44da-929f-7db3ec82472f","properties":{"accountName":"source-sql","apiType":"Sql","creationTime":"2021-01-05T21:27:08Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"c43022bd-9262-4421-a550-3566dda0191f","creationTime":"2021-01-05T21:27:09Z"},{"locationName":"Australia
+        Southeast","regionalDatabaseAccountInstanceId":"45e72c23-3fc3-45fa-8c05-444717f61eed","creationTime":"2021-01-05T22:14:59Z"},{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"bc1e9044-6d2f-4943-8a7f-1a0e345913ee","creationTime":"2021-01-05T21:38:36Z","deletionTime":"2021-01-05T22:25:59Z"}]}},{"name":"8ab61be5-bc16-408b-b33b-90a341eb00f8","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/8ab61be5-bc16-408b-b33b-90a341eb00f8","properties":{"accountName":"source-sql-cli0108-r1","apiType":"Sql","creationTime":"2021-01-08T23:00:22Z","restorableLocations":[{"locationName":"Australia
+        Southeast","regionalDatabaseAccountInstanceId":"18d3b111-3091-4c7b-9494-38d55cf6b591","creationTime":"2021-01-08T23:00:22Z"}]}},{"name":"97aecfb1-60ea-47eb-8ba6-b18a9d63d5ea","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/97aecfb1-60ea-47eb-8ba6-b18a9d63d5ea","properties":{"accountName":"source-sql-cli0108-r4","apiType":"Sql","creationTime":"2021-01-08T23:42:23Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"204031a3-e50f-4357-9e30-e0ed40d2edfe","creationTime":"2021-01-08T23:42:23Z"}]}},{"name":"44fd125a-9c78-43ec-a408-7bde337284d7","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/44fd125a-9c78-43ec-a408-7bde337284d7","properties":{"accountName":"source-sql-cli0108-r5","apiType":"Sql","creationTime":"2021-01-08T23:48:38Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"bcdbe26c-e95e-4d13-8ed2-65ed87835440","creationTime":"2021-01-08T23:48:38Z"}]}},{"name":"28c894c1-564c-4751-a581-0899fe982fb2","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/28c894c1-564c-4751-a581-0899fe982fb2","properties":{"accountName":"source-sql-cli0108-r6","apiType":"Sql","creationTime":"2021-01-09T00:10:01Z","restorableLocations":[{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"04fc930f-e6f4-4247-909b-a019fca6d3c3","creationTime":"2021-01-09T00:10:01Z"}]}},{"name":"e5d37ca0-4cad-4f68-8b01-798ab80d4e29","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/e5d37ca0-4cad-4f68-8b01-798ab80d4e29","properties":{"accountName":"source-sql-r1-all-dr1","apiType":"Sql","creationTime":"2021-01-06T00:38:07Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"b025ecf9-c5cb-4dd8-8808-ff91d5a3585d","creationTime":"2021-01-06T00:38:07Z"}]}},{"name":"c2725545-e90d-46e1-b952-3de18e28229d","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c2725545-e90d-46e1-b952-3de18e28229d","properties":{"accountName":"source-sql-r1-procol1","apiType":"Sql","creationTime":"2021-01-05T22:57:00Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"1a218afa-4d6e-4a9e-8dcb-c50e811b921d","creationTime":"2021-01-05T22:57:00Z"}]}},{"name":"360f37cf-0874-4d58-9cf8-fd5f3fc87d07","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/360f37cf-0874-4d58-9cf8-fd5f3fc87d07","properties":{"accountName":"source-sql-restored-kal-1","apiType":"Sql","creationTime":"2021-01-25T22:47:07Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"6e9003ca-f7f7-482a-8bcc-e7ecb383cce7","creationTime":"2021-01-25T22:47:07Z"}]}},{"name":"23e99a35-cd36-4df4-9614-f767a03b9995","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/23e99a35-cd36-4df4-9614-f767a03b9995","properties":{"accountName":"subbannageeta","apiType":"Sql","creationTime":"2020-08-08T01:04:53Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"30701557-ecf8-43ce-8810-2c8be01dccf9","creationTime":"2020-08-08T01:04:53Z"},{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"8283b088-b67d-4975-bfbe-0705e3e7a599","creationTime":"2020-08-08T01:15:44Z"}]}},{"name":"a97044b4-5be9-4f17-acc5-05bd58f0156e","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a97044b4-5be9-4f17-acc5-05bd58f0156e","properties":{"accountName":"target-mongo36-beforecolla","apiType":"MongoDB","creationTime":"2021-01-06T00:06:55Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"4af906ad-1a4a-4eb7-8453-f6cd8c795e91","creationTime":"2021-01-06T00:06:55Z"}]}},{"name":"1e88cc09-a8d1-4c02-b3bc-45621aa14532","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1e88cc09-a8d1-4c02-b3bc-45621aa14532","properties":{"accountName":"targetacct","apiType":"Sql","creationTime":"2021-01-27T16:27:39Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"a6b133b0-11d9-49c6-b747-7e81b8ca91d0","creationTime":"2021-01-27T16:27:39Z"}]}},{"name":"2cfb9266-6837-4c5c-b7ae-ec8e72913cd1","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/2cfb9266-6837-4c5c-b7ae-ec8e72913cd1","properties":{"accountName":"test-bk-cont-restore1","apiType":"Sql","creationTime":"2020-10-15T23:55:03Z","restorableLocations":[{"locationName":"South
+        Central US","regionalDatabaseAccountInstanceId":"a1893351-8aa8-4ff0-8457-47ce4e6c2790","creationTime":"2020-10-15T23:55:03Z"}]}},{"name":"05640131-c5c8-4d30-adec-aa623e28866b","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/05640131-c5c8-4d30-adec-aa623e28866b","properties":{"accountName":"test-cli2loqd5ro7y4w-restore-del","apiType":"Sql","creationTime":"2021-01-08T01:37:39Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"d137f5e4-3154-43fd-9f16-179b6c9bb8fa","creationTime":"2021-01-08T01:37:39Z"}]}},{"name":"c51d3c61-fa49-426f-96d0-77dd6c8592f4","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c51d3c61-fa49-426f-96d0-77dd6c8592f4","properties":{"accountName":"test-pitr-restore3","apiType":"Sql","creationTime":"2021-01-06T09:26:15Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"a9153da9-30fe-44bf-beaf-6ad266823926","creationTime":"2021-01-06T09:26:15Z"}]}},{"name":"329aedaa-1997-4c0d-b3c9-40e890c3dc08","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/329aedaa-1997-4c0d-b3c9-40e890c3dc08","properties":{"accountName":"test-restore-pitr1","apiType":"Sql","creationTime":"2021-01-06T09:20:17Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"20d74db9-927d-4e1c-9944-5386a9ce1eda","creationTime":"2021-01-06T09:20:17Z"}]}},{"name":"c914554e-5881-4048-b427-240d3c9ffda6","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c914554e-5881-4048-b427-240d3c9ffda6","properties":{"accountName":"test-restore-pitr2","apiType":"Sql","creationTime":"2021-01-06T09:23:25Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"7f2f80b7-20ec-47ce-a2eb-f9143781908b","creationTime":"2021-01-06T09:23:25Z"}]}},{"name":"7ccb546f-804d-4fe3-902f-bdb162d2ca51","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/7ccb546f-804d-4fe3-902f-bdb162d2ca51","properties":{"accountName":"virangai-test-pitr-restore-del","apiType":"Sql","creationTime":"2020-12-10T02:06:22Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"fbbdcce1-e4cc-4fb9-8a5c-64f96438e722","creationTime":"2020-12-10T02:06:22Z"}]}},{"name":"26c6c802-2477-422f-b3a0-9da58299b82e","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/26c6c802-2477-422f-b3a0-9da58299b82e","properties":{"accountName":"virangai-test-pitr-restore-del-restore","apiType":"Sql","creationTime":"2021-01-08T00:50:35Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"9eaed152-86f9-4576-b201-2301ea9e9719","creationTime":"2021-01-08T00:50:35Z"}]}},{"name":"e89306b9-137a-4293-b692-263bb3406366","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/e89306b9-137a-4293-b692-263bb3406366","properties":{"accountName":"virangai-test-pitr-restore-del-restore1","apiType":"Sql","creationTime":"2021-01-08T01:07:16Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"2e16165a-c3f1-44c5-99a7-bef5e8a2311f","creationTime":"2021-01-08T01:07:16Z"}]}},{"name":"adc221c8-8826-4d48-8c8d-af48be84b678","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/adc221c8-8826-4d48-8c8d-af48be84b678","properties":{"accountName":"virangai-test-pitr-restore-del-restore2","apiType":"Sql","creationTime":"2021-01-08T01:12:07Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"e6c2237b-56a2-4e27-9ba5-d3da7d136504","creationTime":"2021-01-08T01:12:07Z"}]}},{"name":"b2bcdd92-0b33-4574-ba6e-56f1b3e346e4","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b2bcdd92-0b33-4574-ba6e-56f1b3e346e4","properties":{"accountName":"virangai-test-pitr-restore-del-restore3","apiType":"Sql","creationTime":"2021-01-08T01:15:26Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"75d75dd1-21da-47d0-bc25-fa01c0e3ed3e","creationTime":"2021-01-08T01:15:26Z"}]}},{"name":"e96a653a-cc5e-49f0-a3ae-36a4d461cf07","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/e96a653a-cc5e-49f0-a3ae-36a4d461cf07","properties":{"accountName":"virangai-test-pitr-restore-del-restore4","apiType":"Sql","creationTime":"2021-01-08T01:36:22Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"e59deecb-9222-4a80-b5d4-09af4a886f55","creationTime":"2021-01-08T01:36:22Z"}]}},{"name":"bb466093-aad0-4e58-8ae5-94c4b48caa3d","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/bb466093-aad0-4e58-8ae5-94c4b48caa3d","properties":{"accountName":"virangai-test-pitr-restore-del1","apiType":"Sql","creationTime":"2021-01-08T20:19:57Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"f14d0c9e-ac38-4809-b5f3-f7c37d712012","creationTime":"2021-01-08T20:19:57Z"}]}},{"name":"86db30d3-1725-4ece-b2f5-591ea37e14f9","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/86db30d3-1725-4ece-b2f5-591ea37e14f9","properties":{"accountName":"virangai-test-pitr-restore-del2","apiType":"Sql","creationTime":"2021-01-08T20:20:20Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"36f57e91-674e-49d0-891a-f4be394b8e3a","creationTime":"2021-01-08T20:20:20Z"}]}},{"name":"baf212fa-867f-4979-a007-4db919a87868","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/baf212fa-867f-4979-a007-4db919a87868","properties":{"accountName":"virangai-test-pitr-restore-del5","apiType":"Sql","creationTime":"2021-01-08T20:23:32Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"76ee28bb-12d9-4829-a473-cb5e29ad9a55","creationTime":"2021-01-08T20:23:32Z"}]}},{"name":"0278f25e-74d3-432c-9bef-8af67bb0d2c0","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0278f25e-74d3-432c-9bef-8af67bb0d2c0","properties":{"accountName":"clizv5pcgzbsl7a","apiType":"Sql","creationTime":"2021-01-28T22:28:06Z","deletionTime":"2021-01-28T22:29:41Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"4f5f85bb-a229-472f-89dc-33115193e985","creationTime":"2021-01-28T22:28:06Z","deletionTime":"2021-01-28T22:29:41Z"}]}},{"name":"0651d578-4267-432f-9b14-e829f7b55ca8","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0651d578-4267-432f-9b14-e829f7b55ca8","properties":{"accountName":"cliemi42xntjcpg","apiType":"Sql","creationTime":"2021-01-28T22:55:24Z","deletionTime":"2021-01-28T22:56:59Z","restorableLocations":[]}},{"name":"08f8360d-830d-4e8b-ab58-c4bdefe180a1","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/08f8360d-830d-4e8b-ab58-c4bdefe180a1","properties":{"accountName":"clij264u6pvpgg5","apiType":"Sql","creationTime":"2021-01-28T22:55:23Z","deletionTime":"2021-01-28T22:56:58Z","restorableLocations":[]}},{"name":"1ac1ade1-7f87-4764-81d4-61e2bf271d1c","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1ac1ade1-7f87-4764-81d4-61e2bf271d1c","properties":{"accountName":"restored-cosmosdb-1212","apiType":"Sql","creationTime":"2021-01-07T02:45:14Z","deletionTime":"2021-01-07T06:37:29Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"8cad4147-b0e8-43d0-bb4c-2562d435daf0","creationTime":"2021-01-07T02:45:14Z","deletionTime":"2021-01-07T06:37:29Z"}]}},{"name":"20e131eb-6e59-403d-afe6-5cd5687b06f3","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/20e131eb-6e59-403d-afe6-5cd5687b06f3","properties":{"accountName":"clicjskuodwwh4y","apiType":"Sql","creationTime":"2021-01-28T22:55:30Z","deletionTime":"2021-01-28T22:56:57Z","restorableLocations":[]}},{"name":"2e57506a-6aa1-4a3a-8a2b-b46d1be47d3a","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/2e57506a-6aa1-4a3a-8a2b-b46d1be47d3a","properties":{"accountName":"clilet52fhyl5fe","apiType":"MongoDB","creationTime":"2021-01-16T01:19:20Z","deletionTime":"2021-01-16T01:20:03Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"3df175b1-d106-42c3-89e6-716bdfab208f","creationTime":"2021-01-16T01:19:21Z","deletionTime":"2021-01-16T01:20:03Z"}]}},{"name":"3183f258-d6c7-42da-9260-0345d7a5775d","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3183f258-d6c7-42da-9260-0345d7a5775d","properties":{"accountName":"mongo-continuous-1212","apiType":"MongoDB","creationTime":"2021-01-06T22:54:49Z","deletionTime":"2021-01-07T06:37:29Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"baf545cb-b632-4a1b-b9a8-8fec4a019c02","creationTime":"2021-01-06T22:54:49Z","deletionTime":"2021-01-07T06:37:29Z"}]}},{"name":"3325eb2c-3a59-4ebb-882f-27fe519f2253","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3325eb2c-3a59-4ebb-882f-27fe519f2253","properties":{"accountName":"pitracc","apiType":"Sql","creationTime":"2020-10-15T00:44:16Z","deletionTime":"2021-01-08T05:31:20Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"9b2e4539-1898-4f11-b568-5b72c913eb53","creationTime":"2020-10-15T06:41:52Z","deletionTime":"2021-01-08T05:31:20Z"},{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"b7cb54bc-b620-4d34-a004-11bda0dab218","creationTime":"2020-10-15T00:44:17Z","deletionTime":"2021-01-08T05:31:20Z"}]}},{"name":"651acce6-dd9b-4cb0-a236-444fa0760775","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/651acce6-dd9b-4cb0-a236-444fa0760775","properties":{"accountName":"continuous-db2121","apiType":"Sql","creationTime":"2020-08-06T21:04:16Z","deletionTime":"2021-01-07T06:37:29Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"7119a7d0-aab2-4dac-90d2-68880d3fa967","creationTime":"2020-08-06T21:04:17Z","deletionTime":"2021-01-07T06:37:29Z"}]}},{"name":"68592cbb-6b1d-45d5-92c4-5e768127801d","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/68592cbb-6b1d-45d5-92c4-5e768127801d","properties":{"accountName":"cliwgffp7vsxcnn","apiType":"MongoDB","creationTime":"2021-01-16T01:46:25Z","deletionTime":"2021-01-16T01:51:06Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"1ab48938-70a0-4233-9270-266ede1c697f","creationTime":"2021-01-16T01:46:26Z","deletionTime":"2021-01-16T01:51:06Z"}]}},{"name":"6a0b5950-99b7-4684-b296-8e1525b6a38f","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6a0b5950-99b7-4684-b296-8e1525b6a38f","properties":{"accountName":"sivarv-restored-sdb","apiType":"Sql","creationTime":"2021-01-05T23:29:51Z","deletionTime":"2021-01-06T00:16:23Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"cb909054-6a6f-4e06-811c-363bb5acd7d3","creationTime":"2021-01-05T23:29:51Z","deletionTime":"2021-01-06T00:16:23Z"}]}},{"name":"6f7de73f-d3aa-4b35-9bab-f4359a8415a5","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6f7de73f-d3aa-4b35-9bab-f4359a8415a5","properties":{"accountName":"vinhpitrrestored1015","apiType":"Sql","creationTime":"2020-10-15T16:08:39Z","deletionTime":"2021-01-08T05:31:30Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"2d731560-b500-49c7-ad88-acba387c072c","creationTime":"2020-10-15T16:08:39Z","deletionTime":"2021-01-08T05:31:30Z"}]}},{"name":"7781ad7c-a95f-4b8a-9a65-5b7e20292263","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/7781ad7c-a95f-4b8a-9a65-5b7e20292263","properties":{"accountName":"clirvbpeuorjlez","apiType":"Sql","creationTime":"2021-01-28T22:28:07Z","deletionTime":"2021-01-28T22:29:42Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"d04575bb-6713-48ed-9e2d-9d5d1d945dc1","creationTime":"2021-01-28T22:28:07Z","deletionTime":"2021-01-28T22:29:42Z"}]}},{"name":"780425ec-5b37-4661-ab56-bdeac3ca2763","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/780425ec-5b37-4661-ab56-bdeac3ca2763","properties":{"accountName":"continuous-db2332","apiType":"Sql","creationTime":"2020-08-06T22:43:01Z","deletionTime":"2021-01-07T06:37:29Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"4d097971-9228-459b-8687-e6016e34599e","creationTime":"2020-08-06T22:43:02Z","deletionTime":"2021-01-07T06:37:29Z"}]}},{"name":"8e9595e6-628e-4583-bbcb-e79b7594be6e","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/8e9595e6-628e-4583-bbcb-e79b7594be6e","properties":{"accountName":"source-sql-r1-all","apiType":"Sql","creationTime":"2021-01-05T23:53:13Z","deletionTime":"2021-01-06T00:12:22Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"0384eed4-096c-425d-b2c1-a081f254cf02","creationTime":"2021-01-05T23:53:13Z","deletionTime":"2021-01-06T00:12:22Z"}]}},{"name":"a18feb1f-15a9-4000-ade0-ffc81a16309c","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a18feb1f-15a9-4000-ade0-ffc81a16309c","properties":{"accountName":"restored2-cosmosdb-1212-1","apiType":"Sql","creationTime":"2021-01-07T01:55:14Z","deletionTime":"2021-01-07T06:37:29Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"3ab440db-4ae7-4ff2-8da1-dfdad6853a08","creationTime":"2021-01-07T01:55:14Z","deletionTime":"2021-01-07T06:37:29Z"}]}},{"name":"b27cbd07-72f0-4769-9bc7-8cfbe0523d29","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b27cbd07-72f0-4769-9bc7-8cfbe0523d29","properties":{"accountName":"continuous-db2121-r1","apiType":"Sql","creationTime":"2020-09-03T17:58:34Z","deletionTime":"2021-01-07T06:37:29Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"c800c27e-ec05-4656-9391-6e31f28e3e8b","creationTime":"2020-09-03T17:58:34Z","deletionTime":"2021-01-07T06:37:29Z"}]}},{"name":"bed4f838-b8ea-4998-a373-d71b28ae239d","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/bed4f838-b8ea-4998-a373-d71b28ae239d","properties":{"accountName":"cliwvj2gl4plqwc","apiType":"Sql","creationTime":"2021-01-28T22:28:07Z","deletionTime":"2021-01-28T22:29:42Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"84e00b11-921a-4bee-bfa7-bcabbb63759c","creationTime":"2021-01-28T22:28:07Z","deletionTime":"2021-01-28T22:29:42Z"}]}},{"name":"d412cde0-dcee-4e6c-9e8f-69770224be1a","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d412cde0-dcee-4e6c-9e8f-69770224be1a","properties":{"accountName":"restored2-continuous-db2121-2","apiType":"Sql","creationTime":"2020-08-07T18:16:30Z","deletionTime":"2021-01-07T06:37:29Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"a52cc373-6f32-4feb-b28b-15c0bb9842c3","creationTime":"2020-08-07T18:16:30Z","deletionTime":"2021-01-07T06:37:29Z"}]}},{"name":"e27e7197-8a10-4082-808f-bdd67fc65d93","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/e27e7197-8a10-4082-808f-bdd67fc65d93","properties":{"accountName":"sivarv-pitr-test","apiType":"Sql","creationTime":"2021-01-05T21:32:38Z","deletionTime":"2021-01-05T22:26:13Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"a948a101-396b-4c50-83a3-73b01d1c52db","creationTime":"2021-01-05T21:32:38Z","deletionTime":"2021-01-05T22:26:13Z"}]}},{"name":"e333d05f-7c78-41cb-842f-a543f2eb9116","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/e333d05f-7c78-41cb-842f-a543f2eb9116","properties":{"accountName":"cosmosdb-1212","apiType":"Sql","creationTime":"2021-01-06T22:26:11Z","deletionTime":"2021-01-07T06:37:29Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"4a41012e-3313-4825-8064-da2a6f6da7fb","creationTime":"2021-01-06T22:26:11Z","deletionTime":"2021-01-07T06:37:29Z"}]}},{"name":"eeb45f7f-4c05-4b52-9f42-6807d8eb8703","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/eeb45f7f-4c05-4b52-9f42-6807d8eb8703","properties":{"accountName":"powershell-restore","apiType":"Sql","creationTime":"2020-08-10T19:20:14Z","deletionTime":"2021-01-07T06:37:29Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"3cd8b081-4b95-47d8-86f5-a17da18e3b88","creationTime":"2020-08-10T19:20:14Z","deletionTime":"2021-01-07T06:37:29Z"}]}},{"name":"f780ef6c-1fea-4a6a-9c33-784bf8a52edd","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/f780ef6c-1fea-4a6a-9c33-784bf8a52edd","properties":{"accountName":"restored-continuous-db2121-1","apiType":"Sql","creationTime":"2020-08-07T17:55:45Z","deletionTime":"2021-01-07T06:37:29Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"ce739365-8e46-4e12-81e5-9ba7f7ee5ff9","creationTime":"2020-08-07T17:55:45Z","deletionTime":"2021-01-07T06:37:29Z"}]}},{"name":"c0291614-213c-4629-a26a-12802ca1b761","location":"West
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/c0291614-213c-4629-a26a-12802ca1b761","properties":{"accountName":"virangai-test-mongo-pitr","creationTime":"2020-11-24T21:46:06.459782Z","apiType":"MongoDB","restorableLocations":[{"locationName":"West
-        US 2","creationTime":"2020-11-24T21:46:07.1249476Z","regionalDatabaseAccountInstanceId":"12e12ed9-5da1-4a35-9ecf-09dff1515d58"}]}},{"name":"7ccb546f-804d-4fe3-902f-bdb162d2ca51","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/7ccb546f-804d-4fe3-902f-bdb162d2ca51","properties":{"accountName":"virangai-test-pitr-restore-del","creationTime":"2020-12-10T02:06:21.2690247Z","apiType":"Sql","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-12-10T02:06:21.2690247Z","regionalDatabaseAccountInstanceId":"fbbdcce1-e4cc-4fb9-8a5c-64f96438e722"}]}},{"name":"02cf4c6e-8c16-48ed-9626-e135a1e3fc01","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/02cf4c6e-8c16-48ed-9626-e135a1e3fc01","properties":{"accountName":"cli6sjyklw2shv5","creationTime":"2020-12-10T22:11:55.0479455Z","apiType":"Sql","deletionTime":"2020-12-10T22:16:27.9464018Z","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-12-10T22:11:55.8079602Z","deletionTime":"2020-12-10T22:16:27.9464018Z","regionalDatabaseAccountInstanceId":"244e1781-aead-45ba-b987-06d7cf9d9016"}]}},{"name":"0f15c95d-762e-465d-a31c-a66b9d880bfc","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0f15c95d-762e-465d-a31c-a66b9d880bfc","properties":{"accountName":"virangai-test-pitr-restore1","creationTime":"2020-11-17T23:20:50.6676642Z","apiType":"Sql","deletionTime":"2020-11-19T07:21:17.9581005Z","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-11-17T23:20:50.6676642Z","deletionTime":"2020-11-19T07:21:17.9581005Z","regionalDatabaseAccountInstanceId":"718a2356-4556-4d54-90fb-b8c65b065d38"}]}},{"name":"1d16299c-e79e-4130-9647-1fa47f738892","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1d16299c-e79e-4130-9647-1fa47f738892","properties":{"accountName":"clid4bvkfsumrnr","creationTime":"2020-12-10T21:41:44.7967591Z","apiType":"MongoDB","deletionTime":"2020-12-10T21:46:01.404794Z","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-12-10T21:41:45.8387477Z","deletionTime":"2020-12-10T21:46:01.404794Z","regionalDatabaseAccountInstanceId":"0583b6dc-1c55-4786-be03-8a5ecc6ff7b1"}]}},{"name":"352dffff-44ea-4189-91e3-56ecc28ab6f3","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/352dffff-44ea-4189-91e3-56ecc28ab6f3","properties":{"accountName":"cliexqjj6kvornz","creationTime":"2020-12-14T04:14:26.6871551Z","apiType":"Sql","deletionTime":"2020-12-14T04:15:30.0463177Z","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-12-14T04:14:26.6871551Z","deletionTime":"2020-12-14T04:15:30.0463177Z","regionalDatabaseAccountInstanceId":"1fab8739-9782-420e-81b3-052c273d233e"}]}},{"name":"4fae7f97-17a8-4e16-b1ec-c403112381e1","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/4fae7f97-17a8-4e16-b1ec-c403112381e1","properties":{"accountName":"virangai-test-pitr","creationTime":"2020-11-17T05:43:36.9551156Z","apiType":"Sql","deletionTime":"2020-11-19T07:24:27.2721258Z","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-11-17T05:43:37.7451168Z","deletionTime":"2020-11-19T07:24:27.2721258Z","regionalDatabaseAccountInstanceId":"09b126d6-b6f2-490f-8ab9-71fab19bde3a"}]}},{"name":"5c8a5401-1159-40cc-9e1d-99af7c7bc289","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/5c8a5401-1159-40cc-9e1d-99af7c7bc289","properties":{"accountName":"clilm56fyqbjl2a","creationTime":"2020-12-14T03:53:12.2321417Z","apiType":"Sql","deletionTime":"2020-12-14T04:15:29.2266642Z","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-12-14T03:53:12.9771426Z","deletionTime":"2020-12-14T04:15:29.2266642Z","regionalDatabaseAccountInstanceId":"63446e97-a8fb-4373-b0fd-57bd2d700bfa"}]}},{"name":"5fdb9f12-f0ec-4600-85c2-bc747a65a794","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/5fdb9f12-f0ec-4600-85c2-bc747a65a794","properties":{"accountName":"cliddnyz7svsjkw","creationTime":"2020-12-10T20:04:05.7748719Z","apiType":"MongoDB","deletionTime":"2020-12-10T20:06:37.8091556Z","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-12-10T20:04:06.5848765Z","deletionTime":"2020-12-10T20:06:37.8091556Z","regionalDatabaseAccountInstanceId":"15115e15-54a6-4798-9492-9021583f9449"}]}},{"name":"7f6eb33c-2b17-44f5-a956-0acd1bd9437d","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/7f6eb33c-2b17-44f5-a956-0acd1bd9437d","properties":{"accountName":"clie4ftgf4chlgo","creationTime":"2020-12-10T22:08:58.6534483Z","apiType":"MongoDB","deletionTime":"2020-12-10T22:13:41.7778806Z","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-12-10T22:08:59.5384495Z","deletionTime":"2020-12-10T22:13:41.7778806Z","regionalDatabaseAccountInstanceId":"3ff2c3f0-9ee9-4010-980b-2e5f48066f75"}]}},{"name":"8547cf42-c6b3-40c4-8803-5f9028ebf8b9","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/8547cf42-c6b3-40c4-8803-5f9028ebf8b9","properties":{"accountName":"cliv27tkdmumnms","creationTime":"2020-12-09T23:55:23.3285739Z","apiType":"MongoDB","deletionTime":"2020-12-09T23:56:36.6896944Z","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-12-09T23:55:25.0086107Z","deletionTime":"2020-12-09T23:56:36.6896944Z","regionalDatabaseAccountInstanceId":"50ba6bf9-62df-42c0-b86e-7d2e5f7e1dcf"}]}},{"name":"9b2e1fd4-16b5-42c6-b1a7-106d5854e6bb","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/9b2e1fd4-16b5-42c6-b1a7-106d5854e6bb","properties":{"accountName":"clia4mcsvr7ks4h","creationTime":"2020-12-09T23:34:23.0830227Z","apiType":"Sql","deletionTime":"2020-12-09T23:35:35.022734Z","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-12-09T23:34:24.16302Z","deletionTime":"2020-12-09T23:35:35.022734Z","regionalDatabaseAccountInstanceId":"d7cc4411-8e9a-4e5d-a013-7e7add065426"}]}},{"name":"9df51477-54dc-4b4f-905f-1ed43537317f","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/9df51477-54dc-4b4f-905f-1ed43537317f","properties":{"accountName":"clibqfjknjmazv2","creationTime":"2020-12-10T21:05:11.5937687Z","apiType":"MongoDB","deletionTime":"2020-12-10T21:09:42.3504596Z","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-12-10T21:05:12.7519752Z","deletionTime":"2020-12-10T21:09:42.3504596Z","regionalDatabaseAccountInstanceId":"491d82d1-4212-4dcd-b96e-a8eda0082222"}]}},{"name":"b4069826-61d2-4e50-aa0d-2cd03d81642c","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b4069826-61d2-4e50-aa0d-2cd03d81642c","properties":{"accountName":"clipfj35yw42xny","creationTime":"2020-12-10T00:45:43.8449527Z","apiType":"MongoDB","deletionTime":"2020-12-10T00:47:06.4394815Z","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-12-10T00:45:44.6499584Z","deletionTime":"2020-12-10T00:47:06.4394815Z","regionalDatabaseAccountInstanceId":"9da90b42-f7b3-48bb-8512-66be68306d10"}]}},{"name":"c05c602b-ab23-4a18-84e9-290d58baacbf","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c05c602b-ab23-4a18-84e9-290d58baacbf","properties":{"accountName":"clipop7ki4e6xqj","creationTime":"2020-12-10T21:44:27.2688628Z","apiType":"Sql","deletionTime":"2020-12-10T21:48:55.2953289Z","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-12-10T21:44:28.1288929Z","deletionTime":"2020-12-10T21:48:55.2953289Z","regionalDatabaseAccountInstanceId":"f0c11f0f-89cc-4b0d-b752-ea0077244dfc"}]}},{"name":"c4b9598a-0ebc-4f67-8fac-2b21a77155a7","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c4b9598a-0ebc-4f67-8fac-2b21a77155a7","properties":{"accountName":"viragai-test-pitr-restore","creationTime":"2020-11-17T08:02:02.2299935Z","apiType":"Sql","deletionTime":"2020-11-17T23:08:08.3790553Z","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-11-17T08:02:02.2299935Z","deletionTime":"2020-11-17T23:08:08.3790553Z","regionalDatabaseAccountInstanceId":"63ec2eb9-1037-4785-8aee-fc7bcc71b2ea"}]}},{"name":"d3f80d92-65bc-4c29-9441-a9a048d304d7","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d3f80d92-65bc-4c29-9441-a9a048d304d7","properties":{"accountName":"cli2loqd5ro7y4w","creationTime":"2020-12-10T06:23:42.3337138Z","apiType":"Sql","deletionTime":"2020-12-10T06:30:25.9454783Z","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-12-10T06:23:43.6317337Z","deletionTime":"2020-12-10T06:30:25.9454783Z","regionalDatabaseAccountInstanceId":"c23c9314-e31d-47c5-a735-ba2b1b200adc"}]}},{"name":"dd81c490-1c9f-46e7-941c-4bc466d1aa57","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/dd81c490-1c9f-46e7-941c-4bc466d1aa57","properties":{"accountName":"clipvtgubbsmtym","creationTime":"2020-12-10T19:35:40.4977301Z","apiType":"MongoDB","deletionTime":"2020-12-10T19:37:24.8071209Z","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-12-10T19:35:41.337723Z","deletionTime":"2020-12-10T19:37:24.8071209Z","regionalDatabaseAccountInstanceId":"3ecbb255-c516-4620-868c-c05e49dc5fe1"}]}}]}'
+        US 2","creationTime":"2020-11-24T21:46:07.1249476Z","regionalDatabaseAccountInstanceId":"12e12ed9-5da1-4a35-9ecf-09dff1515d58"}]}},{"name":"c484bb25-9a8e-4c3e-9359-df5dd84c7f16","location":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/c484bb25-9a8e-4c3e-9359-df5dd84c7f16","properties":{"accountName":"virangai-test-pitr-sql","creationTime":"2021-01-16T01:05:59.1231999Z","apiType":"Sql","restorableLocations":[{"locationName":"West
+        US 2","creationTime":"2021-01-16T01:05:59.7287705Z","regionalDatabaseAccountInstanceId":"2f0ca6dc-a022-438e-9451-384c8ebdf50b"}]}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '24021'
+      - '57901'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 14 Dec 2020 04:48:49 GMT
+      - Thu, 28 Jan 2021 23:00:03 GMT
       expires:
       - '-1'
       pragma:
@@ -1443,6 +951,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-original-request-ids:
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
       - ''
       - ''
       - ''
@@ -1463,15 +976,15 @@ interactions:
       ParameterSetName:
       - -n -g --is-restore-request --restore-source --restore-timestamp
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-resource/12.0.0 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cosmosdb_restore_using_create000001?api-version=2020-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cosmosdb_restore_using_create000001?api-version=2020-10-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_using_create000001","name":"cli_test_cosmosdb_restore_using_create000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-12-14T04:39:23Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_using_create000001","name":"cli_test_cosmosdb_restore_using_create000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2021-01-28T22:57:14Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1480,7 +993,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 14 Dec 2020 04:52:50 GMT
+      - Thu, 28 Jan 2021 23:04:03 GMT
       expires:
       - '-1'
       pragma:
@@ -1498,8 +1011,8 @@ interactions:
     body: '{"location": "westus", "kind": "GlobalDocumentDB", "properties": {"locations":
       [{"locationName": "westus", "failoverPriority": 0, "isZoneRedundant": false}],
       "databaseAccountOfferType": "Standard", "apiProperties": {}, "createMode": "Restore",
-      "restoreParameters": {"restoreMode": "PointInTime", "restoreSource": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/e794d811-cb33-4f8c-a039-0409dfa6a840",
-      "restoreTimestampInUtc": "2020-12-14T04:51:04.730828Z"}}}'
+      "restoreParameters": {"restoreMode": "PointInTime", "restoreSource": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/7346d3b4-8657-441b-8661-c1eb1071b700",
+      "restoreTimestampInUtc": "2021-01-28T23:02:07.000Z"}}}'
     headers:
       Accept:
       - application/json
@@ -1510,14 +1023,14 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '537'
+      - '534'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
       - -n -g --is-restore-request --restore-source --restore-timestamp
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: PUT
@@ -1525,24 +1038,24 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_using_create000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004","name":"cli000004","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2020-12-14T04:52:59.8281056Z"},"properties":{"provisioningState":"Creating","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"8b4434d4-35a5-48dd-9988-89e998226fa9","createMode":"Restore","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-28T23:04:08.090751Z"},"properties":{"provisioningState":"Creating","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"67ec7d38-038b-4007-b3ba-f06425510dc6","createMode":"Restore","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000004-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/e794d811-cb33-4f8c-a039-0409dfa6a840","restoreTimestampInUtc":"2020-12-14T04:51:04.730828Z","databasesToRestore":[]}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/7346d3b4-8657-441b-8661-c1eb1071b700","restoreTimestampInUtc":"2021-01-28T23:02:07Z","databasesToRestore":[]}},"identity":{"type":"None"}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/bcb81128-f36e-4224-9433-3d783f0b14f4?api-version=2020-06-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d7d73283-7d14-40b4-823d-fd4e4ad6ef88?api-version=2020-06-01-preview
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2212'
+      - '2204'
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:53:00 GMT
+      - Thu, 28 Jan 2021 23:04:09 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_using_create000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004/operationResults/bcb81128-f36e-4224-9433-3d783f0b14f4?api-version=2020-06-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_using_create000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004/operationResults/d7d73283-7d14-40b4-823d-fd4e4ad6ef88?api-version=2020-06-01-preview
       pragma:
       - no-cache
       server:
@@ -1576,10 +1089,10 @@ interactions:
       ParameterSetName:
       - -n -g --is-restore-request --restore-source --restore-timestamp
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/bcb81128-f36e-4224-9433-3d783f0b14f4?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d7d73283-7d14-40b4-823d-fd4e4ad6ef88?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1591,7 +1104,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:53:31 GMT
+      - Thu, 28 Jan 2021 23:04:39 GMT
       pragma:
       - no-cache
       server:
@@ -1623,10 +1136,10 @@ interactions:
       ParameterSetName:
       - -n -g --is-restore-request --restore-source --restore-timestamp
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/bcb81128-f36e-4224-9433-3d783f0b14f4?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d7d73283-7d14-40b4-823d-fd4e4ad6ef88?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1638,7 +1151,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:54:01 GMT
+      - Thu, 28 Jan 2021 23:05:09 GMT
       pragma:
       - no-cache
       server:
@@ -1670,10 +1183,10 @@ interactions:
       ParameterSetName:
       - -n -g --is-restore-request --restore-source --restore-timestamp
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/bcb81128-f36e-4224-9433-3d783f0b14f4?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d7d73283-7d14-40b4-823d-fd4e4ad6ef88?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1685,7 +1198,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:54:32 GMT
+      - Thu, 28 Jan 2021 23:05:39 GMT
       pragma:
       - no-cache
       server:
@@ -1717,10 +1230,10 @@ interactions:
       ParameterSetName:
       - -n -g --is-restore-request --restore-source --restore-timestamp
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/bcb81128-f36e-4224-9433-3d783f0b14f4?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d7d73283-7d14-40b4-823d-fd4e4ad6ef88?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1732,7 +1245,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:55:02 GMT
+      - Thu, 28 Jan 2021 23:06:09 GMT
       pragma:
       - no-cache
       server:
@@ -1764,10 +1277,10 @@ interactions:
       ParameterSetName:
       - -n -g --is-restore-request --restore-source --restore-timestamp
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/bcb81128-f36e-4224-9433-3d783f0b14f4?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d7d73283-7d14-40b4-823d-fd4e4ad6ef88?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1779,7 +1292,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:55:33 GMT
+      - Thu, 28 Jan 2021 23:06:41 GMT
       pragma:
       - no-cache
       server:
@@ -1811,10 +1324,10 @@ interactions:
       ParameterSetName:
       - -n -g --is-restore-request --restore-source --restore-timestamp
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/bcb81128-f36e-4224-9433-3d783f0b14f4?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d7d73283-7d14-40b4-823d-fd4e4ad6ef88?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1826,7 +1339,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:56:03 GMT
+      - Thu, 28 Jan 2021 23:07:11 GMT
       pragma:
       - no-cache
       server:
@@ -1858,10 +1371,10 @@ interactions:
       ParameterSetName:
       - -n -g --is-restore-request --restore-source --restore-timestamp
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/bcb81128-f36e-4224-9433-3d783f0b14f4?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d7d73283-7d14-40b4-823d-fd4e4ad6ef88?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1873,7 +1386,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:56:33 GMT
+      - Thu, 28 Jan 2021 23:07:40 GMT
       pragma:
       - no-cache
       server:
@@ -1905,10 +1418,10 @@ interactions:
       ParameterSetName:
       - -n -g --is-restore-request --restore-source --restore-timestamp
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/bcb81128-f36e-4224-9433-3d783f0b14f4?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d7d73283-7d14-40b4-823d-fd4e4ad6ef88?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1920,7 +1433,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:57:03 GMT
+      - Thu, 28 Jan 2021 23:08:11 GMT
       pragma:
       - no-cache
       server:
@@ -1952,10 +1465,10 @@ interactions:
       ParameterSetName:
       - -n -g --is-restore-request --restore-source --restore-timestamp
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/bcb81128-f36e-4224-9433-3d783f0b14f4?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d7d73283-7d14-40b4-823d-fd4e4ad6ef88?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1967,7 +1480,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:57:35 GMT
+      - Thu, 28 Jan 2021 23:08:41 GMT
       pragma:
       - no-cache
       server:
@@ -1999,10 +1512,10 @@ interactions:
       ParameterSetName:
       - -n -g --is-restore-request --restore-source --restore-timestamp
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/bcb81128-f36e-4224-9433-3d783f0b14f4?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d7d73283-7d14-40b4-823d-fd4e4ad6ef88?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2014,7 +1527,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:58:05 GMT
+      - Thu, 28 Jan 2021 23:09:11 GMT
       pragma:
       - no-cache
       server:
@@ -2046,10 +1559,10 @@ interactions:
       ParameterSetName:
       - -n -g --is-restore-request --restore-source --restore-timestamp
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/bcb81128-f36e-4224-9433-3d783f0b14f4?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d7d73283-7d14-40b4-823d-fd4e4ad6ef88?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2061,7 +1574,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:58:36 GMT
+      - Thu, 28 Jan 2021 23:09:42 GMT
       pragma:
       - no-cache
       server:
@@ -2093,10 +1606,10 @@ interactions:
       ParameterSetName:
       - -n -g --is-restore-request --restore-source --restore-timestamp
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/bcb81128-f36e-4224-9433-3d783f0b14f4?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d7d73283-7d14-40b4-823d-fd4e4ad6ef88?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2108,7 +1621,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:59:06 GMT
+      - Thu, 28 Jan 2021 23:10:12 GMT
       pragma:
       - no-cache
       server:
@@ -2140,10 +1653,10 @@ interactions:
       ParameterSetName:
       - -n -g --is-restore-request --restore-source --restore-timestamp
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/bcb81128-f36e-4224-9433-3d783f0b14f4?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d7d73283-7d14-40b4-823d-fd4e4ad6ef88?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2155,7 +1668,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 04:59:37 GMT
+      - Thu, 28 Jan 2021 23:10:43 GMT
       pragma:
       - no-cache
       server:
@@ -2187,10 +1700,10 @@ interactions:
       ParameterSetName:
       - -n -g --is-restore-request --restore-source --restore-timestamp
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/bcb81128-f36e-4224-9433-3d783f0b14f4?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d7d73283-7d14-40b4-823d-fd4e4ad6ef88?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2202,7 +1715,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 05:00:06 GMT
+      - Thu, 28 Jan 2021 23:11:13 GMT
       pragma:
       - no-cache
       server:
@@ -2234,10 +1747,10 @@ interactions:
       ParameterSetName:
       - -n -g --is-restore-request --restore-source --restore-timestamp
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/bcb81128-f36e-4224-9433-3d783f0b14f4?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d7d73283-7d14-40b4-823d-fd4e4ad6ef88?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2249,7 +1762,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 05:00:37 GMT
+      - Thu, 28 Jan 2021 23:11:43 GMT
       pragma:
       - no-cache
       server:
@@ -2281,10 +1794,10 @@ interactions:
       ParameterSetName:
       - -n -g --is-restore-request --restore-source --restore-timestamp
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/bcb81128-f36e-4224-9433-3d783f0b14f4?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d7d73283-7d14-40b4-823d-fd4e4ad6ef88?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2296,7 +1809,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 05:01:08 GMT
+      - Thu, 28 Jan 2021 23:12:13 GMT
       pragma:
       - no-cache
       server:
@@ -2328,10 +1841,10 @@ interactions:
       ParameterSetName:
       - -n -g --is-restore-request --restore-source --restore-timestamp
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/bcb81128-f36e-4224-9433-3d783f0b14f4?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d7d73283-7d14-40b4-823d-fd4e4ad6ef88?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2343,7 +1856,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 05:01:38 GMT
+      - Thu, 28 Jan 2021 23:12:43 GMT
       pragma:
       - no-cache
       server:
@@ -2375,10 +1888,10 @@ interactions:
       ParameterSetName:
       - -n -g --is-restore-request --restore-source --restore-timestamp
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/bcb81128-f36e-4224-9433-3d783f0b14f4?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d7d73283-7d14-40b4-823d-fd4e4ad6ef88?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2390,7 +1903,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 05:02:09 GMT
+      - Thu, 28 Jan 2021 23:13:14 GMT
       pragma:
       - no-cache
       server:
@@ -2422,10 +1935,10 @@ interactions:
       ParameterSetName:
       - -n -g --is-restore-request --restore-source --restore-timestamp
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/bcb81128-f36e-4224-9433-3d783f0b14f4?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d7d73283-7d14-40b4-823d-fd4e4ad6ef88?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2437,7 +1950,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 05:02:39 GMT
+      - Thu, 28 Jan 2021 23:13:44 GMT
       pragma:
       - no-cache
       server:
@@ -2469,433 +1982,10 @@ interactions:
       ParameterSetName:
       - -n -g --is-restore-request --restore-source --restore-timestamp
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/bcb81128-f36e-4224-9433-3d783f0b14f4?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 05:03:10 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --is-restore-request --restore-source --restore-timestamp
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/bcb81128-f36e-4224-9433-3d783f0b14f4?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 05:03:40 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --is-restore-request --restore-source --restore-timestamp
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/bcb81128-f36e-4224-9433-3d783f0b14f4?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 05:04:10 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --is-restore-request --restore-source --restore-timestamp
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/bcb81128-f36e-4224-9433-3d783f0b14f4?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 05:04:42 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --is-restore-request --restore-source --restore-timestamp
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/bcb81128-f36e-4224-9433-3d783f0b14f4?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 05:05:12 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --is-restore-request --restore-source --restore-timestamp
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/bcb81128-f36e-4224-9433-3d783f0b14f4?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 05:05:42 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --is-restore-request --restore-source --restore-timestamp
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/bcb81128-f36e-4224-9433-3d783f0b14f4?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 05:06:12 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --is-restore-request --restore-source --restore-timestamp
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/bcb81128-f36e-4224-9433-3d783f0b14f4?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 05:06:43 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --is-restore-request --restore-source --restore-timestamp
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/bcb81128-f36e-4224-9433-3d783f0b14f4?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 14 Dec 2020 05:07:15 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --is-restore-request --restore-source --restore-timestamp
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/bcb81128-f36e-4224-9433-3d783f0b14f4?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d7d73283-7d14-40b4-823d-fd4e4ad6ef88?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -2907,7 +1997,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 05:07:45 GMT
+      - Thu, 28 Jan 2021 23:14:14 GMT
       pragma:
       - no-cache
       server:
@@ -2939,27 +2029,27 @@ interactions:
       ParameterSetName:
       - -n -g --is-restore-request --restore-source --restore-timestamp
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_using_create000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004?api-version=2020-06-01-preview
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_using_create000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004","name":"cli000004","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2020-12-14T05:07:33.0410837Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"8b4434d4-35a5-48dd-9988-89e998226fa9","createMode":"Restore","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-28T23:14:08.1674742Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"67ec7d38-038b-4007-b3ba-f06425510dc6","createMode":"Restore","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000004-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/e794d811-cb33-4f8c-a039-0409dfa6a840","restoreTimestampInUtc":"2020-12-14T04:51:04.730828Z","databasesToRestore":[]}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/7346d3b4-8657-441b-8661-c1eb1071b700","restoreTimestampInUtc":"2021-01-28T23:02:07Z","databasesToRestore":[]}},"identity":{"type":"None"}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2286'
+      - '2279'
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 05:07:45 GMT
+      - Thu, 28 Jan 2021 23:14:14 GMT
       pragma:
       - no-cache
       server:
@@ -2991,8 +2081,8 @@ interactions:
       ParameterSetName:
       - -n -g --is-restore-request --restore-source --restore-timestamp
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: GET
@@ -3000,20 +2090,20 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_using_create000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004","name":"cli000004","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2020-12-14T05:07:33.0410837Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"8b4434d4-35a5-48dd-9988-89e998226fa9","createMode":"Restore","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-28T23:14:08.1674742Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"67ec7d38-038b-4007-b3ba-f06425510dc6","createMode":"Restore","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000004-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/e794d811-cb33-4f8c-a039-0409dfa6a840","restoreTimestampInUtc":"2020-12-14T04:51:04.730828Z","databasesToRestore":[]}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/7346d3b4-8657-441b-8661-c1eb1071b700","restoreTimestampInUtc":"2021-01-28T23:02:07Z","databasesToRestore":[]}},"identity":{"type":"None"}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2286'
+      - '2279'
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 05:07:47 GMT
+      - Thu, 28 Jan 2021 23:14:16 GMT
       pragma:
       - no-cache
       server:
@@ -3045,8 +2135,8 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: GET
@@ -3054,20 +2144,20 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_using_create000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004","name":"cli000004","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2020-12-14T05:07:33.0410837Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"8b4434d4-35a5-48dd-9988-89e998226fa9","createMode":"Restore","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-28T23:14:08.1674742Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"67ec7d38-038b-4007-b3ba-f06425510dc6","createMode":"Restore","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000004-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/e794d811-cb33-4f8c-a039-0409dfa6a840","restoreTimestampInUtc":"2020-12-14T04:51:04.730828Z","databasesToRestore":[]}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/7346d3b4-8657-441b-8661-c1eb1071b700","restoreTimestampInUtc":"2021-01-28T23:02:07Z","databasesToRestore":[]}},"identity":{"type":"None"}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2286'
+      - '2279'
       content-type:
       - application/json
       date:
-      - Mon, 14 Dec 2020 05:07:47 GMT
+      - Thu, 28 Jan 2021 23:14:16 GMT
       pragma:
       - no-cache
       server:

--- a/src/cosmosdb-preview/azext_cosmosdb_preview/tests/latest/recordings/test_cosmosdb_sql_restorable_commands.yaml
+++ b/src/cosmosdb-preview/azext_cosmosdb_preview/tests/latest/recordings/test_cosmosdb_sql_restorable_commands.yaml
@@ -13,15 +13,15 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-resource/12.0.0 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cosmosdb_sql_restorable_commands000001?api-version=2020-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cosmosdb_sql_restorable_commands000001?api-version=2020-10-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_restorable_commands000001","name":"cli_test_cosmosdb_sql_restorable_commands000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-12-10T21:59:13Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_restorable_commands000001","name":"cli_test_cosmosdb_sql_restorable_commands000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2021-01-28T22:57:14Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -30,7 +30,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 10 Dec 2020 21:59:16 GMT
+      - Thu, 28 Jan 2021 22:57:16 GMT
       expires:
       - '-1'
       pragma:
@@ -65,8 +65,8 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: PUT
@@ -74,14 +74,14 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_restorable_commands000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004","name":"cli000004","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2020-12-10T21:59:18.3874203Z"},"properties":{"provisioningState":"Creating","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"02cf4c6e-8c16-48ed-9626-e135a1e3fc01","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-28T22:57:19.3966779Z"},"properties":{"provisioningState":"Creating","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"edf13eb4-5bcd-443c-802c-099edcb9b1c7","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
         US","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000004-westus","locationName":"West
         US","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000004-westus","locationName":"West
         US","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000004-westus","locationName":"West
         US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"}},"identity":{"type":"None"}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d307826b-cc2b-450f-8b8e-dad6e5467c28?api-version=2020-06-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/a17a7022-fc36-4fc4-9b73-0627af12db52?api-version=2020-06-01-preview
       cache-control:
       - no-store, no-cache
       content-length:
@@ -89,9 +89,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 21:59:18 GMT
+      - Thu, 28 Jan 2021 22:57:20 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_restorable_commands000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004/operationResults/d307826b-cc2b-450f-8b8e-dad6e5467c28?api-version=2020-06-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_restorable_commands000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004/operationResults/a17a7022-fc36-4fc4-9b73-0627af12db52?api-version=2020-06-01-preview
       pragma:
       - no-cache
       server:
@@ -125,10 +125,10 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d307826b-cc2b-450f-8b8e-dad6e5467c28?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/a17a7022-fc36-4fc4-9b73-0627af12db52?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -140,7 +140,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 21:59:49 GMT
+      - Thu, 28 Jan 2021 22:57:50 GMT
       pragma:
       - no-cache
       server:
@@ -172,10 +172,10 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d307826b-cc2b-450f-8b8e-dad6e5467c28?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/a17a7022-fc36-4fc4-9b73-0627af12db52?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -187,7 +187,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:00:19 GMT
+      - Thu, 28 Jan 2021 22:58:21 GMT
       pragma:
       - no-cache
       server:
@@ -219,1091 +219,10 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d307826b-cc2b-450f-8b8e-dad6e5467c28?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:00:50 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d307826b-cc2b-450f-8b8e-dad6e5467c28?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:01:20 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d307826b-cc2b-450f-8b8e-dad6e5467c28?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:01:51 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d307826b-cc2b-450f-8b8e-dad6e5467c28?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:02:22 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d307826b-cc2b-450f-8b8e-dad6e5467c28?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:02:51 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d307826b-cc2b-450f-8b8e-dad6e5467c28?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:03:22 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d307826b-cc2b-450f-8b8e-dad6e5467c28?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:03:53 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d307826b-cc2b-450f-8b8e-dad6e5467c28?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:04:23 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d307826b-cc2b-450f-8b8e-dad6e5467c28?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:04:54 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d307826b-cc2b-450f-8b8e-dad6e5467c28?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:05:24 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d307826b-cc2b-450f-8b8e-dad6e5467c28?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:05:55 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d307826b-cc2b-450f-8b8e-dad6e5467c28?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:06:25 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d307826b-cc2b-450f-8b8e-dad6e5467c28?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:06:56 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d307826b-cc2b-450f-8b8e-dad6e5467c28?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:07:27 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d307826b-cc2b-450f-8b8e-dad6e5467c28?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:07:57 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d307826b-cc2b-450f-8b8e-dad6e5467c28?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:08:28 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d307826b-cc2b-450f-8b8e-dad6e5467c28?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:08:58 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d307826b-cc2b-450f-8b8e-dad6e5467c28?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:09:29 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d307826b-cc2b-450f-8b8e-dad6e5467c28?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:09:59 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d307826b-cc2b-450f-8b8e-dad6e5467c28?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:10:30 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d307826b-cc2b-450f-8b8e-dad6e5467c28?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:11:00 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d307826b-cc2b-450f-8b8e-dad6e5467c28?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:11:31 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d307826b-cc2b-450f-8b8e-dad6e5467c28?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:12:00 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d307826b-cc2b-450f-8b8e-dad6e5467c28?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/a17a7022-fc36-4fc4-9b73-0627af12db52?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -1315,7 +234,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:12:31 GMT
+      - Thu, 28 Jan 2021 22:58:51 GMT
       pragma:
       - no-cache
       server:
@@ -1347,14 +266,14 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_restorable_commands000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004?api-version=2020-06-01-preview
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_restorable_commands000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004","name":"cli000004","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2020-12-10T22:11:55.0479455Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"02cf4c6e-8c16-48ed-9626-e135a1e3fc01","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-28T22:58:06.6618909Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"edf13eb4-5bcd-443c-802c-099edcb9b1c7","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000004-westus","locationName":"West
@@ -1367,7 +286,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:12:32 GMT
+      - Thu, 28 Jan 2021 22:58:51 GMT
       pragma:
       - no-cache
       server:
@@ -1399,8 +318,8 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: GET
@@ -1408,7 +327,7 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_restorable_commands000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004","name":"cli000004","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2020-12-10T22:11:55.0479455Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"02cf4c6e-8c16-48ed-9626-e135a1e3fc01","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-28T22:58:06.6618909Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"edf13eb4-5bcd-443c-802c-099edcb9b1c7","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000004-westus","locationName":"West
@@ -1421,7 +340,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:12:32 GMT
+      - Thu, 28 Jan 2021 22:58:52 GMT
       pragma:
       - no-cache
       server:
@@ -1453,8 +372,8 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: GET
@@ -1462,7 +381,7 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_restorable_commands000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004","name":"cli000004","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2020-12-10T22:11:55.0479455Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"02cf4c6e-8c16-48ed-9626-e135a1e3fc01","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-28T22:58:06.6618909Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"edf13eb4-5bcd-443c-802c-099edcb9b1c7","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000004-westus","locationName":"West
@@ -1475,7 +394,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:12:33 GMT
+      - Thu, 28 Jan 2021 22:58:52 GMT
       pragma:
       - no-cache
       server:
@@ -1511,8 +430,8 @@ interactions:
       ParameterSetName:
       - -g -a -n
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: PUT
@@ -1522,7 +441,7 @@ interactions:
       string: '{"status":"Enqueued"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/cf052f1b-3c23-4452-9875-814c2095b222?api-version=2020-04-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/f3852243-c797-4685-8ac2-b145559bca2e?api-version=2020-04-01
       cache-control:
       - no-store, no-cache
       content-length:
@@ -1530,9 +449,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:12:34 GMT
+      - Thu, 28 Jan 2021 22:58:54 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_restorable_commands000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004/sqlDatabases/cli000003/operationResults/cf052f1b-3c23-4452-9875-814c2095b222?api-version=2020-04-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_restorable_commands000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004/sqlDatabases/cli000003/operationResults/f3852243-c797-4685-8ac2-b145559bca2e?api-version=2020-04-01
       pragma:
       - no-cache
       server:
@@ -1544,7 +463,7 @@ interactions:
       x-ms-gatewayversion:
       - version=2.11.0
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1197'
     status:
       code: 202
       message: Accepted
@@ -1562,10 +481,10 @@ interactions:
       ParameterSetName:
       - -g -a -n
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/cf052f1b-3c23-4452-9875-814c2095b222?api-version=2020-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/f3852243-c797-4685-8ac2-b145559bca2e?api-version=2020-04-01
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -1577,7 +496,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:13:04 GMT
+      - Thu, 28 Jan 2021 22:59:23 GMT
       pragma:
       - no-cache
       server:
@@ -1609,13 +528,13 @@ interactions:
       ParameterSetName:
       - -g -a -n
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_restorable_commands000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004/sqlDatabases/cli000003?api-version=2020-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_restorable_commands000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004/sqlDatabases/cli000003","type":"Microsoft.DocumentDB/databaseAccounts/sqlDatabases","name":"cli000003","properties":{"resource":{"id":"cli000003","_rid":"Ay0bAA==","_self":"dbs/Ay0bAA==/","_etag":"\"00007f00-0000-0700-0000-5fd29d580000\"","_colls":"colls/","_users":"users/","_ts":1607638360}}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_restorable_commands000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004/sqlDatabases/cli000003","type":"Microsoft.DocumentDB/databaseAccounts/sqlDatabases","name":"cli000003","properties":{"resource":{"id":"cli000003","_rid":"TJFxAA==","_self":"dbs/TJFxAA==/","_etag":"\"0000c500-0000-0700-0000-601341b20000\"","_colls":"colls/","_users":"users/","_ts":1611874738}}}'
     headers:
       cache-control:
       - no-store, no-cache
@@ -1624,7 +543,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:13:05 GMT
+      - Thu, 28 Jan 2021 22:59:24 GMT
       pragma:
       - no-cache
       server:
@@ -1663,8 +582,8 @@ interactions:
       ParameterSetName:
       - -g -a -d -n -p
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: PUT
@@ -1674,7 +593,7 @@ interactions:
       string: '{"status":"Enqueued"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/bee6d23f-40a9-45ec-b6bf-a29242fa02f1?api-version=2020-04-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/83c426f8-0adc-47ef-a692-ebd66c4f4c81?api-version=2020-04-01
       cache-control:
       - no-store, no-cache
       content-length:
@@ -1682,9 +601,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:13:08 GMT
+      - Thu, 28 Jan 2021 22:59:26 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_restorable_commands000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004/sqlDatabases/cli000003/containers/cli000002/operationResults/bee6d23f-40a9-45ec-b6bf-a29242fa02f1?api-version=2020-04-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_restorable_commands000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004/sqlDatabases/cli000003/containers/cli000002/operationResults/83c426f8-0adc-47ef-a692-ebd66c4f4c81?api-version=2020-04-01
       pragma:
       - no-cache
       server:
@@ -1696,7 +615,7 @@ interactions:
       x-ms-gatewayversion:
       - version=2.11.0
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
     status:
       code: 202
       message: Accepted
@@ -1714,10 +633,10 @@ interactions:
       ParameterSetName:
       - -g -a -d -n -p
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/bee6d23f-40a9-45ec-b6bf-a29242fa02f1?api-version=2020-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/83c426f8-0adc-47ef-a692-ebd66c4f4c81?api-version=2020-04-01
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -1729,7 +648,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:13:38 GMT
+      - Thu, 28 Jan 2021 22:59:56 GMT
       pragma:
       - no-cache
       server:
@@ -1761,13 +680,13 @@ interactions:
       ParameterSetName:
       - -g -a -d -n -p
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_restorable_commands000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004/sqlDatabases/cli000003/containers/cli000002?api-version=2020-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_restorable_commands000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004/sqlDatabases/cli000003/containers/cli000002","type":"Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers","name":"cli000002","properties":{"resource":{"id":"cli000002","indexingPolicy":{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"/*"}],"excludedPaths":[{"path":"/\"_etag\"/?"}]},"partitionKey":{"paths":["/pk"],"kind":"Hash"},"uniqueKeyPolicy":{"uniqueKeys":[]},"conflictResolutionPolicy":{"mode":"LastWriterWins","conflictResolutionPath":"/_ts","conflictResolutionProcedure":""},"backupPolicy":{"type":1},"allowMaterializedViews":false,"geospatialConfig":{"type":"Geography"},"_rid":"Ay0bANxoMHs=","_ts":1607638395,"_self":"dbs/Ay0bAA==/colls/Ay0bANxoMHs=/","_etag":"\"00008300-0000-0700-0000-5fd29d7b0000\"","_docs":"docs/","_sprocs":"sprocs/","_triggers":"triggers/","_udfs":"udfs/","_conflicts":"conflicts/","statistics":[{"id":"0","sizeInKB":0,"documentCount":0,"partitionKeys":[]}]}}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_restorable_commands000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004/sqlDatabases/cli000003/containers/cli000002","type":"Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers","name":"cli000002","properties":{"resource":{"id":"cli000002","indexingPolicy":{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"/*"}],"excludedPaths":[{"path":"/\"_etag\"/?"}]},"partitionKey":{"paths":["/pk"],"kind":"Hash"},"uniqueKeyPolicy":{"uniqueKeys":[]},"conflictResolutionPolicy":{"mode":"LastWriterWins","conflictResolutionPath":"/_ts","conflictResolutionProcedure":""},"backupPolicy":{"type":1},"allowMaterializedViews":false,"geospatialConfig":{"type":"Geography"},"_rid":"TJFxALeTxfc=","_ts":1611874770,"_self":"dbs/TJFxAA==/colls/TJFxALeTxfc=/","_etag":"\"0000c800-0000-0700-0000-601341d20000\"","_docs":"docs/","_sprocs":"sprocs/","_triggers":"triggers/","_udfs":"udfs/","_conflicts":"conflicts/","statistics":[{"id":"0","sizeInKB":0,"documentCount":0,"partitionKeys":[]}]}}}'
     headers:
       cache-control:
       - no-store, no-cache
@@ -1776,7 +695,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:13:38 GMT
+      - Thu, 28 Jan 2021 22:59:57 GMT
       pragma:
       - no-cache
       server:
@@ -1808,25 +727,25 @@ interactions:
       ParameterSetName:
       - --location --instance-id
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/02cf4c6e-8c16-48ed-9626-e135a1e3fc01?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/edf13eb4-5bcd-443c-802c-099edcb9b1c7?api-version=2020-06-01-preview
   response:
     body:
-      string: '{"name":"02cf4c6e-8c16-48ed-9626-e135a1e3fc01","location":"West US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/02cf4c6e-8c16-48ed-9626-e135a1e3fc01","properties":{"accountName":"cli000004","creationTime":"2020-12-10T22:11:55.0479455Z","apiType":"Sql","restorableLocations":[{"locationName":"West
-        US","creationTime":"2020-12-10T22:11:55.8079602Z","regionalDatabaseAccountInstanceId":"244e1781-aead-45ba-b987-06d7cf9d9016"}]}}'
+      string: '{"name":"edf13eb4-5bcd-443c-802c-099edcb9b1c7","location":"West US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/edf13eb4-5bcd-443c-802c-099edcb9b1c7","properties":{"accountName":"cli000004","apiType":"Sql","creationTime":"2021-01-28T22:58:07Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"fc9b8e20-570c-44ba-927b-22e9e1c3124f","creationTime":"2021-01-28T22:58:08Z"}]}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '587'
+      - '571'
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:13:40 GMT
+      - Thu, 28 Jan 2021 23:00:02 GMT
       pragma:
       - no-cache
       server:
@@ -1858,15 +777,15 @@ interactions:
       ParameterSetName:
       - --location --instance-id
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/02cf4c6e-8c16-48ed-9626-e135a1e3fc01/restorableSqlDatabases?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/edf13eb4-5bcd-443c-802c-099edcb9b1c7/restorableSqlDatabases?api-version=2020-06-01-preview
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/02cf4c6e-8c16-48ed-9626-e135a1e3fc01/restorableSqlDatabases/ddbad31f-fd75-48e1-a2b4-80aa7343d968","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts/restorableSqlDatabases","name":"ddbad31f-fd75-48e1-a2b4-80aa7343d968","properties":{"resource":{"_rid":"J3JNvgAAAA==","eventTimestamp":"2020-12-10T22:12:40Z","ownerId":"cli000003","ownerResourceId":"Ay0bAA==","operationType":"Create","database":{"id":"cli000003","_rid":"Ay0bAA==","_self":"dbs/Ay0bAA==/","_etag":"\"00007f00-0000-0700-0000-5fd29d580000\"","_colls":"colls/","_users":"users/"}}}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/edf13eb4-5bcd-443c-802c-099edcb9b1c7/restorableSqlDatabases/d804d617-b30b-4ed2-9455-e21a8602ff13","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts/restorableSqlDatabases","name":"d804d617-b30b-4ed2-9455-e21a8602ff13","properties":{"resource":{"_rid":"CVlRqwAAAA==","eventTimestamp":"2021-01-28T22:58:58Z","ownerId":"cli000003","ownerResourceId":"TJFxAA==","operationType":"Create","database":{"id":"cli000003","_rid":"TJFxAA==","_self":"dbs/TJFxAA==/","_etag":"\"0000c500-0000-0700-0000-601341b20000\"","_colls":"colls/","_users":"users/"}}}}]}'
     headers:
       cache-control:
       - no-store, no-cache
@@ -1875,7 +794,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:13:42 GMT
+      - Thu, 28 Jan 2021 23:00:08 GMT
       pragma:
       - no-cache
       server:
@@ -1907,15 +826,15 @@ interactions:
       ParameterSetName:
       - --location --instance-id --database-rid
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/02cf4c6e-8c16-48ed-9626-e135a1e3fc01/restorableSqlContainers?api-version=2020-06-01-preview&restorableSqlDatabaseRid=Ay0bAA%3D%3D
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/edf13eb4-5bcd-443c-802c-099edcb9b1c7/restorableSqlContainers?api-version=2020-06-01-preview&restorableSqlDatabaseRid=TJFxAA%3D%3D
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/02cf4c6e-8c16-48ed-9626-e135a1e3fc01/restorableSqlContainers/3033d8fe-f145-413f-bdef-bcb640d79a22","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts/restorableSqlContainers","name":"3033d8fe-f145-413f-bdef-bcb640d79a22","properties":{"resource":{"_rid":"DexqVgAAAA==","eventTimestamp":"2020-12-10T22:13:15Z","ownerId":"cli000002","ownerResourceId":"Ay0bANxoMHs=","operationType":"Create","container":{"id":"cli000002","indexingPolicy":{"indexingMode":"consistent","automatic":true,"supportSpatialLegacyCoordinates":false,"usePolygonsSmallerThanAHemisphere":false,"includedPaths":[{"path":"/*"},{"path":"/\"_ts\"/?"}],"excludedPaths":[{"path":"/\"_etag\"/?"}]},"partitionKey":{"paths":["/pk"],"kind":"Hash"},"uniqueKeyPolicy":{"uniqueKeys":[]},"internalIndexingProperties":{"enableIndexingFullFidelity":true,"logicalIndexVersion":2,"indexEncodingOptions":65551},"conflictResolutionPolicy":{"mode":"LastWriterWins","conflictResolutionPath":"/_ts","conflictResolutionProcedure":""},"backupPolicy":{"type":1},"allowMaterializedViews":false,"geospatialConfig":{"type":"Geography"},"typeSystemPolicy":{"typeSystem":"CosmosCore"},"uniqueIndexNameEncodingMode":1,"_idxpolicyver":2,"_rid":"Ay0bANxoMHs=","_self":"dbs/Ay0bAA==/colls/Ay0bANxoMHs=/","_etag":"\"00008300-0000-0700-0000-5fd29d7b0000\"","_docs":"docs/","_sprocs":"sprocs/","_triggers":"triggers/","_udfs":"udfs/","_conflicts":"conflicts/"}}}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/edf13eb4-5bcd-443c-802c-099edcb9b1c7/restorableSqlContainers/3a9802c8-d934-455a-bb23-9c8b455334b3","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts/restorableSqlContainers","name":"3a9802c8-d934-455a-bb23-9c8b455334b3","properties":{"resource":{"_rid":"ARYNvQAAAA==","eventTimestamp":"2021-01-28T22:59:30Z","ownerId":"cli000002","ownerResourceId":"TJFxALeTxfc=","operationType":"Create","container":{"id":"cli000002","indexingPolicy":{"indexingMode":"consistent","automatic":true,"supportSpatialLegacyCoordinates":false,"usePolygonsSmallerThanAHemisphere":false,"includedPaths":[{"path":"/*"},{"path":"/\"_ts\"/?"}],"excludedPaths":[{"path":"/\"_etag\"/?"}]},"partitionKey":{"paths":["/pk"],"kind":"Hash"},"uniqueKeyPolicy":{"uniqueKeys":[]},"internalIndexingProperties":{"enableIndexingFullFidelity":true,"logicalIndexVersion":2,"indexEncodingOptions":65567},"conflictResolutionPolicy":{"mode":"LastWriterWins","conflictResolutionPath":"/_ts","conflictResolutionProcedure":""},"backupPolicy":{"type":1},"allowMaterializedViews":false,"geospatialConfig":{"type":"Geography"},"typeSystemPolicy":{"typeSystem":"CosmosCore"},"uniqueIndexNameEncodingMode":1,"_idxpolicyver":2,"_rid":"TJFxALeTxfc=","_self":"dbs/TJFxAA==/colls/TJFxALeTxfc=/","_etag":"\"0000c800-0000-0700-0000-601341d20000\"","_docs":"docs/","_sprocs":"sprocs/","_triggers":"triggers/","_udfs":"udfs/","_conflicts":"conflicts/"}}}}]}'
     headers:
       cache-control:
       - no-store, no-cache
@@ -1924,7 +843,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:13:44 GMT
+      - Thu, 28 Jan 2021 23:00:13 GMT
       pragma:
       - no-cache
       server:
@@ -1956,12 +875,12 @@ interactions:
       ParameterSetName:
       - --restore-location -l --instance-id --restore-timestamp
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/02cf4c6e-8c16-48ed-9626-e135a1e3fc01/restorableSqlResources?api-version=2020-06-01-preview&restoreLocation=westus&restoreTimestampInUtc=2020-12-10T22%3A13%3A55.047945%2B00%3A00
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/edf13eb4-5bcd-443c-802c-099edcb9b1c7/restorableSqlResources?api-version=2020-06-01-preview&restoreLocation=westus&restoreTimestampInUtc=2021-01-28T23%3A00%3A07%2B00%3A00
   response:
     body:
       string: '{"value":[{"databaseName":"cli000003","collectionNames":["cli000002"]}]}'
@@ -1973,7 +892,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:15:45 GMT
+      - Thu, 28 Jan 2021 23:02:17 GMT
       pragma:
       - no-cache
       server:

--- a/src/cosmosdb-preview/azext_cosmosdb_preview/tests/latest/recordings/test_cosmosdb_sql_role.yaml
+++ b/src/cosmosdb-preview/azext_cosmosdb_preview/tests/latest/recordings/test_cosmosdb_sql_role.yaml
@@ -1,0 +1,2011 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --locations
+      User-Agent:
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-resource/12.0.0 Azure-SDK-For-Python AZURECLI/2.18.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cosmosdb_sql_role000001?api-version=2020-10-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001","name":"cli_test_cosmosdb_sql_role000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2021-01-28T23:15:44Z"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '428'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 28 Jan 2021 23:15:45 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "westus", "kind": "GlobalDocumentDB", "properties": {"locations":
+      [{"locationName": "eastus2", "failoverPriority": 0, "isZoneRedundant": false}],
+      "databaseAccountOfferType": "Standard", "apiProperties": {}, "createMode": "Default"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '245'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --locations
+      User-Agent:
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002?api-version=2020-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002","name":"cli000002","location":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-28T23:15:51.5985637Z"},"properties":{"provisioningState":"Creating","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"90be94a2-3368-420d-b50f-d3d457eef58f","createMode":"Default","databaseAccountOfferType":"Standard","enableCassandraConnector":false,"connectorOffer":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000002-eastus2","locationName":"East
+        US 2","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000002-eastus2","locationName":"East
+        US 2","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000002-eastus2","locationName":"East
+        US 2","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000002-eastus2","locationName":"East
+        US 2","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":1}}},"identity":{"type":"None"}}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/dcddcf31-e508-4353-8226-23b75e1c0b6b?api-version=2020-06-01-preview
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '1854'
+      content-type:
+      - application/json
+      date:
+      - Thu, 28 Jan 2021 23:15:52 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/dcddcf31-e508-4353-8226-23b75e1c0b6b?api-version=2020-06-01-preview
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.11.0
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --locations
+      User-Agent:
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/dcddcf31-e508-4353-8226-23b75e1c0b6b?api-version=2020-06-01-preview
+  response:
+    body:
+      string: '{"status":"Dequeued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Thu, 28 Jan 2021 23:16:22 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.11.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --locations
+      User-Agent:
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/dcddcf31-e508-4353-8226-23b75e1c0b6b?api-version=2020-06-01-preview
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '22'
+      content-type:
+      - application/json
+      date:
+      - Thu, 28 Jan 2021 23:16:52 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.11.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --locations
+      User-Agent:
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002?api-version=2020-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002","name":"cli000002","location":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-28T23:16:18.1405067Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000002.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"90be94a2-3368-420d-b50f-d3d457eef58f","createMode":"Default","databaseAccountOfferType":"Standard","enableCassandraConnector":false,"connectorOffer":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000002-eastus2","locationName":"East
+        US 2","documentEndpoint":"https://cli000002-eastus2.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000002-eastus2","locationName":"East
+        US 2","documentEndpoint":"https://cli000002-eastus2.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000002-eastus2","locationName":"East
+        US 2","documentEndpoint":"https://cli000002-eastus2.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000002-eastus2","locationName":"East
+        US 2","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":1}}},"identity":{"type":"None"}}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '2162'
+      content-type:
+      - application/json
+      date:
+      - Thu, 28 Jan 2021 23:16:53 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.11.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --locations
+      User-Agent:
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002?api-version=2020-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002","name":"cli000002","location":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-28T23:16:18.1405067Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000002.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"90be94a2-3368-420d-b50f-d3d457eef58f","createMode":"Default","databaseAccountOfferType":"Standard","enableCassandraConnector":false,"connectorOffer":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000002-eastus2","locationName":"East
+        US 2","documentEndpoint":"https://cli000002-eastus2.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000002-eastus2","locationName":"East
+        US 2","documentEndpoint":"https://cli000002-eastus2.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000002-eastus2","locationName":"East
+        US 2","documentEndpoint":"https://cli000002-eastus2.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000002-eastus2","locationName":"East
+        US 2","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":1}}},"identity":{"type":"None"}}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '2162'
+      content-type:
+      - application/json
+      date:
+      - Thu, 28 Jan 2021 23:16:53 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.11.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: '{"properties": {"resource": {"id": "cli000003"}, "options": {}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql database create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '70'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -a -n
+      User-Agent:
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.18.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlDatabases/cli000003?api-version=2020-04-01
+  response:
+    body:
+      string: '{"status":"Enqueued"}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/36f2784c-6e1e-4a5a-9b5c-7218106d9ad0?api-version=2020-04-01
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Thu, 28 Jan 2021 23:16:54 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlDatabases/cli000003/operationResults/36f2784c-6e1e-4a5a-9b5c-7218106d9ad0?api-version=2020-04-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.11.0
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql database create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -a -n
+      User-Agent:
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.18.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/36f2784c-6e1e-4a5a-9b5c-7218106d9ad0?api-version=2020-04-01
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '22'
+      content-type:
+      - application/json
+      date:
+      - Thu, 28 Jan 2021 23:17:24 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.11.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql database create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -a -n
+      User-Agent:
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/1.0.0 Azure-SDK-For-Python AZURECLI/2.18.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlDatabases/cli000003?api-version=2020-04-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlDatabases/cli000003","type":"Microsoft.DocumentDB/databaseAccounts/sqlDatabases","name":"cli000003","properties":{"resource":{"id":"cli000003","_rid":"gVJQAA==","_self":"dbs/gVJQAA==/","_etag":"\"00009902-0000-0200-0000-601345ea0000\"","_colls":"colls/","_users":"users/","_ts":1611875818}}}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '526'
+      content-type:
+      - application/json
+      date:
+      - Thu, 28 Jan 2021 23:17:25 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.11.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: '{"properties": {"roleName": "roleName", "type": "CustomRole", "assignableScopes":
+      ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/"],
+      "permissions": [{"dataActions": ["Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/items/create",
+      "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/items/read"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql role definition create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '485'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -a -b
+      User-Agent:
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleDefinitions/be79875a-2cc4-40d5-8958-566017875b39?api-version=2020-06-01-preview
+  response:
+    body:
+      string: '{"status":"Enqueued"}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/19500681-3e2a-4a34-9d6f-aa52e816cea7?api-version=2020-06-01-preview
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Thu, 28 Jan 2021 23:17:27 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleDefinitions/be79875a-2cc4-40d5-8958-566017875b39/operationResults/19500681-3e2a-4a34-9d6f-aa52e816cea7?api-version=2020-06-01-preview
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.11.0
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql role definition create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -a -b
+      User-Agent:
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/19500681-3e2a-4a34-9d6f-aa52e816cea7?api-version=2020-06-01-preview
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '22'
+      content-type:
+      - application/json
+      date:
+      - Thu, 28 Jan 2021 23:17:57 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.11.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql role definition create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -a -b
+      User-Agent:
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleDefinitions/be79875a-2cc4-40d5-8958-566017875b39?api-version=2020-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleDefinitions/be79875a-2cc4-40d5-8958-566017875b39","name":"be79875a-2cc4-40d5-8958-566017875b39","properties":{"roleName":"roleName","type":1,"assignableScopes":["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002"],"permissions":[{"dataActions":["Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/items/create","Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/items/read"],"notDataActions":[]}]},"type":"Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '865'
+      content-type:
+      - application/json
+      date:
+      - Thu, 28 Jan 2021 23:17:58 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.11.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql role definition exists
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -a -i
+      User-Agent:
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleDefinitions/be79875a-2cc4-40d5-8958-566017875b39?api-version=2020-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleDefinitions/be79875a-2cc4-40d5-8958-566017875b39","name":"be79875a-2cc4-40d5-8958-566017875b39","properties":{"roleName":"roleName","type":1,"assignableScopes":["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002"],"permissions":[{"dataActions":["Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/items/create","Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/items/read"],"notDataActions":[]}]},"type":"Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '865'
+      content-type:
+      - application/json
+      date:
+      - Thu, 28 Jan 2021 23:17:59 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.11.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql role definition show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -a -i
+      User-Agent:
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleDefinitions/be79875a-2cc4-40d5-8958-566017875b39?api-version=2020-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleDefinitions/be79875a-2cc4-40d5-8958-566017875b39","name":"be79875a-2cc4-40d5-8958-566017875b39","properties":{"roleName":"roleName","type":1,"assignableScopes":["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002"],"permissions":[{"dataActions":["Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/items/create","Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/items/read"],"notDataActions":[]}]},"type":"Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '865'
+      content-type:
+      - application/json
+      date:
+      - Thu, 28 Jan 2021 23:18:00 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.11.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql role definition update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -a -b
+      User-Agent:
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleDefinitions/be79875a-2cc4-40d5-8958-566017875b39?api-version=2020-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleDefinitions/be79875a-2cc4-40d5-8958-566017875b39","name":"be79875a-2cc4-40d5-8958-566017875b39","properties":{"roleName":"roleName","type":1,"assignableScopes":["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002"],"permissions":[{"dataActions":["Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/items/create","Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/items/read"],"notDataActions":[]}]},"type":"Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '865'
+      content-type:
+      - application/json
+      date:
+      - Thu, 28 Jan 2021 23:18:01 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.11.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: '{"properties": {"roleName": "roleName2", "type": "CustomRole", "assignableScopes":
+      ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/"],
+      "permissions": [{"dataActions": ["Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/items/create"]},
+      {"dataActions": ["Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/items/read"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql role definition update
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '505'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -a -b
+      User-Agent:
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleDefinitions/be79875a-2cc4-40d5-8958-566017875b39?api-version=2020-06-01-preview
+  response:
+    body:
+      string: '{"status":"Enqueued"}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/546b999f-f544-49d4-b401-2fce23d13dd6?api-version=2020-06-01-preview
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Thu, 28 Jan 2021 23:18:02 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleDefinitions/be79875a-2cc4-40d5-8958-566017875b39/operationResults/546b999f-f544-49d4-b401-2fce23d13dd6?api-version=2020-06-01-preview
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.11.0
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql role definition update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -a -b
+      User-Agent:
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/546b999f-f544-49d4-b401-2fce23d13dd6?api-version=2020-06-01-preview
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '22'
+      content-type:
+      - application/json
+      date:
+      - Thu, 28 Jan 2021 23:18:33 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.11.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql role definition update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -a -b
+      User-Agent:
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleDefinitions/be79875a-2cc4-40d5-8958-566017875b39?api-version=2020-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleDefinitions/be79875a-2cc4-40d5-8958-566017875b39","name":"be79875a-2cc4-40d5-8958-566017875b39","properties":{"roleName":"roleName2","type":1,"assignableScopes":["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002"],"permissions":[{"dataActions":["Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/items/create"],"notDataActions":[]},{"dataActions":["Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/items/read"],"notDataActions":[]}]},"type":"Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '904'
+      content-type:
+      - application/json
+      date:
+      - Thu, 28 Jan 2021 23:18:34 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.11.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: '{"properties": {"roleName": "roleName3", "type": "CustomRole", "assignableScopes":
+      ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/"],
+      "permissions": [{"dataActions": ["Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/items/create"]},
+      {"dataActions": ["Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/items/read"]},
+      {"dataActions": ["Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/items/replace"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql role definition create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '603'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -a -b
+      User-Agent:
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleDefinitions/6328f5f7-dbf7-4244-bba8-fbb9d8066506?api-version=2020-06-01-preview
+  response:
+    body:
+      string: '{"status":"Enqueued"}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/544c626e-299d-4286-9eeb-af70ba255c15?api-version=2020-06-01-preview
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Thu, 28 Jan 2021 23:18:37 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleDefinitions/6328f5f7-dbf7-4244-bba8-fbb9d8066506/operationResults/544c626e-299d-4286-9eeb-af70ba255c15?api-version=2020-06-01-preview
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.11.0
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql role definition create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -a -b
+      User-Agent:
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/544c626e-299d-4286-9eeb-af70ba255c15?api-version=2020-06-01-preview
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '22'
+      content-type:
+      - application/json
+      date:
+      - Thu, 28 Jan 2021 23:19:08 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.11.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql role definition create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -a -b
+      User-Agent:
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleDefinitions/6328f5f7-dbf7-4244-bba8-fbb9d8066506?api-version=2020-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleDefinitions/6328f5f7-dbf7-4244-bba8-fbb9d8066506","name":"6328f5f7-dbf7-4244-bba8-fbb9d8066506","properties":{"roleName":"roleName3","type":1,"assignableScopes":["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002"],"permissions":[{"dataActions":["Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/items/create"],"notDataActions":[]},{"dataActions":["Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/items/read"],"notDataActions":[]},{"dataActions":["Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/items/replace"],"notDataActions":[]}]},"type":"Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '1020'
+      content-type:
+      - application/json
+      date:
+      - Thu, 28 Jan 2021 23:19:09 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.11.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql role definition list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -a
+      User-Agent:
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleDefinitions?api-version=2020-06-01-preview
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleDefinitions/be79875a-2cc4-40d5-8958-566017875b39","name":"be79875a-2cc4-40d5-8958-566017875b39","properties":{"roleName":"roleName2","type":1,"assignableScopes":["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002"],"permissions":[{"dataActions":["Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/items/create"],"notDataActions":[]},{"dataActions":["Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/items/read"],"notDataActions":[]}]},"type":"Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleDefinitions/6328f5f7-dbf7-4244-bba8-fbb9d8066506","name":"6328f5f7-dbf7-4244-bba8-fbb9d8066506","properties":{"roleName":"roleName3","type":1,"assignableScopes":["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002"],"permissions":[{"dataActions":["Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/items/create"],"notDataActions":[]},{"dataActions":["Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/items/read"],"notDataActions":[]},{"dataActions":["Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/items/replace"],"notDataActions":[]}]},"type":"Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions"}]}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '1937'
+      content-type:
+      - application/json
+      date:
+      - Thu, 28 Jan 2021 23:19:10 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.11.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: '{"properties": {"roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleDefinitions/be79875a-2cc4-40d5-8958-566017875b39",
+      "scope": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/dbs/cli000003",
+      "principalId": "ed4c2395-a18c-4018-afb3-6e521e7534d2"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql role assignment create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '596'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -a -s -p -d -i
+      User-Agent:
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleAssignments/cb8ed2d7-2371-4e3c-bd31-6cc1560e84f8?api-version=2020-06-01-preview
+  response:
+    body:
+      string: '{"status":"Enqueued"}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/29488306-a62e-4ebb-8457-0dc993411ee4?api-version=2020-06-01-preview
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Thu, 28 Jan 2021 23:20:49 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleAssignments/cb8ed2d7-2371-4e3c-bd31-6cc1560e84f8/operationResults/29488306-a62e-4ebb-8457-0dc993411ee4?api-version=2020-06-01-preview
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.11.0
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql role assignment create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -a -s -p -d -i
+      User-Agent:
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/29488306-a62e-4ebb-8457-0dc993411ee4?api-version=2020-06-01-preview
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '22'
+      content-type:
+      - application/json
+      date:
+      - Thu, 28 Jan 2021 23:21:21 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.11.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql role assignment create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -a -s -p -d -i
+      User-Agent:
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleAssignments/cb8ed2d7-2371-4e3c-bd31-6cc1560e84f8?api-version=2020-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleAssignments/cb8ed2d7-2371-4e3c-bd31-6cc1560e84f8","name":"cb8ed2d7-2371-4e3c-bd31-6cc1560e84f8","properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleDefinitions/be79875a-2cc4-40d5-8958-566017875b39","principalId":"ed4c2395-a18c-4018-afb3-6e521e7534d2","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/dbs/cli000003"},"type":"Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '972'
+      content-type:
+      - application/json
+      date:
+      - Thu, 28 Jan 2021 23:21:22 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.11.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql role assignment exists
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -a -i
+      User-Agent:
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleAssignments/cb8ed2d7-2371-4e3c-bd31-6cc1560e84f8?api-version=2020-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleAssignments/cb8ed2d7-2371-4e3c-bd31-6cc1560e84f8","name":"cb8ed2d7-2371-4e3c-bd31-6cc1560e84f8","properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleDefinitions/be79875a-2cc4-40d5-8958-566017875b39","principalId":"ed4c2395-a18c-4018-afb3-6e521e7534d2","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/dbs/cli000003"},"type":"Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '972'
+      content-type:
+      - application/json
+      date:
+      - Thu, 28 Jan 2021 23:21:23 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.11.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql role assignment show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -a -i
+      User-Agent:
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleAssignments/cb8ed2d7-2371-4e3c-bd31-6cc1560e84f8?api-version=2020-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleAssignments/cb8ed2d7-2371-4e3c-bd31-6cc1560e84f8","name":"cb8ed2d7-2371-4e3c-bd31-6cc1560e84f8","properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleDefinitions/be79875a-2cc4-40d5-8958-566017875b39","principalId":"ed4c2395-a18c-4018-afb3-6e521e7534d2","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/dbs/cli000003"},"type":"Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '972'
+      content-type:
+      - application/json
+      date:
+      - Thu, 28 Jan 2021 23:21:25 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.11.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql role assignment update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -a -d -i
+      User-Agent:
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleAssignments/cb8ed2d7-2371-4e3c-bd31-6cc1560e84f8?api-version=2020-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleAssignments/cb8ed2d7-2371-4e3c-bd31-6cc1560e84f8","name":"cb8ed2d7-2371-4e3c-bd31-6cc1560e84f8","properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleDefinitions/be79875a-2cc4-40d5-8958-566017875b39","principalId":"ed4c2395-a18c-4018-afb3-6e521e7534d2","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/dbs/cli000003"},"type":"Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '972'
+      content-type:
+      - application/json
+      date:
+      - Thu, 28 Jan 2021 23:21:26 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.11.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: '{"properties": {"roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleDefinitions/6328f5f7-dbf7-4244-bba8-fbb9d8066506",
+      "scope": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/dbs/cli000003",
+      "principalId": "ed4c2395-a18c-4018-afb3-6e521e7534d2"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql role assignment update
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '596'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -a -d -i
+      User-Agent:
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleAssignments/cb8ed2d7-2371-4e3c-bd31-6cc1560e84f8?api-version=2020-06-01-preview
+  response:
+    body:
+      string: '{"status":"Enqueued"}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/253b7df2-f797-47a4-ba48-1bacbb595116?api-version=2020-06-01-preview
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Thu, 28 Jan 2021 23:21:27 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleAssignments/cb8ed2d7-2371-4e3c-bd31-6cc1560e84f8/operationResults/253b7df2-f797-47a4-ba48-1bacbb595116?api-version=2020-06-01-preview
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.11.0
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql role assignment update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -a -d -i
+      User-Agent:
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/253b7df2-f797-47a4-ba48-1bacbb595116?api-version=2020-06-01-preview
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '22'
+      content-type:
+      - application/json
+      date:
+      - Thu, 28 Jan 2021 23:21:58 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.11.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql role assignment update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -a -d -i
+      User-Agent:
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleAssignments/cb8ed2d7-2371-4e3c-bd31-6cc1560e84f8?api-version=2020-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleAssignments/cb8ed2d7-2371-4e3c-bd31-6cc1560e84f8","name":"cb8ed2d7-2371-4e3c-bd31-6cc1560e84f8","properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleDefinitions/6328f5f7-dbf7-4244-bba8-fbb9d8066506","principalId":"ed4c2395-a18c-4018-afb3-6e521e7534d2","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/dbs/cli000003"},"type":"Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '972'
+      content-type:
+      - application/json
+      date:
+      - Thu, 28 Jan 2021 23:21:59 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.11.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql role assignment list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -a
+      User-Agent:
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleAssignments?api-version=2020-06-01-preview
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleAssignments/cb8ed2d7-2371-4e3c-bd31-6cc1560e84f8","name":"cb8ed2d7-2371-4e3c-bd31-6cc1560e84f8","properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleDefinitions/6328f5f7-dbf7-4244-bba8-fbb9d8066506","principalId":"ed4c2395-a18c-4018-afb3-6e521e7534d2","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/dbs/cli000003"},"type":"Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments"}]}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '984'
+      content-type:
+      - application/json
+      date:
+      - Thu, 28 Jan 2021 23:22:01 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.11.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql role assignment delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -a -i --yes
+      User-Agent:
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
+      accept-language:
+      - en-US
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleAssignments/cb8ed2d7-2371-4e3c-bd31-6cc1560e84f8?api-version=2020-06-01-preview
+  response:
+    body:
+      string: '{"status":"Enqueued"}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/173f1c89-10ea-4de9-a05a-dd3e87546c26?api-version=2020-06-01-preview
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Thu, 28 Jan 2021 23:22:02 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleAssignments/cb8ed2d7-2371-4e3c-bd31-6cc1560e84f8/operationResults/173f1c89-10ea-4de9-a05a-dd3e87546c26?api-version=2020-06-01-preview
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.11.0
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14999'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql role assignment delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -a -i --yes
+      User-Agent:
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/173f1c89-10ea-4de9-a05a-dd3e87546c26?api-version=2020-06-01-preview
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '22'
+      content-type:
+      - application/json
+      date:
+      - Thu, 28 Jan 2021 23:22:33 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.11.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql role assignment list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -a
+      User-Agent:
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleAssignments?api-version=2020-06-01-preview
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json
+      date:
+      - Thu, 28 Jan 2021 23:22:34 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.11.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql role definition delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -a -i --yes
+      User-Agent:
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
+      accept-language:
+      - en-US
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleDefinitions/be79875a-2cc4-40d5-8958-566017875b39?api-version=2020-06-01-preview
+  response:
+    body:
+      string: '{"status":"Enqueued"}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/9a086ddb-44b8-465b-8047-e4f34c2921b0?api-version=2020-06-01-preview
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Thu, 28 Jan 2021 23:22:36 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleDefinitions/be79875a-2cc4-40d5-8958-566017875b39/operationResults/9a086ddb-44b8-465b-8047-e4f34c2921b0?api-version=2020-06-01-preview
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.11.0
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14999'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql role definition delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -a -i --yes
+      User-Agent:
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/9a086ddb-44b8-465b-8047-e4f34c2921b0?api-version=2020-06-01-preview
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '22'
+      content-type:
+      - application/json
+      date:
+      - Thu, 28 Jan 2021 23:23:07 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.11.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql role definition delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -a -i --yes
+      User-Agent:
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
+      accept-language:
+      - en-US
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleDefinitions/6328f5f7-dbf7-4244-bba8-fbb9d8066506?api-version=2020-06-01-preview
+  response:
+    body:
+      string: '{"status":"Enqueued"}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/124111c4-4f6a-43d4-a034-e024ab2223f3?api-version=2020-06-01-preview
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Thu, 28 Jan 2021 23:23:08 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleDefinitions/6328f5f7-dbf7-4244-bba8-fbb9d8066506/operationResults/124111c4-4f6a-43d4-a034-e024ab2223f3?api-version=2020-06-01-preview
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.11.0
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14999'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql role definition delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -a -i --yes
+      User-Agent:
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/124111c4-4f6a-43d4-a034-e024ab2223f3?api-version=2020-06-01-preview
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '22'
+      content-type:
+      - application/json
+      date:
+      - Thu, 28 Jan 2021 23:23:39 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.11.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb sql role definition list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -a
+      User-Agent:
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_sql_role000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/sqlRoleDefinitions?api-version=2020-06-01-preview
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json
+      date:
+      - Thu, 28 Jan 2021 23:23:40 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.11.0
+    status:
+      code: 200
+      message: Ok
+version: 1

--- a/src/cosmosdb-preview/azext_cosmosdb_preview/tests/latest/recordings/test_update_backup_policy_database_account.yaml
+++ b/src/cosmosdb-preview/azext_cosmosdb_preview/tests/latest/recordings/test_update_backup_policy_database_account.yaml
@@ -13,15 +13,15 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-resource/12.0.0 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_update_backup_policy_database_account000001?api-version=2020-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_update_backup_policy_database_account000001?api-version=2020-10-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_update_backup_policy_database_account000001","name":"cli_update_backup_policy_database_account000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-12-10T22:20:57Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_update_backup_policy_database_account000001","name":"cli_update_backup_policy_database_account000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2021-01-28T22:57:14Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -30,7 +30,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 10 Dec 2020 22:21:00 GMT
+      - Thu, 28 Jan 2021 22:57:16 GMT
       expires:
       - '-1'
       pragma:
@@ -64,8 +64,8 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: PUT
@@ -73,24 +73,24 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_update_backup_policy_database_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002","name":"cli000002","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2020-12-10T22:21:03.7115485Z"},"properties":{"provisioningState":"Creating","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"a92684fe-c610-4cbe-8f7d-993f2511a530","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000002-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-28T22:57:33.7504177Z"},"properties":{"provisioningState":"Creating","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"732fd2de-994c-4fe5-bc96-de2ca3e08e09","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000002-westus","locationName":"West
         US","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000002-westus","locationName":"West
         US","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000002-westus","locationName":"West
         US","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000002-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":1}}},"identity":{"type":"None"}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/1e9387ab-50be-4b38-a27e-dd3fd86526b5?api-version=2020-06-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/9a901d60-ac27-411f-9244-255372d4811c?api-version=2020-06-01-preview
       cache-control:
       - no-store, no-cache
       content-length:
-      - '1911'
+      - '1939'
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:21:03 GMT
+      - Thu, 28 Jan 2021 22:57:34 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_update_backup_policy_database_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/1e9387ab-50be-4b38-a27e-dd3fd86526b5?api-version=2020-06-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_update_backup_policy_database_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/9a901d60-ac27-411f-9244-255372d4811c?api-version=2020-06-01-preview
       pragma:
       - no-cache
       server:
@@ -124,10 +124,10 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/1e9387ab-50be-4b38-a27e-dd3fd86526b5?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/9a901d60-ac27-411f-9244-255372d4811c?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -139,7 +139,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:21:34 GMT
+      - Thu, 28 Jan 2021 22:58:04 GMT
       pragma:
       - no-cache
       server:
@@ -171,668 +171,10 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/1e9387ab-50be-4b38-a27e-dd3fd86526b5?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:22:05 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/1e9387ab-50be-4b38-a27e-dd3fd86526b5?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:22:35 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/1e9387ab-50be-4b38-a27e-dd3fd86526b5?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:23:06 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/1e9387ab-50be-4b38-a27e-dd3fd86526b5?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:23:37 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/1e9387ab-50be-4b38-a27e-dd3fd86526b5?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:24:07 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/1e9387ab-50be-4b38-a27e-dd3fd86526b5?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:24:37 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/1e9387ab-50be-4b38-a27e-dd3fd86526b5?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:25:08 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/1e9387ab-50be-4b38-a27e-dd3fd86526b5?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:25:38 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/1e9387ab-50be-4b38-a27e-dd3fd86526b5?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:26:08 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/1e9387ab-50be-4b38-a27e-dd3fd86526b5?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:26:39 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/1e9387ab-50be-4b38-a27e-dd3fd86526b5?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:27:10 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/1e9387ab-50be-4b38-a27e-dd3fd86526b5?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:27:40 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/1e9387ab-50be-4b38-a27e-dd3fd86526b5?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:28:10 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/1e9387ab-50be-4b38-a27e-dd3fd86526b5?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:28:41 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/1e9387ab-50be-4b38-a27e-dd3fd86526b5?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/9a901d60-ac27-411f-9244-255372d4811c?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -844,7 +186,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:29:12 GMT
+      - Thu, 28 Jan 2021 22:58:35 GMT
       pragma:
       - no-cache
       server:
@@ -876,27 +218,27 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_update_backup_policy_database_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002?api-version=2020-06-01-preview
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_update_backup_policy_database_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002","name":"cli000002","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2020-12-10T22:28:42.5669241Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000002.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"a92684fe-c610-4cbe-8f7d-993f2511a530","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000002-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-28T22:58:03.1026316Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000002.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"732fd2de-994c-4fe5-bc96-de2ca3e08e09","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000002-westus","locationName":"West
         US","documentEndpoint":"https://cli000002-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000002-westus","locationName":"West
         US","documentEndpoint":"https://cli000002-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000002-westus","locationName":"West
         US","documentEndpoint":"https://cli000002-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000002-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":1}}},"identity":{"type":"None"}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2316'
+      - '2344'
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:29:11 GMT
+      - Thu, 28 Jan 2021 22:58:35 GMT
       pragma:
       - no-cache
       server:
@@ -928,8 +270,8 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: GET
@@ -937,20 +279,20 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_update_backup_policy_database_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002","name":"cli000002","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2020-12-10T22:28:42.5669241Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000002.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"a92684fe-c610-4cbe-8f7d-993f2511a530","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000002-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-28T22:58:03.1026316Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000002.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"732fd2de-994c-4fe5-bc96-de2ca3e08e09","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000002-westus","locationName":"West
         US","documentEndpoint":"https://cli000002-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000002-westus","locationName":"West
         US","documentEndpoint":"https://cli000002-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000002-westus","locationName":"West
         US","documentEndpoint":"https://cli000002-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000002-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":1}}},"identity":{"type":"None"}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2316'
+      - '2344'
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:29:12 GMT
+      - Thu, 28 Jan 2021 22:58:35 GMT
       pragma:
       - no-cache
       server:
@@ -982,8 +324,8 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: GET
@@ -991,20 +333,20 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_update_backup_policy_database_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002","name":"cli000002","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2020-12-10T22:28:42.5669241Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000002.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"a92684fe-c610-4cbe-8f7d-993f2511a530","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000002-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-28T22:58:03.1026316Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000002.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"732fd2de-994c-4fe5-bc96-de2ca3e08e09","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000002-westus","locationName":"West
         US","documentEndpoint":"https://cli000002-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000002-westus","locationName":"West
         US","documentEndpoint":"https://cli000002-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000002-westus","locationName":"West
         US","documentEndpoint":"https://cli000002-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000002-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":1}}},"identity":{"type":"None"}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2316'
+      - '2344'
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:29:13 GMT
+      - Thu, 28 Jan 2021 22:58:36 GMT
       pragma:
       - no-cache
       server:
@@ -1036,8 +378,8 @@ interactions:
       ParameterSetName:
       - -n -g --backup-interval --backup-retention
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: GET
@@ -1045,20 +387,20 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_update_backup_policy_database_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002","name":"cli000002","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2020-12-10T22:28:42.5669241Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000002.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"a92684fe-c610-4cbe-8f7d-993f2511a530","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000002-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-28T22:58:03.1026316Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000002.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"732fd2de-994c-4fe5-bc96-de2ca3e08e09","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000002-westus","locationName":"West
         US","documentEndpoint":"https://cli000002-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000002-westus","locationName":"West
         US","documentEndpoint":"https://cli000002-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000002-westus","locationName":"West
         US","documentEndpoint":"https://cli000002-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000002-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":1}}},"identity":{"type":"None"}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2316'
+      - '2344'
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:29:13 GMT
+      - Thu, 28 Jan 2021 22:58:36 GMT
       pragma:
       - no-cache
       server:
@@ -1095,8 +437,8 @@ interactions:
       ParameterSetName:
       - -n -g --backup-interval --backup-retention
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: PATCH
@@ -1104,24 +446,24 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_update_backup_policy_database_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002","name":"cli000002","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2020-12-10T22:28:42.5669241Z"},"properties":{"provisioningState":"Updating","documentEndpoint":"https://cli000002.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"a92684fe-c610-4cbe-8f7d-993f2511a530","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000002-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-28T22:58:03.1026316Z"},"properties":{"provisioningState":"Updating","documentEndpoint":"https://cli000002.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"732fd2de-994c-4fe5-bc96-de2ca3e08e09","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000002-westus","locationName":"West
         US","documentEndpoint":"https://cli000002-westus.documents.azure.com:443/","provisioningState":"Updating","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000002-westus","locationName":"West
         US","documentEndpoint":"https://cli000002-westus.documents.azure.com:443/","provisioningState":"Updating","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000002-westus","locationName":"West
         US","documentEndpoint":"https://cli000002-westus.documents.azure.com:443/","provisioningState":"Updating","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000002-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":1}}},"identity":{"type":"None"}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/85815f85-3389-4f91-a656-e9a8bd6b3cd8?api-version=2020-06-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/5d378897-d4f2-4ba4-8ad0-d2055a6f71ae?api-version=2020-06-01-preview
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2312'
+      - '2340'
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:29:17 GMT
+      - Thu, 28 Jan 2021 22:58:40 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_update_backup_policy_database_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/85815f85-3389-4f91-a656-e9a8bd6b3cd8?api-version=2020-06-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_update_backup_policy_database_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/5d378897-d4f2-4ba4-8ad0-d2055a6f71ae?api-version=2020-06-01-preview
       pragma:
       - no-cache
       server:
@@ -1155,151 +497,10 @@ interactions:
       ParameterSetName:
       - -n -g --backup-interval --backup-retention
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/85815f85-3389-4f91-a656-e9a8bd6b3cd8?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:29:48 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb update
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-interval --backup-retention
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/85815f85-3389-4f91-a656-e9a8bd6b3cd8?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:30:18 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb update
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-interval --backup-retention
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/85815f85-3389-4f91-a656-e9a8bd6b3cd8?api-version=2020-06-01-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Thu, 10 Dec 2020 22:30:49 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.11.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb update
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-interval --backup-retention
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/85815f85-3389-4f91-a656-e9a8bd6b3cd8?api-version=2020-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/5d378897-d4f2-4ba4-8ad0-d2055a6f71ae?api-version=2020-06-01-preview
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -1311,7 +512,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:31:19 GMT
+      - Thu, 28 Jan 2021 22:59:11 GMT
       pragma:
       - no-cache
       server:
@@ -1343,27 +544,27 @@ interactions:
       ParameterSetName:
       - -n -g --backup-interval --backup-retention
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_update_backup_policy_database_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002?api-version=2020-06-01-preview
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_update_backup_policy_database_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002","name":"cli000002","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2020-12-10T22:28:42.5669241Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000002.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"a92684fe-c610-4cbe-8f7d-993f2511a530","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000002-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-28T22:58:03.1026316Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000002.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"732fd2de-994c-4fe5-bc96-de2ca3e08e09","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000002-westus","locationName":"West
         US","documentEndpoint":"https://cli000002-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000002-westus","locationName":"West
         US","documentEndpoint":"https://cli000002-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000002-westus","locationName":"West
         US","documentEndpoint":"https://cli000002-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000002-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":120,"backupRetentionIntervalInHours":8}}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":120,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":1}}},"identity":{"type":"None"}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2316'
+      - '2344'
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:31:20 GMT
+      - Thu, 28 Jan 2021 22:59:12 GMT
       pragma:
       - no-cache
       server:
@@ -1395,8 +596,8 @@ interactions:
       ParameterSetName:
       - -n -g --backup-interval --backup-retention
       User-Agent:
-      - python/3.8.3 (Windows-10-10.0.17763-SP0) msrest/0.6.19 msrest_azure/0.6.4
-        azure-mgmt-cosmosdb/0.7.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.8.4 (Windows-10-10.0.19041-SP0) msrest/0.6.20 msrest_azure/0.6.4
+        azure-mgmt-cosmosdb/2.0.0rc1 Azure-SDK-For-Python AZURECLI/2.18.0
       accept-language:
       - en-US
     method: GET
@@ -1404,20 +605,20 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_update_backup_policy_database_account000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002","name":"cli000002","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2020-12-10T22:28:42.5669241Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000002.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"a92684fe-c610-4cbe-8f7d-993f2511a530","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000002-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-28T22:58:03.1026316Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000002.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"732fd2de-994c-4fe5-bc96-de2ca3e08e09","createMode":"Default","databaseAccountOfferType":"Standard","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000002-westus","locationName":"West
         US","documentEndpoint":"https://cli000002-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000002-westus","locationName":"West
         US","documentEndpoint":"https://cli000002-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000002-westus","locationName":"West
         US","documentEndpoint":"https://cli000002-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000002-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":120,"backupRetentionIntervalInHours":8}}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":120,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":1}}},"identity":{"type":"None"}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2316'
+      - '2344'
       content-type:
       - application/json
       date:
-      - Thu, 10 Dec 2020 22:31:21 GMT
+      - Thu, 28 Jan 2021 22:59:12 GMT
       pragma:
       - no-cache
       server:

--- a/src/cosmosdb-preview/azext_cosmosdb_preview/tests/latest/test_cosmosdb-rbac_scenario.py
+++ b/src/cosmosdb-preview/azext_cosmosdb_preview/tests/latest/test_cosmosdb-rbac_scenario.py
@@ -1,0 +1,111 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from azure.cli.testsdk import (ScenarioTest, ResourceGroupPreparer)
+
+
+class Cosmosdb_previewRbacScenarioTest(ScenarioTest):
+
+    @ResourceGroupPreparer(name_prefix='cli_test_cosmosdb_sql_role')
+    def test_cosmosdb_sql_role(self, resource_group):
+        acc_name = self.create_random_name(prefix='cli', length=15)
+        db_name = self.create_random_name(prefix='cli', length=15)
+
+        subscription = self.get_subscription_id()
+        role_def_id = 'be79875a-2cc4-40d5-8958-566017875b39'
+        role_def_id2 = '6328f5f7-dbf7-4244-bba8-fbb9d8066506'
+        role_assignment_id = 'cb8ed2d7-2371-4e3c-bd31-6cc1560e84f8'
+        role_definition_create_body = ' {{ \\"Id\\": \\"{0}\\", \\"RoleName\\": \\"roleName\\", \\"Type\\": \\"CustomRole\\", \\"AssignableScopes\\": [ \\"/\\" ], \\"DataActions\\": [ \\"Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/items/create\\", \\"Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/items/read\\" ] }} '.format(role_def_id)
+        role_definition_update_body = ' {{ \\"Id\\": \\"{0}\\", \\"RoleName\\": \\"roleName2\\", \\"Type\\": \\"CustomRole\\", \\"AssignableScopes\\": [ \\"/\\" ], \\"Permissions\\": [ {{ \\"DataActions\\": [ \\"Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/items/create\\" ] }}, {{ \\"DataActions\\": [ \\"Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/items/read\\" ] }} ] }}'.format(role_def_id)
+        role_definition_create_body2 = ' {{ \\"Id\\": \\"{0}\\", \\"RoleName\\": \\"roleName3\\", \\"Type\\": \\"CustomRole\\", \\"AssignableScopes\\": [ \\"/\\" ], \\"Permissions\\": [ {{ \\"DataActions\\": [ \\"Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/items/create\\" ] }}, {{ \\"DataActions\\": [ \\"Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/items/read\\" ] }}, {{ \\"DataActions\\": [ \\"Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/items/replace\\" ] }} ] }}'.format(role_def_id2)
+        fully_qualified_role_def_id = '/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.DocumentDB/databaseAccounts/{2}/sqlRoleDefinitions/{3}'.format(subscription, resource_group, acc_name, role_def_id)
+        fully_qualified_role_def_id2 = '/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.DocumentDB/databaseAccounts/{2}/sqlRoleDefinitions/{3}'.format(subscription, resource_group, acc_name, role_def_id2)
+        fully_qualified_role_assignment_id = '/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.DocumentDB/databaseAccounts/{2}/sqlRoleAssignments/{3}'.format(subscription, resource_group, acc_name, role_assignment_id)
+        assignable_scope = '/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.DocumentDB/databaseAccounts/{2}'.format(subscription, resource_group, acc_name)
+        scope = '/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.DocumentDB/databaseAccounts/{2}/dbs/{3}'.format(subscription, resource_group, acc_name, db_name)
+        principal_id = 'ed4c2395-a18c-4018-afb3-6e521e7534d2'
+
+        self.kwargs.update({
+            'acc': acc_name,
+            'db_name': db_name,
+            'create_body': role_definition_create_body,
+            'update_body': role_definition_update_body,
+            'create_body2': role_definition_create_body2,
+            'role_def_id': role_def_id,
+            'fully_qualified_role_def_id': fully_qualified_role_def_id,
+            'role_def_id2': role_def_id2,
+            'fully_qualified_role_def_id2': fully_qualified_role_def_id2,
+            'role_assignment_id': role_assignment_id,
+            'fully_qualified_role_assignment_id': fully_qualified_role_assignment_id,
+            'scope': scope,
+            'principal_id': principal_id
+        })
+
+        self.cmd('az cosmosdb create -n {acc} -g {rg} --locations regionName=eastus2')
+        self.cmd('az cosmosdb sql database create -g {rg} -a {acc} -n {db_name}')
+        self.cmd('az cosmosdb sql role definition create -g {rg} -a {acc} -b "{create_body}"', checks=[
+            self.check('id', fully_qualified_role_def_id),
+            self.check('roleName', 'roleName'),
+            self.check('sqlRoleDefinitionGetResultsType', 'CustomRole'),
+            self.check('assignableScopes[0]', assignable_scope),
+            self.check('length(permissions)', 1)
+        ])
+
+        assert self.cmd('az cosmosdb sql role definition exists -g {rg} -a {acc} -i {role_def_id}').get_output_in_json()
+
+        self.cmd('az cosmosdb sql role definition show -g {rg} -a {acc} -i {role_def_id}', checks=[
+            self.check('roleName', 'roleName')
+        ])
+
+        self.cmd('az cosmosdb sql role definition update -g {rg} -a {acc} -b "{update_body}"', checks=[
+            self.check('id', fully_qualified_role_def_id),
+            self.check('roleName', 'roleName2'),
+            self.check('sqlRoleDefinitionGetResultsType', 'CustomRole'),
+            self.check('assignableScopes[0]', assignable_scope),
+            self.check('length(permissions)', 2)
+        ])
+
+        self.cmd('az cosmosdb sql role definition create -g {rg} -a {acc} -b "{create_body2}"', checks=[
+            self.check('id', fully_qualified_role_def_id2),
+            self.check('roleName', 'roleName3'),
+            self.check('sqlRoleDefinitionGetResultsType', 'CustomRole'),
+            self.check('assignableScopes[0]', assignable_scope),
+            self.check('length(permissions)', 3)
+        ])
+
+        role_definition_list = self.cmd('az cosmosdb sql role definition list -g {rg} -a {acc}').get_output_in_json()
+        assert len(role_definition_list) == 2
+
+        self.cmd('az cosmosdb sql role assignment create -g {rg} -a {acc} -s {scope} -p {principal_id} -d {fully_qualified_role_def_id} -i {role_assignment_id}', checks=[
+            self.check('id', fully_qualified_role_assignment_id),
+            self.check('roleDefinitionId', fully_qualified_role_def_id),
+            self.check('scope', scope),
+            self.check('principalId', principal_id)
+        ])
+
+        assert self.cmd('az cosmosdb sql role assignment exists -g {rg} -a {acc} -i {role_assignment_id}').get_output_in_json()
+
+        self.cmd('az cosmosdb sql role assignment show -g {rg} -a {acc} -i {role_assignment_id}', checks=[
+            self.check('id', fully_qualified_role_assignment_id)
+        ])
+
+        self.cmd('az cosmosdb sql role assignment update -g {rg} -a {acc} -d {role_def_id2} -i {fully_qualified_role_assignment_id}', checks=[
+            self.check('id', fully_qualified_role_assignment_id),
+            self.check('roleDefinitionId', fully_qualified_role_def_id2),
+            self.check('scope', scope),
+            self.check('principalId', principal_id)
+        ])
+
+        role_assignment_list = self.cmd('az cosmosdb sql role assignment list -g {rg} -a {acc}').get_output_in_json()
+        assert len(role_assignment_list) == 1
+
+        self.cmd('az cosmosdb sql role assignment delete -g {rg} -a {acc} -i {role_assignment_id} --yes')
+        role_assignment_list = self.cmd('az cosmosdb sql role assignment list -g {rg} -a {acc}').get_output_in_json()
+        assert len(role_assignment_list) == 0
+
+        self.cmd('az cosmosdb sql role definition delete -g {rg} -a {acc} -i {role_def_id} --yes')
+        self.cmd('az cosmosdb sql role definition delete -g {rg} -a {acc} -i {fully_qualified_role_def_id2} --yes')
+        role_definition_list = self.cmd('az cosmosdb sql role definition list -g {rg} -a {acc}').get_output_in_json()
+        assert len(role_definition_list) == 0

--- a/src/cosmosdb-preview/setup.py
+++ b/src/cosmosdb-preview/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
-VERSION = '0.2.0'
+VERSION = '0.3.0'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Adding commands that allow public preview customers to create and manage Role Definitions and Role Assignments for enforcing data plane RBAC on Cosmos DB SQL accounts. The following commands are introduced:
- cosmosdb sql role definition create
- cosmosdb sql role definition delete
- cosmosdb sql role definition list
- cosmosdb sql role definition show
- cosmosdb sql role definition update
- cosmosdb sql role definition exists
- cosmosdb sql role assignment create
- cosmosdb sql role assignment delete
- cosmosdb sql role assignment list
- cosmosdb sql role assignment show
- cosmosdb sql role assignment update
- cosmosdb sql role assignment exists

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [x] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
