### PR TITLE
[AKS] Polish scripts used in aks pr check-in test pipeline

### DIFF
--- a/src/aks-preview/azcli_aks_live_test/clone_repo.sh
+++ b/src/aks-preview/azcli_aks_live_test/clone_repo.sh
@@ -1,25 +1,40 @@
 #!/usr/bin/env bash
 
-set -eux
+# bash options
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+# check var
+[[ -z "${CLI_REPO}" ]] && (echo "CLI_REPO is empty"; exit 1)
+[[ -z "${CLI_BRANCH}" ]] && (echo "CLI_BRANCH is empty"; exit 1)
+[[ -z "${EXT_REPO}" ]] && (echo "EXT_REPO is empty"; exit 1)
+[[ -z "${EXT_BRANCH}" ]] && (echo "EXT_BRANCH is empty"; exit 1)
+[[ -z "${MANUAL_EXT}" ]] && (echo "MANUAL_EXT is empty"; exit 1)
+
+# dir
 pwd
+ls -alh
 
 # clone azure-cli (default is the official repo)
 # git clone https://github.com/Azure/azure-cli.git
-git clone $CLI_REPO
+git clone ${CLI_REPO}
 
 # ckeckout to a specific azure-cli branch (default is the dev branch)
 pushd azure-cli/
 git branch -a
-git checkout $CLI_BRANCH
+git checkout ${CLI_BRANCH}
 popd
 
 # clone azure-cli-extensions when manually specify the extension repo
-if [[ $MANUAL_EXT == true && -n $EXT_REPO && -n $EXT_BRANCH ]]; then
+if [[ ${MANUAL_EXT} == true ]]; then
     echo "Manually specify the extension repo, delete the current 'azure-cli-extensions' directory!"
     rm -rf azure-cli-extensions/
-    git clone $EXT_REPO
+    git clone ${EXT_REPO}
     pushd azure-cli-extensions/
-    git checkout $EXT_BRANCH
+    git branch -a
+    git checkout ${EXT_BRANCH}
     popd
 fi
 

--- a/src/aks-preview/azcli_aks_live_test/prepare_image.sh
+++ b/src/aks-preview/azcli_aks_live_test/prepare_image.sh
@@ -1,9 +1,21 @@
 #!/usr/bin/env bash
 
-set -eux
+# bash options
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+# check var
+[[ -z "${IMAGE_PREFIX}" ]] && (echo "IMAGE_PREFIX is empty"; exit 1)
+[[ -z "${IMAGE_NAME}" ]] && (echo "IMAGE_NAME is empty"; exit 1)
+[[ -z "${IMAGE_TAG}" ]] && (echo "IMAGE_TAG is empty"; exit 1)
+
+# dir
 pwd
+ls -alh
 
 # prepare docker image
-echo "Pulling test image from '$IMAGE_PREFIX/$IMAGE_NAME:$IMAGE_TAG'..."
-docker pull $IMAGE_PREFIX/$IMAGE_NAME:$IMAGE_TAG
-docker tag $IMAGE_PREFIX/$IMAGE_NAME:$IMAGE_TAG $IMAGE_NAME:$IMAGE_TAG
+echo "Pulling test image from '${IMAGE_PREFIX}/${IMAGE_NAME}:${IMAGE_TAG}'..."
+docker pull ${IMAGE_PREFIX}/${IMAGE_NAME}:${IMAGE_TAG}
+docker tag ${IMAGE_PREFIX}/${IMAGE_NAME}:${IMAGE_TAG} ${IMAGE_NAME}:${IMAGE_TAG}

--- a/src/aks-preview/azcli_aks_live_test/setup_venv.sh
+++ b/src/aks-preview/azcli_aks_live_test/setup_venv.sh
@@ -21,7 +21,7 @@ python${PYTHON_VERSION} -m venv azEnv
 source azEnv/bin/activate
 python -m pip install -U pip
 # install azdev, used later to install azcli and extension
