### PR TITLE
Fix typo in 'separated'

### DIFF
--- a/src/aks-preview/azext_aks_preview/_help.py
+++ b/src/aks-preview/azext_aks_preview/_help.py
@@ -101,7 +101,7 @@ helps['aks create'] = """
           short-summary: Enable Azure RBAC to control authorization checks on cluster.
         - name: --aad-admin-group-object-ids
           type: string
-          short-summary: Comma seperated list of aad group object IDs that will be set as cluster admin.
+          short-summary: Comma-separated list of aad group object IDs that will be set as cluster admin.
         - name: --aad-client-app-id
           type: string
           short-summary: The ID of an Azure Active Directory client application of type "Native". This
@@ -291,7 +291,7 @@ helps['aks create'] = """
           short-summary: Specify an existing user assigned identity for kubelet's usage, which is typically used to pull image from ACR.
         - name: --api-server-authorized-ip-ranges
           type: string
-          short-summary: Comma seperated list of authorized apiserver IP ranges. Set to 0.0.0.0/32 to restrict apiserver traffic to node pools.
+          short-summary: Comma-separated list of authorized apiserver IP ranges. Set to 0.0.0.0/32 to restrict apiserver traffic to node pools.
         - name: --aks-custom-headers
           type: string
           short-summary: Send custom headers. When specified, format should be Key1=Value1,Key2=Value2
@@ -509,13 +509,13 @@ helps['aks update'] = """
           short-summary: Disable the 'acrpull' role assignment to the ACR specified by name or resource ID.
         - name: --api-server-authorized-ip-ranges
           type: string
-          short-summary: Comma seperated list of authorized apiserver IP ranges. Set to "" to allow all traffic on a previously restricted cluster. Set to 0.0.0.0/32 to restrict apiserver traffic to node pools.
+          short-summary: Comma-separated list of authorized apiserver IP ranges. Set to "" to allow all traffic on a previously restricted cluster. Set to 0.0.0.0/32 to restrict apiserver traffic to node pools.
         - name: --enable-aad
           type: bool
           short-summary: Enable managed AAD feature for cluster.
         - name: --aad-admin-group-object-ids
           type: string
-          short-summary: Comma seperated list of aad group object IDs that will be set as cluster admin.
+          short-summary: Comma-separated list of aad group object IDs that will be set as cluster admin.
         - name: --aad-tenant-id
           type: string
           short-summary: The ID of an Azure Active Directory tenant.

--- a/src/application-insights/azext_applicationinsights/_help.py
+++ b/src/application-insights/azext_applicationinsights/_help.py
@@ -178,10 +178,10 @@ helps['monitor app-insights api-key create'] = """
         short-summary: Name of the API key to create.
       - name: --read-properties
         type: list
-        short-summary: A space seperated list of names of read Roles for this API key to inherit. Possible values include ReadTelemetry, AuthenticateSDKControlChannel and "".
+        short-summary: A space-separated list of names of read Roles for this API key to inherit. Possible values include ReadTelemetry, AuthenticateSDKControlChannel and "".
       - name: --write-properties
         type: list
-        short-summary: A space seperated list of names of write Roles for this API key to inherit. Possible values include WriteAnnotations and "".
+        short-summary: A space-separated list of names of write Roles for this API key to inherit. Possible values include WriteAnnotations and "".
     examples:
       - name: Create a component with kind web and location.
         text: |

--- a/src/mesh/azext_mesh/_params.py
+++ b/src/mesh/azext_mesh/_params.py
@@ -39,12 +39,12 @@ def load_arguments(self, _):
         c.argument('location', arg_type=get_location_type(self.cli_ctx), validator=get_default_location_from_resource_group)
         c.argument('template_file', options_list=['--template-file'], help="The full file path of creation template")
         c.argument('template_uri', options_list=['--template-uri'], help="The full file path of creation template on a http or https link")
