### PR TITLE
Add compatible logic for the track 2 migration of resource

### DIFF
--- a/src/aks-preview/HISTORY.md
+++ b/src/aks-preview/HISTORY.md
@@ -2,6 +2,11 @@
 
 Release History
 ===============
+
+0.5.13
++++++
+* Add compatible logic for the track 2 migration of resource dependence
+
 0.5.12
 +++++
 * Add --enable-azure-rbac and --disable-azure-rbac in aks update

--- a/src/aks-preview/azext_aks_preview/custom.py
+++ b/src/aks-preview/azext_aks_preview/custom.py
@@ -317,20 +317,16 @@ def _invoke_deployment(cmd, resource_group_name, deployment_name, template, para
         logger.info(json.dumps(template, indent=2))
         logger.info('==== END TEMPLATE ====')
 
-    if cmd.supported_api_version(min_api='2019-10-01', resource_type=ResourceType.MGMT_RESOURCE_RESOURCES):
-        Deployment = cmd.get_models(
-            'Deployment', resource_type=ResourceType.MGMT_RESOURCE_RESOURCES)
-        deployment = Deployment(properties=properties)
-
-        if validate:
-            validation_poller = smc.validate(
-                resource_group_name, deployment_name, deployment)
-            return LongRunningOperation(cmd.cli_ctx)(validation_poller)
-        return sdk_no_wait(no_wait, smc.create_or_update, resource_group_name, deployment_name, deployment)
-
+    Deployment = cmd.get_models('Deployment', resource_type=ResourceType.MGMT_RESOURCE_RESOURCES)
+    deployment = Deployment(properties=properties)
     if validate:
-        return smc.validate(resource_group_name, deployment_name, properties)
-    return sdk_no_wait(no_wait, smc.create_or_update, resource_group_name, deployment_name, properties)
+        if cmd.supported_api_version(min_api='2019-10-01', resource_type=ResourceType.MGMT_RESOURCE_RESOURCES):
+            validation_poller = smc.begin_validate(resource_group_name, deployment_name, deployment)
+            return LongRunningOperation(cmd.cli_ctx)(validation_poller)
+        else:
+            return smc.validate(resource_group_name, deployment_name, deployment)
+
+    return sdk_no_wait(no_wait, smc.begin_create_or_update, resource_group_name, deployment_name, deployment)
 
 
 def create_application(client, display_name, homepage, identifier_uris,
@@ -2598,29 +2594,27 @@ def _ensure_default_log_analytics_workspace_for_monitoring(cmd, subscription_id,
     resource_groups = cf_resource_groups(cmd.cli_ctx, subscription_id)
     resources = cf_resources(cmd.cli_ctx, subscription_id)
 
+    from azure.cli.core.profiles import ResourceType
     # check if default RG exists
     if resource_groups.check_existence(default_workspace_resource_group):
+        from azure.core.exceptions import HttpResponseError
         try:
             resource = resources.get_by_id(
                 default_workspace_resource_id, '2015-11-01-preview')
             return resource.id
-        except CloudError as ex:
+        except HttpResponseError as ex:
             if ex.status_code != 404:
                 raise ex
     else:
-        resource_groups.create_or_update(default_workspace_resource_group, {
-                                         'location': workspace_region})
+        ResourceGroup = cmd.get_models('ResourceGroup', resource_type=ResourceType.MGMT_RESOURCE_RESOURCES)
+        resource_group = ResourceGroup(location=workspace_region)
+        resource_groups.create_or_update(default_workspace_resource_group, resource_group)
 
-    default_workspace_params = {
-        'location': workspace_region,
-        'properties': {
-            'sku': {
-                'name': 'standalone'
-            }
-        }
-    }
-    async_poller = resources.create_or_update_by_id(default_workspace_resource_id, '2015-11-01-preview',
-                                                    default_workspace_params)
+    GenericResource = cmd.get_models('GenericResource', resource_type=ResourceType.MGMT_RESOURCE_RESOURCES)
+    generic_resource = GenericResource(location=workspace_region, properties={'sku': {'name': 'standalone'}})
+
+    async_poller = resources.begin_create_or_update_by_id(default_workspace_resource_id, '2015-11-01-preview',
+                                                          generic_resource)
 
     ws_resource_id = ''
     while True:
@@ -2669,11 +2663,12 @@ def _ensure_container_insights_for_monitoring(cmd, addon):
 
     # region of workspace can be different from region of RG so find the location of the workspace_resource_id
     resources = cf_resources(cmd.cli_ctx, subscription_id)
+    from azure.core.exceptions import HttpResponseError
     try:
         resource = resources.get_by_id(
             workspace_resource_id, '2015-11-01-preview')
         location = resource.location
-    except CloudError as ex:
+    except HttpResponseError as ex:
         raise ex
 
     unix_time_in_millis = int(

--- a/src/aks-preview/setup.py
+++ b/src/aks-preview/setup.py
@@ -8,7 +8,7 @@
 from codecs import open as open1
 from setuptools import setup, find_packages
 
-VERSION = "0.5.12"
+VERSION = "0.5.13"
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',

--- a/src/connectedk8s/HISTORY.rst
+++ b/src/connectedk8s/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+1.1.4
+++++++
+* Add compatible logic for the track 2 migration of resource dependence
+
 1.1.3
 ++++++
 * Fix for list_node() sdk function for AKS v1.19.x clusters

--- a/src/connectedk8s/azext_connectedk8s/custom.py
+++ b/src/connectedk8s/azext_connectedk8s/custom.py
@@ -201,9 +201,11 @@ def create_connectedk8s(cmd, client, resource_group_name, cluster_name, https_pr
 
     # Resource group Creation
     if resource_group_exists(cmd.cli_ctx, resource_group_name, subscription_id) is False:
-        resource_group_params = {'location': location}
+        from azure.cli.core.profiles import ResourceType
+        ResourceGroup = cmd.get_models('ResourceGroup', resource_type=ResourceType.MGMT_RESOURCE_RESOURCES)
+        parameters = ResourceGroup(location=location)
         try:
-            resourceClient.resource_groups.create_or_update(resource_group_name, resource_group_params)
+            resourceClient.resource_groups.create_or_update(resource_group_name, parameters)
         except Exception as e:  # pylint: disable=broad-except
             utils.arm_exception_handler(e, consts.Create_ResourceGroup_Fault_Type, 'Failed to create the resource group')
 

--- a/src/connectedk8s/setup.py
+++ b/src/connectedk8s/setup.py
@@ -17,7 +17,7 @@ except ImportError:
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
 
-VERSION = '1.1.3'
+VERSION = '1.1.4'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/src/db-up/HISTORY.rst
+++ b/src/db-up/HISTORY.rst
@@ -3,6 +3,10 @@
  Release History
 ===============
 
+0.2.3 (2021-05-10)
+++++++++++++++++++
+* Add compatible logic for the track 2 migration of resource dependence
+
 0.2.2 (2021-03-22)
 ++++++++++++++++++
 * Configure for custom cloud settings

--- a/src/db-up/azext_db_up/custom.py
+++ b/src/db-up/azext_db_up/custom.py
@@ -224,7 +224,7 @@ def server_down(cmd, client, resource_group_name=None, server_name=None, delete_
 
         # delete resource group
         logger.warning('Deleting Resource Group \'%s\'...', resource_group_name)
-        return resource_client.resource_groups.delete(resource_group_name)
+        return resource_client.resource_groups.begin_delete(resource_group_name)
     logger.warning('Deleting server \'%s\'...', server_name)
     return client.delete(resource_group_name, server_name)
 

--- a/src/db-up/setup.py
+++ b/src/db-up/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup, find_packages
 
-VERSION = "0.2.2"
+VERSION = "0.2.3"
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',

--- a/src/k8s-extension/HISTORY.rst
+++ b/src/k8s-extension/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+0.4.1
+++++++++++++++++++
+
+* Add compatible logic for the track 2 migration of resource dependence
+
 0.4.0
 ++++++++++++++++++
 

--- a/src/k8s-extension/azext_k8s_extension/custom.py
+++ b/src/k8s-extension/azext_k8s_extension/custom.py
@@ -223,10 +223,11 @@ def __create_identity(cmd, resource_group_name, cluster_name, cluster_type, clus
             "Error! Cluster type '{}' is not supported for extension identity".format(cluster_type)
         )
 
+    from azure.core.exceptions import HttpResponseError
     try:
         resource = resources.get_by_id(cluster_resource_id, parent_api_version)
         location = str(resource.location.lower())
-    except CloudError as ex:
+    except HttpResponseError as ex:
         raise ex
     identity_type = "SystemAssigned"
 

--- a/src/k8s-extension/setup.py
+++ b/src/k8s-extension/setup.py
@@ -32,7 +32,7 @@ CLASSIFIERS = [
 # TODO: Add any additional SDK dependencies here
 DEPENDENCIES = []
 
-VERSION = "0.4.0"
+VERSION = "0.4.1"
 
 with open('README.rst', 'r', encoding='utf-8') as f:
     README = f.read()

--- a/src/mesh/HISTORY.rst
+++ b/src/mesh/HISTORY.rst
@@ -2,6 +2,12 @@
 
 Release History
 ===============
+
+0.10.7 (2021-5-10)
+++++++++++++++++++
+
+* Add compatible logic for the track 2 migration of resource dependence
+
 0.10.6 (2019-6-24)
 ++++++++++++++++++
 

--- a/src/mesh/setup.py
+++ b/src/mesh/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup, find_packages
 
-VERSION = "0.10.6"
+VERSION = "0.10.7"
 
 
 CLASSIFIERS = [

--- a/src/service_name.json
+++ b/src/service_name.json
@@ -335,6 +335,11 @@
     "URL": "https://docs.microsoft.com/azure/spring-cloud/"
   },
   {
+    "Command": "az sql",
+    "AzureServiceName": "Azure SQL",
+    "URL": "https://docs.microsoft.com/en-us/azure/azure-sql/"
+  },
+  {
     "Command": "az ssh",
     "AzureServiceName": "Azure Virtual Machines",
     "URL": "https://docs.microsoft.com/azure/virtual-machines/linux/mac-create-ssh-keys/"


### PR DESCRIPTION
Because Python SDK used by resource module needs to be migrated to track 2 recently, there are a lot of breaking changes in track 2, while the Python SDK of `azure-mgmt-resource` used by `azure-cli-extension` is the same as `azure-cli`. Therefore, the modules that use Python SDK of `azure-mgmt-resource` in `azure-cli-extension` should be added with the compatible logic of track 2.

Please refer to the PR description https://github.com/Azure/azure-cli/pull/17783 for specific compatibility logic to be added


---
This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
