### PR TITLE
{AKS} Reuse azure-keyvault-secrets-provider addon implementation from cli

### DIFF
--- a/src/aks-preview/azext_aks_preview/decorator.py
+++ b/src/aks-preview/azext_aks_preview/decorator.py
@@ -1032,9 +1032,6 @@ class AKSPreviewCreateDecorator(AKSCreateDecorator):
         :return: the ManagedCluster object
         """
         addon_consts = self.context.get_addon_consts()
-        CONST_AZURE_KEYVAULT_SECRETS_PROVIDER_ADDON_NAME = addon_consts.get(
-            "CONST_AZURE_KEYVAULT_SECRETS_PROVIDER_ADDON_NAME"
-        )
         CONST_GITOPS_ADDON_NAME = addon_consts.get("CONST_GITOPS_ADDON_NAME")
 
         mc = super().set_up_addon_profiles(mc)

--- a/src/aks-preview/azext_aks_preview/decorator.py
+++ b/src/aks-preview/azext_aks_preview/decorator.py
@@ -560,25 +560,12 @@ class AKSPreviewContext(AKSContext):
         """
         from azext_aks_preview._consts import (
             ADDONS,
-            CONST_AZURE_KEYVAULT_SECRETS_PROVIDER_ADDON_NAME,
-            CONST_ROTATION_POLL_INTERVAL,
-            CONST_SECRET_ROTATION_ENABLED,
             CONST_GITOPS_ADDON_NAME,
             CONST_MONITORING_USING_AAD_MSI_AUTH,
-            CONST_SECRET_ROTATION_ENABLED,
         )
 
         addon_consts = super().get_addon_consts()
         addon_consts["ADDONS"] = ADDONS
