### PR TITLE
Fix wrongly used containerLogMaxSizeMB in customized kubelet config

### DIFF
--- a/src/aks-preview/HISTORY.md
+++ b/src/aks-preview/HISTORY.md
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.5.26
++++++
+* Correct containerLogMaxSizeMb to containerLogMaxSizeMB in customized kubelet config
+
 0.5.25
 +++++
 * Add support for http proxy

--- a/src/aks-preview/azext_aks_preview/custom.py
+++ b/src/aks-preview/azext_aks_preview/custom.py
@@ -3991,7 +3991,7 @@ def _get_kubelet_config(file_path):
     config_object.container_log_max_files = kubelet_config.get(
         "containerLogMaxFiles", None)
     config_object.container_log_max_size_mb = kubelet_config.get(
-        "containerLogMaxSizeMb", None)
+        "containerLogMaxSizeMB", None)
 
     return config_object
 

--- a/src/aks-preview/azext_aks_preview/tests/latest/data/kubeletconfig.json
+++ b/src/aks-preview/azext_aks_preview/tests/latest/data/kubeletconfig.json
@@ -11,5 +11,5 @@
     ],
     "failSwapOn": false,
     "containerLogMaxFiles": 10,
-    "containerLogMaxSizeMb": 20
+    "containerLogMaxSizeMB": 20
 }

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -1451,12 +1451,10 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
                      '--kubelet-config={kc_path} --linux-os-config={oc_path} --aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/CustomNodeConfigPreview -o json'
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
-            self.check(
-                'agentPoolProfiles[0].kubeletConfig.cpuManagerPolicy', 'static'),
-            self.check(
-                'agentPoolProfiles[0].linuxOsConfig.swapFileSizeMb', 1500),
-            self.check(
-                'agentPoolProfiles[0].linuxOsConfig.sysctls.netIpv4TcpTwReuse', True)
+            self.check('agentPoolProfiles[0].kubeletConfig.cpuManagerPolicy', 'static'),
+            self.check('agentPoolProfiles[0].kubeletConfig.containerLogMaxSizeMb', 20),
+            self.check('agentPoolProfiles[0].linuxOsConfig.swapFileSizeMb', 1500),
+            self.check('agentPoolProfiles[0].linuxOsConfig.sysctls.netIpv4TcpTwReuse', True)
         ])
 
         # nodepool add
@@ -1465,6 +1463,7 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         self.cmd(nodepool_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
             self.check('kubeletConfig.cpuCfsQuotaPeriod', '200ms'),
+            self.check('kubeletConfig.containerLogMaxSizeMb', 20),
             self.check('linuxOsConfig.sysctls.netCoreSomaxconn', 163849)
         ])
 

--- a/src/aks-preview/setup.py
+++ b/src/aks-preview/setup.py
@@ -8,7 +8,7 @@
 from codecs import open as open1
 from setuptools import setup, find_packages
 
-VERSION = "0.5.25"
+VERSION = "0.5.26"
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',


### PR DESCRIPTION

aks-preview CLI read use input kubelet config and try to read, before this change, wrongly containerLogMaxSizeMb as containerLogMaxSizeMB, fix this by use the correct one.
reference: https://docs.microsoft.com/en-us/azure/templates/microsoft.containerservice/managedclusters?tabs=json

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
