### PR TITLE
remove vmware 2.0.0 from index

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -14918,39 +14918,6 @@
                 "sha256Digest": "e1775b05e22e3afb70ad395bc3cff1cb7fdfc9a90836b61e13d4c54843577ddb"
             },
             {
-                "downloadUrl": "https://azcliprod.blob.core.windows.net/cli-extensions/vmware-2.0.0-py2.py3-none-any.whl",
-                "filename": "vmware-2.0.0-py2.py3-none-any.whl",
-                "metadata": {
-                    "azext.isPreview": false,
-                    "azext.minCliCoreVersion": "2.0.66",
-                    "description_content_type": "text/markdown",
-                    "extensions": {
-                        "python.details": {
-                            "contacts": [
-                                {
-                                    "email": "azpycli@microsoft.com",
-                                    "name": "Microsoft",
-                                    "role": "author"
-                                }
-                            ],
-                            "document_names": {
-                                "description": "DESCRIPTION.rst"
-                            },
-                            "project_urls": {
-                                "Home": "https://github.com/Azure/az-vmware-cli"
-                            }
-                        }
-                    },
-                    "generator": "bdist_wheel (0.30.0)",
-                    "license": "MIT",
-                    "metadata_version": "2.0",
-                    "name": "vmware",
-                    "summary": "Azure VMware Solution commands.",
-                    "version": "2.0.0"
-                },
-                "sha256Digest": "25bb9c9259c924857fa7a3484fbe226f0bedda253c394aa23de227d1f0b050ec"
-            },
-            {
                 "downloadUrl": "https://azcliprod.blob.core.windows.net/cli-extensions/vmware-2.0.1-py2.py3-none-any.whl",
                 "filename": "vmware-2.0.1-py2.py3-none-any.whl",
                 "metadata": {


### PR DESCRIPTION
Now that 2.0.1 is published with a higher minimum version, 2.0.0 needs to be removed to fix #3045. Older clients need to fall back to 1.0.0.