### PR TITLE
[Pipeline] add `azure-batch-cli-extension` in blocklist to avoid command tree generate failure

### DIFF
--- a/scripts/ci/build_ext_cmd_tree.sh
+++ b/scripts/ci/build_ext_cmd_tree.sh
@@ -19,7 +19,8 @@ export AZURE_EXTENSION_INDEX_URL=https://raw.githubusercontent.com/Azure/azure-c
 
 output=$(az extension list-available --query [].name -otsv)
 # azure-cli-ml is replaced by ml
-blocklist=("azure-cli-ml")
+# TODO: azure-batch-cli-extensions is not compatible with latest batch SDK.
+blocklist=("azure-cli-ml" "azure-batch-cli-extensions")
 
 rm -f ~/.azure/extCmdTreeToUpload.json
 


### PR DESCRIPTION
`azure-batch-cli-extension` is not compatible with the latest batch SDK

![image](https://user-images.githubusercontent.com/69238381/126929256-9926d308-70d7-4a47-89af-69efec108cf3.png)


---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
