### PR TITLE
Add support for target specific job parameters

### DIFF
--- a/src/quantum/azext_quantum/_help.py
+++ b/src/quantum/azext_quantum/_help.py
@@ -21,7 +21,7 @@ helps['quantum execute'] = """
       - name: Submit and wait for a Q# program from the current folder with job and program parameters.
         text: |-
             az quantum execute -g MyResourceGroup -w MyWorkspace -l MyLocation -t MyTarget \\
-                --job-params key1=value1 key2=value2 -- --n-qubits 3
+                --job-params key1=value1 key2=value2 -- --n-qubits=3
 """
 
 helps['quantum run'] = """
@@ -34,7 +34,7 @@ helps['quantum run'] = """
       - name: Submit and wait for a Q# program from the current folder with job and program parameters.
         text: |-
             az quantum run -g MyResourceGroup -w MyWorkspace -l MyLocation -t MyTarget \\
-                --job-params key1=value1 key2=value2 -- --n-qubits 3
+                --job-params key1=value1 key2=value2 -- --n-qubits=3
 """
 
 helps['quantum job'] = """
@@ -86,7 +86,7 @@ helps['quantum job submit'] = """
       - name: Submit the Q# program with program parameters (e.g. n-qubits = 2).
         text: |-
             az quantum job submit -g MyResourceGroup -w MyWorkspace -l MyLocation \\
-               --job-name MyJob -- --n-qubits 2
+               --job-name MyJob -- --n-qubits=2
 """
 
 helps['quantum job wait'] = """

--- a/src/quantum/azext_quantum/_help.py
+++ b/src/quantum/azext_quantum/_help.py
@@ -18,6 +18,10 @@ helps['quantum execute'] = """
       - name: Submit the Q# program from the current folder and wait for the result.
         text: |-
             az quantum execute -g MyResourceGroup -w MyWorkspace -l MyLocation -t MyTarget
+      - name: Submit and wait for a Q# program from the current folder with job and program parameters.
+        text: |-
+            az quantum execute -g MyResourceGroup -w MyWorkspace -l MyLocation -t MyTarget \\
+                --job-params key1=value1 key2=value2 -- --n-qubits 3
 """
 
 helps['quantum run'] = """
@@ -27,6 +31,10 @@ helps['quantum run'] = """
       - name: Submit the Q# program from the current folder and wait for the result.
         text: |-
             az quantum run -g MyResourceGroup -w MyWorkspace -l MyLocation -t MyTarget
+      - name: Submit and wait for a Q# program from the current folder with job and program parameters.
+        text: |-
+            az quantum execute -g MyResourceGroup -w MyWorkspace -l MyLocation -t MyTarget \\
+                --job-params key1=value1 key2=value2 -- --n-qubits 3
 """
 
 helps['quantum job'] = """
@@ -71,6 +79,14 @@ helps['quantum job submit'] = """
         text: |-
             az quantum job submit -g MyResourceGroup -w MyWorkspace -l MyLocation \\
                --job-name MyJob
+      - name: Submit the Q# program from the current folder with job parameters for a target.
+        text: |-
+            az quantum job submit -g MyResourceGroup -w MyWorkspace -l MyLocation \\
+               --job-name MyJob --job-params param1=value1 param2=value2
+      - name: Submit the Q# program with program parameters (e.g. n-qubits = 2).
+        text: |-
+            az quantum job submit -g MyResourceGroup -w MyWorkspace -l MyLocation \\
+               --job-name MyJob -- --n-qubits 2
 """
 
 helps['quantum job wait'] = """

--- a/src/quantum/azext_quantum/_help.py
+++ b/src/quantum/azext_quantum/_help.py
@@ -33,7 +33,7 @@ helps['quantum run'] = """
             az quantum run -g MyResourceGroup -w MyWorkspace -l MyLocation -t MyTarget
       - name: Submit and wait for a Q# program from the current folder with job and program parameters.
         text: |-
-            az quantum execute -g MyResourceGroup -w MyWorkspace -l MyLocation -t MyTarget \\
+            az quantum run -g MyResourceGroup -w MyWorkspace -l MyLocation -t MyTarget \\
                 --job-params key1=value1 key2=value2 -- --n-qubits 3
 """
 

--- a/src/quantum/azext_quantum/_params.py
+++ b/src/quantum/azext_quantum/_params.py
@@ -7,6 +7,7 @@
 import argparse
 from knack.arguments import CLIArgumentType, CLIError
 
+
 # pylint: disable=protected-access
 class JobParamsAction(argparse._AppendAction):
     def __call__(self, parser, namespace, values, option_string):
