### PR TITLE
{AKS} Update aks check-in pipeline

### DIFF
--- a/src/aks-preview/azcli_aks_live_test/scripts/test_cli_live.sh
+++ b/src/aks-preview/azcli_aks_live_test/scripts/test_cli_live.sh
@@ -24,6 +24,12 @@ source azEnv/bin/activate
 source ./scripts/setup_venv.sh
 removeAKSPreview
 
+# login before the recording test to avoid the newly added test case does not include a corresponding
+# recording file and fall back to live mode, otherwise it will prompt `az login`.
+az login --service-principal -u "${AZCLI_ALT_CLIENT_ID}" -p "${AZCLI_ALT_CLIENT_SECRET}" -t "${TENANT_ID}"
+az account set -s "${AZCLI_ALT_SUBSCRIPTION_ID}"
+az account show
+
 # prepare running options
 # base options
 base_options="-c --no-exitfirst --report-path ./reports --reruns 3 --capture=sys"
@@ -63,9 +69,6 @@ fi
 # live test
 if [[ ${TEST_MODE} == "live" || ${TEST_MODE} == "all" ]]; then
     echo "Test in live mode!"
-    az login --service-principal -u "${AZCLI_ALT_CLIENT_ID}" -p "${AZCLI_ALT_CLIENT_SECRET}" -t "${TENANT_ID}"
-    az account set -s "${AZCLI_ALT_SUBSCRIPTION_ID}"
-    az account show
     live_options="${base_options}${filter_options}"
     live_options+=" -l --json-report-file=cli_live_report.json"
     live_options+=" --xml-file=cli_live_result.xml"

--- a/src/aks-preview/azcli_aks_live_test/scripts/test_ext_live.sh
+++ b/src/aks-preview/azcli_aks_live_test/scripts/test_ext_live.sh
@@ -23,6 +23,12 @@ source azEnv/bin/activate
 # setup aks-preview
 ./scripts/setup_venv.sh setup-akspreview
 
+# login before the recording test to avoid the newly added test case does not include a corresponding
+# recording file and fall back to live mode, otherwise it will prompt `az login`.
+az login --service-principal -u "${AZCLI_ALT_CLIENT_ID}" -p "${AZCLI_ALT_CLIENT_SECRET}" -t "${TENANT_ID}"
+az account set -s "${AZCLI_ALT_SUBSCRIPTION_ID}"
+az account show
+
 # prepare running options
 # base options
 base_options="-e --no-exitfirst --report-path ./reports --reruns 3 --capture=sys"
@@ -62,9 +68,6 @@ fi
 # live test
 if [[ ${TEST_MODE} == "live" || ${TEST_MODE} == "all" ]]; then
     echo "Test in live mode!"
-    az login --service-principal -u "${AZCLI_ALT_CLIENT_ID}" -p "${AZCLI_ALT_CLIENT_SECRET}" -t "${TENANT_ID}"
-    az account set -s "${AZCLI_ALT_SUBSCRIPTION_ID}"
-    az account show
     live_options="${base_options}${filter_options}"
     live_options+=" -l --json-report-file=ext_live_report.json"
     live_options+=" --xml-file=ext_live_result.xml"


### PR DESCRIPTION
Set up `az login` before running recording test to avoid the newly added test case does not include a corresponding
recording file and fall back to live mode, otherwise it will prompt `az login`.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
