### PR TITLE
fix(aks): check parent scopes role assignments in pod identity assignment

### DIFF
--- a/src/aks-preview/azext_aks_preview/custom.py
+++ b/src/aks-preview/azext_aks_preview/custom.py
@@ -4184,15 +4184,25 @@ def _ensure_managed_identity_operator_permission(cli_ctx, instance, scope):
 
     factory = get_auth_management_client(cli_ctx, scope)
     assignments_client = factory.role_assignments
+    cluster_identity_object_id = cluster_identity_object_id.lower()
+    scope = scope.lower()
 
-    for i in assignments_client.list_for_scope(scope=scope, filter='atScope()'):
-        if i.scope.lower() != scope.lower():
-            continue
+    # list all assignments of the target identity (scope) that assigned to the cluster identity
+    filter_query = "atScope() and assignedTo('{}')".format(cluster_identity_object_id)
+    for i in assignments_client.list_for_scope(scope=scope, filter=filter_query):
         if not i.role_definition_id.lower().endswith(CONST_MANAGED_IDENTITY_OPERATOR_ROLE_ID):
             continue
-        if i.principal_id.lower() != cluster_identity_object_id.lower():
+
+        # sanity checks to make sure we see the correct assignments
+        if i.principal_id.lower() != cluster_identity_object_id:
+            # assignedTo() should return the assignment to cluster identity
             continue
+        if not scope.startswith(i.scope.lower()):
+            # atScope() should return the assignments in subscription / resource group / resource level
+            continue
+
         # already assigned
+        logger.debug('Managed Identity Opereator role has been assigned to {}'.format(i.scope))
         return
 
     if not _add_role_assignment(cli_ctx, CONST_MANAGED_IDENTITY_OPERATOR_ROLE, cluster_identity_object_id,


### PR DESCRIPTION
In previous `pod identity add`'s implementation, we check for role assignment with full scope match, which is an incorrect assumption to the [Azure RBAC assignments](https://docs.microsoft.com/en-us/azure/role-based-access-control/role-assignments-steps#step-3-identify-the-needed-scope). 

This pull request fixed the pod identity role assignment check as follows:

1. updated the role assignments list filter to `atScope() and assignedTo('{cluster_identity_id}')`. This could give us all role assignments targeted for the cluster identity
2. fixed scope check logic: we check with prefixed resource id

Fix #3679

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
