### PR TITLE
publish vmware 3.0.0

### DIFF
--- a/src/vmware/CHANGELOG.md
+++ b/src/vmware/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 3.0.0 (2021-06)
+## 3.0.0 (2021-07)
 - [BREAKING CHANGE] `az vmware datastore create` has been removed. Please use `az vmware datastore netapp-volume create` or `az vmware datastore disk-pool-volume create` instead.
 
 Other changes:

--- a/src/vmware/setup.py
+++ b/src/vmware/setup.py
@@ -8,7 +8,7 @@
 from io import open
 from setuptools import setup, find_packages
 
-VERSION = "2.0.1"
+VERSION = "3.0.0"
 
 with open('README.md', encoding='utf-8') as f:
     readme = f.read()


### PR DESCRIPTION
Now that the 2021-06-01 API has rolled out, it is time to publish the vmware extension version 3.0.0.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
