### PR TITLE
[AKS] fix aks pr check-in test pipeline

### DIFF
--- a/src/aks-preview/az_aks_tool/main.py
+++ b/src/aks-preview/az_aks_tool/main.py
@@ -67,6 +67,9 @@ def main():
     print("raw args: {}".format(sys.argv))
     args = init_argparse(sys.argv[1:])
 
+    # check directory
+    utils.create_directory(args.report_path)
+
     # setup logger
     root_module_name = log.parse_module_name(levels=1)
     log.setup_logging(root_module_name, os.path.join(

--- a/src/aks-preview/az_aks_tool/utils.py
+++ b/src/aks-preview/az_aks_tool/utils.py
@@ -8,10 +8,19 @@ import os
 import sys
 import re
 import logging
+import pathlib
 
-import az_aks_tool.const as const
 import az_aks_tool.filter as custom_filter
 logger = logging.getLogger(__name__)
+
+
+def create_directory(dir_path):
+    if dir_path:
+        if not os.path.isdir(dir_path):
+            print("Directory '{}' not exist, creating...".format(dir_path))
+            pathlib.Path(dir_path).mkdir(parents=True, exist_ok=True)
+    else:
+        print("Invalid dir path: '{}'".format(dir_path))
 
 
 def check_file_existence(file_path):

--- a/src/aks-preview/azcli_aks_live_test/ext_matrix_default.json
+++ b/src/aks-preview/azcli_aks_live_test/ext_matrix_default.json
@@ -21,11 +21,13 @@
             "test_aks_update_azurekeyvaultsecretsprovider_with_secret_rotation",
             "test_aks_enable_addon_with_azurekeyvaultsecretsprovider",
             "test_aks_enable_addon_with_gitops",
-            "test_aks_create_with_fips"
+            "test_aks_create_with_fips",
+            "test_aks_disable_local_accounts"
         ],
         "unknown": [
             "test_aks_create_and_update_with_managed_aad_enable_azure_rbac",
-            "test_aks_create_with_virtual_node_addon"
+            "test_aks_create_with_virtual_node_addon",
+            "test_aks_update_to_msi_cluster_with_addons"
         ],
         "code bug": [
             "test_aks_create_with_ingress_appgw_addon_with_deprecated_subet_prefix",

--- a/src/aks-preview/azcli_aks_live_test/ext_matrix_default.json
+++ b/src/aks-preview/azcli_aks_live_test/ext_matrix_default.json
@@ -22,7 +22,9 @@
             "test_aks_enable_addon_with_azurekeyvaultsecretsprovider",
             "test_aks_enable_addon_with_gitops",
             "test_aks_create_with_fips",
-            "test_aks_disable_local_accounts"
+            "test_aks_disable_local_accounts",
+            "test_aks_nodepool_add_with_ossku",
+            "test_aks_create_with_ossku"
         ],
         "unknown": [
             "test_aks_create_and_update_with_managed_aad_enable_azure_rbac",

--- a/src/aks-preview/azcli_aks_live_test/test_ext_live.sh
+++ b/src/aks-preview/azcli_aks_live_test/test_ext_live.sh
@@ -55,6 +55,10 @@ fi
 if [[ -n ${TEST_CASES} ]]; then
     run_flags+=" -t ${TEST_CASES}"
 fi
+# ext matrix
+if [[ -n ${EXT_TEST_MATRIX} ]]; then
+    run_flags+=" -em ${EXT_TEST_MATRIX}"
+fi
 # ext extra filter
 if [[ -n ${EXT_TEST_FILTER} ]]; then
     run_flags+=" -ef ${EXT_TEST_FILTER}"

--- a/src/aks-preview/azcli_aks_live_test/test_ext_live.sh
+++ b/src/aks-preview/azcli_aks_live_test/test_ext_live.sh
@@ -14,6 +14,7 @@ set -o xtrace
 [[ -z "${TEST_MODE}" ]] && (echo "TEST_MODE is empty"; exit 1)
 [[ -z "${PARALLELISM}" ]] && (echo "PARALLELISM is empty"; exit 1)
 [[ -z "${TEST_CASES}" ]] && (echo "TEST_CASES is empty")
+[[ -z "${EXT_TEST_MATRIX}" ]] && (echo "EXT_TEST_MATRIX is empty")
 [[ -z "${EXT_TEST_FILTER}" ]] && (echo "EXT_TEST_FILTER is empty")
 [[ -z "${EXT_TEST_COVERAGE}" ]] && (echo "EXT_TEST_COVERAGE is empty")
 
@@ -74,7 +75,7 @@ if [[ ${TEST_MODE} == "record" || ${TEST_MODE} == "all" ]]; then
     run_flags+=" --json-report-file=ext_report.json"
     run_flags+=" --xml-file=ext_result.xml"
     echo "run flags: ${run_flags}"
-    echo ${run_flags} | xargs python -u az_aks_tool/main.py
+    echo "${run_flags}" | xargs python -u az_aks_tool/main.py
 fi
 
 # live test
@@ -86,5 +87,5 @@ if [[ ${TEST_MODE} == "live" || ${TEST_MODE} == "all" ]]; then
     run_flags+=" -l --json-report-file=ext_live_report.json"
     run_flags+=" --xml-file=ext_live_result.xml"
     echo "run flags: ${run_flags}"
-    echo ${run_flags} | xargs python -u az_aks_tool/main.py 
+    echo "${run_flags}" | xargs python -u az_aks_tool/main.py 
 fi

--- a/src/aks-preview/azcli_aks_live_test/transcribe_env.sh
+++ b/src/aks-preview/azcli_aks_live_test/transcribe_env.sh
@@ -51,6 +51,7 @@ echo "COVERAGE=${COVERAGE}" >> env.list
 echo "TEST_MODE=${TEST_MODE}" >> env.list
 echo "PARALLELISM=${PARALLELISM}" >> env.list
 echo "TEST_CASES=${TEST_CASES}" >> env.list
+echo "EXT_TEST_MATRIX=${EXT_TEST_MATRIX}" >> env.list
 echo "EXT_TEST_FILTER=${EXT_TEST_FILTER}" >> env.list
 echo "EXT_TEST_COVERAGE=${EXT_TEST_COVERAGE}" >> env.list
 

--- a/src/aks-preview/azcli_aks_live_test/transcribe_env.sh
+++ b/src/aks-preview/azcli_aks_live_test/transcribe_env.sh
@@ -17,6 +17,7 @@ set -o xtrace
 [[ -z "${TEST_MODE}" ]] && (echo "TEST_MODE is empty"; exit 1)
 [[ -z "${PARALLELISM}" ]] && (echo "PARALLELISM is empty"; exit 1)
 [[ -z "${TEST_CASES}" ]] && (echo "TEST_CASES is empty")
+[[ -z "${EXT_TEST_MATRIX}" ]] && (echo "EXT_TEST_MATRIX is empty")
 [[ -z "${EXT_TEST_FILTER}" ]] && (echo "EXT_TEST_FILTER is empty")
 [[ -z "${EXT_TEST_COVERAGE}" ]] && (echo "EXT_TEST_COVERAGE is empty")
 [[ -z "${CLI_REPO}" ]] && (echo "CLI_REPO is empty"; exit 1)

--- a/src/aks-preview/azcli_aks_live_test/vsts-azcli-aks-live-test.yaml
+++ b/src/aks-preview/azcli_aks_live_test/vsts-azcli-aks-live-test.yaml
@@ -58,7 +58,9 @@ jobs:
       inputs:
         contents: 'reports/**'
         targetFolder: $(Build.ArtifactStagingDirectory)
+      condition: succeededOrFailed()
     - task: PublishBuildArtifacts@1
       inputs:
         pathToPublish: $(Build.ArtifactStagingDirectory)
         artifactName: 'live test reports'
+      condition: succeededOrFailed()

--- a/src/aks-preview/azcli_aks_live_test/vsts-azcli-aks-unit-test.yaml
+++ b/src/aks-preview/azcli_aks_live_test/vsts-azcli-aks-unit-test.yaml
@@ -58,7 +58,9 @@ jobs:
       inputs:
         contents: 'reports/**'
         targetFolder: $(Build.ArtifactStagingDirectory)
+      condition: succeededOrFailed()
     - task: PublishBuildArtifacts@1
       inputs:
         pathToPublish: $(Build.ArtifactStagingDirectory)
         artifactName: 'unit test reports'
+      condition: succeededOrFailed()

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -1649,7 +1649,7 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
 
     @live_only()
     @AllowLargeResponse()
-    @ResourceGroupPreparer(random_name_length=17, name_prefix='clitest', location='westus2')
+    @AKSCustomResourceGroupPreparer(random_name_length=17, name_prefix='clitest', location='westus2')
     def test_aks_disable_local_accounts(self, resource_group, resource_group_location):
         aks_name = self.create_random_name('cliakstest', 16)
         self.kwargs.update({


### PR DESCRIPTION
Base on [PR#3415](https://github.com/Azure/azure-cli-extensions/pull/3415), this PR further fix some other known issues of the AKS PR check-in test pipeline. The main changes are as follows:

* Update az_aks_tool, add path check to avoid unexpected errors caused by invalid path
* Fix the problem that the variable passed to az_aks_tool in the extensions test script is lost
* Add two new test cases excluded by default (test_aks_disable_local_accounts, test_aks_update_to_msi_cluster_with_addons)
* Add a new pipeline variable *EXT_TEST_MATRIX* to override the default filtering rules

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
