### PR TITLE
{CI} Update `vmImage` to `ubuntu-20.04`

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,7 +36,7 @@ jobs:
 - job: CheckLicenseHeader
   displayName: "Check License"
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-20.04'
   steps:
   - task: UsePythonVersion@0
     displayName: 'Use Python 3.6'
@@ -67,7 +67,7 @@ jobs:
 - job: StaticAnalysis
   displayName: "Static Analysis"
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-20.04'
   steps:
     - task: UsePythonVersion@0
       displayName: 'Use Python 3.6'
@@ -81,7 +81,7 @@ jobs:
 - job: IndexVerify
   displayName: "Verify Extensions Index"
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-20.04'
   steps:
   - task: UsePythonVersion@0
     displayName: 'Use Python 3.7'
@@ -98,7 +98,7 @@ jobs:
 - job: SourceTests
   displayName: "Integration Tests, Build Tests"
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-20.04'
   strategy:
     matrix:
       Python36:
@@ -122,7 +122,7 @@ jobs:
   displayName: "CLI Linter on Modified Extensions"
   condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-20.04'
   steps:
     - task: UsePythonVersion@0
       displayName: 'Use Python 3.6'
@@ -158,7 +158,7 @@ jobs:
 - job: IndexRefDocVerify
   displayName: "Verify Ref Docs"
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-20.04'
   steps:
   - task: UsePythonVersion@0
     displayName: 'Use Python 3.7'


### PR DESCRIPTION
ADO has dropped Ubuntu 16.04 image:

https://dev.azure.com/azure-sdk/public/_build/results?buildId=1148403&view=logs&j=ccdac6d3-465a-5ada-8819-d5b4a6b3a631

```
##[warning]An image label with the label ubuntu-16.04 does not exist.
```

Update to the latest 20.04.