### PR TITLE
[Quantum] Bug fix: Wrong location is used when waiting for 'az quantum execute'

### DIFF
--- a/src/quantum/azext_quantum/operations/job.py
+++ b/src/quantum/azext_quantum/operations/job.py
@@ -271,7 +271,7 @@ def run(cmd, program_args, resource_group_name=None, workspace_name=None, locati
     if not job.status == "Succeeded":
         return job
 
-    return output(cmd, job.id, resource_group_name, workspace_name)
+    return output(cmd, job.id, resource_group_name, workspace_name, location)
 
 
 def cancel(cmd, job_id, resource_group_name=None, workspace_name=None, location=None):


### PR DESCRIPTION
Fixing bug on location used to show job output in synchronous submissions.

Due to this bug, if a default workspace is not set, then location is ignored when waiting for the output of a submitted job, so it will fail to be displayed even when the job has completed.

---

### General Guidelines

- [X] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [X] Have you run `python scripts/ci/test_index.py -q` locally?
