### PR TITLE
Add quantum version check

### DIFF
--- a/src/quantum/azext_quantum/__init__.py
+++ b/src/quantum/azext_quantum/__init__.py
@@ -4,6 +4,8 @@
 # --------------------------------------------------------------------------------------------
 
 from azure.cli.core import AzCommandsLoader
+from datetime import datetime
+from ._version_check_helper import check_version
 
 import azext_quantum._help  # pylint: disable=unused-import
 
@@ -33,32 +35,7 @@ class QuantumCommandsLoader(AzCommandsLoader):
 
         # Once each day, see if the user is running the latest version of the quantum extension.
         # If not, recommend upgrading.
-        from datetime import datetime
-        from azure.cli.core.extension.operations import list_versions
-        from azure.cli.core.util import ConfiguredDefaultSetter
-        from .operations.workspace import _show_tip
-
-        today = str(datetime.today()).split(' ')[0]
-        try:
-            config = self.cli_ctx_config
-            with ConfiguredDefaultSetter(config, False):
-                date_checked = config.get('quantum', 'version_check_date', None)
-
-            if date_checked is None or date_checked != today:
-                with ConfiguredDefaultSetter(config, False):
-                    config.set_value('quantum', 'version_check_date', today)
-
-                available_versions = list_versions("quantum")
-                latest_version_dict = available_versions[len(available_versions) - 1]
-                latest_version = latest_version_dict['version'].split(' ')[0]
-
-                if CLI_REPORTED_VERSION != latest_version:
-                    _show_tip(f"\nVersion {CLI_REPORTED_VERSION} of the quantum extension "
-                              f"is installed locally, but version {latest_version} is now available.\n"
-                              "You can use 'az extension update -n quantum' to upgrade.\n")
-        except:
-            # If an error occurs, we ignore it!
-            return
+        check_version(self.cli_ctx_config, CLI_REPORTED_VERSION, str(datetime.today()).split(' ')[0])
 
 
 COMMAND_LOADER_CLS = QuantumCommandsLoader

--- a/src/quantum/azext_quantum/__init__.py
+++ b/src/quantum/azext_quantum/__init__.py
@@ -18,6 +18,32 @@ class QuantumCommandsLoader(AzCommandsLoader):
 
     def __init__(self, cli_ctx=None):
         super(QuantumCommandsLoader, self).__init__(cli_ctx=cli_ctx)
+        
+        # Once each day, see if the user is running the latest version of the quantum extension.
+        # If not, recommend upgrading. 
+        from datetime import datetime
+        from azure.cli.core.extension.operations import list_versions
+        from azure.cli.core.util import ConfiguredDefaultSetter
+        from .operations.workspace import _show_tip
+
+        today = str(datetime.today()).split(' ')[0]
+        try:
+            with ConfiguredDefaultSetter(cli_ctx.config, False):
+                date_checked = cli_ctx.config.get('quantum', 'version_check_date', None)
+
+            if date_checked is None or date_checked != today:
+                with ConfiguredDefaultSetter(cli_ctx.config, False):
+                    cli_ctx.config.set_value('quantum', 'version_check_date', today)
+
+                available_versions = list_versions("quantum")
+                latest_version_dict = available_versions[len(available_versions) - 1]
+                latest_version = latest_version_dict['version'].split(' ')[0]
+                
+                if CLI_REPORTED_VERSION != latest_version:
+                    _show_tip(f"\nVersion {CLI_REPORTED_VERSION} of the quantum extension is installed locally, but Version {latest_version} is now available.\nYou can use ‘az extension update -n quantum’ to upgrade.\n")
+        except:
+            # If an error occurs, we ignore it!
+            return
 
     def load_command_table(self, args):
         from azext_quantum.commands import load_command_table

--- a/src/quantum/azext_quantum/__init__.py
+++ b/src/quantum/azext_quantum/__init__.py
@@ -19,33 +19,8 @@ class QuantumCommandsLoader(AzCommandsLoader):
     def __init__(self, cli_ctx=None):
         super(QuantumCommandsLoader, self).__init__(cli_ctx=cli_ctx)
 
