### PR TITLE
Remove the limitation of using azure packages in dependency

### DIFF
--- a/scripts/ci/test_index.py
+++ b/scripts/ci/test_index.py
@@ -19,7 +19,7 @@ import shutil
 from packaging import version
 from wheel.install import WHEEL_INFO_RE
 
-from util import get_ext_metadata, get_whl_from_url, get_index_data, verify_dependency
+from util import get_ext_metadata, get_whl_from_url, get_index_data
 
 
 def get_sha256sum(a_file):
@@ -183,13 +183,7 @@ class TestIndex(unittest.TestCase):
                                  "Metadata for {} in index doesn't match the expected of: \n"
                                  "{}".format(item['filename'], json.dumps(metadata, indent=2, sort_keys=True,
                                                                           separators=(',', ': '))))
-            run_requires = metadata.get('run_requires')
-            if run_requires:
-                deps = run_requires[0]['requires']
-                self.assertTrue(
-                    all(verify_dependency(dep) for dep in deps),
-                    "Dependencies of {} use disallowed extension dependencies. "
-                    "Remove these dependencies: {}".format(item['filename'], deps))
+
         shutil.rmtree(extensions_dir)
 
 

--- a/scripts/ci/test_source.py
+++ b/scripts/ci/test_source.py
@@ -19,7 +19,7 @@ import mock
 from wheel.install import WHEEL_INFO_RE
 from six import with_metaclass
 
-from util import get_ext_metadata, verify_dependency, SRC_PATH
+from util import SRC_PATH
 
 
 ALL_TESTS = []
@@ -104,17 +104,6 @@ class TestSourceWheels(unittest.TestCase):
                 check_output(['python', 'setup.py', 'bdist_wheel', '-q', '-d', built_whl_dir], cwd=s)
             except CalledProcessError as err:
                 self.fail("Unable to build extension {} : {}".format(s, err))
-        for filename in os.listdir(built_whl_dir):
-            ext_file = os.path.join(built_whl_dir, filename)
-            ext_dir = tempfile.mkdtemp(dir=built_whl_dir)
-            ext_name = WHEEL_INFO_RE(filename).groupdict().get('name')
-            metadata = get_ext_metadata(ext_dir, ext_file, ext_name)
-            run_requires = metadata.get('run_requires')
-            if run_requires:
-                deps = run_requires[0]['requires']
-                self.assertTrue(all(verify_dependency(dep) for dep in deps),
-                                "Dependencies of {} use disallowed extension dependencies. "
-                                "Remove these dependencies: {}".format(filename, deps))
         shutil.rmtree(built_whl_dir)
 
 

--- a/scripts/ci/util.py
+++ b/scripts/ci/util.py
@@ -121,10 +121,3 @@ def get_index_data():
             return json.load(f, object_pairs_hook=_catch_dup_keys)
     except ValueError as err:
         raise AssertionError("Invalid JSON in {}: {}".format(INDEX_PATH, err))
-
-
-def verify_dependency(dep):
-    # ex. "azure-batch-extensions (<3.1,>=3.0.0)", "paho-mqtt (==1.3.1)", "pyyaml"
-    # check if 'azure-' dependency, as they use 'azure' namespace.
-    dep_split = dep.split()
-    return not (dep_split and dep_split[0].startswith('azure-') and dep_split[0] not in SKIP_DEP_CHECK)

--- a/scripts/ci/util.py
+++ b/scripts/ci/util.py
@@ -8,10 +8,6 @@ import re
 import json
 import zipfile
 
-# Dependencies that will not be checked.
-# This is for packages starting with 'azure-' but do not use the 'azure' namespace.
-SKIP_DEP_CHECK = ['azure-batch-extensions']
-
 # copy from wheel==0.30.0
 WHEEL_INFO_RE = re.compile(
     r"""^(?P<namever>(?P<name>.+?)(-(?P<ver>\d.+?))?)


### PR DESCRIPTION
With the work of [PEP420](https://github.com/Azure/azure-cli/pull/14372) and [Enable CLI extensions to include packages in the 'azure' namespace](https://github.com/Azure/azure-cli/pull/13163), we can remove the check in CI that the dependencies of extension cannot start with `azure-`. It's blocking https://github.com/Azure/azure-cli-extensions/pull/3047.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
