### PR TITLE
Block azure-cli-ml in extension command tree

### DIFF
--- a/scripts/ci/build_ext_cmd_tree.sh
+++ b/scripts/ci/build_ext_cmd_tree.sh
@@ -19,8 +19,8 @@ export AZURE_CORE_COLLECT_TELEMETRY=False
 sleep 360
 
 output=$(az extension list-available --query [].name -otsv)
-# azure-cli-iot-ext is the deprecated old versions of the renamed azure-iot extension
-blocklist=("azure-cli-iot-ext")
+# azure-cli-ml is replaced by ml
+blocklist=("azure-cli-ml")
 
 rm -f ~/.azure/extCmdTreeToUpload.json
 


### PR DESCRIPTION
New `ml` extension will be released in #3341.
It has overlapping commands with the old `azure-cli-ml`. Both extensions will coexist for a while. Block the `azure-cli-ml` first to avoid trouble when building extension command tree which requires that 2 extensions cannot have the same command.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
