### PR TITLE
Add `az quantum job cancel` command to CLI extension

### DIFF
--- a/src/quantum/azext_quantum/_help.py
+++ b/src/quantum/azext_quantum/_help.py
@@ -70,7 +70,7 @@ helps['quantum job submit'] = """
       - name: Submit the Q# program from the current folder.
         text: |-
             az quantum job submit -g MyResourceGroup -w MyWorkspace -l MyLocation \\
-               -l MyLocation --job-name MyJob
+               --job-name MyJob
 """
 
 helps['quantum job wait'] = """
@@ -81,6 +81,16 @@ helps['quantum job wait'] = """
         text: |-
             az quantum job wait -g MyResourceGroup -w MyWorkspace -l MyLocation \\
                 -j yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy --max-poll-wait-secs 60 -o table
+"""
+
+helps['quantum job cancel'] = """
+    type: command
+    short-summary: Request to cancel a job on Azure Quantum if it hasn't completed.
+    examples:
+      - name: Cancel an Azure Quantum job by id.
+        text: |-
+            az quantum job cancel -g MyResourceGroup -w MyWorkspace -l MyLocation \\
+                -j yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy
 """
 
 helps['quantum offerings'] = """

--- a/src/quantum/azext_quantum/commands.py
+++ b/src/quantum/azext_quantum/commands.py
@@ -115,6 +115,7 @@ def load_command_table(self, _):
         j.command('submit', 'submit', validator=validate_workspace_and_target_info, table_transformer=transform_job)
         j.command('wait', 'wait', validator=validate_workspace_info, table_transformer=transform_job)
         j.command('output', 'output', validator=validate_workspace_info, table_transformer=transform_output)
+        j.command('cancel', 'cancel', validator=validate_workspace_info, table_transformer=transform_job)
 
     with self.command_group('quantum', job_ops, is_preview=True) as q:
         q.command('run', 'run', validator=validate_workspace_and_target_info, table_transformer=transform_output)

--- a/src/quantum/azext_quantum/operations/job.py
+++ b/src/quantum/azext_quantum/operations/job.py
@@ -272,3 +272,22 @@ def run(cmd, program_args, resource_group_name=None, workspace_name=None, locati
         return job
 
     return output(cmd, job.id, resource_group_name, workspace_name)
+
+
+def cancel(cmd, job_id, resource_group_name=None, workspace_name=None, location=None):
+    """
+    Request to cancel a job on Azure Quantum if it hasn't completed.
+    """
+    info = WorkspaceInfo(cmd, resource_group_name, workspace_name, location)
+    client = cf_jobs(cmd.cli_ctx, info.subscription, info.resource_group, info.name, info.location)
+    job = client.get(job_id)
+
+    if job.status == "Succeeded" or job.status == "Failed" or job.status == "Cancelled":
+        print(f"Job {job_id} has already completed with status: {job.status}.")
+        return
+    
+    # If the job hasn't succeeded or failed, attempt to cancel.
+    client.cancel(job_id)
+
+    # Return the updated job status
+    return client.get(job_id)

--- a/src/quantum/azext_quantum/operations/job.py
+++ b/src/quantum/azext_quantum/operations/job.py
@@ -286,7 +286,7 @@ def cancel(cmd, job_id, resource_group_name=None, workspace_name=None, location=
     if _has_completed(job):
         print(f"Job {job_id} has already completed with status: {job.status}.")
         return
-    
+
     # If the job hasn't succeeded or failed, attempt to cancel.
     client.cancel(job_id)
 


### PR DESCRIPTION
This change adds a new command to the `az quantum` CLI extension to request a job to be cancelled.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [X] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [X] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
