### PR TITLE
[Storage] `az storage blob download`: Support write to stdout(used by pipe)

### DIFF
--- a/src/storage-blob-preview/azext_storage_blob_preview/_help.py
+++ b/src/storage-blob-preview/azext_storage_blob_preview/_help.py
@@ -71,6 +71,13 @@ examples:
 helps['storage blob download'] = """
 type: command
 short-summary: Download a blob to a file path, with automatic chunking and progress notifications.
+examples:
+  - name: Download a blob to local file.
+    text: az storage blob download -f /path/to/file -c mycontainer -n myblob --account-name mystorageaccount --account-key myaccountkey
+  - name: Download to local file with blob sas url
+    text: az storage blob download -f /path/to/file --blob-url https://mystorageaccount.blob.core.windows.net/mycontainer/myblob?sv=2019-02-02&st=2020-12-22T07%3A07%3A29Z&se=2020-12-23T07%3A07%3A29Z&sr=b&sp=racw&sig=redacted
+  - name: Download a blob content to stdout(pipe support).
+    text: az storage blob download -c mycontainer -n myblob --account-name mystorageaccount --account-key myaccountkey
 """
 
 helps['storage blob filter'] = """

--- a/src/storage-blob-preview/azext_storage_blob_preview/_params.py
+++ b/src/storage-blob-preview/azext_storage_blob_preview/_params.py
@@ -236,7 +236,8 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
         c.register_blob_arguments()
         c.register_precondition_options()
         c.argument('file_path', options_list=('--file', '-f'), type=file_type, completer=FilesCompleter(),
-                   help='Path of file to write out to.')
+                   help='Path of file to write out to. If not specified, stdout will be used '
+                        'and max_connections will be set to 1.')
         c.extra('start_range', type=int,
                 help='Start of byte range to use for downloading a section of the blob. If no end_range is given, '
                 'all bytes after the start_range will be downloaded. The start_range and end_range params are '


### PR DESCRIPTION
Feature requested by https://github.com/Azure/azure-cli/issues/16925
`--file` used to be required as local file path for `az storage blob download`.
This PR allows download blob content to `stdout` for pipe support when no `--file` specified.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
