### PR TITLE
[AKS] Fix error that msi client always get managed identity in ctx's sub

### DIFF
--- a/src/aks-preview/HISTORY.md
+++ b/src/aks-preview/HISTORY.md
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.5.6
++++++
+* Fix issue that assigning identity in another subscription will fail
+
 0.5.5
 +++++
 * Add support for Azure KeyVault Secrets Provider as an AKS addon

--- a/src/aks-preview/azext_aks_preview/_client_factory.py
+++ b/src/aks-preview/azext_aks_preview/_client_factory.py
@@ -118,5 +118,6 @@ def get_resource_by_name(cli_ctx, resource_name, resource_type):
                 resource_type, resource_name))
 
 
-def get_msi_client(cli_ctx, **_):
-    return get_mgmt_service_client(cli_ctx, ManagedServiceIdentityClient)
+def get_msi_client(cli_ctx, subscription_id=None):
+    return get_mgmt_service_client(cli_ctx, ManagedServiceIdentityClient,
+                                   subscription_id=subscription_id)

--- a/src/aks-preview/azext_aks_preview/custom.py
+++ b/src/aks-preview/azext_aks_preview/custom.py
@@ -592,12 +592,13 @@ _re_user_assigned_identity_resource_id = re.compile(
 
 
 def _get_user_assigned_identity(cli_ctx, resource_id):
-    msi_client = get_msi_client(cli_ctx)
     resource_id = resource_id.lower()
     match = _re_user_assigned_identity_resource_id.search(resource_id)
     if match:
+        subscription_id = match.group(1)
         resource_group_name = match.group(2)
         identity_name = match.group(3)
+        msi_client = get_msi_client(cli_ctx, subscription_id)
         try:
             identity = msi_client.user_assigned_identities.get(resource_group_name=resource_group_name,
                                                                resource_name=identity_name)

--- a/src/aks-preview/setup.py
+++ b/src/aks-preview/setup.py
@@ -8,7 +8,7 @@
 from codecs import open as open1
 from setuptools import setup, find_packages
 
-VERSION = "0.5.5"
+VERSION = "0.5.6"
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',


### PR DESCRIPTION
Currently, the MSI client is created using current context's subscription, which is incorrect when the identity is in another subscription. This PR fix the error.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [X] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
