### PR TITLE
[alertsmanagement] Add an example were the recurrence type is set to once

### DIFF
--- a/src/alertsmanagement/HISTORY.rst
+++ b/src/alertsmanagement/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+0.1.1
+++++++
+* Add an example were the recurrence type is set to once.
+* Fix error: when the recurrence type is set to once, 'Action Rule property 'properties.suppressionConfig.schedule' cannot be null.'
+
 0.1.0
 ++++++
 * Initial release.

--- a/src/alertsmanagement/azext_alertsmanagement/_help.py
+++ b/src/alertsmanagement/azext_alertsmanagement/_help.py
@@ -27,6 +27,9 @@ helps['monitor action-rule create'] = """
       - name: Create an action rule to suppress notifications in a resource group
         text: |-
                az monitor action-rule create --resource-group rg --name rule --location Global --status Enabled --rule-type Suppression --scope-type ResourceGroup --scope /subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/rg --suppression-recurrence-type Always --alert-context Contains Computer-01 --monitor-service Equals "Log Analytics"
+      - name: Create an action rule with a recurrenceType of Once
+        text: |-
+               az monitor action-rule create --resource-group rg --name rule --location Global --status Enabled --rule-type Suppression --scope-type ResourceGroup --scope /subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/rg --severity Equals Sev0 Sev2 --monitor-service Equals Platform "Application Insights" --monitor-condition Equals Fired --target-resource-type NotEquals Microsoft.Compute/VirtualMachines --suppression-recurrence-type Once --suppression-start-date 08/09/2021 --suppression-end-date 08/10/2021 --suppression-start-time 06:00:00 --suppression-end-time 14:00:00
 """
 
 helps['monitor action-rule update'] = """

--- a/src/alertsmanagement/azext_alertsmanagement/_help.py
+++ b/src/alertsmanagement/azext_alertsmanagement/_help.py
@@ -26,10 +26,10 @@ helps['monitor action-rule create'] = """
                az monitor action-rule create --resource-group rg --name rule --location Global --status Enabled --rule-type Suppression --suppression-recurrence-type Always --alert-context Contains Computer-01 --monitor-service Equals "Log Analytics"
       - name: Create an action rule to suppress notifications in a resource group
         text: |-
-               az monitor action-rule create --resource-group rg --name rule --location Global --status Enabled --rule-type Suppression --scope-type ResourceGroup --scope /subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/rg --suppression-recurrence-type Always --alert-context Contains Computer-01 --monitor-service Equals "Log Analytics"
+               az monitor action-rule create --resource-group rg --name rule --location Global --status Enabled --rule-type Suppression --scope-type ResourceGroup --scope /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg --suppression-recurrence-type Always --alert-context Contains Computer-01 --monitor-service Equals "Log Analytics"
       - name: Create an action rule with a recurrenceType of Once
         text: |-
-               az monitor action-rule create --resource-group rg --name rule --location Global --status Enabled --rule-type Suppression --scope-type ResourceGroup --scope /subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/rg --severity Equals Sev0 Sev2 --monitor-service Equals Platform "Application Insights" --monitor-condition Equals Fired --target-resource-type NotEquals Microsoft.Compute/VirtualMachines --suppression-recurrence-type Once --suppression-start-date 08/09/2021 --suppression-end-date 08/10/2021 --suppression-start-time 06:00:00 --suppression-end-time 14:00:00
+               az monitor action-rule create --resource-group rg --name rule --location Global --status Enabled --rule-type Suppression --scope-type ResourceGroup --scope /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg --severity Equals Sev0 Sev2 --monitor-service Equals Platform "Application Insights" --monitor-condition Equals Fired --target-resource-type NotEquals Microsoft.Compute/VirtualMachines --suppression-recurrence-type Once --suppression-start-date 08/09/2021 --suppression-end-date 08/10/2021 --suppression-start-time 06:00:00 --suppression-end-time 14:00:00
 """
 
 helps['monitor action-rule update'] = """

