### PR TITLE
[AKS] Check addon profile if it exists

### DIFF
--- a/src/aks-preview/HISTORY.md
+++ b/src/aks-preview/HISTORY.md
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+0.5.9
++++++
+* Display result better for `az aks command invoke`, while still honor output option
+* Fix the bug that checking the addon profile whether it exists
+
 0.5.8
 +++++
 * Update to use 2021-03-01 api-version

--- a/src/aks-preview/setup.py
+++ b/src/aks-preview/setup.py
@@ -8,7 +8,7 @@
 from codecs import open as open1
 from setuptools import setup, find_packages
 
-VERSION = "0.5.8"
+VERSION = "0.5.9"
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',


### PR DESCRIPTION
The addon profile is null when there is no addon added before. Here need to check it in the update scenario. 
Ref: #3248 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
