### PR TITLE
{AKS} Remove some previously filtered test cases in aks live test pipeline

### DIFF
--- a/src/aks-preview/azcli_aks_live_test/configs/ext_matrix_default.json
+++ b/src/aks-preview/azcli_aks_live_test/configs/ext_matrix_default.json
@@ -31,13 +31,6 @@
             "test_aks_create_with_monitoring_aad_auth_uai",
             "test_aks_enable_monitoring_with_aad_auth_msi",
             "test_aks_enable_monitoring_with_aad_auth_uai"
-        ],
-        "unknown": [
-            "test_aks_create_and_update_with_managed_aad_enable_azure_rbac",
-            "test_aks_update_to_msi_cluster_with_addons"
-        ],
-        "code bug": [
-            "test_aks_nodepool_get_upgrades"
         ]
     }
 }

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -822,8 +822,8 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
                  '--nodepool-name={node_pool_name}',
                  checks=[
                      # if rerun the recording, please update latestNodeImageVersion to the latest value
-                     self.check('latestNodeImageVersion',
-                                'AKSUbuntu-1804gen2containerd-2021.06.02'),
+                     self.check_pattern('latestNodeImageVersion',
+                                'AKSUbuntu-1804gen2containerd-2021.(0[1-9]|1[012]).(0[1-9]|[12]\d|3[01])'),
                      self.check(
                          'type', "Microsoft.ContainerService/managedClusters/agentPools/upgradeProfiles")
                  ])


### PR DESCRIPTION
Remove some test cases that can be executed normally now which are filtered by default previously in the live test check-in pipeline ([AZCLI AKS LIVE TEST V2](https://dev.azure.com/msazure/CloudNativeCompute/_build?definitionId=219428&_a=summary)) .

Removed filtered test cases:
* test_aks_create_and_update_with_managed_aad_enable_azure_rbac
* test_aks_update_to_msi_cluster_with_addons
* test_aks_nodepool_get_upgrades

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
