### PR TITLE
[k8s-extension] Fix index.json of k8s_extension

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -12775,22 +12775,14 @@
                             }
                         }
                     },
-                    "extras": [],
                     "generator": "bdist_wheel (0.30.0)",
                     "license": "MIT",
                     "metadata_version": "2.0",
                     "name": "k8s-extension",
-                    "run_requires": [
-                        {
-                            "requires": [
-                                "pyhelm"
-                            ]
-                        }
-                    ],
                     "summary": "Microsoft Azure Command-Line Tools K8s-extension Extension",
                     "version": "0.5.1"
                 },
-                "sha256Digest": "da636a38097d8e1e83494afc784f26ffcc0d962e08e8bb6f202b3fc23e291309"
+                "sha256Digest": "b04378d1c1699cf8cf37fc84a0f77fd5b87c653cc4d06049ba546660ce57fe42"
             }
         ],
         "k8sconfiguration": [


### PR DESCRIPTION
Triggered by Azure CLI Extensions Release Pipeline - ADO_BUILD_ID=990645

Last commit: https://github.com/Azure/azure-cli-extensions/commit/cb184be8a165200bde068142c7b5f88db30c0fd1

Co-authored-by: Xing Zhou <Zhou.Xing@microsoft.com>

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