-pip install azdev
+pip install azdev==0.1.32
 # install pytest plugins
 pip install pytest-json-report pytest-rerunfailures --upgrade
 # pip install pytest-html --upgrade

--- a/src/aks-preview/azcli_aks_live_test/setup_venv.sh
+++ b/src/aks-preview/azcli_aks_live_test/setup_venv.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 
-set -eux
+# bash options
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+# check var
+PYTHON_VERSION=${PYTHON_VERSION:-"3.8"}
+
+# dir
 pwd
 ls -alh
 
@@ -8,11 +17,11 @@ ls -alh
 rm -rf azEnv || true
 
 # install python packages
-python$PYTHON_VERSION -m venv azEnv
+python${PYTHON_VERSION} -m venv azEnv
 source azEnv/bin/activate
 python -m pip install -U pip
-# fixed azdev version to avoid call failure in az_aks_tool
-pip install azdev==0.1.32
+# install azdev, used later to install azcli and extension
+pip install azdev
 # install pytest plugins
 pip install pytest-json-report pytest-rerunfailures --upgrade
 # pip install pytest-html --upgrade
@@ -25,11 +34,10 @@ which az || az version || az extension list || true
 # install az from cloned repos with azdev
 azdev setup -c azure-cli/ -r azure-cli-extensions/
 deactivate
-source azEnv/bin/activate
 
-# post-install: check installation result
-which az
-az version
+# post-install: reactivate venv to check installation result
+source azEnv/bin/activate
+which az && az version
 
 # mkdir to store reports
 mkdir -p reports/

--- a/src/aks-preview/azcli_aks_live_test/start_container.sh
+++ b/src/aks-preview/azcli_aks_live_test/start_container.sh
@@ -1,13 +1,25 @@
 #!/usr/bin/env bash
 
-set -eux
-pwd
+# bash options
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
 
-# transcribe environment variables into file 'env.list'
-source ./transcribe_env.sh
-
+# check var
 # take the first arg as container name
 container_name=${1:-"azcli-aks-live-test-container"}
+[[ -z "${MAPPED_AZCLI_ALT_CLIENT_SECRET}" ]] && (echo "MAPPED_AZCLI_ALT_CLIENT_SECRET is empty"; exit 1)
+[[ -z "${MAPPED_AZCLI_ALT_CLIENT_SECRET}" ]] && (echo "MAPPED_AZCLI_ALT_CLIENT_SECRET is empty"; exit 1)
+[[ -z "${IMAGE_NAME}" ]] && (echo "IMAGE_NAME is empty"; exit 1)
+[[ -z "${IMAGE_TAG}" ]] && (echo "IMAGE_TAG is empty"; exit 1)
+
+# dir
+pwd
+ls -alh
+
+# transcribe environment variables into file 'env.list'
+./transcribe_env.sh
 
 # start container in backgroud with tty
 # mount current directory ($(Agent.BuildDirectory)/s) to /opt in container
@@ -15,10 +27,10 @@ container_name=${1:-"azcli-aks-live-test-container"}
 # pass secrects as environment variables directly (instead of storing in env.list)
 # pass other environment variables with env.list
 docker run -t -d -v $PWD:/opt -w /opt \
--e AZCLI_ALT_CLIENT_SECRET=$MAPPED_AZCLI_ALT_CLIENT_SECRET \
--e AZURE_CLI_TEST_DEV_SP_PASSWORD=$MAPPED_AZCLI_ALT_CLIENT_SECRET \
+-e AZCLI_ALT_CLIENT_SECRET=${MAPPED_AZCLI_ALT_CLIENT_SECRET} \
+-e AZURE_CLI_TEST_DEV_SP_PASSWORD=${MAPPED_AZCLI_ALT_CLIENT_SECRET} \
 --env-file ./env.list \
---name $container_name $IMAGE_NAME:$IMAGE_TAG
+--name ${container_name} ${IMAGE_NAME}:${IMAGE_TAG}
 
 # remove env.list
 rm ./env.list