-        c.argument('input_yaml_files', options_list=['--input-yaml-files'], help="List of comma seperated yaml files or a directory which contains all the yaml files")
+        c.argument('input_yaml_files', options_list=['--input-yaml-files'], help="List of comma-separated yaml files or a directory which contains all the yaml files")
         c.argument('parameters', action='append', nargs='+', completer=FilesCompleter())
 
     with self.argument_context('mesh generate armtemplate') as c:
         c.argument('input_yaml_files', options_list=['--input-yaml-files'], required=True,
-                   help="List of comma seperated yaml files or a directory which contains all the yaml files")
+                   help="List of comma-separated yaml files or a directory which contains all the yaml files")
         c.argument('parameters', action='append', nargs='+', completer=FilesCompleter())
 
     with self.argument_context('mesh network') as c:

--- a/src/storage-preview/azext_storage_preview/vendored_sdks/azure_adls_storage_preview/v2019_02_02_preview/common/_deserialization.py
+++ b/src/storage-preview/azext_storage_preview/vendored_sdks/azure_adls_storage_preview/v2019_02_02_preview/common/_deserialization.py
@@ -258,8 +258,8 @@ def _convert_xml_to_service_properties(response):
                 <AllowedOrigins>comma-separated-list-of-allowed-origins</AllowedOrigins>
                 <AllowedMethods>comma-separated-list-of-HTTP-verb</AllowedMethods>
                 <MaxAgeInSeconds>max-caching-age-in-seconds</MaxAgeInSeconds>
-                <ExposedHeaders>comma-seperated-list-of-response-headers</ExposedHeaders>
-                <AllowedHeaders>comma-seperated-list-of-request-headers</AllowedHeaders>
+                <ExposedHeaders>comma-separated-list-of-response-headers</ExposedHeaders>
+                <AllowedHeaders>comma-separated-list-of-request-headers</AllowedHeaders>
             </CorsRule>
         </Cors>
         <DeleteRetentionPolicy>

