### PR TITLE
chore(arcdata): version bump to 0.0.2 preview

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -3999,6 +3999,63 @@
             }
         ],
         "arcdata": [
+           {
+                "downloadUrl": "https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-0.0.2-py2.py3-none-any.whl",
+                "filename": "arcdata-0.0.2-py2.py3-none-any.whl",
+                "metadata": {
+                    "azext.isExperimental": false,
+                    "azext.minCliCoreVersion": "2.3.1",
+                    "classifiers": [
+                        "Development Status :: 1 - Beta",
+                        "Intended Audience :: Developers",
+                        "Programming Language :: Python",
+                        "Programming Language :: Python :: 3",
+                        "Programming Language :: Python :: 3.6",
+                        "Programming Language :: Python :: 3.7",
+                        "Programming Language :: Python :: 3.8",
+                        "License :: OSI Approved :: MIT License"
+                    ],
+                    "extensions": {
+                        "python.details": {
+                            "contacts": [
+                                {
+                                    "email": "dpgswdist@microsoft.com",
+                                    "name": "Microsoft Corporation",
+                                    "role": "author"
+                                }
+                            ],
+                            "document_names": {
+                                "description": "DESCRIPTION.rst"
+                            },
+                            "project_urls": {
+                                "Home": "https://docs.microsoft.com/en-us/sql/sql-server/azure-arc/overview?view=sql-server-ver15"
+                            }
+                        }
+                    },
+                    "extras": [],
+                    "generator": "bdist_wheel (0.30.0)",
+                    "license": "MIT",
+                    "license_file": "LICENSE",
+                    "metadata_version": "2.0",
+                    "name": "arcdata",
+                    "run_requires": [
+                        {
+                            "requires": [
+                                "jinja2 (==2.10.3)",
+                                "jsonpatch (==1.24)",
+                                "jsonpath-ng (==1.4.3)",
+                                "kubernetes (==12.0.1)",
+                                "pydash (==4.8.0)",
+                                "jsonschema (==3.2.0)",
+                                "ndjson (==0.3.1)"
+                            ]
+                        }
+                    ],
+                    "summary": "Tools for managing ArcData.",
+                    "version": "0.0.2"
+                },
+                "sha256Digest": "d14aa3046b7a9c3bca67c735eeb35fb24ff5ed240212724d3f229eb23280abae"
+            },
             {
                 "downloadUrl": "https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-0.0.1-py2.py3-none-any.whl",
                 "filename": "arcdata-0.0.1-py2.py3-none-any.whl",

--- a/src/index.json
+++ b/src/index.json
@@ -4004,6 +4004,7 @@
                 "filename": "arcdata-0.0.2-py2.py3-none-any.whl",
                 "metadata": {
                     "azext.isExperimental": false,
+                    "azext.isPreview": true,
                     "azext.minCliCoreVersion": "2.3.1",
                     "classifiers": [
                         "Development Status :: 1 - Beta",
@@ -4044,10 +4045,10 @@
                                 "jinja2 (==2.10.3)",
                                 "jsonpatch (==1.24)",
                                 "jsonpath-ng (==1.4.3)",
-                                "kubernetes (==12.0.1)",
-                                "pydash (==4.8.0)",
                                 "jsonschema (==3.2.0)",
-                                "ndjson (==0.3.1)"
+                                "kubernetes (==12.0.1)",
+                                "ndjson (==0.3.1)",
+                                "pydash (==4.8.0)"
                             ]
                         }
                     ],

--- a/src/service_name.json
+++ b/src/service_name.json
@@ -428,5 +428,10 @@
     "Command": "az dataprotection",
     "AzureServiceName": "Azure Data Protection",
     "URL": ""
+  },
+  {
+    "Command": "az arcdata",
+    "AzureServiceName": "Azure Data Services",
+    "URL": "https://docs.microsoft.com/en-us/sql/sql-server/azure-arc/overview?view=sql-server-ver15"
   }
 ]


### PR DESCRIPTION
---

chore(arcdata): version bump to 0.0.2 preview

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

```
 Results 
=========

-  pass: faulty_help_example_parameters_rule 
-  pass: faulty_help_example_rule 
-  pass: faulty_help_type_rule 
-  pass: unrecognized_help_entry_rule 
-  pass: unrecognized_help_parameter_rule 
-  pass: expired_command_group 
-  pass: missing_group_help 
-  pass: expired_command 
-  pass: missing_command_help 
-  pass: no_ids_for_list_commands 
-  pass: bad_short_option 
-  pass: expired_option 
-  pass: expired_parameter 
-  pass: missing_parameter_help 
-  pass: no_parameter_defaults_for_update_commands 
-  pass: no_positional_parameters 
-  pass: option_length_too_long 
-  pass: option_should_not_contain_under_score 
```
```
python scripts/ci/test_index.py -q
----------------------------------------------------------------------
Ran 9 tests in 0.020s

OK (skipped=2)
No violations found for linter rules.
```