--- a/src/aks-preview/azcli_aks_live_test/test_cli_live.sh
+++ b/src/aks-preview/azcli_aks_live_test/test_cli_live.sh
@@ -1,7 +1,22 @@
 #!/usr/bin/env bash
 
-set -eux
+# bash options
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+# check var
+[[ -z "${TENANT_ID}" ]] && (echo "TENANT_ID is empty"; exit 1)
+[[ -z "${AZCLI_ALT_SUBSCRIPTION_ID}" ]] && (echo "AZCLI_ALT_SUBSCRIPTION_ID is empty"; exit 1)
+[[ -z "${AZCLI_ALT_CLIENT_ID}" ]] && (echo "AZCLI_ALT_CLIENT_ID is empty"; exit 1)
+[[ -z "${AZCLI_ALT_CLIENT_SECRET}" ]] && (echo "AZCLI_ALT_CLIENT_SECRET is empty"; exit 1)
+[[ -z "${TEST_MODE}" ]] && (echo "TEST_MODE is empty"; exit 1)
+[[ -z "${PARALLELISM}" ]] && (echo "PARALLELISM is empty"; exit 1)
+
+# dir
 pwd
+ls -alh
 
 # activate virtualenv
 source azEnv/bin/activate
@@ -14,17 +29,17 @@ if az extension remove --name aks-preview || azdev extension remove aks-preview;
 fi
 
 # test cli
-if [[ $TEST_MODE == "record" || $TEST_MODE == "all" ]]; then
+if [[ ${TEST_MODE} == "record" || ${TEST_MODE} == "all" ]]; then
     echo "Test in record mode!"
-    azdev test acs --no-exitfirst --xml-path cli_result.xml --discover -a "-n $PARALLELISM --json-report --json-report-file=cli_report.json --reruns 3 --capture=sys"
+    azdev test acs --no-exitfirst --xml-path cli_result.xml --discover -a "-n ${PARALLELISM} --json-report --json-report-file=cli_report.json --reruns 3 --capture=sys"
     cp *cli_report.json *cli_result.xml reports/
 fi
 
-if [[ $TEST_MODE == "live" || $TEST_MODE == "all" ]]; then
+if [[ ${TEST_MODE} == "live" || ${TEST_MODE} == "all" ]]; then
     echo "Test in live mode!"
-    az login --service-principal -u $AZCLI_ALT_CLIENT_ID -p $AZCLI_ALT_CLIENT_SECRET -t $TENANT_ID
-    az account set -s $AZCLI_ALT_SUBSCRIPTION_ID
+    az login --service-principal -u ${AZCLI_ALT_CLIENT_ID} -p ${AZCLI_ALT_CLIENT_SECRET} -t ${TENANT_ID}
+    az account set -s ${AZCLI_ALT_SUBSCRIPTION_ID}
     az account show
-    azdev test acs --live --no-exitfirst --xml-path cli_live_result.xml --discover -a "-n $PARALLELISM --json-report --json-report-file=cli_live_report.json --reruns 3 --capture=sys"
+    azdev test acs --live --no-exitfirst --xml-path cli_live_result.xml --discover -a "-n ${PARALLELISM} --json-report --json-report-file=cli_live_report.json --reruns 3 --capture=sys"
     cp *cli_live_report.json *cli_live_result.xml reports/
 fi

--- a/src/aks-preview/azcli_aks_live_test/test_cli_unit.sh
+++ b/src/aks-preview/azcli_aks_live_test/test_cli_unit.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
 
-set -eux
+# bash options
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+# dir
 pwd
+ls -alh
 
 # activate virtualenv
 source azEnv/bin/activate

--- a/src/aks-preview/azcli_aks_live_test/test_ext_live.sh
+++ b/src/aks-preview/azcli_aks_live_test/test_ext_live.sh
@@ -1,7 +1,25 @@
 #!/usr/bin/env bash
 
