### PR TITLE
{AKS} create ssh-key in advance when perform concurrent tests

### DIFF
--- a/src/aks-preview/azcli_aks_live_test/scripts/setup_venv.sh
+++ b/src/aks-preview/azcli_aks_live_test/scripts/setup_venv.sh
@@ -109,7 +109,7 @@ setupAKSPreview(){
 createSSHKey(){
     # create ssh-key in advance to avoid the race condition that is prone to occur when key creation is handled by
     # azure-cli when performing test cases concurrently, this command will not overwrite the existing ssh-key
-    custom_ssh_dir=${1:-"/opt/.ssh"}
+    custom_ssh_dir=${1:-"/tmp/azaks/.ssh"}
     mkdir -p ${custom_ssh_dir}
     ssh-keygen -t rsa -b 2048 -C "azcli_aks_live_test@example.com" -f ${custom_ssh_dir}/id_rsa -N "" -q <<< n
 }

--- a/src/aks-preview/azcli_aks_live_test/scripts/setup_venv.sh
+++ b/src/aks-preview/azcli_aks_live_test/scripts/setup_venv.sh
@@ -3,6 +3,7 @@
 # check var
 # specify the version of python3, e.g. 3.6
 [[ -z "${PYTHON_VERSION}" ]] && (echo "PYTHON_VERSION is empty"; exit 1)
+[[ -z "${ACS_BASE_DIR}" ]] && (echo "ACS_BASE_DIR is empty"; exit 1)
 
 setupVenv(){
     # delete existing venv
@@ -109,8 +110,13 @@ setupAKSPreview(){
 createSSHKey(){
     # create ssh-key in advance to avoid the race condition that is prone to occur when key creation is handled by
     # azure-cli when performing test cases concurrently, this command will not overwrite the existing ssh-key
-    custom_ssh_dir=${1:-"/tmp/azaks/.ssh"}
-    mkdir -p ${custom_ssh_dir}
+    custom_ssh_dir=${1:-"${ACS_BASE_DIR}/tests/latest/data/.ssh"}
+    # remove dir if exists (clean up), otherwise create it
+    if [[ -d ${custom_ssh_dir} ]]; then
+        rm -rf ${custom_ssh_dir}
+    else
+        mkdir -p ${custom_ssh_dir}
+    fi
     ssh-keygen -t rsa -b 2048 -C "azcli_aks_live_test@example.com" -f ${custom_ssh_dir}/id_rsa -N "" -q <<< n
 }
 

--- a/src/aks-preview/azcli_aks_live_test/scripts/setup_venv.sh
+++ b/src/aks-preview/azcli_aks_live_test/scripts/setup_venv.sh
@@ -109,7 +109,9 @@ setupAKSPreview(){
 createSSHKey(){
     # create ssh-key in advance to avoid the race condition that is prone to occur when key creation is handled by
     # azure-cli when performing test cases concurrently, this command will not overwrite the existing ssh-key
-    ssh-keygen -t rsa -b 2048 -C "azcli_aks_live_test@example.com" -f ~/.ssh/id_rsa -N "" -q <<< $'\n'
+    custom_ssh_dir=${1:-"/opt/.ssh"}
+    mkdir -p ${custom_ssh_dir}
+    ssh-keygen -t rsa -b 2048 -C "azcli_aks_live_test@example.com" -f ${custom_ssh_dir}/id_rsa -N "" -q <<< n
 }
 
 setup_option=${1:-""}

--- a/src/aks-preview/azcli_aks_live_test/scripts/setup_venv.sh
+++ b/src/aks-preview/azcli_aks_live_test/scripts/setup_venv.sh
@@ -106,6 +106,12 @@ setupAKSPreview(){
     source azEnv/bin/activate
 }
 
+createSSHKey(){
+    # create ssh-key in advance to avoid the race condition that is prone to occur when key creation is handled by
+    # azure-cli when performing test cases concurrently, this command will not overwrite the existing ssh-key
+    ssh-keygen -t rsa -b 2048 -C "azcli_aks_live_test@example.com" -f ~/.ssh/id_rsa -N "" -q <<< $'\n'
+}
+
 setup_option=${1:-""}
 if [[ -n ${setup_option} ]]; then
     # bash options
@@ -142,6 +148,7 @@ if [[ -n ${setup_option} ]]; then
         ext_repo=${4:-""}
         setupAZ "${cli_repo}" "${ext_repo}"
         installTestPackages
+        createSSHKey
     elif [[ ${setup_option} == "setup-akspreview" ]]; then
         echo "Start to setup aks-preview!"
         setupAKSPreview

--- a/src/aks-preview/azcli_aks_live_test/scripts/transcribe_env.sh
+++ b/src/aks-preview/azcli_aks_live_test/scripts/transcribe_env.sh
@@ -18,10 +18,6 @@ set -o xtrace
 [[ -z "${IMAGE_TAG}" ]] && (echo "IMAGE_TAG is empty"; exit 1)
 # specify the version of python3
 [[ -z "${PYTHON_VERSION}" ]] && (echo "PYTHON_VERSION is empty"; exit 1)
-# base directories for acs, aks-preview and live test
-[[ -z "${ACS_BASE_DIR}" ]] && (echo "ACS_BASE_DIR is empty"; exit 1)
-[[ -z "${AKS_PREVIEW_BASE_DIR}" ]] && (echo "AKS_PREVIEW_BASE_DIR is empty"; exit 1)
-[[ -z "${LIVE_TEST_BASE_DIR}" ]] && (echo "LIVE_TEST_BASE_DIR is empty"; exit 1)
 
 # from azure devops
 [[ -z "${BUILD_REASON}" ]] && (echo "BUILD_REASON is empty")
@@ -43,6 +39,10 @@ set -o xtrace
 [[ -z "${CLI_BRANCH}" ]] && (echo "CLI_BRANCH is empty"; exit 1)
 [[ -z "${EXT_REPO}" ]] && (echo "EXT_REPO is empty"; exit 1)
 [[ -z "${EXT_BRANCH}" ]] && (echo "EXT_BRANCH is empty"; exit 1)
+# base directories for acs, aks-preview and live test
+[[ -z "${ACS_BASE_DIR}" ]] && (echo "ACS_BASE_DIR is empty"; exit 1)
+[[ -z "${AKS_PREVIEW_BASE_DIR}" ]] && (echo "AKS_PREVIEW_BASE_DIR is empty"; exit 1)
+[[ -z "${LIVE_TEST_BASE_DIR}" ]] && (echo "LIVE_TEST_BASE_DIR is empty"; exit 1)
 
 # clear
 cat /dev/null > env.list

--- a/src/aks-preview/azcli_aks_live_test/scripts/transcribe_env.sh
+++ b/src/aks-preview/azcli_aks_live_test/scripts/transcribe_env.sh
@@ -18,6 +18,10 @@ set -o xtrace
 [[ -z "${IMAGE_TAG}" ]] && (echo "IMAGE_TAG is empty"; exit 1)
 # specify the version of python3
 [[ -z "${PYTHON_VERSION}" ]] && (echo "PYTHON_VERSION is empty"; exit 1)
+# base directories for acs, aks-preview and live test
+[[ -z "${ACS_BASE_DIR}" ]] && (echo "ACS_BASE_DIR is empty"; exit 1)
+[[ -z "${AKS_PREVIEW_BASE_DIR}" ]] && (echo "AKS_PREVIEW_BASE_DIR is empty"; exit 1)
+[[ -z "${LIVE_TEST_BASE_DIR}" ]] && (echo "LIVE_TEST_BASE_DIR is empty"; exit 1)
 
 # from azure devops
 [[ -z "${BUILD_REASON}" ]] && (echo "BUILD_REASON is empty")
@@ -59,6 +63,11 @@ echo "SYSTEM_PULLREQUEST_TARGETBRANCH=${SYSTEM_PULLREQUEST_TARGETBRANCH}" >> env
 
 # python version
 echo "PYTHON_VERSION=${PYTHON_VERSION}" >> env.list
+
+# base directories
+echo "ACS_BASE_DIR=${ACS_BASE_DIR}" >> env.list
+echo "AKS_PREVIEW_BASE_DIR=${AKS_PREVIEW_BASE_DIR}" >> env.list
+echo "LIVE_TEST_BASE_DIR=${LIVE_TEST_BASE_DIR}" >> env.list
 
 # azdev env
 echo "AZURE_CLI_TEST_DEV_SP_NAME=${AZCLI_ALT_CLIENT_ID}" >> env.list

--- a/src/aks-preview/azcli_aks_live_test/vsts-azcli-aks-live-test.yaml
+++ b/src/aks-preview/azcli_aks_live_test/vsts-azcli-aks-live-test.yaml
@@ -16,12 +16,6 @@ variables:
     value: "azcli-aks-live-test"
   - name: REPO_NAME
     value: "azure-cli-extensions"
-  - name: LIVE_TEST_BASE_DIR
-    value: "azure-cli-extensions/src/aks-preview/azcli_aks_live_test"
-  - name: ACS_BASE_DIR
-    value: "azure-cli/src/azure-cli/azure/cli/command_modules/acs"
-  - name: AKS_PREVIEW_BASE_DIR
-    value: "azure-cli-extensions/src/aks-preview/azext_aks_preview"
 
 jobs:
 - job: LiveTest

--- a/src/aks-preview/azcli_aks_live_test/vsts-azcli-aks-live-test.yaml
+++ b/src/aks-preview/azcli_aks_live_test/vsts-azcli-aks-live-test.yaml
@@ -16,6 +16,12 @@ variables:
     value: "azcli-aks-live-test"
   - name: REPO_NAME
     value: "azure-cli-extensions"
+  - name: LIVE_TEST_BASE_DIR
+    value: "azure-cli-extensions/src/aks-preview/azcli_aks_live_test"
+  - name: ACS_BASE_DIR
+    value: "azure-cli/src/azure-cli/azure/cli/command_modules/acs"
+  - name: AKS_PREVIEW_BASE_DIR
+    value: "azure-cli-extensions/src/aks-preview/azext_aks_preview"
 
 jobs:
 - job: LiveTest

--- a/src/aks-preview/azcli_aks_live_test/vsts-azcli-aks-unit-test.yaml
+++ b/src/aks-preview/azcli_aks_live_test/vsts-azcli-aks-unit-test.yaml
@@ -16,8 +16,6 @@ variables:
     value: "azcli-aks-unit-test"
   - name: REPO_NAME
     value: "azure-cli-extensions"
-  - name: LIVE_TEST_BASE_DIR
-    value: "azure-cli-extensions/src/aks-preview/azcli_aks_live_test"
 
 jobs:
 - job: UnitTest

--- a/src/aks-preview/azcli_aks_live_test/vsts-azcli-aks-unit-test.yaml
+++ b/src/aks-preview/azcli_aks_live_test/vsts-azcli-aks-unit-test.yaml
@@ -16,6 +16,12 @@ variables:
     value: "azcli-aks-unit-test"
   - name: REPO_NAME
     value: "azure-cli-extensions"
+  - name: LIVE_TEST_BASE_DIR
+    value: "azure-cli-extensions/src/aks-preview/azcli_aks_live_test"
+  - name: ACS_BASE_DIR
+    value: "azure-cli/src/azure-cli/azure/cli/command_modules/acs"
+  - name: AKS_PREVIEW_BASE_DIR
+    value: "azure-cli-extensions/src/aks-preview/azext_aks_preview"
 
 jobs:
 - job: UnitTest

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -45,12 +45,15 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         # In order to avoid misuse of personal ssh-key during testing and the race condition that is prone to occur when key creation
         # is handled by azure-cli when performing test cases concurrently, we provide this function as a workround.
 
-        # In the scenario of runner and AKS check-in pipeline, a temporary ssh-key will be generated in advance under the "/tmp/azaks/.ssh"
-        # directory when setting up the environment. Each test case will read the ssh-key from a pre-generated file during execution,
-        # so there will be no race conditions caused by concurrent reading and writing/creating of the same file.
-        pre_generated_ssh_key_path = "/tmp/azaks/.ssh/id_rsa.pub"
-        if os.path.exists(pre_generated_ssh_key_path):
-            return pre_generated_ssh_key_path.replace('\\', '\\\\')
+        # In the scenario of runner and AKS check-in pipeline, a temporary ssh-key will be generated in advance under the
+        # "tests/latest/data/.ssh" sub-directory of the acs module in the cloned azure-cli repository when setting up the
+        # environment. Each test case will read the ssh-key from a pre-generated file during execution, so there will be no
+        # race conditions caused by concurrent reading and writing/creating of the same file.
+        acs_base_dir = os.getenv("ACS_BASE_DIR", None)
+        if acs_base_dir:
+            pre_generated_ssh_key_path = os.path.join(acs_base_dir, "tests/latest/data/.ssh")
+            if os.path.exists(pre_generated_ssh_key_path):
+                return pre_generated_ssh_key_path.replace('\\', '\\\\')
 
         # In the CLI check-in pipeline scenario, the following fake ssh-key will be used. Each test case will read the ssh-key from
         # a different temporary file during execution, so there will be no race conditions caused by concurrent reading and

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -39,6 +39,28 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         create_version = next(x for x in versions if not x.startswith(prefix))
         return create_version, upgrade_version
 
+    def generate_ssh_keys(self):
+        # If the `--ssh-key-value` option is not specified, the validator will try to read the ssh-key from the "~/.ssh" directory,
+        # and if no key exists, it will call the method provided by azure-cli.core to generate one under the "~/.ssh" directory.
+        # In order to avoid misuse of personal ssh-key during testing and the race condition that is prone to occur when key creation
+        # is handled by azure-cli when performing test cases concurrently, we provide this function as a workround.
+
+        # In the scenario of runner and AKS check-in pipeline, a temporary ssh-key will be generated in advance under the "/opt/.ssh"
+        # directory when setting up the environment. Each test case will read the ssh-key from a pre-generated file during execution,
+        # so there will be no race conditions caused by concurrent reading and writing/creating of the same file.
+        pre_generated_ssh_key_path = "/opt/.ssh/id_rsa.pub"
+        if os.path.exists(pre_generated_ssh_key_path):
+            return pre_generated_ssh_key_path.replace('\\', '\\\\')
+
+        # In the CLI check-in pipeline scenario, the following fake ssh-key will be used. Each test case will read the ssh-key from
+        # a different temporary file during execution, so there will be no race conditions caused by concurrent reading and
+        # writing/creating of the same file.
+        TEST_SSH_KEY_PUB = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ== test@example.com\n"  # pylint: disable=line-too-long
+        _, pathname = tempfile.mkstemp()
+        with open(pathname, 'w') as key_file:
+            key_file.write(TEST_SSH_KEY_PUB)
+        return pathname.replace('\\', '\\\\')
+
     @live_only()  # live only is required for test environment setup like `az login`
     @AllowLargeResponse()
     def test_get_version(self):
@@ -64,13 +86,14 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         aks_name = self.create_random_name('cliakstest', 16)
         self.kwargs.update({
             'resource_group': resource_group,
-            'name': aks_name
+            'name': aks_name,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
         create_cmd = 'aks create --resource-group={resource_group} --name={name} ' \
                      '--vm-set-type VirtualMachineScaleSets -c 1 ' \
                      '--enable-aad --aad-admin-group-object-ids 00000000-0000-0000-0000-000000000001 ' \
-                     '--generate-ssh-keys -o json'
+                     '--ssh-key-value={ssh_key_value} -o json'
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
             self.check('aadProfile.managed', True),
@@ -96,7 +119,8 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         aks_name = self.create_random_name('cliakstest', 16)
         self.kwargs.update({
             'resource_group': resource_group,
-            'name': aks_name
+            'name': aks_name,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
         create_cmd = 'aks create --resource-group={resource_group} --name={name} ' \
@@ -105,7 +129,7 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
                      '--aad-server-app-secret fake-secret ' \
                      '--aad-client-app-id 00000000-0000-0000-0000-000000000002 ' \
                      '--aad-tenant-id d5b55040-0c14-48cc-a028-91457fc190d9 ' \
-                     '--generate-ssh-keys -o json'
+                     '--ssh-key-value={ssh_key_value} -o json'
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
             self.check('aadProfile.managed', None),
@@ -136,12 +160,13 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         aks_name = self.create_random_name('cliakstest', 16)
         self.kwargs.update({
             'resource_group': resource_group,
-            'name': aks_name
+            'name': aks_name,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
         create_cmd = 'aks create --resource-group={resource_group} --name={name} ' \
                      '--vm-set-type VirtualMachineScaleSets --node-count=1 ' \
-                     '--generate-ssh-keys -o json'
+                     '--ssh-key-value={ssh_key_value} -o json'
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
             self.check('aadProfile', None)
@@ -166,13 +191,14 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         aks_name = self.create_random_name('cliakstest', 16)
         self.kwargs.update({
             'resource_group': resource_group,
-            'name': aks_name
+            'name': aks_name,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
         create_cmd = 'aks create --resource-group={resource_group} --name={name} ' \
                      '--vm-set-type VirtualMachineScaleSets -c 1 ' \
                      '--enable-aad --aad-admin-group-object-ids 00000000-0000-0000-0000-000000000001 ' \
-                     '--generate-ssh-keys -o json'
+                     '--ssh-key-value={ssh_key_value} -o json'
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
             self.check('aadProfile.managed', True),
@@ -200,11 +226,13 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         aks_name = self.create_random_name('cliakstest', 16)
         self.kwargs.update({
             'resource_group': resource_group,
-            'name': aks_name
+            'name': aks_name,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
-        create_cmd = 'aks create --resource-group={resource_group} --name={name} --enable-managed-identity --generate-ssh-keys ' \
-                     '-a ingress-appgw --appgw-subnet-cidr 10.2.0.0/16 -o json'
+        create_cmd = 'aks create --resource-group={resource_group} --name={name} --enable-managed-identity ' \
+                     '-a ingress-appgw --appgw-subnet-cidr 10.2.0.0/16 ' \
+                     '--ssh-key-value={ssh_key_value} -o json'
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
             self.check('addonProfiles.ingressApplicationGateway.enabled', True),
@@ -218,11 +246,13 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         aks_name = self.create_random_name('cliakstest', 16)
         self.kwargs.update({
             'resource_group': resource_group,
-            'name': aks_name
+            'name': aks_name,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
-        create_cmd = 'aks create --resource-group={resource_group} --name={name} --enable-managed-identity --generate-ssh-keys ' \
-                     '-a ingress-appgw --appgw-subnet-prefix 10.2.0.0/16 -o json'
+        create_cmd = 'aks create --resource-group={resource_group} --name={name} --enable-managed-identity ' \
+                     '-a ingress-appgw --appgw-subnet-prefix 10.2.0.0/16 ' \
+                     '--ssh-key-value={ssh_key_value} -o json'
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
             self.check('addonProfiles.ingressApplicationGateway.enabled', True),
@@ -241,7 +271,8 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             'resource_group': resource_group,
             'aks_name': aks_name,
             'vnet_name': vnet_name,
-            'appgw_name': appgw_name
+            'appgw_name': appgw_name,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
         # create virtual network
@@ -264,9 +295,10 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         })
 
         # create aks cluster
-        create_cmd = 'aks create --resource-group={resource_group} --name={aks_name} --enable-managed-identity --generate-ssh-keys ' \
-                     '--vnet-subnet-id {vnet_id}/subnets/aks-subnet ' \
-                     '-a ingress-appgw --appgw-name gateway --appgw-subnet-id {vnet_id}/subnets/appgw-subnet --yes -o json'
+        create_cmd = 'aks create --resource-group={resource_group} --name={aks_name} --enable-managed-identity ' \
+                     '--vnet-subnet-id {vnet_id}/subnets/aks-subnet -a ingress-appgw ' \
+                     '--appgw-name gateway --appgw-subnet-id {vnet_id}/subnets/appgw-subnet ' \
+                     '--yes --ssh-key-value={ssh_key_value} -o json'
         aks_cluster = self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
             self.check('addonProfiles.ingressApplicationGateway.enabled', True),
@@ -291,7 +323,8 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         self.kwargs.update({
             'resource_group': resource_group,
             'aks_name': aks_name,
-            'vnet_name': vnet_name
+            'vnet_name': vnet_name,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
         # create virtual network
@@ -338,9 +371,10 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         })
 
         # create aks cluster
-        create_cmd = 'aks create -n {aks_name} -g {resource_group} --enable-managed-identity --generate-ssh-keys ' \
+        create_cmd = 'aks create -n {aks_name} -g {resource_group} --enable-managed-identity ' \
                      '--vnet-subnet-id {vnet_id}/subnets/aks-subnet ' \
-                     '-a ingress-appgw --appgw-id {appgw_id} --yes -o json'
+                     '-a ingress-appgw --appgw-id {appgw_id} ' \
+                     '--yes --ssh-key-value={ssh_key_value} -o json'
         aks_cluster = self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
             self.check('addonProfiles.ingressApplicationGateway.enabled', True),
@@ -361,10 +395,11 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         self.kwargs.update({
             'resource_group': resource_group,
             'name': aks_name,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
-        create_cmd = 'aks create --resource-group={resource_group} --name={name} --enable-managed-identity --generate-ssh-keys ' \
-                     '-a open-service-mesh -o json'
+        create_cmd = 'aks create --resource-group={resource_group} --name={name} --enable-managed-identity ' \
+                     '-a open-service-mesh --ssh-key-value={ssh_key_value} -o json'
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
             self.check('addonProfiles.openServiceMesh.enabled', True),
@@ -377,9 +412,11 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         self.kwargs.update({
             'resource_group': resource_group,
             'name': aks_name,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
-        create_cmd = 'aks create --resource-group={resource_group} --name={name} --enable-managed-identity --generate-ssh-keys -o json'
+        create_cmd = 'aks create --resource-group={resource_group} --name={name} --enable-managed-identity ' \
+                     '--ssh-key-value={ssh_key_value} -o json'
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
             self.check('addonProfiles.openServiceMesh', None),
@@ -398,10 +435,11 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         self.kwargs.update({
             'resource_group': resource_group,
             'name': aks_name,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
-        create_cmd = 'aks create --resource-group={resource_group} --name={name} --enable-managed-identity --generate-ssh-keys ' \
-                     '-a open-service-mesh -o json'
+        create_cmd = 'aks create --resource-group={resource_group} --name={name} --enable-managed-identity ' \
+                     '-a open-service-mesh --ssh-key-value={ssh_key_value} -o json'
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
             self.check('addonProfiles.openServiceMesh.enabled', True),
@@ -421,10 +459,11 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         self.kwargs.update({
             'resource_group': resource_group,
             'name': aks_name,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
-        create_cmd = 'aks create --resource-group={resource_group} --name={name} --generate-ssh-keys ' \
-                     '-a azure-keyvault-secrets-provider -o json'
+        create_cmd = 'aks create --resource-group={resource_group} --name={name} ' \
+                     '-a azure-keyvault-secrets-provider --ssh-key-value={ssh_key_value} -o json'
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
             self.check(
@@ -446,10 +485,12 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         self.kwargs.update({
             'resource_group': resource_group,
             'name': aks_name,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
-        create_cmd = 'aks create --resource-group={resource_group} --name={name} --generate-ssh-keys ' \
-                     '-a azure-keyvault-secrets-provider --enable-secret-rotation -o json'
+        create_cmd = 'aks create --resource-group={resource_group} --name={name} ' \
+                     '-a azure-keyvault-secrets-provider --enable-secret-rotation ' \
+                     '--ssh-key-value={ssh_key_value} -o json'
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
             self.check(
@@ -471,9 +512,10 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         self.kwargs.update({
             'resource_group': resource_group,
             'name': aks_name,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
-        create_cmd = 'aks create --resource-group={resource_group} --name={name} --generate-ssh-keys'
+        create_cmd = 'aks create --resource-group={resource_group} --name={name} --ssh-key-value={ssh_key_value}'
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
             self.check('addonProfiles.azureKeyvaultSecretsProvider', None)
@@ -519,10 +561,11 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         self.kwargs.update({
             'resource_group': resource_group,
             'name': aks_name,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
-        create_cmd = 'aks create --resource-group={resource_group} --name={name} --generate-ssh-keys ' \
-                     '-a azure-keyvault-secrets-provider'
+        create_cmd = 'aks create --resource-group={resource_group} --name={name} -a azure-keyvault-secrets-provider ' \
+                     '--ssh-key-value={ssh_key_value}'
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
             self.check(
@@ -561,11 +604,12 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         aks_name = self.create_random_name('cliakstest', 16)
         self.kwargs.update({
             'resource_group': resource_group,
-            'name': aks_name
+            'name': aks_name,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
-        create_cmd = 'aks create --resource-group={resource_group} --name={name} --enable-managed-identity --generate-ssh-keys ' \
-                     '-a confcom -o json'
+        create_cmd = 'aks create --resource-group={resource_group} --name={name} --enable-managed-identity ' \
+                     '-a confcom --ssh-key-value={ssh_key_value} -o json'
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
             self.check('addonProfiles.ACCSGXDevicePlugin.enabled', True),
@@ -579,11 +623,12 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         aks_name = self.create_random_name('cliakstest', 16)
         self.kwargs.update({
             'resource_group': resource_group,
-            'name': aks_name
+            'name': aks_name,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
-        create_cmd = 'aks create --resource-group={resource_group} --name={name} --enable-managed-identity --generate-ssh-keys ' \
-                     '-a confcom --enable-sgxquotehelper -o json'
+        create_cmd = 'aks create --resource-group={resource_group} --name={name} --enable-managed-identity ' \
+                     '-a confcom --enable-sgxquotehelper --ssh-key-value={ssh_key_value} -o json'
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
             self.check('addonProfiles.ACCSGXDevicePlugin.enabled', True),
@@ -597,11 +642,12 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         aks_name = self.create_random_name('cliakstest', 16)
         self.kwargs.update({
             'resource_group': resource_group,
-            'name': aks_name
+            'name': aks_name,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
-        create_cmd = 'aks create --resource-group={resource_group} --name={name} --enable-managed-identity --generate-ssh-keys ' \
-                     '-o json'
+        create_cmd = 'aks create --resource-group={resource_group} --name={name} --enable-managed-identity ' \
+                     '--ssh-key-value={ssh_key_value} -o json'
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
             self.check('addonProfiles.ACCSGXDevicePlugin', None)
@@ -621,11 +667,12 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         aks_name = self.create_random_name('cliakstest', 16)
         self.kwargs.update({
             'resource_group': resource_group,
-            'name': aks_name
+            'name': aks_name,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
-        create_cmd = 'aks create --resource-group={resource_group} --name={name} --enable-managed-identity --generate-ssh-keys ' \
-                     '-a confcom -o json'
+        create_cmd = 'aks create --resource-group={resource_group} --name={name} --enable-managed-identity ' \
+                     '-a confcom --ssh-key-value={ssh_key_value} -o json'
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
             self.check('addonProfiles.ACCSGXDevicePlugin.enabled', True),
@@ -649,7 +696,8 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         self.kwargs.update({
             'resource_group': resource_group,
             'aks_name': aks_name,
-            'vnet_name': vnet_name
+            'vnet_name': vnet_name,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
         # create virtual network
@@ -672,9 +720,10 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         })
 
         # create aks cluster
-        create_cmd = 'aks create --resource-group={resource_group} --name={aks_name} --enable-managed-identity --generate-ssh-keys ' \
+        create_cmd = 'aks create --resource-group={resource_group} --name={aks_name} --enable-managed-identity ' \
                      '--vnet-subnet-id {vnet_id}/subnets/aks-subnet --network-plugin azure ' \
-                     '-a virtual-node --aci-subnet-name aci-subnet --yes -o json'
+                     '-a virtual-node --aci-subnet-name aci-subnet --yes ' \
+                     '--ssh-key-value={ssh_key_value} -o json'
         aks_cluster = self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
             self.check('addonProfiles.aciConnectorLinux.enabled', True),
@@ -700,10 +749,11 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         aks_name = self.create_random_name('cliakstest', 16)
         self.kwargs.update({
             'resource_group': resource_group,
-            'name': aks_name
+            'name': aks_name,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
-        create_cmd = 'aks create --resource-group={resource_group} --name={name} --generate-ssh-keys'
+        create_cmd = 'aks create --resource-group={resource_group} --name={name} --ssh-key-value={ssh_key_value}'
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
         ])
@@ -720,12 +770,13 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         aks_name = self.create_random_name('cliakstest', 16)
         self.kwargs.update({
             'resource_group': resource_group,
-            'name': aks_name
+            'name': aks_name,
+            'ssh_key_value': self.generate_ssh_keys()
         })
         create_cmd = 'aks create --resource-group={resource_group} --name={name} ' \
-                     '--generate-ssh-keys ' \
                      '--vm-set-type VirtualMachineScaleSets -c 1 ' \
-                     '--node-osdisk-type=Managed'
+                     '--node-osdisk-type=Managed ' \
+                     '--ssh-key-value={ssh_key_value}'
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
             self.check('agentPoolProfiles[0].osDiskType', 'Managed'),
@@ -737,13 +788,14 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         aks_name = self.create_random_name('cliakstest', 16)
         self.kwargs.update({
             'resource_group': resource_group,
-            'name': aks_name
+            'name': aks_name,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
         create_cmd = 'aks create --resource-group={resource_group} --name={name} ' \
-                     '--generate-ssh-keys ' \
                      '--vm-set-type VirtualMachineScaleSets -c 1 ' \
-                     '--node-osdisk-type=Ephemeral --node-osdisk-size 60'
+                     '--node-osdisk-type=Ephemeral --node-osdisk-size 60 ' \
+                     '--ssh-key-value={ssh_key_value}'
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
             self.check('agentPoolProfiles[0].osDiskType', 'Ephemeral'),
@@ -755,12 +807,13 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         aks_name = self.create_random_name('cliakstest', 16)
         self.kwargs.update({
             'resource_group': resource_group,
-            'name': aks_name
+            'name': aks_name,
+            'ssh_key_value': self.generate_ssh_keys()
         })
         create_cmd = 'aks create --resource-group={resource_group} --name={name} ' \
-                     '--generate-ssh-keys ' \
                      '--vm-set-type VirtualMachineScaleSets -c 1 ' \
-                     '--os-sku CBLMariner'
+                     '--os-sku CBLMariner ' \
+                     '--ssh-key-value={ssh_key_value}'
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
             self.check('agentPoolProfiles[0].osSku', 'CBLMariner'),
@@ -779,13 +832,13 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             'resource_group': resource_group,
             'name': aks_name,
             'node_pool_name': node_pool_name,
-            'node_pool_name_second': node_pool_name_second
+            'node_pool_name_second': node_pool_name_second,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
         create_cmd = 'aks create --resource-group={resource_group} --name={name} ' \
-                     '--generate-ssh-keys ' \
-                     '--nodepool-name {node_pool_name} ' \
-                     '-c 1'
+                     '--nodepool-name {node_pool_name} -c 1 ' \
+                     '--ssh-key-value={ssh_key_value}'
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
         ])
@@ -813,13 +866,13 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         self.kwargs.update({
             'resource_group': resource_group,
             'name': aks_name,
-            'node_pool_name': node_pool_name
+            'node_pool_name': node_pool_name,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
         create_cmd = 'aks create --resource-group={resource_group} --name={name} ' \
-                     '--generate-ssh-keys ' \
-                     '--nodepool-name {node_pool_name} ' \
-                     '-c 1'
+                     '--nodepool-name {node_pool_name} -c 1 ' \
+                     '--ssh-key-value={ssh_key_value}'
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
         ])
@@ -850,14 +903,14 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         self.kwargs.update({
             'resource_group': resource_group,
             'name': aks_name,
-            'node_pool_name': node_pool_name
+            'node_pool_name': node_pool_name,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
         create_cmd = 'aks create --resource-group={resource_group} --name={name} ' \
                      '--nodepool-name {node_pool_name} ' \
-                     '--generate-ssh-keys ' \
                      '--vm-set-type VirtualMachineScaleSets --node-count=1 ' \
-                     '-o json'
+                     '--ssh-key-value={ssh_key_value} -o json'
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded')
         ])
@@ -881,14 +934,14 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         self.kwargs.update({
             'resource_group': resource_group,
             'name': aks_name,
-            'node_pool_name': node_pool_name
+            'node_pool_name': node_pool_name,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
         create_cmd = 'aks create --resource-group={resource_group} --name={name} ' \
                      '--nodepool-name {node_pool_name} ' \
-                     '--generate-ssh-keys ' \
                      '--vm-set-type VirtualMachineScaleSets --node-count=1 ' \
-                     '-o json'
+                     '--ssh-key-value={ssh_key_value} -o json'
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded')
         ])
@@ -928,14 +981,15 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             'nodepool2_name': 'npwin',
             'k8s_version': create_version,
             'upgrade_k8s_version': upgrade_version,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
         # create AKS cluster
         create_cmd = 'aks create --resource-group={resource_group} --name={name} --location={location} ' \
-                     '--dns-name-prefix={dns_name_prefix} --node-count=1 --generate-ssh-keys ' \
+                     '--dns-name-prefix={dns_name_prefix} --node-count=1 ' \
                      '--windows-admin-username={windows_admin_username} --windows-admin-password={windows_admin_password} ' \
                      '--load-balancer-sku=standard --vm-set-type=virtualmachinescalesets --network-plugin=azure ' \
-                     '--kubernetes-version={k8s_version}'
+                     '--kubernetes-version={k8s_version} --ssh-key-value={ssh_key_value}'
         self.cmd(create_cmd, checks=[
             self.exists('fqdn'),
             self.exists('nodeResourceGroup'),
@@ -980,13 +1034,15 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             'windows_admin_username': 'azureuser1',
             'windows_admin_password': 'replace-Password1234$',
             'nodepool2_name': 'npwin',
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
         # create
         create_cmd = 'aks create --resource-group={resource_group} --name={name} --location={location} ' \
-                     '--dns-name-prefix={dns_name_prefix} --node-count=1 --generate-ssh-keys ' \
+                     '--dns-name-prefix={dns_name_prefix} --node-count=1 ' \
                      '--windows-admin-username={windows_admin_username} --windows-admin-password={windows_admin_password} ' \
-                     '--load-balancer-sku=standard --vm-set-type=virtualmachinescalesets --network-plugin=azure'
+                     '--load-balancer-sku=standard --vm-set-type=virtualmachinescalesets --network-plugin=azure ' \
+                     '--ssh-key-value={ssh_key_value}'
         self.cmd(create_cmd, checks=[
             self.exists('fqdn'),
             self.exists('nodeResourceGroup'),
@@ -1027,11 +1083,12 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             'location': resource_group_location,
             'resource_type': 'Microsoft.ContainerService/ManagedClusters',
             'nodepool2_name': 'np2',
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
         # create
         create_cmd = 'aks create --resource-group={resource_group} --name={name} --enable-fips-image ' \
-                     '--generate-ssh-keys '
+                     '--ssh-key-value={ssh_key_value}'
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
             self.check('agentPoolProfiles[0].enableFips', True)
@@ -1063,13 +1120,15 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             'windows_admin_username': 'azureuser1',
             'windows_admin_password': 'replace-Password1234$',
             'nodepool2_name': 'npwin',
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
         # create
         create_cmd = 'aks create --resource-group={resource_group} --name={name} --location={location} ' \
-                     '--dns-name-prefix={dns_name_prefix} --node-count=1 --generate-ssh-keys ' \
+                     '--dns-name-prefix={dns_name_prefix} --node-count=1 ' \
                      '--windows-admin-username={windows_admin_username} --windows-admin-password={windows_admin_password} ' \
-                     '--load-balancer-sku=standard --vm-set-type=virtualmachinescalesets --network-plugin=azure --enable-ahub'
+                     '--load-balancer-sku=standard --vm-set-type=virtualmachinescalesets --network-plugin=azure --enable-ahub ' \
+                     '--ssh-key-value={ssh_key_value}'
         self.cmd(create_cmd, checks=[
             self.exists('fqdn'),
             self.exists('nodeResourceGroup'),
@@ -1103,10 +1162,11 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         aks_name = self.create_random_name('cliakstest', 16)
         self.kwargs.update({
             'resource_group': resource_group,
-            'name': aks_name
+            'name': aks_name,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
-        create_cmd = 'aks create --resource-group={resource_group} --name={name} --generate-ssh-keys'
+        create_cmd = 'aks create --resource-group={resource_group} --name={name} --ssh-key-value={ssh_key_value}'
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
         ])
@@ -1129,10 +1189,11 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         self.kwargs.update({
             'resource_group': resource_group,
             'name': aks_name,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
         create_cmd = 'aks create --resource-group={resource_group} --name={name} -a gitops ' \
-                     '--generate-ssh-keys -o json'
+                     '--ssh-key-value={ssh_key_value} -o json'
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
             self.check('addonProfiles.gitops.enabled', True),
@@ -1146,10 +1207,11 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         self.kwargs.update({
             'resource_group': resource_group,
             'name': aks_name,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
         create_cmd = 'aks create --resource-group={resource_group} --name={name} ' \
-                     '--generate-ssh-keys -o json'
+                     '--ssh-key-value={ssh_key_value} -o json'
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
             self.check('addonProfiles.gitops', None),
@@ -1169,10 +1231,11 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         self.kwargs.update({
             'resource_group': resource_group,
             'name': aks_name,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
         create_cmd = 'aks create --resource-group={resource_group} --name={name} -a gitops ' \
-                     '--generate-ssh-keys -o json'
+                     '--ssh-key-value={ssh_key_value} -o json'
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
             self.check('addonProfiles.gitops.enabled', True),
@@ -1192,10 +1255,12 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         aks_name = self.create_random_name('cliakstest', 16)
         self.kwargs.update({
             'resource_group': resource_group,
-            'name': aks_name
+            'name': aks_name,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
-        create_cmd = 'aks create --resource-group={resource_group} --name={name} --generate-ssh-keys --enable-addons monitoring'
+        create_cmd = 'aks create --resource-group={resource_group} --name={name} --enable-addons monitoring ' \
+                     '--ssh-key-value={ssh_key_value}'
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
         ])
@@ -1234,6 +1299,7 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             'resource_group': resource_group,
             'name': aks_name,
             'location': resource_group_location,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
         if user_assigned_identity:
@@ -1246,10 +1312,11 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
 
         # create
         create_cmd = f'aks create --resource-group={resource_group} --name={aks_name} --location={resource_group_location} ' \
-                     '--generate-ssh-keys --enable-managed-identity ' \
+                     '--enable-managed-identity ' \
                      '--enable-addons monitoring ' \
                      '--enable-msi-auth-for-monitoring ' \
-                     '--node-count 1 '
+                     '--node-count 1 ' \
+                     '--ssh-key-value={ssh_key_value} '
         create_cmd += f'--assign-identity {identity_id}' if user_assigned_identity else ''
 
         response = self.cmd(create_cmd, checks=[
@@ -1304,6 +1371,7 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             'resource_group': resource_group,
             'name': aks_name,
             'location': resource_group_location,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
         if user_assigned_identity:
@@ -1316,8 +1384,9 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
 
         # create
         create_cmd = f'aks create --resource-group={resource_group} --name={aks_name} --location={resource_group_location} ' \
-                     '--generate-ssh-keys --enable-managed-identity ' \
-                     '--node-count 1 '
+                     '--enable-managed-identity ' \
+                     '--node-count 1 ' \
+                     '--ssh-key-value={ssh_key_value} '
         create_cmd += f'--assign-identity {identity_id}' if user_assigned_identity else ''
         self.cmd(create_cmd)
 
@@ -1365,13 +1434,15 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             'resource_group': resource_group,
             'name': aks_name,
             'location': resource_group_location,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
         # create
         create_cmd = 'aks create --resource-group={resource_group} --name={name} --location={location} ' \
-                     '--generate-ssh-keys --enable-managed-identity ' \
+                     '--enable-managed-identity ' \
                      '--enable-addons monitoring ' \
-                     '--node-count 1 '
+                     '--node-count 1 ' \
+                     '--ssh-key-value={ssh_key_value} '
         response = self.cmd(create_cmd, checks=[
             self.check('addonProfiles.omsagent.enabled', True),
             self.exists('addonProfiles.omsagent.config.logAnalyticsWorkspaceResourceID'),
@@ -1414,12 +1485,14 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             'resource_group': resource_group,
             'name': aks_name,
             'location': resource_group_location,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
         # create
         create_cmd = 'aks create --resource-group={resource_group} --name={name} --location={location} ' \
-                     '--generate-ssh-keys --enable-managed-identity ' \
-                     '--auto-upgrade-channel rapid'
+                     '--enable-managed-identity ' \
+                     '--auto-upgrade-channel rapid ' \
+                     '--ssh-key-value={ssh_key_value}'
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
             self.check('autoUpgradeProfile.upgradeChannel', 'rapid')
@@ -1443,12 +1516,15 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             'resource_group': resource_group,
             'name': aks_name,
             'kc_path': _get_test_data_file('kubeletconfig.json'),
-            'oc_path': _get_test_data_file('linuxosconfig.json')
+            'oc_path': _get_test_data_file('linuxosconfig.json'),
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
         # use custom feature so it does not require subscription to regiter the feature
-        create_cmd = 'aks create --resource-group={resource_group} --name={name} --generate-ssh-keys ' \
-                     '--kubelet-config={kc_path} --linux-os-config={oc_path} --aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/CustomNodeConfigPreview -o json'
+        create_cmd = 'aks create --resource-group={resource_group} --name={name} ' \
+                     '--kubelet-config={kc_path} --linux-os-config={oc_path} ' \
+                     '--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/CustomNodeConfigPreview ' \
+                     '--ssh-key-value={ssh_key_value} -o json'
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
             self.check(
@@ -1475,11 +1551,13 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         self.kwargs.update({
             'resource_group': resource_group,
             'name': aks_name,
-            'http_proxy_path': _get_test_data_file('httpproxyconfig.json')
+            'http_proxy_path': _get_test_data_file('httpproxyconfig.json'),
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
         # use custom feature so it does not require subscription to regiter the feature
-        create_cmd = 'aks create --resource-group={resource_group} --name={name} --generate-ssh-keys --http-proxy-config={http_proxy_path} -o json'
+        create_cmd = 'aks create --resource-group={resource_group} --name={name} --http-proxy-config={http_proxy_path} ' \
+                     '--ssh-key-value={ssh_key_value} -o json'
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
             self.check('httpProxyConfig', None),
@@ -1494,13 +1572,15 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         aks_name = self.create_random_name('cliakstest', 16)
         self.kwargs.update({
             'resource_group': resource_group,
-            'name': aks_name
+            'name': aks_name,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
         # create
         create_cmd = 'aks create --resource-group={resource_group} --name={name} ' \
-                     '--node-count=1 --generate-ssh-keys ' \
-                     '--load-balancer-sku=standard --enable-private-cluster --private-dns-zone none'
+                     '--node-count=1 --load-balancer-sku=standard ' \
+                     '--enable-private-cluster --private-dns-zone none ' \
+                     '--ssh-key-value={ssh_key_value}'
         self.cmd(create_cmd, checks=[
             self.exists('privateFqdn'),
             self.exists('nodeResourceGroup'),
@@ -1521,13 +1601,15 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         aks_name = self.create_random_name('cliakstest', 16)
         self.kwargs.update({
             'resource_group': resource_group,
-            'name': aks_name
+            'name': aks_name,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
         # create
         create_cmd = 'aks create --resource-group={resource_group} --name={name} ' \
-                     '--node-count=1 --generate-ssh-keys ' \
-                     '--enable-public-fqdn --enable-private-cluster --aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/EnablePrivateClusterPublicFQDN'
+                     '--node-count=1 --enable-public-fqdn ' \
+                     '--enable-private-cluster --aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/EnablePrivateClusterPublicFQDN ' \
+                     '--ssh-key-value={ssh_key_value}'
         self.cmd(create_cmd, checks=[
             self.exists('privateFqdn'),
             self.exists('fqdn'),
@@ -1560,7 +1642,8 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             'name': aks_name,
             'identity_name': identity_name,
             'subdomain_name': subdomain_name,
-            'location': resource_group_location
+            'location': resource_group_location,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
         # create private dns zone
@@ -1596,8 +1679,9 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
 
         # create
         create_cmd = 'aks create --resource-group={resource_group} --name={name} ' \
-                     '--node-count=1 --generate-ssh-keys --fqdn-subdomain={subdomain_name} ' \
-                     '--load-balancer-sku=standard --enable-private-cluster --private-dns-zone={zone_id} --enable-managed-identity --assign-identity {identity_resource_id}'
+                     '--node-count=1 --fqdn-subdomain={subdomain_name} --load-balancer-sku=standard ' \
+                     '--enable-private-cluster --private-dns-zone={zone_id} --enable-managed-identity --assign-identity {identity_resource_id} ' \
+                     '--ssh-key-value={ssh_key_value}'
         self.cmd(create_cmd, checks=[
             self.exists('privateFqdn'),
             self.exists('fqdnSubdomain'),
@@ -1618,13 +1702,15 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             'resource_group': resource_group,
             'name': aks_name,
             'location': resource_group_location,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
         # create
-        cmd = ('aks create --resource-group={resource_group} --name={name} --location={location} '
-               '--generate-ssh-keys --enable-managed-identity '
-               '--enable-pod-identity --enable-pod-identity-with-kubenet')
-        self.cmd(cmd, checks=[
+        create_cmd = 'aks create --resource-group={resource_group} --name={name} --location={location} ' \
+                     '--enable-managed-identity ' \
+                     '--enable-pod-identity --enable-pod-identity-with-kubenet ' \
+                     '--ssh-key-value={ssh_key_value}'
+        self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
             self.check('podIdentityProfile.enabled', True),
             self.check('podIdentityProfile.allowNetworkPluginKubenet', True)
@@ -1699,13 +1785,15 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             'resource_group': resource_group,
             'name': aks_name,
             'location': resource_group_location,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
         # create
-        cmd = ('aks create --resource-group={resource_group} --name={name} --location={location} '
-               '--generate-ssh-keys --enable-managed-identity '
-               '--enable-pod-identity --network-plugin azure')
-        self.cmd(cmd, checks=[
+        create_cmd = 'aks create --resource-group={resource_group} --name={name} --location={location} ' \
+                     '--enable-managed-identity ' \
+                     '--enable-pod-identity --network-plugin azure ' \
+                     '--ssh-key-value={ssh_key_value}'
+        self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
             self.check('podIdentityProfile.enabled', True)
         ])
@@ -1785,6 +1873,7 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             'location': resource_group_location,
             'identity_name': identity_name,
             'binding_selector': binding_selector_name,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
         # create identity
@@ -1797,10 +1886,11 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         })
 
         # create
-        cmd = ('aks create --resource-group={resource_group} --name={name} --location={location} '
-               '--generate-ssh-keys --enable-managed-identity '
-               '--enable-pod-identity --enable-pod-identity-with-kubenet')
-        self.cmd(cmd, checks=[
+        create_cmd = 'aks create --resource-group={resource_group} --name={name} --location={location} ' \
+                     '--enable-managed-identity ' \
+                     '--enable-pod-identity --enable-pod-identity-with-kubenet ' \
+                     '--ssh-key-value={ssh_key_value}'
+        self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
             self.check('podIdentityProfile.enabled', True)
         ])
@@ -1880,13 +1970,15 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             'windows_admin_password': self.create_random_name('p@0A', 16),
             'nodepool2_name': 'npwin',
             'new_windows_admin_password': self.create_random_name('n!C3', 16),
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
         # create
         create_cmd = 'aks create --resource-group={resource_group} --name={name} --location={location} ' \
-                     '--dns-name-prefix={dns_name_prefix} --node-count=1 --generate-ssh-keys ' \
+                     '--dns-name-prefix={dns_name_prefix} --node-count=1 ' \
                      '--windows-admin-username={windows_admin_username} --windows-admin-password={windows_admin_password} ' \
-                     '--load-balancer-sku=standard --vm-set-type=virtualmachinescalesets --network-plugin=azure'
+                     '--load-balancer-sku=standard --vm-set-type=virtualmachinescalesets --network-plugin=azure ' \
+                     '--ssh-key-value={ssh_key_value}'
         self.cmd(create_cmd, checks=[
             self.exists('fqdn'),
             self.exists('nodeResourceGroup'),
@@ -1920,6 +2012,7 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             'name': aks_name,
             'control_plane_identity_name': control_plane_identity_name,
             'kubelet_identity_name': kubelet_identity_name,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
         # create control plane identity
@@ -1946,8 +2039,9 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
 
         # create
         create_cmd = 'aks create --resource-group={resource_group} --name={name} ' \
-                     '--node-count=1 --generate-ssh-keys --enable-managed-identity ' \
-                     '--assign-identity {control_plane_identity_resource_id} --assign-kubelet-identity {kubelet_identity_resource_id}'
+                     '--node-count=1 --enable-managed-identity ' \
+                     '--assign-identity {control_plane_identity_resource_id} --assign-kubelet-identity {kubelet_identity_resource_id} ' \
+                     '--ssh-key-value={ssh_key_value}'
         self.cmd(create_cmd, checks=[
             self.exists('identity'),
             self.exists('identityProfile'),
@@ -1967,11 +2061,13 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         aks_name = self.create_random_name('cliakstest', 16)
         self.kwargs.update({
             'resource_group': resource_group,
-            'name': aks_name
+            'name': aks_name,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
-        create_cmd = 'aks create --resource-group={resource_group} --name={name} --generate-ssh-keys ' \
-                     '--enable-managed-identity --disable-local-accounts'
+        create_cmd = 'aks create --resource-group={resource_group} --name={name} ' \
+                     '--enable-managed-identity --disable-local-accounts ' \
+                     '--ssh-key-value={ssh_key_value}'
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
             self.check('disableLocalAccounts', True)
@@ -1993,11 +2089,13 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         aks_name = self.create_random_name('cliakstest', 16)
         self.kwargs.update({
             'resource_group': resource_group,
-            'name': aks_name
+            'name': aks_name,
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
-        create_cmd = 'aks create --resource-group={resource_group} --name={name} --generate-ssh-keys ' \
-                     '--node-vm-size Standard_D2s_v3 --zones 1 2 3 --enable-ultra-ssd'
+        create_cmd = 'aks create --resource-group={resource_group} --name={name} ' \
+                     '--node-vm-size Standard_D2s_v3 --zones 1 2 3 --enable-ultra-ssd ' \
+                     '--ssh-key-value={ssh_key_value}'
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded')
         ])
@@ -2013,10 +2111,11 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         self.kwargs.update({
             'resource_group': resource_group,
             'name': aks_name,
-            'mc_path': _get_test_data_file('maintenanceconfig.json')
+            'mc_path': _get_test_data_file('maintenanceconfig.json'),
+            'ssh_key_value': self.generate_ssh_keys()
         })
 
-        create_cmd = 'aks create --resource-group={resource_group} --name={name} --generate-ssh-keys'
+        create_cmd = 'aks create --resource-group={resource_group} --name={name} --ssh-key-value={ssh_key_value}'
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded')
         ])

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -39,7 +39,8 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         create_version = next(x for x in versions if not x.startswith(prefix))
         return create_version, upgrade_version
 
-    def generate_ssh_keys(self):
+    @classmethod
+    def generate_ssh_keys(cls):
         # If the `--ssh-key-value` option is not specified, the validator will try to read the ssh-key from the "~/.ssh" directory,
         # and if no key exists, it will call the method provided by azure-cli.core to generate one under the "~/.ssh" directory.
         # In order to avoid misuse of personal ssh-key during testing and the race condition that is prone to occur when key creation

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -45,10 +45,10 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         # In order to avoid misuse of personal ssh-key during testing and the race condition that is prone to occur when key creation
         # is handled by azure-cli when performing test cases concurrently, we provide this function as a workround.
 
-        # In the scenario of runner and AKS check-in pipeline, a temporary ssh-key will be generated in advance under the "/opt/.ssh"
+        # In the scenario of runner and AKS check-in pipeline, a temporary ssh-key will be generated in advance under the "/tmp/azaks/.ssh"
         # directory when setting up the environment. Each test case will read the ssh-key from a pre-generated file during execution,
         # so there will be no race conditions caused by concurrent reading and writing/creating of the same file.
-        pre_generated_ssh_key_path = "/opt/.ssh/id_rsa.pub"
+        pre_generated_ssh_key_path = "/tmp/azaks/.ssh/id_rsa.pub"
         if os.path.exists(pre_generated_ssh_key_path):
             return pre_generated_ssh_key_path.replace('\\', '\\\\')
 

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -51,7 +51,7 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         # race conditions caused by concurrent reading and writing/creating of the same file.
         acs_base_dir = os.getenv("ACS_BASE_DIR", None)
         if acs_base_dir:
-            pre_generated_ssh_key_path = os.path.join(acs_base_dir, "tests/latest/data/.ssh")
+            pre_generated_ssh_key_path = os.path.join(acs_base_dir, "tests/latest/data/.ssh/id_rsa.pub")
             if os.path.exists(pre_generated_ssh_key_path):
                 return pre_generated_ssh_key_path.replace('\\', '\\\\')
 


### PR DESCRIPTION
Create ssh-key in advance to avoid the race condition that is prone to occur when key creation is handled by azure-cli when performing test cases concurrently.

For more details, please refer to issue [#18854](https://github.com/Azure/azure-cli/issues/18854).

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
