### PR TITLE
[next] Fix the bug that the nested command history could not be logged

### DIFF
--- a/src/next/HISTORY.rst
+++ b/src/next/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.1.2
+++++++
+* Fix the bug that the nested command history could not be logged
+
 0.1.1
 ++++++
 * Support personalized recommendation

--- a/src/next/azext_next/__init__.py
+++ b/src/next/azext_next/__init__.py
@@ -34,14 +34,11 @@ class NextCommandsLoader(AzCommandsLoader):
     # but also recursively calls load_command_table() again, and fall into infinite nested call
     # So NextCommandsLoader is a singleton, and _has_reload_command_table is used to avoid infinite nested calls
     def load_command_table(self, args):
-        if self._has_reload_command_table:
-            return self.command_table
-
         # When executing "azdev linter --include-whl-extensions next" in CI, args is none, so judgment is added
         if args:
             from azure.cli.core.util import roughly_parse_command
             command = roughly_parse_command(args)
-            if command == 'next':
+            if command == 'next' and not self._has_reload_command_table:
                 self._has_reload_command_table = True
                 from unittest.mock import patch
                 with patch.dict("os.environ", {'AZURE_CORE_USE_COMMAND_INDEX': 'False'}):

--- a/src/next/setup.py
+++ b/src/next/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
-VERSION = '0.1.1'
+VERSION = '0.1.2'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Because `NextCommandsLoader` is a singleton, the `_has_reload_command_table` is True when executing the recommended nested command for `az next`, then the execution history of the nested command will not be recorded

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [x] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
