### PR TITLE
Add support for user agent string in calls to AQ via CLI

### DIFF
--- a/src/quantum/azext_quantum/__init__.py
+++ b/src/quantum/azext_quantum/__init__.py
@@ -8,6 +8,12 @@ from azure.cli.core import AzCommandsLoader
 import azext_quantum._help  # pylint: disable=unused-import
 
 
+# This is the version reported by the CLI to the service when submitting requests.
+# This should be in sync with the extension version in 'setup.py', unless we need to
+# submit using a different version.
+CLI_REPORTED_VERSION = "0.4.0"
+
+
 class QuantumCommandsLoader(AzCommandsLoader):
 
     def __init__(self, cli_ctx=None):

--- a/src/quantum/azext_quantum/__init__.py
+++ b/src/quantum/azext_quantum/__init__.py
@@ -11,7 +11,7 @@ import azext_quantum._help  # pylint: disable=unused-import
 # This is the version reported by the CLI to the service when submitting requests.
 # This should be in sync with the extension version in 'setup.py', unless we need to
 # submit using a different version.
-CLI_REPORTED_VERSION = "0.4.0"
+CLI_REPORTED_VERSION = "0.5.0"
 
 
 class QuantumCommandsLoader(AzCommandsLoader):

--- a/src/quantum/azext_quantum/_client_factory.py
+++ b/src/quantum/azext_quantum/_client_factory.py
@@ -38,9 +38,6 @@ def get_appid():
 
 # Control Plane clients
 
-from pprint import pprint
-from inspect import getmembers
-from types import FunctionType
 
 def cf_quantum_mgmt(cli_ctx, *_):
     from azure.cli.core.commands.client_factory import get_mgmt_service_client

--- a/src/quantum/azext_quantum/_client_factory.py
+++ b/src/quantum/azext_quantum/_client_factory.py
@@ -7,6 +7,7 @@
 
 import os
 from ._location_helper import normalize_location
+from ..setup import VERSION
 
 
 def is_env(name):
@@ -31,12 +32,18 @@ def _get_data_credentials(cli_ctx, subscription_id=None):
     return creds
 
 
+def get_appid():
+    return f"azure-cli-extension/{VERSION}"
+
+
 # Control Plane clients
 
 def cf_quantum_mgmt(cli_ctx, *_):
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
     from .vendored_sdks.azure_mgmt_quantum import QuantumManagementClient
-    return get_mgmt_service_client(cli_ctx, QuantumManagementClient)
+    client = get_mgmt_service_client(cli_ctx, QuantumManagementClient)
+    client.config.add_user_agent(get_appid())
+    return client
 
 
 def cf_workspaces(cli_ctx, *_):
@@ -52,7 +59,9 @@ def cf_offerings(cli_ctx, *_):
 def cf_quantum(cli_ctx, subscription_id=None, resource_group_name=None, workspace_name=None, location=None):
     from .vendored_sdks.azure_quantum import QuantumClient
     creds = _get_data_credentials(cli_ctx, subscription_id)
-    return QuantumClient(creds, subscription_id, resource_group_name, workspace_name, base_url=base_url(location))
+    client = QuantumClient(creds, subscription_id, resource_group_name, workspace_name, base_url=base_url(location))
+    client.config.add_user_agent(get_appid())
+    return client
 
 
 def cf_providers(cli_ctx, subscription_id=None, resource_group_name=None, workspace_name=None, location=None):

--- a/src/quantum/azext_quantum/_client_factory.py
+++ b/src/quantum/azext_quantum/_client_factory.py
@@ -7,7 +7,7 @@
 
 import os
 from ._location_helper import normalize_location
-from ..setup import VERSION
+from .__init__ import CLI_REPORTED_VERSION
 
 
 def is_env(name):
@@ -33,10 +33,14 @@ def _get_data_credentials(cli_ctx, subscription_id=None):
 
 
 def get_appid():
-    return f"azure-cli-extension/{VERSION}"
+    return f"azure-cli-extension/{CLI_REPORTED_VERSION}"
 
 
 # Control Plane clients
+
+from pprint import pprint
+from inspect import getmembers
+from types import FunctionType
 
 def cf_quantum_mgmt(cli_ctx, *_):
     from azure.cli.core.commands.client_factory import get_mgmt_service_client

--- a/src/quantum/azext_quantum/azext_metadata.json
+++ b/src/quantum/azext_quantum/azext_metadata.json
@@ -1,4 +1,4 @@
 {
     "azext.isPreview": true,
-    "azext.minCliCoreVersion": "2.5.1"
+    "azext.minCliCoreVersion": "2.23.0"
 }

--- a/src/quantum/azext_quantum/operations/job.py
+++ b/src/quantum/azext_quantum/operations/job.py
@@ -102,8 +102,8 @@ def _generate_submit_args(program_args, ws, target, token, project, job_name, sh
     args.append("--aad-token")
     args.append(token)
 
-    args.append("--base-uri")
-    args.append(base_url(ws.location))
+    args.append("--location")
+    args.append(ws.location)
 
     args.extend(program_args)
 
@@ -111,6 +111,18 @@ def _generate_submit_args(program_args, ws, target, token, project, job_name, sh
     logger.debug(args)
 
     return args
+
+
+def _set_cli_version():
+    # This is a temporary approach for runtime compatibility between a runtime version
+    # before support for the --user-agent parameter is added. We'll rely on the environment
+    # variable before the stand alone executable submits to the service.
+    try:
+        import os
+        from .._client_factory import get_appid
+        os.environ["USER_AGENT"] = get_appid()
+    except:
+        logger.warning("User Agent environment variable could not be set.")
 
 
 def submit(cmd, program_args, resource_group_name=None, workspace_name=None, location=None,
@@ -132,6 +144,7 @@ def submit(cmd, program_args, resource_group_name=None, workspace_name=None, loc
     token = _get_data_credentials(cmd.cli_ctx, ws.subscription).get_token().token
 
     args = _generate_submit_args(program_args, ws, target, token, project, job_name, shots, storage)
+    _set_cli_version()
 
     import subprocess
     result = subprocess.run(args, stdout=subprocess.PIPE, check=False)

--- a/src/quantum/setup.py
+++ b/src/quantum/setup.py
@@ -14,8 +14,9 @@ except ImportError:
     from distutils import log as logger
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
 
-# TODO: Confirm this is the right version number you want and it matches your
-# HISTORY.rst entry.
+# This version should match the latest entry in HISTORY.rst
+# Also, when updating this review the version used by the extension to submit
+# requests, which can be found at './azext_quantum/__init__.py'
 VERSION = '0.4.0'
 
 # The full list of classifiers is available at

--- a/src/quantum/setup.py
+++ b/src/quantum/setup.py
@@ -15,8 +15,8 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
 
 # This version should match the latest entry in HISTORY.rst
-# Also, when updating this review the version used by the extension to submit
-# requests, which can be found at './azext_quantum/__init__.py'
+# Also, when updating this, please review the version used by the extension to
+# submit requests, which can be found at './azext_quantum/__init__.py'
 VERSION = '0.4.0'
 
 # The full list of classifiers is available at


### PR DESCRIPTION
As part of this change we are:
- Defining a user-agent-like string to represent the client used to submit jobs via the CLI.
- Append this to the user agent of the Control Plane and Data Plane clients.
- Set this as an environment variable for child processes to read it, as in the case of invoked standalone executables.