### PR TITLE
aks: fix wrong behavior when applying default value for pod identity exception pod labels.

### DIFF
--- a/src/aks-preview/HISTORY.md
+++ b/src/aks-preview/HISTORY.md
@@ -2,6 +2,10 @@
 
 Release History
 ===============
+0.5.41
+++++++
+* Fix default value behavior for pod identity esception pod labels.
+
 0.5.40
 +++++
 * Add support for new snapshot commands

--- a/src/aks-preview/HISTORY.md
+++ b/src/aks-preview/HISTORY.md
@@ -4,7 +4,7 @@ Release History
 ===============
 0.5.41
 ++++++
-* Fix default value behavior for pod identity esception pod labels.
+* Fix default value behavior for pod identity exception pod labels.
 
 0.5.40
 +++++

--- a/src/aks-preview/setup.py
+++ b/src/aks-preview/setup.py
@@ -8,7 +8,7 @@
 from codecs import open as open1
 from setuptools import setup, find_packages
 
-VERSION = "0.5.40"
+VERSION = "0.5.41"
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',


### PR DESCRIPTION
In previous version, we accidentally allowed user to specify empty pod labels for pod identity exception, which will be converted to `None` in response. As a result, this behavior will break the exception when using 2021-09-01 model. This is because we marked the `podLabels` as required while updating it with `None` value.

To unblock customer, this pull request added support for backfilling the null `podLabels` before sending to the server side. In the meanwhile, AKS will apply change to fix the response value.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