-set -eux
+# bash options
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+# check var
+[[ -z "${TENANT_ID}" ]] && (echo "TENANT_ID is empty"; exit 1)
+[[ -z "${AZCLI_ALT_SUBSCRIPTION_ID}" ]] && (echo "AZCLI_ALT_SUBSCRIPTION_ID is empty"; exit 1)
+[[ -z "${AZCLI_ALT_CLIENT_ID}" ]] && (echo "AZCLI_ALT_CLIENT_ID is empty"; exit 1)
+[[ -z "${AZCLI_ALT_CLIENT_SECRET}" ]] && (echo "AZCLI_ALT_CLIENT_SECRET is empty"; exit 1)
+[[ -z "${TEST_MODE}" ]] && (echo "TEST_MODE is empty"; exit 1)
+[[ -z "${PARALLELISM}" ]] && (echo "PARALLELISM is empty"; exit 1)
+[[ -z "${TEST_CASES}" ]] && (echo "TEST_CASES is empty")
+[[ -z "${EXT_TEST_FILTER}" ]] && (echo "EXT_TEST_FILTER is empty")
+[[ -z "${EXT_TEST_COVERAGE}" ]] && (echo "EXT_TEST_COVERAGE is empty")
+
+# dir
 pwd
+ls -alh
 
 # activate virtualenv
 source azEnv/bin/activate
@@ -21,60 +39,48 @@ azdev extension list | grep "aks-preview" -C 5
 deactivate
 source azEnv/bin/activate
 
-# Ensure that the command index is updated by calling a specific command in aks-preview, so that all the commands defined in aks-preview are loaded correctly
-# Otherwise, cold boot execution of azdev test may use the api version adopted by the acs command group in azure-cli (which may diverge from the api version used in current aks-preview)
-retry_count=0
-while ! az aks maintenanceconfiguration show --help && [[ $retry_count < 3 ]]
-do
-    retry_count=`expr $retry_count + 1`
-    echo $retry_count"th retry to install aks-preview..." 
-    azdev extension add aks-preview --debug
-    az extension list --debug
-    azdev extension list --debug | grep "aks-preview" -C 5
-    deactivate
-    source azEnv/bin/activate
-done
+# use a fake command to force trigger the command index update of azure-cli, in order to load aks-preview commands
+# otherwise, cold boot execution of azdev test / pytest would only use commands in the acs module
+az aks fake-command --debug || true
 
 # prepare run flags
-run_flags="-e -em ext_matrix_default.json --no-exitfirst --report-path ./ --reruns 3 --capture=sys"
+run_flags="-e -em ext_matrix_default.json --no-exitfirst --report-path ./reports --reruns 3 --capture=sys"
 # parallel
-if [ $PARALLELISM -ge 2 ]; then
-    run_flags+=" -j $PARALLELISM"
+if [ ${PARALLELISM} -ge 2 ]; then
+    run_flags+=" -j ${PARALLELISM}"
 else
     run_flags+=" -s"
 fi
 # test cases
-if [[ -n $TEST_CASES ]]; then
-    run_flags+=" -t $TEST_CASES"
+if [[ -n ${TEST_CASES} ]]; then
+    run_flags+=" -t ${TEST_CASES}"
 fi
 # ext extra filter
-if [[ -n $EXT_TEST_FILTER ]]; then
-    run_flags+=" -ef $EXT_TEST_FILTER"
+if [[ -n ${EXT_TEST_FILTER} ]]; then
+    run_flags+=" -ef ${EXT_TEST_FILTER}"
 fi
 # ext extra coverage
-if [[ -n $EXT_TEST_COVERAGE ]]; then
-    run_flags+=" -ec $EXT_TEST_COVERAGE"
+if [[ -n ${EXT_TEST_COVERAGE} ]]; then
+    run_flags+=" -ec ${EXT_TEST_COVERAGE}"
 fi
 
 # recording test
-if [[ $TEST_MODE == "record" || $TEST_MODE == "all" ]]; then
+if [[ ${TEST_MODE} == "record" || ${TEST_MODE} == "all" ]]; then
     echo "Test in record mode!"
     run_flags+=" --json-report-file=ext_report.json"
     run_flags+=" --xml-file=ext_result.xml"
     echo "run flags: ${run_flags}"
     echo ${run_flags} | xargs python -u az_aks_tool/main.py
