### PR TITLE
New version required to fix the inclusion of file 'scripts/linux-buil…

### DIFF
--- a/src/vm-repair/setup.py
+++ b/src/vm-repair/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup, find_packages
 
-VERSION = "0.3.7"
+VERSION = "0.3.8"
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
@@ -48,7 +48,6 @@ setup(
             'scripts/linux-mount-encrypted-disk.sh',
             'scripts/win-mount-encrypted-disk.ps1',
             'scripts/linux-build_setup-cloud-init.txt',
-            'linux-build_setup-cloud-init.txt',
             'azext_metadata.json'
         ]
     },


### PR DESCRIPTION
…d_setup-cloud-init.txt' in the generated package

I'm sorry for the mess @zhoxing-ms . Just recognized a new version is required. Updated the history number accordingly. Cleaned up also the azext_vm_repair list.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