@@ -18,6 +19,7 @@ class JobParamsAction(argparse._AppendAction):
             except ValueError:
                 raise CLIError('Usage error: {} KEY=VALUE [KEY=VALUE ...]'.format(option_string))
         namespace.job_params = params
+
 
 def load_arguments(self, _):
     workspace_name_type = CLIArgumentType(options_list=['--workspace-name', '-w'], help='Name of the Quantum Workspace. You can configure the default workspace using `az quantum workspace set`.', id_part=None, required=False)

--- a/src/quantum/azext_quantum/_params.py
+++ b/src/quantum/azext_quantum/_params.py
@@ -9,7 +9,7 @@ from knack.arguments import CLIArgumentType, CLIError
 
 
 class JobParamsAction(argparse._AppendAction):
-    def __call__(self, parser, namespace, values, option_string):
+    def __call__(self, parser, namespace, values, option_string=None):
         params = {}
         for item in values:
             try:
@@ -18,6 +18,7 @@ class JobParamsAction(argparse._AppendAction):
             except ValueError:
                 raise CLIError('Usage error: {} KEY=VALUE [KEY=VALUE ...]'.format(option_string))
         namespace.job_params = params
+        return params
 
 
 def load_arguments(self, _):

--- a/src/quantum/azext_quantum/_params.py
+++ b/src/quantum/azext_quantum/_params.py
@@ -10,6 +10,10 @@ from knack.arguments import CLIArgumentType, CLIError
 
 class JobParamsAction(argparse._AppendAction):
     def __call__(self, parser, namespace, values, option_string=None):
+        action = self.get_action(values, option_string)
+        namespace.job_params = action
+
+    def get_action(self, values, option_string):
         params = {}
         for item in values:
             try:
@@ -17,7 +21,6 @@ class JobParamsAction(argparse._AppendAction):
                 params[key] = value
             except ValueError:
                 raise CLIError('Usage error: {} KEY=VALUE [KEY=VALUE ...]'.format(option_string))
-        namespace.job_params = params
         return params
 
 

--- a/src/quantum/azext_quantum/_params.py
+++ b/src/quantum/azext_quantum/_params.py
@@ -2,13 +2,12 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
-# pylint: disable=line-too-long
+# pylint: disable=line-too-long,protected-access
 
 import argparse
 from knack.arguments import CLIArgumentType, CLIError
 
 
-# pylint: disable=protected-access
 class JobParamsAction(argparse._AppendAction):
     def __call__(self, parser, namespace, values, option_string):
         params = {}