-    cp *ext_report.json *ext_result.xml reports/
 fi
 
 # live test
-if [[ $TEST_MODE == "live" || $TEST_MODE == "all" ]]; then
+if [[ ${TEST_MODE} == "live" || ${TEST_MODE} == "all" ]]; then
     echo "Test in live mode!"
-    az login --service-principal -u $AZCLI_ALT_CLIENT_ID -p $AZCLI_ALT_CLIENT_SECRET -t $TENANT_ID
-    az account set -s $AZCLI_ALT_SUBSCRIPTION_ID
+    az login --service-principal -u ${AZCLI_ALT_CLIENT_ID} -p ${AZCLI_ALT_CLIENT_SECRET} -t ${TENANT_ID}
+    az account set -s ${AZCLI_ALT_SUBSCRIPTION_ID}
     az account show
     run_flags+=" -l --json-report-file=ext_live_report.json"
     run_flags+=" --xml-file=ext_live_result.xml"
     echo "run flags: ${run_flags}"
     echo ${run_flags} | xargs python -u az_aks_tool/main.py 
-    cp *ext_live_report.json *ext_live_result.xml reports/
 fi

--- a/src/aks-preview/azcli_aks_live_test/transcribe_env.sh
+++ b/src/aks-preview/azcli_aks_live_test/transcribe_env.sh
@@ -1,40 +1,69 @@
 #!/usr/bin/env bash
 
+# bash options
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+# check var
+[[ -z "${TENANT_ID}" ]] && (echo "TENANT_ID is empty"; exit 1)
+[[ -z "${AZCLI_ALT_SUBSCRIPTION_ID}" ]] && (echo "AZCLI_ALT_SUBSCRIPTION_ID is empty"; exit 1)
+[[ -z "${AZCLI_ALT_CLIENT_ID}" ]] && (echo "AZCLI_ALT_CLIENT_ID is empty"; exit 1)
+[[ -z "${TEST_LOCATION}" ]] && (echo "TEST_LOCATION is empty"; exit 1)
+[[ -z "${BUILD_REASON}" ]] && (echo "BUILD_REASON is empty")
+[[ -z "${SYSTEM_PULLREQUEST_TARGETBRANCH}" ]] && (echo "SYSTEM_PULLREQUEST_TARGETBRANCH is empty")
+[[ -z "${COVERAGE}" ]] && (echo "COVERAGE is empty"; exit 1)
+[[ -z "${TEST_MODE}" ]] && (echo "TEST_MODE is empty"; exit 1)
+[[ -z "${PARALLELISM}" ]] && (echo "PARALLELISM is empty"; exit 1)
+[[ -z "${TEST_CASES}" ]] && (echo "TEST_CASES is empty")
+[[ -z "${EXT_TEST_FILTER}" ]] && (echo "EXT_TEST_FILTER is empty")
+[[ -z "${EXT_TEST_COVERAGE}" ]] && (echo "EXT_TEST_COVERAGE is empty")
+[[ -z "${CLI_REPO}" ]] && (echo "CLI_REPO is empty"; exit 1)
+[[ -z "${CLI_BRANCH}" ]] && (echo "CLI_BRANCH is empty"; exit 1)
+[[ -z "${EXT_REPO}" ]] && (echo "EXT_REPO is empty"; exit 1)
+[[ -z "${EXT_BRANCH}" ]] && (echo "EXT_BRANCH is empty"; exit 1)
+[[ -z "${MANUAL_EXT}" ]] && (echo "MANUAL_EXT is empty"; exit 1)
+[[ -z "${IMAGE_PREFIX}" ]] && (echo "IMAGE_PREFIX is empty"; exit 1)
+[[ -z "${IMAGE_NAME}" ]] && (echo "IMAGE_NAME is empty"; exit 1)
+[[ -z "${IMAGE_TAG}" ]] && (echo "IMAGE_TAG is empty"; exit 1)
+[[ -z "${PYTHON_VERSION}" ]] && (echo "PYTHON_VERSION is empty")
+
 # clear
 cat /dev/null > env.list
 
 # tenant, sub, client
