### PR TITLE
Azure Quantum CLI: Add --user-agent param when submitting standalone executable

### DIFF
--- a/src/quantum/azext_quantum/operations/job.py
+++ b/src/quantum/azext_quantum/operations/job.py
@@ -126,6 +126,9 @@ def _generate_submit_args(program_args, ws, target, token, project, job_name, sh
     args.append("--location")
     args.append(ws.location)
 
+    args.append("--user-agent")
+    args.append("CLI")
+
     if job_params:
         args.append("--job-params")
         for k, v in job_params.items():


### PR DESCRIPTION
By appending the "CLI" to the UserAgent we can distinguish calls to the Azure Quantum APIs coming from different clients like IQ# and standalone executables and standalone executables submitted via CLI.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [X] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [X] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
