### PR TITLE
chore(arcdata): Welcome arcdata v0.0.1 preview

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -3512,6 +3512,7 @@
                     },
                     "extras": [],
                     "generator": "bdist_wheel (0.30.0)",
+                    "keywords": ["az", "sql", "arcdata", "cli", "azure", "sqlmi", "dc"],                    
                     "license": "MIT",
                     "metadata_version": "2.0",
                     "name": "application-insights",
@@ -3743,8 +3744,10 @@
         "arcdata": [
             {
                 "downloadUrl": "https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-0.0.1-py2.py3-none-any.whl",
-                "filename": "arcdata-0.0.1-py2.py3-none-any.whl",
+                "filename": "arcdata-0.0.1-py2.py3-none-any.whl",               
                 "metadata": {
+                    "azext.isExperimental": false,
+                    "azext.minCliCoreVersion": "2.3.1",                     
                     "classifiers": [
                         "Development Status :: 1 - Beta",
                         "Intended Audience :: Developers",
@@ -3760,40 +3763,40 @@
                             "contacts": [
                                 {
                                     "email": "dpgswdist@microsoft.com",
-                                    "name": "Microsoft",
+                                    "name": "Microsoft Corporation",
                                     "role": "author"
                                 }
                             ],
                             "document_names": {
-                                "description": "DESCRIPTION.rst",
-                                "license": "LICENSE"
+                                "description": "DESCRIPTION.rst"
                             },
                             "project_urls": {
                                 "Home": "https://docs.microsoft.com/en-us/sql/sql-server/azure-arc/overview?view=sql-server-ver15"
                             }
                         }
                     },
-
                     "extras": [],
                     "generator": "bdist_wheel (0.30.0)",
+                    "keywords": ["az", "sql", "arcdata", "cli", "azure", "sqlmi", "dc"],                    
                     "license": "MIT",
+                    "license_file": "LICENSE",
                     "metadata_version": "2.0",
                     "name": "arcdata",
                     "run_requires": [
                         {
-                            "requires": [
-                                "kubernetes (==11.0.0)",
-                                "pydash (==4.8.0)",
+                            "requires": [                                                                
                                 "jinja2 (==2.10.3)",
+                                "jsonpatch (==1.24)",                                
                                 "jsonpath-ng (==1.4.3)",
-                                "jsonpatch (==1.24)"
+                                "kubernetes (==11.0.0)",
+                                "pydash (==4.8.0)"
                             ]
                         }
                     ],
                     "summary": "Tools for managing ArcData.",
                     "version": "0.0.1"
                 },
-                "sha256Digest": "29f90899b6afca8e18aaab66830362db29208bddd69a13dc780a55c5b97b5267"
+                "sha256Digest": "73a4f975e454fc4e39ad24f0adfc2e962423d5ebeefa51a42791dab637f76958"
             }
         ],        
         "attestation": [

--- a/src/index.json
+++ b/src/index.json
@@ -3511,8 +3511,7 @@
                         }
                     },
                     "extras": [],
-                    "generator": "bdist_wheel (0.30.0)",
-                    "keywords": ["az", "sql", "arcdata", "cli", "azure", "sqlmi", "dc"],                    
+                    "generator": "bdist_wheel (0.30.0)",               
                     "license": "MIT",
                     "metadata_version": "2.0",
                     "name": "application-insights",

--- a/src/index.json
+++ b/src/index.json
@@ -3777,7 +3777,6 @@
                     },
                     "extras": [],
                     "generator": "bdist_wheel (0.30.0)",
-                    "keywords": ["az", "sql", "arcdata", "cli", "azure", "sqlmi", "dc"],                    
                     "license": "MIT",
                     "license_file": "LICENSE",
                     "metadata_version": "2.0",
@@ -3796,7 +3795,7 @@
                     "summary": "Tools for managing ArcData.",
                     "version": "0.0.1"
                 },
-                "sha256Digest": "73a4f975e454fc4e39ad24f0adfc2e962423d5ebeefa51a42791dab637f76958"
+                "sha256Digest": "e727a7bf123aa15b406455f268be8a906907d6d32bd314d122b83d006767adc8"
             }
         ],        
         "attestation": [

--- a/src/index.json
+++ b/src/index.json
@@ -3511,7 +3511,7 @@
                         }
                     },
                     "extras": [],