--- a/src/alertsmanagement/azext_alertsmanagement/custom.py
+++ b/src/alertsmanagement/azext_alertsmanagement/custom.py
@@ -114,7 +114,7 @@ def create_alertsmanagement_action_rule(cmd, client,
     properties['suppressionConfig'] = {
         'recurrenceType': suppression_recurrence_type
     }
-    if suppression_recurrence_type not in ['Always', 'Once']:
+    if suppression_recurrence_type not in ['Always']:
         properties['suppressionConfig']['schedule'] = {
             'startDate': suppression_start_date,
             'endDate': suppression_end_date,

--- a/src/alertsmanagement/azext_alertsmanagement/tests/latest/recordings/test_alertsmanagement_action_rule.yaml
+++ b/src/alertsmanagement/azext_alertsmanagement/tests/latest/recordings/test_alertsmanagement_action_rule.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: 'b''{"location": "Global", "properties": {"scope": {"scopeType": "ResourceGroup",
+    body: '{"location": "Global", "properties": {"scope": {"scopeType": "ResourceGroup",
       "values": ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001"]},
       "conditions": {"severity": {"operator": "Equals", "values": ["Sev0", "Sev2"]},
       "monitorService": {"operator": "Equals", "values": ["Platform", "Application
@@ -8,7 +8,7 @@ interactions:
       "targetResourceType": {"operator": "NotEquals", "values": ["Microsoft.Compute/VirtualMachines"]}},
       "status": "Enabled", "type": "Suppression", "suppressionConfig": {"recurrenceType":
       "Daily", "schedule": {"startDate": "12/09/2018", "endDate": "12/18/2018", "startTime":
-      "06:00:00", "endTime": "14:00:00"}}}}'''
+      "06:00:00", "endTime": "14:00:00"}}}}'
     headers:
       Accept:
       - application/json
@@ -27,27 +27,149 @@ interactions:
         --severity --monitor-service --monitor-condition --target-resource-type --suppression-recurrence-type
         --suppression-start-date --suppression-end-date --suppression-start-time --suppression-end-time
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-alertsmanagement/0.2.0rc2 Azure-SDK-For-Python AZURECLI/2.2.0
+      - python/3.8.9 (Windows-10-10.0.19041-SP0) msrest/0.6.21 msrest_azure/0.6.3
+        azure-mgmt-alertsmanagement/0.2.0rc2 Azure-SDK-For-Python AZURECLI/2.27.1
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001/providers/Microsoft.AlertsManagement/actionRules/rule1?api-version=2019-05-05-preview
   response:
     body:
-      string: '{"properties":{"conditions":{"severity":{"operator":"Equals","values":["Sev0","Sev2"]},"monitorService":{"operator":"Equals","values":["Platform","Application
-        Insights"]},"monitorCondition":{"operator":"Equals","values":["Fired"]},"targetResourceType":{"operator":"NotEquals","values":["Microsoft.Compute/VirtualMachines"]}},"status":"Enabled","type":"Suppression","scope":{"scopeType":"ResourceGroup","values":["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001"]},"suppressionConfig":{"recurrenceType":"Daily","schedule":{"startDate":"12/09/2018","endDate":"12/18/2018","startTime":"06:00:00","endTime":"14:00:00"}},"createdAt":"2020-03-17T02:49:50.29547Z","createdBy":"User","lastModifiedAt":"2020-03-17T02:49:50.29547Z","lastModifiedBy":"User"},"location":"Global","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001/providers/Microsoft.AlertsManagement/actionRules/rule1","type":"Microsoft.AlertsManagement/actionRules","name":"rule1"}'
+      string: '{"properties":{"scope":{"scopeType":"ResourceGroup","values":["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001"]},"suppressionConfig":{"recurrenceType":"Daily","schedule":{"startDate":"12/09/2018","endDate":"12/18/2018","startTime":"06:00:00","endTime":"14:00:00"}},"conditions":{"severity":{"operator":"Equals","values":["Sev0","Sev2"]},"monitorService":{"operator":"Equals","values":["Platform","Application
+        Insights"]},"monitorCondition":{"operator":"Equals","values":["Fired"]},"targetResourceType":{"operator":"NotEquals","values":["Microsoft.Compute/VirtualMachines"]}},"status":"Enabled","type":"Suppression","createdAt":"2021-08-23T02:26:18.6717783Z","createdBy":"v-jingszhang@microsoft.com","lastModifiedAt":"2021-08-23T02:26:18.6717783Z","lastModifiedBy":"v-jingszhang@microsoft.com"},"location":"Global","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001/providers/Microsoft.AlertsManagement/actionRules/rule1","type":"Microsoft.AlertsManagement/actionRules","name":"rule1"}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '1130'
+      - '1178'
       content-security-policy:
       - script-src 'self'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 17 Mar 2020 02:49:51 GMT
+      - Mon, 23 Aug 2021 02:26:20 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - monitor action-rule show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name
+      User-Agent:
+      - python/3.8.9 (Windows-10-10.0.19041-SP0) msrest/0.6.21 msrest_azure/0.6.3
+        azure-mgmt-alertsmanagement/0.2.0rc2 Azure-SDK-For-Python AZURECLI/2.27.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001/providers/Microsoft.AlertsManagement/actionRules/rule1?api-version=2019-05-05-preview
+  response:
+    body:
+      string: '{"properties":{"scope":{"scopeType":"ResourceGroup","values":["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001"]},"suppressionConfig":{"recurrenceType":"Daily","schedule":{"startDate":"12/09/2018","endDate":"12/18/2018","startTime":"06:00:00","endTime":"14:00:00"}},"conditions":{"severity":{"operator":"Equals","values":["Sev0","Sev2"]},"monitorService":{"operator":"Equals","values":["Platform","Application
+        Insights"]},"monitorCondition":{"operator":"Equals","values":["Fired"]},"targetResourceType":{"operator":"NotEquals","values":["Microsoft.Compute/VirtualMachines"]}},"status":"Enabled","type":"Suppression","createdAt":"2021-08-23T02:26:18.6717783Z","createdBy":"v-jingszhang@microsoft.com","lastModifiedAt":"2021-08-23T02:26:18.6717783Z","lastModifiedBy":"v-jingszhang@microsoft.com"},"location":"Global","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001/providers/Microsoft.AlertsManagement/actionRules/rule1","type":"Microsoft.AlertsManagement/actionRules","name":"rule1"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '1178'
+      content-security-policy:
+      - script-src 'self'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 23 Aug 2021 02:26:21 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '999'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "Global", "properties": {"scope": {"scopeType": "ResourceGroup",
+      "values": ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001"]},
+      "conditions": {"severity": {"operator": "Equals", "values": ["Sev0", "Sev2"]},
+      "monitorService": {"operator": "Equals", "values": ["Platform", "Application
+      Insights"]}, "monitorCondition": {"operator": "Equals", "values": ["Fired"]},
+      "targetResourceType": {"operator": "NotEquals", "values": ["Microsoft.Compute/VirtualMachines"]}},
+      "status": "Enabled", "type": "Suppression", "suppressionConfig": {"recurrenceType":
+      "Once", "schedule": {"startDate": "08/25/2021", "endDate": "08/26/2021", "startTime":
+      "06:00:00", "endTime": "14:00:00"}}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - monitor action-rule create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '777'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --resource-group --name --location --status --rule-type --scope-type --scope
+        --severity --monitor-service --monitor-condition --target-resource-type --suppression-recurrence-type
+        --suppression-start-date --suppression-end-date --suppression-start-time --suppression-end-time
+      User-Agent:
+      - python/3.8.9 (Windows-10-10.0.19041-SP0) msrest/0.6.21 msrest_azure/0.6.3
+        azure-mgmt-alertsmanagement/0.2.0rc2 Azure-SDK-For-Python AZURECLI/2.27.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001/providers/Microsoft.AlertsManagement/actionRules/rule2?api-version=2019-05-05-preview
+  response:
+    body:
+      string: '{"properties":{"scope":{"scopeType":"ResourceGroup","values":["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001"]},"suppressionConfig":{"recurrenceType":"Once","schedule":{"startDate":"08/25/2021","endDate":"08/26/2021","startTime":"06:00:00","endTime":"14:00:00"}},"conditions":{"severity":{"operator":"Equals","values":["Sev0","Sev2"]},"monitorService":{"operator":"Equals","values":["Platform","Application
+        Insights"]},"monitorCondition":{"operator":"Equals","values":["Fired"]},"targetResourceType":{"operator":"NotEquals","values":["Microsoft.Compute/VirtualMachines"]}},"status":"Enabled","type":"Suppression","createdAt":"2021-08-23T02:26:24.86681Z","createdBy":"v-jingszhang@microsoft.com","lastModifiedAt":"2021-08-23T02:26:24.86681Z","lastModifiedBy":"v-jingszhang@microsoft.com"},"location":"Global","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001/providers/Microsoft.AlertsManagement/actionRules/rule2","type":"Microsoft.AlertsManagement/actionRules","name":"rule2"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '1173'
+      content-security-policy:
+      - script-src 'self'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 23 Aug 2021 02:26:26 GMT
       expires:
       - '-1'
       pragma:
@@ -81,27 +203,27 @@ interactions:
       ParameterSetName:
       - --resource-group --name
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-alertsmanagement/0.2.0rc2 Azure-SDK-For-Python AZURECLI/2.2.0
+      - python/3.8.9 (Windows-10-10.0.19041-SP0) msrest/0.6.21 msrest_azure/0.6.3
+        azure-mgmt-alertsmanagement/0.2.0rc2 Azure-SDK-For-Python AZURECLI/2.27.1
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001/providers/Microsoft.AlertsManagement/actionRules/rule1?api-version=2019-05-05-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001/providers/Microsoft.AlertsManagement/actionRules/rule2?api-version=2019-05-05-preview
   response:
     body:
-      string: '{"properties":{"conditions":{"severity":{"operator":"Equals","values":["Sev0","Sev2"]},"monitorService":{"operator":"Equals","values":["Platform","Application
-        Insights"]},"monitorCondition":{"operator":"Equals","values":["Fired"]},"targetResourceType":{"operator":"NotEquals","values":["Microsoft.Compute/VirtualMachines"]}},"status":"Enabled","type":"Suppression","scope":{"scopeType":"ResourceGroup","values":["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001"]},"suppressionConfig":{"recurrenceType":"Daily","schedule":{"startDate":"12/09/2018","endDate":"12/18/2018","startTime":"06:00:00","endTime":"14:00:00"}},"createdAt":"2020-03-17T02:49:50.29547Z","createdBy":"User","lastModifiedAt":"2020-03-17T02:49:50.29547Z","lastModifiedBy":"User"},"location":"Global","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001/providers/Microsoft.AlertsManagement/actionRules/rule1","type":"Microsoft.AlertsManagement/actionRules","name":"rule1"}'
+      string: '{"properties":{"scope":{"scopeType":"ResourceGroup","values":["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001"]},"suppressionConfig":{"recurrenceType":"Once","schedule":{"startDate":"08/25/2021","endDate":"08/26/2021","startTime":"06:00:00","endTime":"14:00:00"}},"conditions":{"severity":{"operator":"Equals","values":["Sev0","Sev2"]},"monitorService":{"operator":"Equals","values":["Platform","Application
+        Insights"]},"monitorCondition":{"operator":"Equals","values":["Fired"]},"targetResourceType":{"operator":"NotEquals","values":["Microsoft.Compute/VirtualMachines"]}},"status":"Enabled","type":"Suppression","createdAt":"2021-08-23T02:26:24.86681Z","createdBy":"v-jingszhang@microsoft.com","lastModifiedAt":"2021-08-23T02:26:24.86681Z","lastModifiedBy":"v-jingszhang@microsoft.com"},"location":"Global","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001/providers/Microsoft.AlertsManagement/actionRules/rule2","type":"Microsoft.AlertsManagement/actionRules","name":"rule2"}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '1130'
+      - '1173'
       content-security-policy:
       - script-src 'self'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 17 Mar 2020 02:49:54 GMT
+      - Mon, 23 Aug 2021 02:26:28 GMT
       expires:
       - '-1'
       pragma:
@@ -135,27 +257,27 @@ interactions:
       ParameterSetName:
       - --resource-group --name --status
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-alertsmanagement/0.2.0rc2 Azure-SDK-For-Python AZURECLI/2.2.0
+      - python/3.8.9 (Windows-10-10.0.19041-SP0) msrest/0.6.21 msrest_azure/0.6.3
+        azure-mgmt-alertsmanagement/0.2.0rc2 Azure-SDK-For-Python AZURECLI/2.27.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001/providers/Microsoft.AlertsManagement/actionRules/rule1?api-version=2019-05-05-preview
   response:
     body:
-      string: '{"properties":{"conditions":{"severity":{"operator":"Equals","values":["Sev0","Sev2"]},"monitorService":{"operator":"Equals","values":["Platform","Application
-        Insights"]},"monitorCondition":{"operator":"Equals","values":["Fired"]},"targetResourceType":{"operator":"NotEquals","values":["Microsoft.Compute/VirtualMachines"]}},"status":"Enabled","type":"Suppression","scope":{"scopeType":"ResourceGroup","values":["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001"]},"suppressionConfig":{"recurrenceType":"Daily","schedule":{"startDate":"12/09/2018","endDate":"12/18/2018","startTime":"06:00:00","endTime":"14:00:00"}},"createdAt":"2020-03-17T02:49:50.29547Z","createdBy":"User","lastModifiedAt":"2020-03-17T02:49:50.29547Z","lastModifiedBy":"User"},"location":"Global","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001/providers/Microsoft.AlertsManagement/actionRules/rule1","type":"Microsoft.AlertsManagement/actionRules","name":"rule1"}'
+      string: '{"properties":{"scope":{"scopeType":"ResourceGroup","values":["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001"]},"suppressionConfig":{"recurrenceType":"Daily","schedule":{"startDate":"12/09/2018","endDate":"12/18/2018","startTime":"06:00:00","endTime":"14:00:00"}},"conditions":{"severity":{"operator":"Equals","values":["Sev0","Sev2"]},"monitorService":{"operator":"Equals","values":["Platform","Application
+        Insights"]},"monitorCondition":{"operator":"Equals","values":["Fired"]},"targetResourceType":{"operator":"NotEquals","values":["Microsoft.Compute/VirtualMachines"]}},"status":"Enabled","type":"Suppression","createdAt":"2021-08-23T02:26:18.6717783Z","createdBy":"v-jingszhang@microsoft.com","lastModifiedAt":"2021-08-23T02:26:18.6717783Z","lastModifiedBy":"v-jingszhang@microsoft.com"},"location":"Global","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001/providers/Microsoft.AlertsManagement/actionRules/rule1","type":"Microsoft.AlertsManagement/actionRules","name":"rule1"}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '1130'
+      - '1178'
       content-security-policy:
       - script-src 'self'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 17 Mar 2020 02:49:57 GMT
+      - Mon, 23 Aug 2021 02:26:29 GMT
       expires:
       - '-1'
       pragma:
@@ -176,7 +298,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: 'b''{"location": "Global", "properties": {"scope": {"scopeType": "ResourceGroup",
+    body: '{"location": "Global", "properties": {"scope": {"scopeType": "ResourceGroup",
       "values": ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001"]},
       "conditions": {"severity": {"operator": "Equals", "values": ["Sev0", "Sev2"]},
       "monitorService": {"operator": "Equals", "values": ["Platform", "Application
@@ -184,7 +306,7 @@ interactions:
       "targetResourceType": {"operator": "NotEquals", "values": ["Microsoft.Compute/VirtualMachines"]}},
       "status": "Disabled", "type": "Suppression", "suppressionConfig": {"recurrenceType":
       "Daily", "schedule": {"startDate": "12/09/2018", "endDate": "12/18/2018", "startTime":
-      "06:00:00", "endTime": "14:00:00"}}}}'''
+      "06:00:00", "endTime": "14:00:00"}}}}'
     headers:
       Accept:
       - application/json