-echo "TENANT_ID=$TENANT_ID" >> env.list
-echo "AZCLI_ALT_SUBSCRIPTION_ID=$AZCLI_ALT_SUBSCRIPTION_ID" >> env.list
-echo "AZCLI_ALT_CLIENT_ID=$AZCLI_ALT_CLIENT_ID" >> env.list
+echo "TENANT_ID=${TENANT_ID}" >> env.list
+echo "AZCLI_ALT_SUBSCRIPTION_ID=${AZCLI_ALT_SUBSCRIPTION_ID}" >> env.list
+echo "AZCLI_ALT_CLIENT_ID=${AZCLI_ALT_CLIENT_ID}" >> env.list
 
 # azdev env
-echo "AZURE_CLI_TEST_DEV_SP_NAME=$AZCLI_ALT_CLIENT_ID" >> env.list
-echo "AZURE_CLI_TEST_DEV_RESOURCE_GROUP_LOCATION=$TEST_LOCATION" >> env.list
+echo "AZURE_CLI_TEST_DEV_SP_NAME=${AZCLI_ALT_CLIENT_ID}" >> env.list
+echo "AZURE_CLI_TEST_DEV_RESOURCE_GROUP_LOCATION=${TEST_LOCATION}" >> env.list
 
 # predefined variables 
-echo "BUILD_REASON=$BUILD_REASON" >> env.list
-echo "SYSTEM_PULLREQUEST_TARGETBRANCH=$SYSTEM_PULLREQUEST_TARGETBRANCH" >> env.list
+echo "BUILD_REASON=${BUILD_REASON}" >> env.list
+echo "SYSTEM_PULLREQUEST_TARGETBRANCH=${SYSTEM_PULLREQUEST_TARGETBRANCH}" >> env.list
 
 # test
-echo "COVERAGE=$COVERAGE" >> env.list
-echo "TEST_MODE=$TEST_MODE" >> env.list
-echo "PARALLELISM=$PARALLELISM" >> env.list
-echo "TEST_CASES=$TEST_CASES" >> env.list
-echo "EXT_TEST_FILTER=$EXT_TEST_FILTER" >> env.list
-echo "EXT_TEST_COVERAGE=$EXT_TEST_COVERAGE" >> env.list
+echo "COVERAGE=${COVERAGE}" >> env.list
+echo "TEST_MODE=${TEST_MODE}" >> env.list
+echo "PARALLELISM=${PARALLELISM}" >> env.list
+echo "TEST_CASES=${TEST_CASES}" >> env.list
+echo "EXT_TEST_FILTER=${EXT_TEST_FILTER}" >> env.list
+echo "EXT_TEST_COVERAGE=${EXT_TEST_COVERAGE}" >> env.list
 
 # repo
-echo "CLI_REPO=$CLI_REPO" >> env.list
-echo "CLI_BRANCH=$CLI_BRANCH" >> env.list
-echo "MANUAL_EXT=$MANUAL_EXT" >> env.list
-echo "EXT_REPO=$EXT_REPO" >> env.list
-echo "EXT_BRANCH=$EXT_BRANCH" >> env.list
+echo "CLI_REPO=${CLI_REPO}" >> env.list
+echo "CLI_BRANCH=${CLI_BRANCH}" >> env.list
+echo "EXT_REPO=${EXT_REPO}" >> env.list
+echo "EXT_BRANCH=${EXT_BRANCH}" >> env.list
+echo "MANUAL_EXT=${MANUAL_EXT}" >> env.list
 
 # image