-        # Once each day, see if the user is running the latest version of the quantum extension.
-        # If not, recommend upgrading.
-        from datetime import datetime
-        from azure.cli.core.extension.operations import list_versions
-        from azure.cli.core.util import ConfiguredDefaultSetter
-        from .operations.workspace import _show_tip
-
-        today = str(datetime.today()).split(' ')[0]
-        try:
-            with ConfiguredDefaultSetter(cli_ctx.config, False):
-                date_checked = cli_ctx.config.get('quantum', 'version_check_date', None)
-
-            if date_checked is None or date_checked != today:
-                with ConfiguredDefaultSetter(cli_ctx.config, False):
-                    cli_ctx.config.set_value('quantum', 'version_check_date', today)
-
-                available_versions = list_versions("quantum")
-                latest_version_dict = available_versions[len(available_versions) - 1]
-                latest_version = latest_version_dict['version'].split(' ')[0]
-
-                if CLI_REPORTED_VERSION != latest_version:
-                    _show_tip(f"\nVersion {CLI_REPORTED_VERSION} of the quantum extension "
-                              f"is installed locally, but version {latest_version} is now available.\n"
-                              "You can use 'az extension update -n quantum' to upgrade.")
-        except:
-            # If an error occurs, we ignore it!
-            return
+        # Save the CLI context config for use in load_arguments
+        self.cli_ctx_config = cli_ctx.config
 
     def load_command_table(self, args):
         from azext_quantum.commands import load_command_table
@@ -55,6 +30,35 @@ class QuantumCommandsLoader(AzCommandsLoader):
     def load_arguments(self, command):
         from azext_quantum._params import load_arguments
         load_arguments(self, command)
+
+        # Once each day, see if the user is running the latest version of the quantum extension.
+        # If not, recommend upgrading.
+        from datetime import datetime
+        from azure.cli.core.extension.operations import list_versions
+        from azure.cli.core.util import ConfiguredDefaultSetter
+        from .operations.workspace import _show_tip
+
+        today = str(datetime.today()).split(' ')[0]
+        try:
+            config = self.cli_ctx_config
+            with ConfiguredDefaultSetter(config, False):
+                date_checked = config.get('quantum', 'version_check_date', None)
+
+            if date_checked is None or date_checked != today:
+                with ConfiguredDefaultSetter(config, False):
+                    config.set_value('quantum', 'version_check_date', today)
+
+                available_versions = list_versions("quantum")
+                latest_version_dict = available_versions[len(available_versions) - 1]
+                latest_version = latest_version_dict['version'].split(' ')[0]
+
+                if CLI_REPORTED_VERSION != latest_version:
+                    _show_tip(f"\nVersion {CLI_REPORTED_VERSION} of the quantum extension "
+                              f"is installed locally, but version {latest_version} is now available.\n"
+                              "You can use 'az extension update -n quantum' to upgrade.\n")
+        except:
+            # If an error occurs, we ignore it!
+            return
 
 
 COMMAND_LOADER_CLS = QuantumCommandsLoader

--- a/src/quantum/azext_quantum/__init__.py
+++ b/src/quantum/azext_quantum/__init__.py
@@ -18,9 +18,9 @@ class QuantumCommandsLoader(AzCommandsLoader):
 
     def __init__(self, cli_ctx=None):
         super(QuantumCommandsLoader, self).__init__(cli_ctx=cli_ctx)
-        
+
         # Once each day, see if the user is running the latest version of the quantum extension.
-        # If not, recommend upgrading. 
+        # If not, recommend upgrading.
         from datetime import datetime
         from azure.cli.core.extension.operations import list_versions
         from azure.cli.core.util import ConfiguredDefaultSetter
@@ -38,9 +38,11 @@ class QuantumCommandsLoader(AzCommandsLoader):
                 available_versions = list_versions("quantum")
                 latest_version_dict = available_versions[len(available_versions) - 1]
                 latest_version = latest_version_dict['version'].split(' ')[0]
-                
+
                 if CLI_REPORTED_VERSION != latest_version:
-                    _show_tip(f"\nVersion {CLI_REPORTED_VERSION} of the quantum extension is installed locally, but Version {latest_version} is now available.\nYou can use ‘az extension update -n quantum’ to upgrade.\n")
+                    _show_tip(f"\nVersion {CLI_REPORTED_VERSION} of the quantum extension "
+                              f"is installed locally, but version {latest_version} is now available.\n"
+                              "You can use 'az extension update -n quantum' to upgrade.")
         except:
             # If an error occurs, we ignore it!
             return

--- a/src/quantum/azext_quantum/__init__.py
+++ b/src/quantum/azext_quantum/__init__.py
@@ -4,8 +4,6 @@
 # --------------------------------------------------------------------------------------------
 
 from azure.cli.core import AzCommandsLoader
-from datetime import datetime
-from ._version_check_helper import check_version
 
 import azext_quantum._help  # pylint: disable=unused-import
 