-                    "generator": "bdist_wheel (0.30.0)",               
+                    "generator": "bdist_wheel (0.30.0)",
                     "license": "MIT",
                     "metadata_version": "2.0",
                     "name": "application-insights",

--- a/src/index.json
+++ b/src/index.json
@@ -3740,6 +3740,62 @@
                 "sha256Digest": "8c3ace89d98781f2e0c952a7197862d0f64afded0c6e8e83f229fea3e014806b"
             }
         ],
+        "arcdata": [
+            {
+                "downloadUrl": "https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-0.0.1-py2.py3-none-any.whl",
+                "filename": "arcdata-0.0.1-py2.py3-none-any.whl",
+                "metadata": {
+                    "classifiers": [
+                        "Development Status :: 1 - Beta",
+                        "Intended Audience :: Developers",
+                        "Programming Language :: Python",
+                        "Programming Language :: Python :: 3",
+                        "Programming Language :: Python :: 3.6",
+                        "Programming Language :: Python :: 3.7",
+                        "Programming Language :: Python :: 3.8",
+                        "License :: OSI Approved :: MIT License"
+                    ],
+                    "extensions": {
+                        "python.details": {
+                            "contacts": [
+                                {
+                                    "email": "dpgswdist@microsoft.com",
+                                    "name": "Microsoft",
+                                    "role": "author"
+                                }
+                            ],
+                            "document_names": {
+                                "description": "DESCRIPTION.rst",
+                                "license": "LICENSE"
+                            },
+                            "project_urls": {
+                                "Home": "https://docs.microsoft.com/en-us/sql/sql-server/azure-arc/overview?view=sql-server-ver15"
+                            }
+                        }
+                    },
+
+                    "extras": [],
+                    "generator": "bdist_wheel (0.30.0)",
+                    "license": "MIT",
+                    "metadata_version": "2.0",
+                    "name": "arcdata",
+                    "run_requires": [
+                        {
+                            "requires": [
+                                "kubernetes (==11.0.0)",
+                                "pydash (==4.8.0)",
+                                "jinja2 (==2.10.3)",
+                                "jsonpath-ng (==1.4.3)",
+                                "jsonpatch (==1.24)"
+                            ]
+                        }
+                    ],
+                    "summary": "Tools for managing ArcData.",
+                    "version": "0.0.1"
+                },
+                "sha256Digest": "29f90899b6afca8e18aaab66830362db29208bddd69a13dc780a55c5b97b5267"
+            }
+        ],        
         "attestation": [
             {
                 "downloadUrl": "https://azurecliprod.blob.core.windows.net/cli-extensions/attestation-0.1.0-py3-none-any.whl",


### PR DESCRIPTION
chore(arcdata): Welcome arcdata v0.0.1 preview

Introduce arcdata  v0.0.1 preview. The source is housed in an external repository and not here.

---

### General Guidelines


- [X] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [X] Have you run `python scripts/ci/test_index.py -q` locally?
```
→ python scripts/ci/test_index.py -q
----------------------------------------------------------------------
Ran 9 tests in 103.891s


OK (skipped=2)
```



```
→  azdev linter --include-whl-extensions arcdata


Results 
=========

-  pass: faulty_help_example_parameters_rule 
-  pass: faulty_help_example_rule 
-  pass: faulty_help_type_rule 
-  pass: unrecognized_help_entry_rule 
-  pass: unrecognized_help_parameter_rule 
-  pass: expired_command_group 
-  pass: missing_group_help 
-  pass: expired_command 
-  pass: missing_command_help 
-  pass: no_ids_for_list_commands 
-  pass: bad_short_option 
-  pass: expired_option 
-  pass: expired_parameter 
-  pass: missing_parameter_help 
-  pass: no_parameter_defaults_for_update_commands 
-  pass: no_positional_parameters 
-  pass: option_length_too_long 
-  pass: option_should_not_contain_under_score 

No violations found for linter rules.

Run custom pylint rules.
Running pylint on extensions...

No violations found for custom pylint rules.
Linter: PASSED
```

For new extensions:

- [X] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).