@@ -201,27 +323,27 @@ interactions:
       ParameterSetName:
       - --resource-group --name --status
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-alertsmanagement/0.2.0rc2 Azure-SDK-For-Python AZURECLI/2.2.0
+      - python/3.8.9 (Windows-10-10.0.19041-SP0) msrest/0.6.21 msrest_azure/0.6.3
+        azure-mgmt-alertsmanagement/0.2.0rc2 Azure-SDK-For-Python AZURECLI/2.27.1
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001/providers/Microsoft.AlertsManagement/actionRules/rule1?api-version=2019-05-05-preview
   response:
     body:
-      string: '{"properties":{"conditions":{"severity":{"operator":"Equals","values":["Sev0","Sev2"]},"monitorService":{"operator":"Equals","values":["Platform","Application
-        Insights"]},"monitorCondition":{"operator":"Equals","values":["Fired"]},"targetResourceType":{"operator":"NotEquals","values":["Microsoft.Compute/VirtualMachines"]}},"status":"Disabled","type":"Suppression","scope":{"scopeType":"ResourceGroup","values":["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001"]},"suppressionConfig":{"recurrenceType":"Daily","schedule":{"startDate":"12/09/2018","endDate":"12/18/2018","startTime":"06:00:00","endTime":"14:00:00"}},"createdAt":"2020-03-17T02:49:50.29547Z","createdBy":"User","lastModifiedAt":"2020-03-17T02:50:00.8682607Z","lastModifiedBy":"User"},"location":"Global","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001/providers/Microsoft.AlertsManagement/actionRules/rule1","type":"Microsoft.AlertsManagement/actionRules","name":"rule1"}'
+      string: '{"properties":{"scope":{"scopeType":"ResourceGroup","values":["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001"]},"suppressionConfig":{"recurrenceType":"Daily","schedule":{"startDate":"12/09/2018","endDate":"12/18/2018","startTime":"06:00:00","endTime":"14:00:00"}},"conditions":{"severity":{"operator":"Equals","values":["Sev0","Sev2"]},"monitorService":{"operator":"Equals","values":["Platform","Application
+        Insights"]},"monitorCondition":{"operator":"Equals","values":["Fired"]},"targetResourceType":{"operator":"NotEquals","values":["Microsoft.Compute/VirtualMachines"]}},"status":"Disabled","type":"Suppression","createdAt":"2021-08-23T02:26:18.6717783Z","createdBy":"v-jingszhang@microsoft.com","lastModifiedAt":"2021-08-23T02:26:30.7042783Z","lastModifiedBy":"v-jingszhang@microsoft.com"},"location":"Global","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001/providers/Microsoft.AlertsManagement/actionRules/rule1","type":"Microsoft.AlertsManagement/actionRules","name":"rule1"}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '1133'
+      - '1179'
       content-security-policy:
       - script-src 'self'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 17 Mar 2020 02:50:00 GMT
