### PR TITLE
Revert unnecessary version upgrade for aks_extension

### DIFF
--- a/src/k8s-extension/HISTORY.rst
+++ b/src/k8s-extension/HISTORY.rst
@@ -3,13 +3,9 @@
 Release History
 ===============
 
-0.5.2
-++++++++++++++++++
-* Remove pyhelm dependency from setup.py
-
 0.5.1
 ++++++++++++++++++
-* Remove pyhelm dependency from osm customization
+* Remove pyhelm dependency
 
 0.5.0
 ++++++++++++++++++

--- a/src/k8s-extension/setup.py
+++ b/src/k8s-extension/setup.py
@@ -32,7 +32,7 @@ CLASSIFIERS = [
 # TODO: Add any additional SDK dependencies here
 DEPENDENCIES = []
 
-VERSION = "0.5.2"
+VERSION = "0.5.1"
 
 with open('README.rst', 'r', encoding='utf-8') as f:
     README = f.read()


### PR DESCRIPTION
---
The modification #3605 has been added in this PR #3610
Therefore, there is no need to upgrade the version to `0.5.2` (release pipeline failed before, so this package version has not been released yet)
So revert this PR #3608

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