-echo "IMAGE_PREFIX=$IMAGE_PREFIX" >> env.list
-echo "IMAGE_NAME=$IMAGE_NAME" >> env.list
-echo "IMAGE_TAG=$IMAGE_TAG" >> env.list
+echo "IMAGE_PREFIX=${IMAGE_PREFIX}" >> env.list
+echo "IMAGE_NAME=${IMAGE_NAME}" >> env.list
+echo "IMAGE_TAG=${IMAGE_TAG}" >> env.list
 
 # misc
-echo "PYTHON_VERSION=$PYTHON_VERSION" >> env.list
+echo "PYTHON_VERSION=${PYTHON_VERSION}" >> env.list

--- a/src/aks-preview/azcli_aks_live_test/vsts-azcli-aks-live-test.yaml
+++ b/src/aks-preview/azcli_aks_live_test/vsts-azcli-aks-live-test.yaml
@@ -2,6 +2,14 @@ name: $(Date:yyyyMMdd)$(Rev:.r)_Python$(PYTHON_VERSION)_Coverage-$(COVERAGE)_Mod
 
 trigger: none
 
+pr:
+  branches:
+    include:
+    - master
+  paths:
+    include:
+    - src/aks-preview/
+
 jobs:
 - job: LiveTest
   pool:
@@ -19,15 +27,15 @@ jobs:
         ls -alh
       displayName: "Move All Checkout Files to the Newly Created 'azure-cli-extensions' Directory"
     - bash: |
-        source ./azure-cli-extensions/src/aks-preview/azcli_aks_live_test/clone_repo.sh
+        ./azure-cli-extensions/src/aks-preview/azcli_aks_live_test/clone_repo.sh
       condition: succeeded()
       displayName: "Clone GitHub Repo and Move Live Test Related Files"
     - bash: |
-        source ./prepare_image.sh
+        ./prepare_image.sh
       condition: succeeded()
       displayName: "Prepare Live Test Image"
     - bash: |
-        source ./start_container.sh
+        ./start_container.sh
       env:
         MAPPED_AZCLI_ALT_CLIENT_SECRET: $(AZCLI_ALT_CLIENT_SECRET)
         BUILD_REASON: $(Build.Reason)

--- a/src/aks-preview/azcli_aks_live_test/vsts-azcli-aks-unit-test.yaml
+++ b/src/aks-preview/azcli_aks_live_test/vsts-azcli-aks-unit-test.yaml
@@ -2,6 +2,14 @@ name: $(Date:yyyyMMdd)$(Rev:.r)_Python$(PYTHON_VERSION)_Coverage-$(COVERAGE)_Mod
 
 trigger: none
 
+pr:
+  branches:
+    include:
+    - master
+  paths:
+    include:
+    - src/aks-preview/
+
 jobs:
 - job: UnitTest
   pool:
@@ -19,15 +27,15 @@ jobs:
         ls -alh
       displayName: "Move All Checkout Files to the Newly Created 'azure-cli-extensions' Directory"
     - bash: |
-        source ./azure-cli-extensions/src/aks-preview/azcli_aks_live_test/clone_repo.sh
+        ./azure-cli-extensions/src/aks-preview/azcli_aks_live_test/clone_repo.sh
       condition: succeeded()
       displayName: "Clone GitHub Repo and Move Test Related Files"
     - bash: |
-        source ./prepare_image.sh
+        ./prepare_image.sh
       condition: succeeded()
       displayName: "Prepare Test Image"
     - bash: |
-        source ./start_container.sh "azcli-aks-unit-test-container"
+        ./start_container.sh "azcli-aks-unit-test-container"
       env:
         MAPPED_AZCLI_ALT_CLIENT_SECRET: $(AZCLI_ALT_CLIENT_SECRET)
         BUILD_REASON: $(Build.Reason)

--- a/src/aks-preview/azext_aks_preview/tests/latest/custom_preparers.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/custom_preparers.py
@@ -4,59 +4,36 @@
 # --------------------------------------------------------------------------------------------
 
 import os
-from datetime import datetime
 