@@ -33,9 +31,12 @@ class QuantumCommandsLoader(AzCommandsLoader):
         from azext_quantum._params import load_arguments
         load_arguments(self, command)
 
-        # Once each day, see if the user is running the latest version of the quantum extension.
-        # If not, recommend upgrading.
-        check_version(self.cli_ctx_config, CLI_REPORTED_VERSION, str(datetime.today()).split(' ')[0])
-
+        # See if the user is running the latest version of the quantum extension.
+        from ._version_check_helper import check_version
+        from .operations.workspace import _show_tip
+        from datetime import datetime
+        message = check_version(self.cli_ctx_config, CLI_REPORTED_VERSION, str(datetime.today()).split(' ')[0])
+        if message is not None:
+            _show_tip(message)
 
 COMMAND_LOADER_CLS = QuantumCommandsLoader

--- a/src/quantum/azext_quantum/__init__.py
+++ b/src/quantum/azext_quantum/__init__.py
@@ -39,4 +39,5 @@ class QuantumCommandsLoader(AzCommandsLoader):
         if message is not None:
             _show_tip(message)
 
+
 COMMAND_LOADER_CLS = QuantumCommandsLoader

--- a/src/quantum/azext_quantum/_version_check_helper.py
+++ b/src/quantum/azext_quantum/_version_check_helper.py
@@ -5,28 +5,44 @@
 
 from azure.cli.core.extension.operations import list_versions
 from azure.cli.core.util import ConfiguredDefaultSetter
-from .operations.workspace import _show_tip
 
 # Once each day, see if the user is running the latest version of the quantum extension.
-# If not, recommend upgrading.
+# If not, return a message that recommends upgrading.
+
 
 def check_version(config, reported_version, today):
+    # Retrieve the last version-check date
+    date_checked = None
     try:
         with ConfiguredDefaultSetter(config, False):
             date_checked = config.get('quantum', 'version_check_date', None)
 
+        # Save the today's date if it hasn't already been saved
         if date_checked is None or date_checked != today:
             with ConfiguredDefaultSetter(config, False):
                 config.set_value('quantum', 'version_check_date', today)
+    except:
+        pass    # Ignore errors here. This error is expected in the unit tests because cli_ctx is unavailable.
 
+    # Retrieve the list of available versions of the quantum extension
+    available_versions = None
+    latest_version_dict = None
+    latest_version = None
+
+    if date_checked is None or date_checked != today:   # This logic is intentionally duplicated...
+        # The preceding line with this logical expression needed to be inside the previous "try" block.
+        try:
             available_versions = list_versions("quantum")
+        except:
+            pass    # If an error occurs here, we ignore it.
+
+        if available_versions is not None:
             latest_version_dict = available_versions[len(available_versions) - 1]
+
+        if latest_version_dict is not None:
             latest_version = latest_version_dict['version'].split(' ')[0]
 
-            if reported_version != latest_version:
-                _show_tip(f"\nVersion {reported_version} of the quantum extension "
-                          f"is installed locally, but version {latest_version} is now available.\n"
-                          "You can use 'az extension update -n quantum' to upgrade.\n")
-    except:
-        # If an error occurs, we ignore it!
-        return
+        if reported_version != latest_version:
+            return (f"\nVersion {reported_version} of the quantum extension is installed locally,"
+                    f" but version {latest_version} is now available.\n"
+                    "You can use 'az extension update -n quantum' to upgrade.\n")

--- a/src/quantum/azext_quantum/_version_check_helper.py
+++ b/src/quantum/azext_quantum/_version_check_helper.py
@@ -1,0 +1,32 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from azure.cli.core.extension.operations import list_versions
+from azure.cli.core.util import ConfiguredDefaultSetter
+from .operations.workspace import _show_tip
+
+# Once each day, see if the user is running the latest version of the quantum extension.
+# If not, recommend upgrading.
+
+def check_version(config, reported_version, today):
+    try:
+        with ConfiguredDefaultSetter(config, False):
+            date_checked = config.get('quantum', 'version_check_date', None)
+
+        if date_checked is None or date_checked != today:
+            with ConfiguredDefaultSetter(config, False):
+                config.set_value('quantum', 'version_check_date', today)
+
+            available_versions = list_versions("quantum")
+            latest_version_dict = available_versions[len(available_versions) - 1]
+            latest_version = latest_version_dict['version'].split(' ')[0]
+
+            if reported_version != latest_version:
+                _show_tip(f"\nVersion {reported_version} of the quantum extension "
+                          f"is installed locally, but version {latest_version} is now available.\n"
+                          "You can use 'az extension update -n quantum' to upgrade.\n")
+    except:
+        # If an error occurs, we ignore it!
+        return

