### PR TITLE
{AKS} Update default test matrix

### DIFF
--- a/src/aks-preview/azcli_aks_live_test/configs/cli_matrix_default.json
+++ b/src/aks-preview/azcli_aks_live_test/configs/cli_matrix_default.json
@@ -7,7 +7,8 @@
     "exclude": {
         "need additional feature": [
             "test_aks_create_enable_encryption",
-            "test_aks_create_edge_zone"
+            "test_aks_create_edge_zone",
+            "test_aks_create_with_auto_upgrade_channel"
         ]
     }
 }

--- a/src/aks-preview/azcli_aks_live_test/configs/ext_matrix_default.json
+++ b/src/aks-preview/azcli_aks_live_test/configs/ext_matrix_default.json
@@ -6,10 +6,7 @@
     },
     "exclude": {
         "need additional feature": [
-            "test_aks_create_with_ossku",
-            "test_aks_nodepool_add_with_ossku",
-            "test_aks_create_with_node_config",
-            "test_aks_create_private_cluster_public_fqdn",
+            "test_aks_create_with_azurekeyvaultsecretsprovider_addon",
             "test_aks_create_addon_with_azurekeyvaultsecretsprovider_with_secret_rotation",
             "test_aks_update_azurekeyvaultsecretsprovider_with_secret_rotation",
             "test_aks_enable_addon_with_azurekeyvaultsecretsprovider",
@@ -20,8 +17,6 @@
             "test_aks_enable_addon_with_openservicemesh",
             "test_aks_disable_addon_openservicemesh",
             "test_aks_create_with_auto_upgrade_channel",
-            "test_aks_create_with_azurekeyvaultsecretsprovider_addon",
-            "test_aks_custom_kubelet_identity",
             "test_aks_disable_local_accounts",
             "test_aks_create_with_pod_identity_enabled",
             "test_aks_create_using_azurecni_with_pod_identity_enabled",


### PR DESCRIPTION
Update default test matrix.
Remove the following exclusions from aks-preview, since they can now be tested normally 
* test_aks_create_with_ossku
* test_aks_nodepool_add_with_ossku
* test_aks_create_with_node_config
* test_aks_create_private_cluster_public_fqdn
* test_aks_custom_kubelet_identity

Add the following exclusion for acs, since they cannot be tested normally
* test_aks_create_with_auto_upgrade_channel

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