-from azure.cli.testsdk import CliTestError
-from azure.cli.testsdk.preparers import NoTrafficRecordingPreparer
-from azure_devtools.scenario_tests import SingleValueReplacer
-from azure.cli.testsdk.reverse_dependency import get_dummy_cli
+from azure.cli.testsdk.preparers import ResourceGroupPreparer
 
 
-class AKSCustomResourceGroupPreparer(NoTrafficRecordingPreparer, SingleValueReplacer):
-    def __init__(self, name_prefix='clitest.rg',
-                 parameter_name='resource_group',
-                 parameter_name_for_location='resource_group_location', location='westus',
-                 dev_setting_name='AZURE_CLI_TEST_DEV_RESOURCE_GROUP_NAME',
-                 dev_setting_location='AZURE_CLI_TEST_DEV_RESOURCE_GROUP_LOCATION',
-                 random_name_length=75, key='rg'):
-        if ' ' in name_prefix:
-            raise CliTestError(
-                'Error: Space character in resource group name prefix \'%s\'' % name_prefix)
+class AKSCustomResourceGroupPreparer(ResourceGroupPreparer):
+    def __init__(
+        self,
+        name_prefix="clitest.rg",
+        parameter_name="resource_group",
+        parameter_name_for_location="resource_group_location",
+        location="westus",
+        dev_setting_name="AZURE_CLI_TEST_DEV_RESOURCE_GROUP_NAME",
+        dev_setting_location="AZURE_CLI_TEST_DEV_RESOURCE_GROUP_LOCATION",
+        random_name_length=75,
+        key="rg",
+    ):
         super(AKSCustomResourceGroupPreparer, self).__init__(
-            name_prefix, random_name_length)
-        self.cli_ctx = get_dummy_cli()
-        self.location = location
-        self.parameter_name = parameter_name
-        self.parameter_name_for_location = parameter_name_for_location
-        self.key = key
+            name_prefix,
+            parameter_name,
+            parameter_name_for_location,
+            location,
+            dev_setting_name,
+            dev_setting_location,
+            random_name_length,
+            key,
+        )
 
-        self.dev_setting_name = os.environ.get(dev_setting_name, None)
         # use environment variable to modify the default value of location
         self.dev_setting_location = os.environ.get(dev_setting_location, None)
-        if self.dev_setting_location is not None and self.dev_setting_location != "":
+        if self.dev_setting_location:
             self.location = self.dev_setting_location
-
-    def create_resource(self, name, **kwargs):
-        if self.dev_setting_name:
-            self.test_class_instance.kwargs[self.key] = self.dev_setting_name
-            return {self.parameter_name: self.dev_setting_name,
-                    self.parameter_name_for_location: self.dev_setting_location}
-
-        tags = {'product': 'azurecli', 'cause': 'automation',
-                'date': datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')}
-        if 'ENV_JOB_NAME' in os.environ:
-            tags['job'] = os.environ['ENV_JOB_NAME']
-        tags = ' '.join(['{}={}'.format(key, value)
-                        for key, value in tags.items()])
-        template = 'az group create --location {} --name {} --tag ' + tags
-        self.live_only_execute(
-            self.cli_ctx, template.format(self.location, name))
-
-        self.test_class_instance.kwargs[self.key] = name
-        return {self.parameter_name: name, self.parameter_name_for_location: self.location}
-
-    def remove_resource(self, name, **kwargs):
-        # delete group if test is being recorded and if the group is not a dev rg
-        if not self.dev_setting_name:
-            self.live_only_execute(
-                self.cli_ctx, 'az group delete --name {} --yes --no-wait'.format(name))
+        else:
+            self.dev_setting_location = location


### PR DESCRIPTION
This PR aims to polish the shell scripts used in aks pr check-in pipeline. The main changes are as follows；

* Update all shell scripts, add required variable checks, set bash options in a clearer way
* Update the way to forcibly update the azure-cli command index to ensure that the aks-preview command has been loaded before performing tests
* Define the trigger method in the pipeline yaml file
* Modify the implementation of AKSCustomResourceGroupPreparer to inherit (same as azure-cli)

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