+      - Mon, 23 Aug 2021 02:26:30 GMT
       expires:
       - '-1'
       pragma:
@@ -235,7 +357,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -253,31 +375,33 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-alertsmanagement/0.2.0rc2 Azure-SDK-For-Python AZURECLI/2.2.0
+      - python/3.8.9 (Windows-10-10.0.19041-SP0) msrest/0.6.21 msrest_azure/0.6.3
+        azure-mgmt-alertsmanagement/0.2.0rc2 Azure-SDK-For-Python AZURECLI/2.27.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.AlertsManagement/actionRules?api-version=2019-05-05-preview
   response:
     body:
-      string: '{"value":[{"properties":{"status":"Enabled","type":"Suppression","suppressionConfig":{"recurrenceType":"Weekly","schedule":{"startDate":"03/13/2020","endDate":"03/14/2020","startTime":"05:54:56","endTime":"05:54:56","recurrenceValues":[0,1,2,4,5,6]}},"description":"","createdAt":"2020-03-13T06:21:58.0932972Z","createdBy":"fey@microsoft.com","lastModifiedAt":"2020-03-13T06:21:58.0932972Z","lastModifiedBy":"fey@microsoft.com"},"location":"global","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fytest/providers/Microsoft.AlertsManagement/actionRules/rule1","type":"Microsoft.AlertsManagement/actionRules","name":"rule1"},{"properties":{"conditions":{"monitorService":{"operator":"Equals","values":["Log
-        Analytics"]},"alertContext":{"operator":"Contains","values":["Computer-01"]}},"status":"Enabled","type":"Suppression","suppressionConfig":{"recurrenceType":"Always"},"createdAt":"2020-03-17T02:48:49.5945669Z","createdBy":"User","lastModifiedAt":"2020-03-17T02:48:49.5945669Z","lastModifiedBy":"User"},"location":"global","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fytest2/providers/Microsoft.AlertsManagement/actionRules/rule1","type":"Microsoft.AlertsManagement/actionRules","name":"rule1"},{"properties":{"conditions":{"severity":{"operator":"Equals","values":["Sev0","Sev2"]},"monitorService":{"operator":"Equals","values":["Platform","Application
-        Insights"]},"monitorCondition":{"operator":"Equals","values":["Fired"]},"targetResourceType":{"operator":"NotEquals","values":["Microsoft.Compute/VirtualMachines"]}},"status":"Disabled","type":"Suppression","scope":{"scopeType":"ResourceGroup","values":["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001"]},"suppressionConfig":{"recurrenceType":"Daily","schedule":{"startDate":"12/09/2018","endDate":"12/18/2018","startTime":"06:00:00","endTime":"14:00:00"}},"createdAt":"2020-03-17T02:49:50.29547Z","createdBy":"User","lastModifiedAt":"2020-03-17T02:50:00.8682607Z","lastModifiedBy":"User"},"location":"Global","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001/providers/Microsoft.AlertsManagement/actionRules/rule1","type":"Microsoft.AlertsManagement/actionRules","name":"rule1"},{"properties":{"conditions":{"severity":{"operator":"Equals","values":["Sev0","Sev2"]}},"status":"Enabled","type":"Suppression","suppressionConfig":{"recurrenceType":"Weekly","schedule":{"startDate":"12/09/2018","endDate":"12/18/2018","startTime":"06:00:00","endTime":"14:00:00","recurrenceValues":[0,6]}},"createdAt":"2020-03-13T06:29:08.1868672Z","createdBy":"fey@microsoft.com","lastModifiedAt":"2020-03-13T06:29:08.1868672Z","lastModifiedBy":"fey@microsoft.com"},"location":"Global","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fytest/providers/Microsoft.AlertsManagement/actionRules/rule2","type":"Microsoft.AlertsManagement/actionRules","name":"rule2"},{"properties":{"conditions":{"severity":{"operator":"Equals","values":["Sev4"]},"targetResourceType":{"operator":"Equals","values":["Microsoft.Compute/VirtualMachines"]}},"status":"Enabled","type":"Suppression","suppressionConfig":{"recurrenceType":"Weekly","schedule":{"startDate":"12/09/2018","endDate":"12/18/2018","startTime":"06:00:00","endTime":"14:00:00","recurrenceValues":[0,6]}},"createdAt":"2020-03-13T06:34:23.1716761Z","createdBy":"fey@microsoft.com","lastModifiedAt":"2020-03-13T06:34:23.1716761Z","lastModifiedBy":"fey@microsoft.com"},"location":"Global","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fytest/providers/Microsoft.AlertsManagement/actionRules/rule3","type":"Microsoft.AlertsManagement/actionRules","name":"rule3"},{"properties":{"conditions":{"monitorService":{"operator":"Equals","values":["Log
-        Analytics"]},"alertContext":{"operator":"Contains","values":["Computer-01"]}},"status":"Enabled","type":"Suppression","suppressionConfig":{"recurrenceType":"Always"},"description":"","createdAt":"2020-03-13T06:49:24.1672254Z","createdBy":"fey@microsoft.com","lastModifiedAt":"2020-03-13T06:49:24.1672254Z","lastModifiedBy":"fey@microsoft.com"},"location":"global","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fytest/providers/Microsoft.AlertsManagement/actionRules/rule4","type":"Microsoft.AlertsManagement/actionRules","name":"rule4"},{"properties":{"conditions":{"monitorService":{"operator":"Equals","values":["Log
-        Analytics"]},"alertContext":{"operator":"Contains","values":["Computer-01"]}},"status":"Enabled","type":"Suppression","suppressionConfig":{"recurrenceType":"Always"},"createdAt":"2020-03-13T06:51:55.0195146Z","createdBy":"fey@microsoft.com","lastModifiedAt":"2020-03-13T06:51:55.0195146Z","lastModifiedBy":"fey@microsoft.com"},"location":"Global","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fytest/providers/Microsoft.AlertsManagement/actionRules/rule5","type":"Microsoft.AlertsManagement/actionRules","name":"rule5"},{"properties":{"conditions":{"monitorService":{"operator":"Equals","values":["Log
-        Analytics"]},"alertContext":{"operator":"Contains","values":["Computer-01"]}},"status":"Enabled","type":"Suppression","scope":{"scopeType":"ResourceGroup","values":["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg"]},"suppressionConfig":{"recurrenceType":"Always"},"createdAt":"2020-03-13T06:55:49.5585692Z","createdBy":"fey@microsoft.com","lastModifiedAt":"2020-03-13T06:55:49.5585692Z","lastModifiedBy":"fey@microsoft.com"},"location":"Global","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fytest/providers/Microsoft.AlertsManagement/actionRules/rule6","type":"Microsoft.AlertsManagement/actionRules","name":"rule6"}]}'
+      string: '{"value":[{"properties":{"suppressionConfig":{"recurrenceType":"Weekly","schedule":{"startDate":"03/13/2020","endDate":"03/14/2020","startTime":"05:54:56","endTime":"05:54:56","recurrenceValues":[0,1,2,4,5,6]}},"status":"Enabled","type":"Suppression","createdAt":"2020-03-13T06:21:58.0932972Z","createdBy":"fey@microsoft.com","lastModifiedAt":"2020-03-13T06:21:58.0932972Z","lastModifiedBy":"fey@microsoft.com","description":""},"location":"global","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fytest/providers/Microsoft.AlertsManagement/actionRules/rule1","type":"Microsoft.AlertsManagement/actionRules","name":"rule1"},{"properties":{"scope":{"scopeType":"ResourceGroup","values":["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_hcvecd6i2es65x2nytxei4rocecynyps7apyf"]},"suppressionConfig":{"recurrenceType":"Daily","schedule":{"startDate":"12/09/2018","endDate":"12/18/2018","startTime":"06:00:00","endTime":"14:00:00"}},"conditions":{"severity":{"operator":"Equals","values":["Sev0","Sev2"]},"monitorService":{"operator":"Equals","values":["Platform","Application
+        Insights"]},"monitorCondition":{"operator":"Equals","values":["Fired"]},"targetResourceType":{"operator":"NotEquals","values":["Microsoft.Compute/VirtualMachines"]}},"status":"Enabled","type":"Suppression","createdAt":"2021-08-23T02:25:18.6893331Z","createdBy":"v-jingszhang@microsoft.com","lastModifiedAt":"2021-08-23T02:25:18.6893331Z","lastModifiedBy":"v-jingszhang@microsoft.com"},"location":"Global","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_hcvecd6i2es65x2nytxei4rocecynyps7apyf/providers/Microsoft.AlertsManagement/actionRules/rule1","type":"Microsoft.AlertsManagement/actionRules","name":"rule1"},{"properties":{"scope":{"scopeType":"ResourceGroup","values":["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001"]},"suppressionConfig":{"recurrenceType":"Daily","schedule":{"startDate":"12/09/2018","endDate":"12/18/2018","startTime":"06:00:00","endTime":"14:00:00"}},"conditions":{"severity":{"operator":"Equals","values":["Sev0","Sev2"]},"monitorService":{"operator":"Equals","values":["Platform","Application
+        Insights"]},"monitorCondition":{"operator":"Equals","values":["Fired"]},"targetResourceType":{"operator":"NotEquals","values":["Microsoft.Compute/VirtualMachines"]}},"status":"Disabled","type":"Suppression","createdAt":"2021-08-23T02:26:18.6717783Z","createdBy":"v-jingszhang@microsoft.com","lastModifiedAt":"2021-08-23T02:26:30.7042783Z","lastModifiedBy":"v-jingszhang@microsoft.com"},"location":"Global","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001/providers/Microsoft.AlertsManagement/actionRules/rule1","type":"Microsoft.AlertsManagement/actionRules","name":"rule1"},{"properties":{"suppressionConfig":{"recurrenceType":"Weekly","schedule":{"startDate":"12/09/2018","endDate":"12/18/2018","startTime":"06:00:00","endTime":"14:00:00","recurrenceValues":[0,6]}},"conditions":{"severity":{"operator":"Equals","values":["Sev0","Sev2"]}},"status":"Enabled","type":"Suppression","createdAt":"2020-03-13T06:29:08.1868672Z","createdBy":"fey@microsoft.com","lastModifiedAt":"2020-03-13T06:29:08.1868672Z","lastModifiedBy":"fey@microsoft.com"},"location":"Global","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fytest/providers/Microsoft.AlertsManagement/actionRules/rule2","type":"Microsoft.AlertsManagement/actionRules","name":"rule2"},{"properties":{"scope":{"scopeType":"ResourceGroup","values":["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_hcvecd6i2es65x2nytxei4rocecynyps7apyf"]},"suppressionConfig":{"recurrenceType":"Once","schedule":{"startDate":"08/25/2021","endDate":"08/26/2021","startTime":"06:00:00","endTime":"14:00:00"}},"conditions":{"severity":{"operator":"Equals","values":["Sev0","Sev2"]},"monitorService":{"operator":"Equals","values":["Platform","Application
+        Insights"]},"monitorCondition":{"operator":"Equals","values":["Fired"]},"targetResourceType":{"operator":"NotEquals","values":["Microsoft.Compute/VirtualMachines"]}},"status":"Enabled","type":"Suppression","createdAt":"2021-08-23T02:25:27.6419808Z","createdBy":"v-jingszhang@microsoft.com","lastModifiedAt":"2021-08-23T02:25:27.6419808Z","lastModifiedBy":"v-jingszhang@microsoft.com"},"location":"Global","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_hcvecd6i2es65x2nytxei4rocecynyps7apyf/providers/Microsoft.AlertsManagement/actionRules/rule2","type":"Microsoft.AlertsManagement/actionRules","name":"rule2"},{"properties":{"scope":{"scopeType":"ResourceGroup","values":["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001"]},"suppressionConfig":{"recurrenceType":"Once","schedule":{"startDate":"08/25/2021","endDate":"08/26/2021","startTime":"06:00:00","endTime":"14:00:00"}},"conditions":{"severity":{"operator":"Equals","values":["Sev0","Sev2"]},"monitorService":{"operator":"Equals","values":["Platform","Application
+        Insights"]},"monitorCondition":{"operator":"Equals","values":["Fired"]},"targetResourceType":{"operator":"NotEquals","values":["Microsoft.Compute/VirtualMachines"]}},"status":"Enabled","type":"Suppression","createdAt":"2021-08-23T02:26:24.86681Z","createdBy":"v-jingszhang@microsoft.com","lastModifiedAt":"2021-08-23T02:26:24.86681Z","lastModifiedBy":"v-jingszhang@microsoft.com"},"location":"Global","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001/providers/Microsoft.AlertsManagement/actionRules/rule2","type":"Microsoft.AlertsManagement/actionRules","name":"rule2"},{"properties":{"suppressionConfig":{"recurrenceType":"Weekly","schedule":{"startDate":"12/09/2018","endDate":"12/18/2018","startTime":"06:00:00","endTime":"14:00:00","recurrenceValues":[0,6]}},"conditions":{"severity":{"operator":"Equals","values":["Sev4"]},"targetResourceType":{"operator":"Equals","values":["Microsoft.Compute/VirtualMachines"]}},"status":"Enabled","type":"Suppression","createdAt":"2020-03-13T06:34:23.1716761Z","createdBy":"fey@microsoft.com","lastModifiedAt":"2020-03-13T06:34:23.1716761Z","lastModifiedBy":"fey@microsoft.com"},"location":"Global","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fytest/providers/Microsoft.AlertsManagement/actionRules/rule3","type":"Microsoft.AlertsManagement/actionRules","name":"rule3"},{"properties":{"suppressionConfig":{"recurrenceType":"Always"},"conditions":{"monitorService":{"operator":"Equals","values":["Log
+        Analytics"]},"alertContext":{"operator":"Contains","values":["Computer-01"]}},"status":"Enabled","type":"Suppression","createdAt":"2020-03-13T06:49:24.1672254Z","createdBy":"fey@microsoft.com","lastModifiedAt":"2020-03-13T06:49:24.1672254Z","lastModifiedBy":"fey@microsoft.com","description":""},"location":"global","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fytest/providers/Microsoft.AlertsManagement/actionRules/rule4","type":"Microsoft.AlertsManagement/actionRules","name":"rule4"},{"properties":{"suppressionConfig":{"recurrenceType":"Always"},"conditions":{"monitorService":{"operator":"Equals","values":["Log
+        Analytics"]},"alertContext":{"operator":"Contains","values":["Computer-01"]}},"status":"Enabled","type":"Suppression","createdAt":"2020-03-13T06:51:55.0195146Z","createdBy":"fey@microsoft.com","lastModifiedAt":"2020-03-13T06:51:55.0195146Z","lastModifiedBy":"fey@microsoft.com"},"location":"Global","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fytest/providers/Microsoft.AlertsManagement/actionRules/rule5","type":"Microsoft.AlertsManagement/actionRules","name":"rule5"},{"properties":{"scope":{"scopeType":"ResourceGroup","values":["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg"]},"suppressionConfig":{"recurrenceType":"Always"},"conditions":{"monitorService":{"operator":"Equals","values":["Log
+        Analytics"]},"alertContext":{"operator":"Contains","values":["Computer-01"]}},"status":"Enabled","type":"Suppression","createdAt":"2020-03-13T06:55:49.5585692Z","createdBy":"fey@microsoft.com","lastModifiedAt":"2020-03-13T06:55:49.5585692Z","lastModifiedBy":"fey@microsoft.com"},"location":"Global","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/fytest/providers/Microsoft.AlertsManagement/actionRules/rule6","type":"Microsoft.AlertsManagement/actionRules","name":"rule6"}]}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '5870'
+      - '8843'
       content-security-policy:
       - script-src 'self'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 17 Mar 2020 02:50:04 GMT
