### PR TITLE
Include CLI extension version info in user agent header in Azure Quantum requests

### DIFF
--- a/src/quantum/azext_quantum/_client_factory.py
+++ b/src/quantum/azext_quantum/_client_factory.py
@@ -43,6 +43,8 @@ def cf_quantum_mgmt(cli_ctx, *_):
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
     from .vendored_sdks.azure_mgmt_quantum import AzureQuantumManagementClient
     client = get_mgmt_service_client(cli_ctx, AzureQuantumManagementClient)
+    # Add user agent on the management client to include extension information
+    client._config.user_agent_policy.add_user_agent(get_appid())
     return client
 
 
@@ -59,7 +61,7 @@ def cf_offerings(cli_ctx, *_):
 def cf_quantum(cli_ctx, subscription_id=None, resource_group_name=None, workspace_name=None, location=None):
     from .vendored_sdks.azure_quantum import QuantumClient
     creds = _get_data_credentials(cli_ctx, subscription_id)
-    client = QuantumClient(creds, subscription_id, resource_group_name, workspace_name, base_url=base_url(location))
+    client = QuantumClient(creds, subscription_id, resource_group_name, workspace_name, base_url=base_url(location), user_agent=get_appid())
     return client
 
 


### PR DESCRIPTION
With this change, we're adding the quantum extension version information to the user agent header as it was done in track 1.
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [X] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [X] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