--- a/src/quantum/azext_quantum/tests/latest/recordings/test_version_check.yaml
+++ b/src/quantum/azext_quantum/tests/latest/recordings/test_version_check.yaml
@@ -1,0 +1,380 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://aka.ms/azure-cli-extension-index-v1
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - max-age=0, no-cache, no-store
+      connection:
+      - keep-alive
+      content-length:
+      - '0'
+      date:
+      - Thu, 23 Sep 2021 07:55:23 GMT
+      expires:
+      - Thu, 23 Sep 2021 07:55:23 GMT
+      location:
+      - https://azcliextensionsync.blob.core.windows.net/index1/index.json
+      pragma:
+      - no-cache
+      request-context:
+      - appId=cid-v1:7d63747b-487e-492a-872d-762362f77974
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000 ; includeSubDomains
+      x-response-cache-status:
+      - 'True'
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://aka.ms/azure-cli-extension-index-v1
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - max-age=0, no-cache, no-store
+      connection:
+      - keep-alive
+      content-length:
+      - '0'
+      date:
+      - Thu, 23 Sep 2021 07:55:25 GMT
+      expires:
+      - Thu, 23 Sep 2021 07:55:25 GMT
+      location:
+      - https://azcliextensionsync.blob.core.windows.net/index1/index.json
+      pragma:
+      - no-cache
+      request-context:
+      - appId=cid-v1:7d63747b-487e-492a-872d-762362f77974
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000 ; includeSubDomains
+      x-response-cache-status:
+      - 'True'
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://aka.ms/azure-cli-extension-index-v1
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - max-age=0, no-cache, no-store
+      connection:
+      - keep-alive
+      content-length:
+      - '0'
+      date:
+      - Thu, 23 Sep 2021 07:55:27 GMT
+      expires:
+      - Thu, 23 Sep 2021 07:55:27 GMT
+      location:
+      - https://azcliextensionsync.blob.core.windows.net/index1/index.json
+      pragma:
+      - no-cache
+      request-context:
+      - appId=cid-v1:7d63747b-487e-492a-872d-762362f77974
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000 ; includeSubDomains
+      x-response-cache-status:
+      - 'True'
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://aka.ms/azure-cli-extension-index-v1
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - max-age=0, no-cache, no-store
+      connection:
+      - keep-alive
+      content-length:
+      - '0'
+      date:
+      - Thu, 23 Sep 2021 07:55:29 GMT
+      expires:
+      - Thu, 23 Sep 2021 07:55:29 GMT
+      location:
+      - https://azcliextensionsync.blob.core.windows.net/index1/index.json
+      pragma:
+      - no-cache
+      request-context:
+      - appId=cid-v1:7d63747b-487e-492a-872d-762362f77974
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000 ; includeSubDomains
+      x-response-cache-status:
+      - 'True'
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://aka.ms/azure-cli-extension-index-v1
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - max-age=0, no-cache, no-store
+      connection:
+      - keep-alive
+      content-length:
+      - '0'
+      date:
+      - Thu, 23 Sep 2021 07:55:30 GMT
+      expires:
+      - Thu, 23 Sep 2021 07:55:30 GMT
+      location:
+      - https://azcliextensionsync.blob.core.windows.net/index1/index.json
+      pragma:
+      - no-cache
+      request-context:
+      - appId=cid-v1:7d63747b-487e-492a-872d-762362f77974
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000 ; includeSubDomains
+      x-response-cache-status:
+      - 'True'
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://aka.ms/azure-cli-extension-index-v1
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - max-age=0, no-cache, no-store
+      connection:
+      - keep-alive
+      content-length:
+      - '0'
+      date:
+      - Thu, 23 Sep 2021 07:55:32 GMT
+      expires:
+      - Thu, 23 Sep 2021 07:55:32 GMT
+      location:
+      - https://azcliextensionsync.blob.core.windows.net/index1/index.json
+      pragma:
+      - no-cache
+      request-context:
+      - appId=cid-v1:7d63747b-487e-492a-872d-762362f77974
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000 ; includeSubDomains
+      x-response-cache-status:
+      - 'True'
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://aka.ms/azure-cli-extension-index-v1
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - max-age=0, no-cache, no-store
+      connection:
+      - keep-alive
+      content-length:
+      - '0'
+      date:
+      - Thu, 23 Sep 2021 07:55:33 GMT
+      expires:
+      - Thu, 23 Sep 2021 07:55:33 GMT
+      location:
+      - https://azcliextensionsync.blob.core.windows.net/index1/index.json
+      pragma:
+      - no-cache
+      request-context:
+      - appId=cid-v1:7d63747b-487e-492a-872d-762362f77974
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000 ; includeSubDomains
+      x-response-cache-status:
+      - 'True'
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://aka.ms/azure-cli-extension-index-v1
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - max-age=0, no-cache, no-store
+      connection:
+      - keep-alive
+      content-length:
+      - '0'
+      date:
+      - Thu, 23 Sep 2021 07:55:34 GMT
+      expires:
+      - Thu, 23 Sep 2021 07:55:34 GMT
+      location:
+      - https://azcliextensionsync.blob.core.windows.net/index1/index.json
+      pragma:
+      - no-cache
+      request-context:
+      - appId=cid-v1:7d63747b-487e-492a-872d-762362f77974
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000 ; includeSubDomains
+      x-response-cache-status:
+      - 'True'
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://aka.ms/azure-cli-extension-index-v1
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - max-age=0, no-cache, no-store
+      connection:
+      - keep-alive
+      content-length:
+      - '0'
+      date:
+      - Thu, 23 Sep 2021 07:55:35 GMT
+      expires:
+      - Thu, 23 Sep 2021 07:55:35 GMT
+      location:
+      - https://azcliextensionsync.blob.core.windows.net/index1/index.json
+      pragma:
+      - no-cache
+      request-context:
+      - appId=cid-v1:7d63747b-487e-492a-872d-762362f77974
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000 ; includeSubDomains
+      x-response-cache-status:
+      - 'True'
+    status:
+      code: 301
+      message: Moved Permanently
+version: 1