+      - Mon, 23 Aug 2021 02:26:31 GMT
       expires:
       - '-1'
       pragma:
@@ -311,27 +435,28 @@ interactions:
       ParameterSetName:
       - -g
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-alertsmanagement/0.2.0rc2 Azure-SDK-For-Python AZURECLI/2.2.0
+      - python/3.8.9 (Windows-10-10.0.19041-SP0) msrest/0.6.21 msrest_azure/0.6.3
+        azure-mgmt-alertsmanagement/0.2.0rc2 Azure-SDK-For-Python AZURECLI/2.27.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001/providers/Microsoft.AlertsManagement/actionRules?api-version=2019-05-05-preview
   response:
     body:
-      string: '{"value":[{"properties":{"conditions":{"severity":{"operator":"Equals","values":["Sev0","Sev2"]},"monitorService":{"operator":"Equals","values":["Platform","Application
-        Insights"]},"monitorCondition":{"operator":"Equals","values":["Fired"]},"targetResourceType":{"operator":"NotEquals","values":["Microsoft.Compute/VirtualMachines"]}},"status":"Disabled","type":"Suppression","scope":{"scopeType":"ResourceGroup","values":["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001"]},"suppressionConfig":{"recurrenceType":"Daily","schedule":{"startDate":"12/09/2018","endDate":"12/18/2018","startTime":"06:00:00","endTime":"14:00:00"}},"createdAt":"2020-03-17T02:49:50.29547Z","createdBy":"User","lastModifiedAt":"2020-03-17T02:50:00.8682607Z","lastModifiedBy":"User"},"location":"Global","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001/providers/Microsoft.AlertsManagement/actionRules/rule1","type":"Microsoft.AlertsManagement/actionRules","name":"rule1"}]}'
+      string: '{"value":[{"properties":{"scope":{"scopeType":"ResourceGroup","values":["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001"]},"suppressionConfig":{"recurrenceType":"Daily","schedule":{"startDate":"12/09/2018","endDate":"12/18/2018","startTime":"06:00:00","endTime":"14:00:00"}},"conditions":{"severity":{"operator":"Equals","values":["Sev0","Sev2"]},"monitorService":{"operator":"Equals","values":["Platform","Application
+        Insights"]},"monitorCondition":{"operator":"Equals","values":["Fired"]},"targetResourceType":{"operator":"NotEquals","values":["Microsoft.Compute/VirtualMachines"]}},"status":"Disabled","type":"Suppression","createdAt":"2021-08-23T02:26:18.6717783Z","createdBy":"v-jingszhang@microsoft.com","lastModifiedAt":"2021-08-23T02:26:30.7042783Z","lastModifiedBy":"v-jingszhang@microsoft.com"},"location":"Global","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001/providers/Microsoft.AlertsManagement/actionRules/rule1","type":"Microsoft.AlertsManagement/actionRules","name":"rule1"},{"properties":{"scope":{"scopeType":"ResourceGroup","values":["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001"]},"suppressionConfig":{"recurrenceType":"Once","schedule":{"startDate":"08/25/2021","endDate":"08/26/2021","startTime":"06:00:00","endTime":"14:00:00"}},"conditions":{"severity":{"operator":"Equals","values":["Sev0","Sev2"]},"monitorService":{"operator":"Equals","values":["Platform","Application
+        Insights"]},"monitorCondition":{"operator":"Equals","values":["Fired"]},"targetResourceType":{"operator":"NotEquals","values":["Microsoft.Compute/VirtualMachines"]}},"status":"Enabled","type":"Suppression","createdAt":"2021-08-23T02:26:24.86681Z","createdBy":"v-jingszhang@microsoft.com","lastModifiedAt":"2021-08-23T02:26:24.86681Z","lastModifiedBy":"v-jingszhang@microsoft.com"},"location":"Global","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001/providers/Microsoft.AlertsManagement/actionRules/rule2","type":"Microsoft.AlertsManagement/actionRules","name":"rule2"}]}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '1145'
+      - '2365'
       content-security-policy:
       - script-src 'self'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 17 Mar 2020 02:50:07 GMT
