### PR TITLE
Fix to allow users to specify a location for a project to run in Azure Quantum

### DIFF
--- a/src/quantum/azext_quantum/operations/job.py
+++ b/src/quantum/azext_quantum/operations/job.py
@@ -42,11 +42,10 @@ def build(cmd, target_id=None, project=None):
 
     args = ["dotnet", "build"]
 
-    args.append(f"-property:ExecutionTarget={target.target_id}")
-
     if project:
-        args.append("--project")
         args.append(project)
+
+    args.append(f"-property:ExecutionTarget={target.target_id}")
 
     logger.debug("Building project with arguments:")
     logger.debug(args)


### PR DESCRIPTION
Because of a syntax difference between commands `dotnet build` and `dotnet run`, one of them expects the project location to be specified as a positional parameter and another as a named parameter. Because of this, we had a bug in which the user could not specify the location of a project outside of the current folder.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [X] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [X] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