--- a/src/storage-preview/azext_storage_preview/vendored_sdks/azure_adls_storage_preview/v2019_02_02_preview/common/_serialization.py
+++ b/src/storage-preview/azext_storage_preview/vendored_sdks/azure_adls_storage_preview/v2019_02_02_preview/common/_serialization.py
@@ -214,8 +214,8 @@ def _convert_service_properties_to_xml(logging, hour_metrics, minute_metrics,
                 <AllowedOrigins>comma-separated-list-of-allowed-origins</AllowedOrigins>
                 <AllowedMethods>comma-separated-list-of-HTTP-verb</AllowedMethods>
                 <MaxAgeInSeconds>max-caching-age-in-seconds</MaxAgeInSeconds>
-                <ExposedHeaders>comma-seperated-list-of-response-headers</ExposedHeaders>
-                <AllowedHeaders>comma-seperated-list-of-request-headers</AllowedHeaders>
+                <ExposedHeaders>comma-separated-list-of-response-headers</ExposedHeaders>
+                <AllowedHeaders>comma-separated-list-of-request-headers</AllowedHeaders>
             </CorsRule>
         </Cors>
         <DeleteRetentionPolicy>

--- a/src/storage-preview/azext_storage_preview/vendored_sdks/azure_storage/v2018_03_28/common/_deserialization.py
+++ b/src/storage-preview/azext_storage_preview/vendored_sdks/azure_storage/v2018_03_28/common/_deserialization.py
@@ -246,8 +246,8 @@ def _convert_xml_to_service_properties(response):
                 <AllowedOrigins>comma-separated-list-of-allowed-origins</AllowedOrigins>
                 <AllowedMethods>comma-separated-list-of-HTTP-verb</AllowedMethods>
                 <MaxAgeInSeconds>max-caching-age-in-seconds</MaxAgeInSeconds>
-                <ExposedHeaders>comma-seperated-list-of-response-headers</ExposedHeaders>
-                <AllowedHeaders>comma-seperated-list-of-request-headers</AllowedHeaders>
+                <ExposedHeaders>comma-separated-list-of-response-headers</ExposedHeaders>
+                <AllowedHeaders>comma-separated-list-of-request-headers</AllowedHeaders>
             </CorsRule>
         </Cors>
         <DeleteRetentionPolicy>

--- a/src/storage-preview/azext_storage_preview/vendored_sdks/azure_storage/v2018_03_28/common/_serialization.py
+++ b/src/storage-preview/azext_storage_preview/vendored_sdks/azure_storage/v2018_03_28/common/_serialization.py
@@ -213,8 +213,8 @@ def _convert_service_properties_to_xml(logging, hour_metrics, minute_metrics,
                 <AllowedOrigins>comma-separated-list-of-allowed-origins</AllowedOrigins>
                 <AllowedMethods>comma-separated-list-of-HTTP-verb</AllowedMethods>
                 <MaxAgeInSeconds>max-caching-age-in-seconds</MaxAgeInSeconds>
-                <ExposedHeaders>comma-seperated-list-of-response-headers</ExposedHeaders>
-                <AllowedHeaders>comma-seperated-list-of-request-headers</AllowedHeaders>
+                <ExposedHeaders>comma-separated-list-of-response-headers</ExposedHeaders>
+                <AllowedHeaders>comma-separated-list-of-request-headers</AllowedHeaders>
             </CorsRule>
         </Cors>
         <DeleteRetentionPolicy>

--- a/src/support/azext_support/_params.py
+++ b/src/support/azext_support/_params.py
@@ -78,7 +78,7 @@ def load_tickets_argument(self, _):
         c.argument('contact_last_name', help='Last Name')
         c.argument('contact_method', arg_type=get_enum_type(['email', 'phone']), help='Preferred contact method')
         c.argument('contact_email', help='Primary email address')
-        c.argument('contact_additional_emails', nargs='+', help='Space seperated list of additional email addresses. ' +
+        c.argument('contact_additional_emails', nargs='+', help='Space-separated list of additional email addresses. ' +
                    'Additional email addresses will be copied on any correspondence about the support ticket.')
         c.argument('contact_phone_number', help='Phone number. This is required if preferred contact method is phone.')
         c.argument('contact_timezone', arg_type=timezone_type_for_update)
@@ -110,7 +110,7 @@ def load_tickets_argument(self, _):
         c.argument('contact_method', arg_type=get_enum_type(['email', 'phone']), help='Preferred contact method',
                    required=True)
         c.argument('contact_email', help='Primary email address', required=True)
-        c.argument('contact_additional_emails', nargs='+', help='Space seperated list of additional email addresses. ' +
+        c.argument('contact_additional_emails', nargs='+', help='Space-separated list of additional email addresses. ' +
                    'Additional email addresses will be copied on any correspondence about the support ticket.')
         c.argument('contact_phone_number', help='Phone number. This is required if preferred contact method is phone.')
         c.argument('contact_timezone', arg_type=timezone_type_for_create)
@@ -125,9 +125,9 @@ def load_tickets_argument(self, _):
         c.argument('quota_change_version', help='Quota change request version.')
         c.argument('quota_change_subtype', help='Required for certain quota types when there is a sub type that ' +
                    'you are requesting quota increase for. Example: Batch')
-        c.argument('quota_change_regions', nargs='+', help='Space seperated list of region for which ' +
+        c.argument('quota_change_regions', nargs='+', help='Space-separated list of region for which ' +
                    'the quota increase request is being made.')
-        c.argument('quota_change_payload', nargs='+', help='Space seperated list of serialized payload of the ' +
+        c.argument('quota_change_payload', nargs='+', help='Space -separated list of serialized payload of the ' +
                    'quota increase request corresponding to regions. Visit ' +
                    'https://aka.ms/supportrpquotarequestpayload for details.')
 


### PR DESCRIPTION
Fixes a typo in "separated" in documentation. This typo is also exposed at places like https://docs.microsoft.com/en-us/cli/azure/monitor/app-insights/api-key?view=azure-cli-latest#az_monitor_app_insights_api_key_create-optional-parameters; I don't know if that ends up being generated from this, or goes through a completely separate documentation process.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required) - N/A
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? - N/A