+      - Mon, 23 Aug 2021 02:26:33 GMT
       expires:
       - '-1'
       pragma:
@@ -345,7 +470,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '998'
+      - '999'
       x-xss-protection:
       - 1; mode=block
     status:
@@ -367,8 +492,8 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-alertsmanagement/0.2.0rc2 Azure-SDK-For-Python AZURECLI/2.2.0
+      - python/3.8.9 (Windows-10-10.0.19041-SP0) msrest/0.6.21 msrest_azure/0.6.3
+        azure-mgmt-alertsmanagement/0.2.0rc2 Azure-SDK-For-Python AZURECLI/2.27.1
       accept-language:
       - en-US
     method: DELETE
@@ -386,7 +511,62 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 17 Mar 2020 02:50:14 GMT
+      - Mon, 23 Aug 2021 02:26:39 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14999'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - monitor action-rule delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.8.9 (Windows-10-10.0.19041-SP0) msrest/0.6.21 msrest_azure/0.6.3
+        azure-mgmt-alertsmanagement/0.2.0rc2 Azure-SDK-For-Python AZURECLI/2.27.1
+      accept-language:
+      - en-US
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_alertsmanagement_action_rule_000001/providers/Microsoft.AlertsManagement/actionRules/rule2?api-version=2019-05-05-preview
+  response:
+    body:
+      string: 'true'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '4'
+      content-security-policy:
+      - script-src 'self'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 23 Aug 2021 02:26:43 GMT
       expires:
       - '-1'
       pragma:

