### PR TITLE
Extend handling of job output to consider empty responses

### DIFF
--- a/src/quantum/azext_quantum/operations/job.py
+++ b/src/quantum/azext_quantum/operations/job.py
@@ -208,20 +208,27 @@ def output(cmd, job_id, resource_group_name=None, workspace_name=None, location=
         blob_service = blob_data_service_factory(cmd.cli_ctx, args)
         blob_service.get_blob_to_path(args['container'], args['blob'], path)
 
-    with open(path) as json_file:
-        if job.target.startswith("microsoft.simulator"):
 
-            lines = [line.strip() for line in json_file.readlines()]
+    with open(path) as json_file:
+        lines = [line.strip() for line in json_file.readlines()]
+
+        # Receiving an empty response is valid.
+        if len(lines) == 0:
+            return 
+
+        if job.target.startswith("microsoft.simulator"):
             result_start_line = len(lines) - 1
             if lines[-1].endswith('"'):
-                while not lines[result_start_line].startswith('"'):
+                while result_start_line >= 0 and not lines[result_start_line].startswith('"'):
                     result_start_line -= 1
+            if result_start_line < 0:
+                raise CLIError("Job output is malformed, mismatched quote characters.")
 
             print('\n'.join(lines[:result_start_line]))
             result = ' '.join(lines[result_start_line:])[1:-1]  # seems the cleanest version to display
             print("_" * len(result) + "\n")
 
-            json_string = "{ \"histogram\" : { \"" + result + "\" : 1 } }"
+            json_string = '{ "histogram" : { "' + result + '" : 1 } }'
             data = json.loads(json_string)
         else:
             data = json.load(json_file)

--- a/src/quantum/azext_quantum/operations/job.py
+++ b/src/quantum/azext_quantum/operations/job.py
@@ -208,13 +208,12 @@ def output(cmd, job_id, resource_group_name=None, workspace_name=None, location=
         blob_service = blob_data_service_factory(cmd.cli_ctx, args)
         blob_service.get_blob_to_path(args['container'], args['blob'], path)
 
-
     with open(path) as json_file:
         lines = [line.strip() for line in json_file.readlines()]
 
         # Receiving an empty response is valid.
         if len(lines) == 0:
-            return 
+            return
 
         if job.target.startswith("microsoft.simulator"):
             result_start_line = len(lines) - 1
@@ -226,7 +225,7 @@ def output(cmd, job_id, resource_group_name=None, workspace_name=None, location=
 
             print('\n'.join(lines[:result_start_line]))
             result = ' '.join(lines[result_start_line:])[1:-1]  # seems the cleanest version to display
-            print("_" * len(result) + "\n")
+            print('_' * len(result) + '\n')
 
             json_string = '{ "histogram" : { "' + result + '" : 1 } }'
             data = json.loads(json_string)


### PR DESCRIPTION
It is valid for an Azure Quantum job to produce an empty file as a response. This change extends the logic to allow this condition, and also detect early mismatched quotes in the output.

---

### General Guidelines

- [X] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [X] Have you run `python scripts/ci/test_index.py -q` locally?
