### PR TITLE
{CI} Install azure-cli from dev

### DIFF
--- a/scripts/ci/test_source.sh
+++ b/scripts/ci/test_source.sh
@@ -9,6 +9,9 @@ pip install -e azure-cli/src/azure-cli-core
 pip install -e azure-cli/src/azure-cli
 echo "Installed."
 
+pip list -v
+az --version
+
 python ./scripts/ci/test_source.py -v
 
 echo "OK. Completed tests."


### PR DESCRIPTION
The current pipeline installs `azure-cli` from edge build. However, when there is a hotfix, like `2.29.1`, it overrides edge build like `2.29.0.postxxx`.

Meanwhile `azure-cli-testsdk` is installed from `dev` branch. When public `azure-cli` and `dev` `azure-cli-testsdk` are not compatible, failures will occur: https://dev.azure.com/azure-sdk/public/_build/results?buildId=1155581&view=logs&j=9c80867e-ccda-50f1-65bc-e11447f3cda9&t=8e28b004-aba6-5a56-67c2-9d40a66e3ed9

```
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.6.15/x64/lib/python3.6/site-packages/azure_devtools/scenario_tests/base.py", line 146, in setUp
    patch(self)
  File "/opt/hostedtoolcache/Python/3.6.15/x64/lib/python3.6/site-packages/azure/cli/testsdk/patches.py", line 76, in patch_retrieve_token_for_user
    mock_in_unit_test(unit_test, 'azure.cli.core.auth.identity.UserCredential', UserCredentialMock)
  File "/opt/hostedtoolcache/Python/3.6.15/x64/lib/python3.6/site-packages/azure_devtools/scenario_tests/patches.py", line 36, in mock_in_unit_test
    mp.__enter__()
  File "/opt/hostedtoolcache/Python/3.6.15/x64/lib/python3.6/unittest/mock.py", line 1231, in __enter__
    self.target = self.getter()
  File "/opt/hostedtoolcache/Python/3.6.15/x64/lib/python3.6/unittest/mock.py", line 1401, in <lambda>
    getter = lambda: _importer(target)
  File "/opt/hostedtoolcache/Python/3.6.15/x64/lib/python3.6/unittest/mock.py", line 1088, in _importer
    thing = _dot_lookup(thing, comp, import_path)
  File "/opt/hostedtoolcache/Python/3.6.15/x64/lib/python3.6/unittest/mock.py", line 1077, in _dot_lookup
    __import__(import_path)
ModuleNotFoundError: No module named 'azure.cli.core.auth.identity'
```

The CI pipeline should install both `azure-cli` and `azure-cli-sdk` from `dev` branch.

Similar issue: https://github.com/Azure/azure-cli-extensions/pull/3950, but the root cause is different.

