### PR TITLE
{AKS} Clean up outdated resource groups after testing

### DIFF
--- a/src/aks-preview/azcli_aks_live_test/scripts/clean_up.sh
+++ b/src/aks-preview/azcli_aks_live_test/scripts/clean_up.sh
@@ -1,12 +1,30 @@
 #!/usr/bin/env bash
 
+# bash options
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+# check var
+[[ -z "${TENANT_ID}" ]] && (echo "TENANT_ID is empty"; exit 1)
+[[ -z "${AZCLI_ALT_SUBSCRIPTION_ID}" ]] && (echo "AZCLI_ALT_SUBSCRIPTION_ID is empty"; exit 1)
+[[ -z "${AZCLI_ALT_CLIENT_ID}" ]] && (echo "AZCLI_ALT_CLIENT_ID is empty"; exit 1)
+[[ -z "${AZCLI_ALT_CLIENT_SECRET}" ]] && (echo "AZCLI_ALT_CLIENT_SECRET is empty"; exit 1)
+[[ -z "${LOOKBACK}" ]] && (echo "LOOKBACK is empty"; exit 1)
+[[ -z "${PREFIX}" ]] && (echo "PREFIX is empty"; exit 1)
+
 # login
 az login --service-principal -u "${AZCLI_ALT_CLIENT_ID}" -p "${AZCLI_ALT_CLIENT_SECRET}" -t "${TENANT_ID}"
 az account set -s "${AZCLI_ALT_SUBSCRIPTION_ID}"
 az account show
 
-# list the details of resource groups whose names start with "clitest"
-az group list --query "([].name)[?starts_with(@, 'clitest')]" -o tsv | xargs -i az group show -n {}
+# get lookback date
+cond_date=$(date -u -d "${LOOKBACK} hours ago" '+%Y-%m-%dT%H:%M:%SZ')
 
-# delete all resource groups whose names start with "clitest"
-# az group list --query "([].name)[?starts_with(@, 'clitest')]" -o tsv | xargs -i az group delete --no-wait -y -n {}
+# list matched result
+az group list --query "[? @.tags.date < '${cond_date}'] | [? starts_with(@.name, '${PREFIX}')]"
+echo "Length:" $(az group list --query "[? @.tags.date < '${cond_date}'] | [? starts_with(@.name, '${PREFIX}')] | length(@)")
+
+# delete
+az group list --query "[? @.tags.date < '${cond_date}'] | [? starts_with(@.name, '${PREFIX}')].name" -o tsv | xargs -i az group delete --no-wait -y -n {}

--- a/src/aks-preview/azcli_aks_live_test/scripts/clean_up.sh
+++ b/src/aks-preview/azcli_aks_live_test/scripts/clean_up.sh
@@ -27,4 +27,4 @@ az group list --query "[? @.tags.date < '${cond_date}'] | [? starts_with(@.name,
 echo "Length:" $(az group list --query "[? @.tags.date < '${cond_date}'] | [? starts_with(@.name, '${PREFIX}')] | length(@)")
 
 # delete
-az group list --query "[? @.tags.date < '${cond_date}'] | [? starts_with(@.name, '${PREFIX}')].name" -o tsv | xargs -i az group delete -y -n {}
+az group list --query "[? @.tags.date < '${cond_date}'] | [? starts_with(@.name, '${PREFIX}')].name" -o tsv | xargs -i az group delete --no-wait -y -n {}

--- a/src/aks-preview/azcli_aks_live_test/scripts/clean_up.sh
+++ b/src/aks-preview/azcli_aks_live_test/scripts/clean_up.sh
@@ -27,4 +27,4 @@ az group list --query "[? @.tags.date < '${cond_date}'] | [? starts_with(@.name,
 echo "Length:" $(az group list --query "[? @.tags.date < '${cond_date}'] | [? starts_with(@.name, '${PREFIX}')] | length(@)")
 
 # delete
-az group list --query "[? @.tags.date < '${cond_date}'] | [? starts_with(@.name, '${PREFIX}')].name" -o tsv | xargs -i az group delete --no-wait -y -n {}
+az group list --query "[? @.tags.date < '${cond_date}'] | [? starts_with(@.name, '${PREFIX}')].name" -o tsv | xargs -i az group delete -y -n {}

--- a/src/aks-preview/azcli_aks_live_test/vsts-azcli-aks-clean-up.yaml
+++ b/src/aks-preview/azcli_aks_live_test/vsts-azcli-aks-clean-up.yaml
@@ -1,4 +1,4 @@
-name: $(Date:yyyyMMdd)$(Rev:.r-)CleanUp
+name: $(Date:yyyyMMdd)$(Rev:.r-)-CleanUp
 
 trigger: none
 
@@ -12,8 +12,10 @@ jobs:
   pool:
     vmImage: 'ubuntu-18.04'
   timeoutInMinutes: 60
-  displayName: "CleanUp"
+  displayName: "Clean Up"
   steps:
     - bash: |
         $(LIVE_TEST_BASE_DIR)/scripts/clean_up.sh
+      env:
+        AZCLI_ALT_CLIENT_SECRET: $(AZCLI_ALT_CLIENT_SECRET)
       displayName: "Clean up outdated resource groups"

--- a/src/aks-preview/azcli_aks_live_test/vsts-azcli-aks-clean-up.yaml
+++ b/src/aks-preview/azcli_aks_live_test/vsts-azcli-aks-clean-up.yaml
@@ -1,0 +1,19 @@
+name: $(Date:yyyyMMdd)$(Rev:.r-)CleanUp
+
+trigger: none
+
+variables:
+  - group: azcli-aks-tool
+  - name: LIVE_TEST_BASE_DIR
+  value: "azure-cli-extensions/src/aks-preview/azcli_aks_live_test"
+
+jobs:
+- job: CleanUp
+  pool:
+    vmImage: 'ubuntu-18.04'
+  timeoutInMinutes: 60
+  displayName: "CleanUp"
+  steps:
+    - bash: |
+        $(LIVE_TEST_BASE_DIR)/scripts/clean_up.sh
+      displayName: "Clean up outdated resource groups"

--- a/src/aks-preview/azcli_aks_live_test/vsts-azcli-aks-clean-up.yaml
+++ b/src/aks-preview/azcli_aks_live_test/vsts-azcli-aks-clean-up.yaml
@@ -5,7 +5,7 @@ trigger: none
 variables:
   - group: azcli-aks-tool
   - name: LIVE_TEST_BASE_DIR
-    value: "azure-cli-extensions/src/aks-preview/azcli_aks_live_test"
+    value: "src/aks-preview/azcli_aks_live_test"
 
 jobs:
 - job: CleanUp

--- a/src/aks-preview/azcli_aks_live_test/vsts-azcli-aks-clean-up.yaml
+++ b/src/aks-preview/azcli_aks_live_test/vsts-azcli-aks-clean-up.yaml
@@ -5,7 +5,7 @@ trigger: none
 variables:
   - group: azcli-aks-tool
   - name: LIVE_TEST_BASE_DIR
-  value: "azure-cli-extensions/src/aks-preview/azcli_aks_live_test"
+    value: "azure-cli-extensions/src/aks-preview/azcli_aks_live_test"
 
 jobs:
 - job: CleanUp


### PR DESCRIPTION
Add a pipeline to periodically clean up outdated  resource groups after testing.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