-        addon_consts[
-            "CONST_AZURE_KEYVAULT_SECRETS_PROVIDER_ADDON_NAME"
-        ] = CONST_AZURE_KEYVAULT_SECRETS_PROVIDER_ADDON_NAME
-        addon_consts[
-            "CONST_ROTATION_POLL_INTERVAL"
-        ] = CONST_ROTATION_POLL_INTERVAL
-        addon_consts[
-            "CONST_SECRET_ROTATION_ENABLED"
-        ] = CONST_SECRET_ROTATION_ENABLED
         addon_consts["CONST_GITOPS_ADDON_NAME"] = CONST_GITOPS_ADDON_NAME
         addon_consts[
             "CONST_MONITORING_USING_AAD_MSI_AUTH"
@@ -666,39 +653,6 @@ class AKSPreviewContext(AKSContext):
                 logger.warning("The set option '--no-wait' has been ignored")
                 no_wait = False
         return no_wait
-
-    def get_enable_secret_rotation(self) -> bool:
-        """Obtain the value of enable_secret_rotation.
-
-        :return: bool
-        """
-        # determine the value of constants
-        addon_consts = self.get_addon_consts()
-        CONST_AZURE_KEYVAULT_SECRETS_PROVIDER_ADDON_NAME = addon_consts.get(
-            "CONST_AZURE_KEYVAULT_SECRETS_PROVIDER_ADDON_NAME"
-        )
-        CONST_SECRET_ROTATION_ENABLED = addon_consts.get(
-            "CONST_SECRET_ROTATION_ENABLED"
-        )
-
-        # read the original value passed by the command
-        enable_secret_rotation = self.raw_param.get("enable_secret_rotation")
-        # try to read the property value corresponding to the parameter from the `mc` object
-        if (
-            self.mc and
-            self.mc.addon_profiles and
-            CONST_AZURE_KEYVAULT_SECRETS_PROVIDER_ADDON_NAME in self.mc.addon_profiles and
-            self.mc.addon_profiles.get(
-                CONST_AZURE_KEYVAULT_SECRETS_PROVIDER_ADDON_NAME
-            ).config.get(CONST_SECRET_ROTATION_ENABLED) is not None
-        ):
-            enable_secret_rotation = self.mc.addon_profiles.get(
-                CONST_AZURE_KEYVAULT_SECRETS_PROVIDER_ADDON_NAME
-            ).config.get(CONST_SECRET_ROTATION_ENABLED) == "true"
-
-        # this parameter does not need dynamic completion
-        # this parameter does not need validation
-        return enable_secret_rotation
 
     # pylint: disable=unused-argument,no-self-use
     def __validate_gmsa_options(
@@ -1060,24 +1014,6 @@ class AKSPreviewCreateDecorator(AKSCreateDecorator):
             ingress_appgw_addon_profile.config[CONST_INGRESS_APPGW_SUBNET_CIDR] = appgw_subnet_prefix
         return ingress_appgw_addon_profile
 
-    def build_azure_keyvault_secrets_provider_addon_profile(self) -> ManagedClusterAddonProfile:
-        """Build azure keyvault secrets provider addon profile.
-
-        :return: a ManagedClusterAddonProfile object
-        """
-        # determine the value of constants
-        addon_consts = self.context.get_addon_consts()
-        CONST_SECRET_ROTATION_ENABLED = addon_consts.get(
-            "CONST_SECRET_ROTATION_ENABLED"
-        )
-
-        azure_keyvault_secrets_provider_addon_profile = self.models.ManagedClusterAddonProfile(
-            enabled=True, config={CONST_SECRET_ROTATION_ENABLED: "false"}
-        )
-        if self.context.get_enable_secret_rotation():
-            azure_keyvault_secrets_provider_addon_profile.config[CONST_SECRET_ROTATION_ENABLED] = "true"
-        return azure_keyvault_secrets_provider_addon_profile
-
     def build_gitops_addon_profile(self) -> ManagedClusterAddonProfile:
         """Build gitops addon profile.
 
@@ -1104,10 +1040,6 @@ class AKSPreviewCreateDecorator(AKSCreateDecorator):
         mc = super().set_up_addon_profiles(mc)
         addon_profiles = mc.addon_profiles
         addons = self.context.get_enable_addons()
-        if "azure-keyvault-secrets-provider" in addons:
-            addon_profiles[
-                CONST_AZURE_KEYVAULT_SECRETS_PROVIDER_ADDON_NAME
-            ] = self.build_azure_keyvault_secrets_provider_addon_profile()
         if "gitops" in addons:
             addon_profiles[
                 CONST_GITOPS_ADDON_NAME

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_decorator.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_decorator.py
@@ -669,29 +669,6 @@ class AKSPreviewContextTestCase(unittest.TestCase):
         ctx_1.set_intermediate("monitoring", True, overwrite_exists=True)
         self.assertEqual(ctx_1.get_no_wait(), False)
 
-    def test_get_enable_secret_rotation(self):
-        # default
-        ctx_1 = AKSPreviewContext(
-            self.cmd,
-            {
-                "enable_secret_rotation": False,
-            },
-            self.models,
-            decorator_mode=DecoratorMode.CREATE,
-        )
-        self.assertEqual(ctx_1.get_enable_secret_rotation(), False)
-        addon_profiles_1 = {
-            CONST_AZURE_KEYVAULT_SECRETS_PROVIDER_ADDON_NAME: self.models.ManagedClusterAddonProfile(
-                enabled=True,
-                config={CONST_SECRET_ROTATION_ENABLED: "true"},
-            )
-        }
-        mc = self.models.ManagedCluster(
-            location="test_location", addon_profiles=addon_profiles_1
-        )
-        ctx_1.attach_mc(mc)
-        self.assertEqual(ctx_1.get_enable_secret_rotation(), True)
-
     def test_validate_gmsa_options(self):
         # default
         ctx = AKSPreviewContext(
@@ -1401,49 +1378,6 @@ class AKSPreviewCreateDecoratorTestCase(unittest.TestCase):
             dec_3.context.get_intermediate("ingress_appgw_addon_enabled"), True
         )
 
-    def test_build_azure_keyvault_secrets_provider_addon_profile(self):
-        # default
-        dec_1 = AKSPreviewCreateDecorator(
-            self.cmd,
-            self.client,
-            {"enable_secret_rotation": False},
-            CUSTOM_MGMT_AKS_PREVIEW,
-        )
-
-        azure_keyvault_secrets_provider_addon_profile = (
-            dec_1.build_azure_keyvault_secrets_provider_addon_profile()
-        )
-        ground_truth_azure_keyvault_secrets_provider_addon_profile = (
-            self.models.ManagedClusterAddonProfile(
-                enabled=True, config={CONST_SECRET_ROTATION_ENABLED: "false"}
-            )
-        )
-        self.assertEqual(
-            azure_keyvault_secrets_provider_addon_profile,
-            ground_truth_azure_keyvault_secrets_provider_addon_profile,
-        )
-
-        # custom value
-        dec_2 = AKSPreviewCreateDecorator(
-            self.cmd,
-            self.client,
-            {"enable_secret_rotation": True},
-            CUSTOM_MGMT_AKS_PREVIEW,
-        )
-
-        azure_keyvault_secrets_provider_addon_profile = (
-            dec_2.build_azure_keyvault_secrets_provider_addon_profile()
-        )
-        ground_truth_azure_keyvault_secrets_provider_addon_profile = (
-            self.models.ManagedClusterAddonProfile(
-                enabled=True, config={CONST_SECRET_ROTATION_ENABLED: "true"}
-            )
-        )
-        self.assertEqual(
-            azure_keyvault_secrets_provider_addon_profile,
-            ground_truth_azure_keyvault_secrets_provider_addon_profile,
-        )
-
     def test_build_gitops_addon_profile(self):
         # default
         dec_1 = AKSPreviewCreateDecorator(
@@ -1478,9 +1412,10 @@ class AKSPreviewCreateDecoratorTestCase(unittest.TestCase):
                 "appgw_subnet_id": None,
                 "appgw_watch_namespace": None,
                 "enable_sgxquotehelper": False,
+                "enable_secret_rotation": False,
+                "rotation_poll_interval": None,
                 "appgw_subnet_prefix": None,
                 "enable_msi_auth_for_monitoring": False,
-                "enable_secret_rotation": False,
             },
             CUSTOM_MGMT_AKS_PREVIEW,
         )
@@ -1511,7 +1446,7 @@ class AKSPreviewCreateDecoratorTestCase(unittest.TestCase):
                 "resource_group_name": "test_rg_name",
                 "location": "test_location",
                 "vnet_subnet_id": "test_vnet_subnet_id",
-                "enable_addons": "monitoring,ingress-appgw,gitops,azure-keyvault-secrets-provider",
+                "enable_addons": "monitoring,ingress-appgw,gitops",
                 "workspace_resource_id": "test_workspace_resource_id",
                 "enable_msi_auth_for_monitoring": True,
                 "appgw_name": "test_appgw_name",
@@ -1519,7 +1454,6 @@ class AKSPreviewCreateDecoratorTestCase(unittest.TestCase):
                 "appgw_id": "test_appgw_id",
                 "appgw_subnet_id": "test_appgw_subnet_id",
                 "appgw_watch_namespace": "test_appgw_watch_namespace",
-                "enable_secret_rotation": True,
             },
             CUSTOM_MGMT_AKS_PREVIEW,
         )
@@ -1550,10 +1484,6 @@ class AKSPreviewCreateDecoratorTestCase(unittest.TestCase):
                     CONST_INGRESS_APPGW_SUBNET_CIDR: "test_appgw_subnet_prefix",
                     CONST_INGRESS_APPGW_WATCH_NAMESPACE: "test_appgw_watch_namespace",
                 },
-            ),
-            CONST_AZURE_KEYVAULT_SECRETS_PROVIDER_ADDON_NAME: self.models.ManagedClusterAddonProfile(
-                enabled=True,
-                config={CONST_SECRET_ROTATION_ENABLED: "true"},
             ),
             CONST_GITOPS_ADDON_NAME: self.models.ManagedClusterAddonProfile(
                 enabled=True,


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

Reuse azure-keyvault-secrets-provider addon implementation from cli.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