--- a/src/quantum/azext_quantum/operations/job.py
+++ b/src/quantum/azext_quantum/operations/job.py
@@ -299,7 +299,8 @@ def run(cmd, program_args, resource_group_name=None, workspace_name=None, locati
     """
     Submit a job to run on Azure Quantum, and waits for the result.
     """
-    job = submit(cmd, program_args, resource_group_name, workspace_name, location, target_id, project, job_name, shots, storage, no_build, job_params)
+    job = submit(cmd, program_args, resource_group_name, workspace_name, location, target_id,
+                 project, job_name, shots, storage, no_build, job_params)
     logger.warning("Job id: %s", job.id)
     logger.debug(job)
 

--- a/src/quantum/azext_quantum/operations/job.py
+++ b/src/quantum/azext_quantum/operations/job.py
@@ -81,7 +81,7 @@ def build(cmd, target_id=None, project=None):
     raise CLIError("Failed to compile program.")
 
 
-def _generate_submit_args(program_args, ws, target, token, project, job_name, shots, storage):
+def _generate_submit_args(program_args, ws, target, token, project, job_name, shots, storage, job_params):
     """ Generates the list of arguments for calling submit on a Q# project """
 
     args = ["dotnet", "run", "--no-build"]
@@ -126,6 +126,11 @@ def _generate_submit_args(program_args, ws, target, token, project, job_name, sh
     args.append("--location")
     args.append(ws.location)
 
+    if job_params:
+        args.append("--job-params")
+        for k, v in job_params.items():
+            args.append(f"{k}={v}")
+
     args.extend(program_args)
 
     logger.debug("Running project with arguments:")
@@ -150,8 +155,8 @@ def _has_completed(job):
     return job.status in ("Succeeded", "Failed", "Cancelled")
 
 
-def submit(cmd, program_args, resource_group_name=None, workspace_name=None, location=None,
-           target_id=None, project=None, job_name=None, shots=None, storage=None, no_build=False):
+def submit(cmd, program_args, resource_group_name=None, workspace_name=None, location=None, target_id=None,
+           project=None, job_name=None, shots=None, storage=None, no_build=False, job_params=None):
     """
     Submit a Q# project to run on Azure Quantum.
     """
@@ -169,7 +174,7 @@ def submit(cmd, program_args, resource_group_name=None, workspace_name=None, loc
     target = TargetInfo(cmd, target_id)
     token = _get_data_credentials(cmd.cli_ctx, ws.subscription).get_token().token
 
-    args = _generate_submit_args(program_args, ws, target, token, project, job_name, shots, storage)
+    args = _generate_submit_args(program_args, ws, target, token, project, job_name, shots, storage, job_params)
     _set_cli_version()
 
     import subprocess
@@ -290,11 +295,11 @@ def wait(cmd, job_id, resource_group_name=None, workspace_name=None, location=No
 
 
 def run(cmd, program_args, resource_group_name=None, workspace_name=None, location=None, target_id=None,
-        project=None, job_name=None, shots=None, storage=None, no_build=False):
+        project=None, job_name=None, shots=None, storage=None, no_build=False, job_params=None):
     """
     Submit a job to run on Azure Quantum, and waits for the result.
     """
-    job = submit(cmd, program_args, resource_group_name, workspace_name, location, target_id, project, job_name, shots, storage, no_build)
+    job = submit(cmd, program_args, resource_group_name, workspace_name, location, target_id, project, job_name, shots, storage, no_build, job_params)
     logger.warning("Job id: %s", job.id)
     logger.debug(job)
 

--- a/src/quantum/azext_quantum/tests/latest/test_quantum_jobs.py
+++ b/src/quantum/azext_quantum/tests/latest/test_quantum_jobs.py
@@ -43,7 +43,8 @@ class QuantumJobsScenarioTest(ScenarioTest):
         job_parameters["key1"] = "value1"
         job_parameters["key2"] = "value2"
 
-        args = _generate_submit_args(["--foo", "--bar"], ws, target, token, project=None, job_name=None, storage=None, shots=None)
+        args = _generate_submit_args(["--foo", "--bar"], ws, target, token, project=None,
+                                     job_name=None, storage=None, shots=None, job_params=None)
         self.assertEquals(args[0], "dotnet")
         self.assertEquals(args[1], "run")
         self.assertEquals(args[2], "--no-build")

--- a/src/quantum/azext_quantum/tests/latest/test_quantum_jobs.py
+++ b/src/quantum/azext_quantum/tests/latest/test_quantum_jobs.py
@@ -39,6 +39,10 @@ class QuantumJobsScenarioTest(ScenarioTest):
         token = _get_data_credentials(self.cli_ctx, get_test_subscription_id()).get_token().token
         assert len(token) > 0
 
+        job_parameters = {}
+        job_parameters["key1"] = "value1"
+        job_parameters["key2"] = "value2"
+
         args = _generate_submit_args(["--foo", "--bar"], ws, target, token, project=None, job_name=None, storage=None, shots=None)
         self.assertEquals(args[0], "dotnet")
         self.assertEquals(args[1], "run")
@@ -57,7 +61,8 @@ class QuantumJobsScenarioTest(ScenarioTest):
         self.assertNotIn("--storage", args)
         self.assertNotIn("--shots", args)
 
-        args = _generate_submit_args(["--foo", "--bar"], ws, target, token, "../other/path", "job-name", 1234, "az-stor")
+        args = _generate_submit_args(["--foo", "--bar"], ws, target, token, "../other/path",
+                                     "job-name", 1234, "az-stor", job_parameters)
         self.assertEquals(args[0], "dotnet")
         self.assertEquals(args[1], "run")
         self.assertEquals(args[2], "--no-build")
@@ -69,6 +74,9 @@ class QuantumJobsScenarioTest(ScenarioTest):
         self.assertIn("--job-name", args)
         self.assertIn("--storage", args)
         self.assertIn("--shots", args)
+        self.assertIn("--job-params", args)
+        self.assertIn("key1=value1", args)
+        self.assertIn("key2=value2", args)
 
     def test_parse_blob_url(self):
         sas = "sv=2018-03-28&sr=c&sig=some-sig&sp=racwl"


### PR DESCRIPTION
This PR adds an optional parameter `--job-params` to the following commands.

+ `az quantum job submit`
+ `az quantum execute`
+ `az quantum run`

This parameter contains a ist of `key=value` pairs that will be passed to the Quantum execution target as part of the job submission. The support for those parameters is specific to each target.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [X] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [X] Have you run `python scripts/ci/test_index.py -q` locally?