--- a/src/alertsmanagement/azext_alertsmanagement/tests/latest/test_alertsmanagement_scenario.py
+++ b/src/alertsmanagement/azext_alertsmanagement/tests/latest/test_alertsmanagement_scenario.py
@@ -64,6 +64,48 @@ class AlertsScenarioTest(ScenarioTest):
                      self.check('properties.suppressionConfig.schedule.startTime', '06:00:00'),
                  ])
 
+        self.cmd('az monitor action-rule create '
+                 '--resource-group {rg} '
+                 '--name rule2 '
+                 '--location Global '
+                 '--status Enabled '
+                 '--rule-type Suppression '
+                 '--scope-type ResourceGroup '
+                 '--scope {rg_id} '
+                 '--severity Equals Sev0 Sev2 '
+                 '--monitor-service Equals Platform "Application Insights" '
+                 '--monitor-condition Equals Fired '
+                 '--target-resource-type NotEquals Microsoft.Compute/VirtualMachines '
+                 '--suppression-recurrence-type Once '
+                 '--suppression-start-date 08/25/2021 '
+                 '--suppression-end-date 08/26/2021 '
+                 '--suppression-start-time 06:00:00 '
+                 '--suppression-end-time 14:00:00',
+                 checks=[])
+
+        self.cmd('az monitor action-rule show '
+                 '--resource-group {rg} '
+                 '--name "rule2"',
+                 checks=[
+                     self.check('name', 'rule2'),
+                     self.check('location', 'Global'),
+                     self.check('properties.status', 'Enabled'),
+                     self.check('properties.type', 'Suppression'),
+                     self.check('properties.conditions.monitorCondition.operator', 'Equals'),
+                     self.check('properties.conditions.monitorCondition.values[0]', 'Fired'),
+                     self.check('properties.conditions.severity.operator', 'Equals'),
+                     self.check('properties.conditions.severity.values[0]', 'Sev0'),
+                     self.check('properties.conditions.severity.values[1]', 'Sev2'),
+                     self.check('properties.conditions.targetResourceType.operator', 'NotEquals'),
+                     self.check('properties.conditions.targetResourceType.values[0]',
+                                'Microsoft.Compute/VirtualMachines'),
+                     self.check('properties.suppressionConfig.recurrenceType', 'Once'),
+                     self.check('properties.suppressionConfig.schedule.endDate', '08/26/2021'),
+                     self.check('properties.suppressionConfig.schedule.endTime', '14:00:00'),
+                     self.check('properties.suppressionConfig.schedule.startDate', '08/25/2021'),
+                     self.check('properties.suppressionConfig.schedule.startTime', '06:00:00'),
+                 ])
+
         self.cmd('az monitor action-rule update '
                  '--resource-group {rg} '
                  '--name "rule1" '
@@ -79,3 +121,4 @@ class AlertsScenarioTest(ScenarioTest):
                  checks=self.check('[0].name', 'rule1'))
 
         self.cmd('az monitor action-rule delete -g {rg} -n rule1')
+        self.cmd('az monitor action-rule delete -g {rg} -n rule2')

--- a/src/alertsmanagement/setup.py
+++ b/src/alertsmanagement/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
-VERSION = '0.1.0'
+VERSION = '0.1.1'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
closed https://github.com/Azure/azure-cli-extensions/issues/3072

---
### Changes:
- Add an example were the recurrence type is set to once.
- Fix error: when the recurrence type is set to once, 'Action Rule property 'properties.suppressionConfig.schedule' cannot be null.'

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
