### PR TITLE
Fix issue during submission of jobs where status is reported incorrectly.

### DIFF
--- a/src/quantum/azext_quantum/operations/job.py
+++ b/src/quantum/azext_quantum/operations/job.py
@@ -150,7 +150,10 @@ def submit(cmd, program_args, resource_group_name=None, workspace_name=None, loc
     result = subprocess.run(args, stdout=subprocess.PIPE, check=False)
 
     if result.returncode == 0:
-        job_id = result.stdout.decode('ascii').strip()
+        output = result.stdout.decode('ascii').strip()
+        # Retrieve the job-id as the last line from standard output.
+        job_id = output.split()[-1]
+        # Query for the job and return status to caller.
         return get(cmd, job_id, resource_group_name, workspace_name, location)
 
     raise CLIError("Failed to submit job.")


### PR DESCRIPTION
This PR is a minor bug fixed related to job ids being retrieved incorrectly from standard output of a caller process.

The fix strips additional information from the output so only the job-id is used.