### PR TITLE
Hotfix 0.6.1 : Using a shorter version of the user agent string

### DIFF
--- a/src/quantum/HISTORY.rst
+++ b/src/quantum/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.6.1
+++++++
+* [2021-07-22] Reduced the lenghth of the user agent reported by the tool.
+
 0.6.0
 ++++++
 * [2021-07-20] Version intended to work with QDK version v0.18.2106.148911

--- a/src/quantum/azext_quantum/__init__.py
+++ b/src/quantum/azext_quantum/__init__.py
@@ -11,7 +11,7 @@ import azext_quantum._help  # pylint: disable=unused-import
 # This is the version reported by the CLI to the service when submitting requests.
 # This should be in sync with the extension version in 'setup.py', unless we need to
 # submit using a different version.
-CLI_REPORTED_VERSION = "0.6.0"
+CLI_REPORTED_VERSION = "0.6.1"
 
 
 class QuantumCommandsLoader(AzCommandsLoader):

--- a/src/quantum/azext_quantum/_client_factory.py
+++ b/src/quantum/azext_quantum/_client_factory.py
@@ -33,7 +33,7 @@ def _get_data_credentials(cli_ctx, subscription_id=None):
 
 
 def get_appid():
-    return f"azure-cli-ext/{CLI_REPORTED_VERSION}"
+    return f"az-cli-ext/{CLI_REPORTED_VERSION}"
 
 
 # Control Plane clients

--- a/src/quantum/azext_quantum/_client_factory.py
+++ b/src/quantum/azext_quantum/_client_factory.py
@@ -33,7 +33,7 @@ def _get_data_credentials(cli_ctx, subscription_id=None):
 
 
 def get_appid():
-    return f"azure-cli-extension/{CLI_REPORTED_VERSION}"
+    return f"azure-cli-ext/{CLI_REPORTED_VERSION}"
 
 
 # Control Plane clients

--- a/src/quantum/setup.py
+++ b/src/quantum/setup.py
@@ -17,7 +17,7 @@ except ImportError:
 # This version should match the latest entry in HISTORY.rst
 # Also, when updating this, please review the version used by the extension to
 # submit requests, which can be found at './azext_quantum/__init__.py'
-VERSION = '0.6.0'
+VERSION = '0.6.1'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Job submissions are limited in the length of the ApplicationID string used.

In order to support this limitation, and keep the user agent consistent, this change is shortening the string to include only `az-cli-ext` instead of `azure-cli-extension` as prefix.
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [X] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [X] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
