### PR TITLE
Update version and history info for 'az quantum' extension 0.7.0

### DIFF
--- a/src/quantum/HISTORY.rst
+++ b/src/quantum/HISTORY.rst
@@ -3,6 +3,13 @@
 Release History
 ===============
 
+0.7.0
+++++++
+* [2021-08-30] Version intended to work with QDK version [[TBD]]
+* Provide compiler output to users in case of error for easier troubleshooting.
+* Fixed bug in which retrieving output from workspaces in a location different to another set as default failed.
+* Processing jobs that produce no output is allowed.
+
 0.6.1
 ++++++
 * [2021-07-22] Reduced the lenghth of the user agent reported by the tool.

--- a/src/quantum/HISTORY.rst
+++ b/src/quantum/HISTORY.rst
@@ -5,7 +5,7 @@ Release History
 
 0.7.0
 ++++++
-* [2021-08-30] Version intended to work with QDK version [[TBD]]
+* [2021-08-30] Version intended to work with QDK version v0.18.2108
 * Provide compiler output to users in case of error for easier troubleshooting.
 * Fixed bug in which retrieving output from workspaces in a location different to another set as default failed.
 * Processing jobs that produce no output is allowed.

--- a/src/quantum/HISTORY.rst
+++ b/src/quantum/HISTORY.rst
@@ -5,7 +5,7 @@ Release History
 
 0.7.0
 ++++++
-* [2021-08-30] Version intended to work with QDK version v0.18.2108
+* [2021-08-31] Version intended to work with QDK version v0.18.2108.160310
 * Provide compiler output to users in case of error for easier troubleshooting.
 * Fixed bug in which retrieving output from workspaces in a location different to another set as default failed.
 * Processing jobs that produce no output is allowed.

--- a/src/quantum/HISTORY.rst
+++ b/src/quantum/HISTORY.rst
@@ -9,6 +9,7 @@ Release History
 * Provide compiler output to users in case of error for easier troubleshooting.
 * Fixed bug in which retrieving output from workspaces in a location different to another set as default failed.
 * Processing jobs that produce no output is allowed.
+* Simplification of resources used in extension tests and allowing overrides via environment variables.
 
 0.6.1
 ++++++

--- a/src/quantum/azext_quantum/__init__.py
+++ b/src/quantum/azext_quantum/__init__.py
@@ -11,7 +11,7 @@ import azext_quantum._help  # pylint: disable=unused-import
 # This is the version reported by the CLI to the service when submitting requests.
 # This should be in sync with the extension version in 'setup.py', unless we need to
 # submit using a different version.
-CLI_REPORTED_VERSION = "0.6.1"
+CLI_REPORTED_VERSION = "0.7.0"
 
 
 class QuantumCommandsLoader(AzCommandsLoader):

--- a/src/quantum/azext_quantum/operations/job.py
+++ b/src/quantum/azext_quantum/operations/job.py
@@ -182,7 +182,7 @@ def submit(cmd, program_args, resource_group_name=None, workspace_name=None, loc
         # Query for the job and return status to caller.
         return get(cmd, job_id, resource_group_name, workspace_name, location)
 
-    # The program compiled succesfully, but executing the stand-alone .exe failed to run.
+    # The program compiled succesfully, but executing the stand-alone .exe failed to run, propagate standard output to the user.
     logger.error(f"Submission of job failed with error code {result.returncode}")
     print(result.stdout.decode('ascii'))
     raise CLIError("Failed to submit job.")

--- a/src/quantum/azext_quantum/operations/job.py
+++ b/src/quantum/azext_quantum/operations/job.py
@@ -182,7 +182,7 @@ def submit(cmd, program_args, resource_group_name=None, workspace_name=None, loc
         # Query for the job and return status to caller.
         return get(cmd, job_id, resource_group_name, workspace_name, location)
 
-    # The program compiled succesfully, but executing the stand-alone .exe failed to run, propagate standard output to the user.
+    # The program compiled succesfully, but executing the stand-alone .exe failed to run.
     logger.error(f"Submission of job failed with error code {result.returncode}")
     print(result.stdout.decode('ascii'))
     raise CLIError("Failed to submit job.")

--- a/src/quantum/setup.py
+++ b/src/quantum/setup.py
@@ -17,7 +17,7 @@ except ImportError:
 # This version should match the latest entry in HISTORY.rst
 # Also, when updating this, please review the version used by the extension to
 # submit requests, which can be found at './azext_quantum/__init__.py'
-VERSION = '0.6.1'
+VERSION = '0.7.0'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
This is a release PR only to start the deployment of the 'az quantum' extension version 0.7.0

---
### General Guidelines

- [X] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [X] Have you run `python scripts/ci/test_index.py -q` locally?