--- a/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
+++ b/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
@@ -10,11 +10,9 @@ from azure_devtools.scenario_tests import AllowLargeResponse, live_only
 from azure.cli.testsdk import (ScenarioTest, ResourceGroupPreparer)
 
 from .utils import get_test_resource_group, get_test_workspace, get_test_workspace_location, get_test_workspace_storage, get_test_workspace_random_name
-#>>>>>
 from ..._version_check_helper import check_version
 from datetime import datetime
 from ...__init__ import CLI_REPORTED_VERSION 
-#<<<<<
 
 TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))
 

--- a/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
+++ b/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
@@ -10,6 +10,11 @@ from azure_devtools.scenario_tests import AllowLargeResponse, live_only
 from azure.cli.testsdk import (ScenarioTest, ResourceGroupPreparer)
 
 from .utils import get_test_resource_group, get_test_workspace, get_test_workspace_location, get_test_workspace_storage, get_test_workspace_random_name
+#>>>>>
+from ..._version_check_helper import check_version
+from datetime import datetime
+from ...__init__ import CLI_REPORTED_VERSION 
+#<<<<<
 
 TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))
 
@@ -65,3 +70,22 @@ class QuantumWorkspacesScenarioTest(ScenarioTest):
            self.check("provisioningState", "Deleting")
         ])
 
+    @live_only()
+    def test_version_check(self):
+        # initialize values
+        test_old_date = "2021-04-01"
+        test_today = str(datetime.today()).split(' ')[0] 
+        test_old_reported_version = "0.1.0"
+        test_current_reported_version = CLI_REPORTED_VERSION
+        test_none_version = None
+        test_config = None
+
+        message = check_version(test_config, test_current_reported_version, test_old_date)
+        assert test_current_reported_version in message
+
+        message = check_version(test_config, test_old_reported_version, test_old_date)
+        assert test_old_reported_version in message
+
+        message = check_version(test_config, test_none_version, test_today)
+        assert message is None  # Note: list_versions("quantum") fails during these tests
+     


### PR DESCRIPTION
Once per day, the Azure CLI quantum extension will perform a version check as part of any command.  If the latest available version of the extension is greater than the one installed, the user will see a yellow warning message in the following format:
```
Version 0.7.0 of the quantum extension is installed locally, but version 0.8.0 is now available.
You can use 'az extension update -n quantum' to upgrade.
```
If the latest available version number cannot be retrieved, or it matches the installed version, no message is shown. We won’t fail the command if we can’t get the most recent version, we’ll just proceed.  We won’t check again until the date changes or the context gets cleared.

This implementation will not cover commands that our extension does not handle directly, like “--help” calls, since they are directly responded by the ‘az’ tool.
