### PR TITLE
{AKS} Fix the getter for outbound_type in decorator pattern

### DIFF
--- a/src/aks-preview/azcli_aks_live_test/configs/ext_matrix_default.json
+++ b/src/aks-preview/azcli_aks_live_test/configs/ext_matrix_default.json
@@ -12,7 +12,6 @@
         "need additional feature": [
             "test_aks_create_with_azurekeyvaultsecretsprovider_addon",
             "test_aks_create_addon_with_azurekeyvaultsecretsprovider_with_secret_rotation",
-            "test_aks_update_azurekeyvaultsecretsprovider_with_secret_rotation",
             "test_aks_enable_addon_with_azurekeyvaultsecretsprovider",
             "test_aks_create_with_gitops_addon",
             "test_aks_enable_addon_with_gitops",

--- a/src/aks-preview/azext_aks_preview/decorator.py
+++ b/src/aks-preview/azext_aks_preview/decorator.py
@@ -23,6 +23,7 @@ from azure.cli.core import AzCommandsLoader
 from azure.cli.core.azclierror import (
     CLIInternalError,
     InvalidArgumentValueError,
+    MutuallyExclusiveArgumentError,
     RequiredArgumentMissingError,
 )
 from azure.cli.core.commands import AzCliCommand
@@ -32,6 +33,12 @@ from knack.log import get_logger
 from knack.prompting import prompt_y_n
 from msrestazure.azure_exceptions import CloudError
 
+from azext_aks_preview._consts import (
+    CONST_OUTBOUND_TYPE_LOAD_BALANCER,
+    CONST_OUTBOUND_TYPE_MANAGED_NAT_GATEWAY,
+    CONST_OUTBOUND_TYPE_USER_ASSIGNED_NAT_GATEWAY,
+    CONST_OUTBOUND_TYPE_USER_DEFINED_ROUTING,
+)
 from azext_aks_preview._natgateway import create_nat_gateway_profile
 from azext_aks_preview.addonconfiguration import (
     ensure_container_insights_for_monitoring,
@@ -663,6 +670,109 @@ class AKSPreviewContext(AKSContext):
                 logger.warning("The set option '--no-wait' has been ignored")
                 no_wait = False
         return no_wait
+
+    # pylint: disable=unused-argument
+    def _get_outbound_type(
+        self,
+        enable_validation: bool = False,
+        read_only: bool = False,
+        load_balancer_profile: ManagedClusterLoadBalancerProfile = None,
+        **kwargs
+    ) -> Union[str, None]:
+        """Internal function to dynamically obtain the value of outbound_type according to the context.
+
+        Note: Inherited and extended in aks-preview to add support for the newly added nat related constants.
+
+        Note: All the external parameters involved in the validation are not verified in their own getters.
+
+        When outbound_type is not assigned, dynamic completion will be triggerd. By default, the value is set to
+        CONST_OUTBOUND_TYPE_LOAD_BALANCER.
+
+        This function supports the option of enable_validation. When enabled, if the value of outbound_type is one of
+        CONST_OUTBOUND_TYPE_MANAGED_NAT_GATEWAY, CONST_OUTBOUND_TYPE_USER_ASSIGNED_NAT_GATEWAY or
+        CONST_OUTBOUND_TYPE_USER_DEFINED_ROUTING, the following checks will be performed. If load_balancer_sku is set
+        to basic, an InvalidArgumentValueError will be raised. If the value of outbound_type is not
+        CONST_OUTBOUND_TYPE_USER_DEFINED_ROUTING and vnet_subnet_id is not assigned, a RequiredArgumentMissingError
+        will be raised. If the value of outbound_type equals to CONST_OUTBOUND_TYPE_USER_DEFINED_ROUTING and
+        any of load_balancer_managed_outbound_ip_count, load_balancer_outbound_ips or load_balancer_outbound_ip_prefixes
+        is assigned, a MutuallyExclusiveArgumentError will be raised.
+        This function supports the option of read_only. When enabled, it will skip dynamic completion and validation.
+        This function supports the option of load_balancer_profile, if provided, when verifying loadbalancer-related
+        parameters, the value in load_balancer_profile will be used for validation.
+
+        :return: string or None
+        """
+        # read the original value passed by the command
+        outbound_type = self.raw_param.get("outbound_type")
+        # try to read the property value corresponding to the parameter from the `mc` object
+        read_from_mc = False
+        if (
+            self.mc and
+            self.mc.network_profile and
+            self.mc.network_profile.outbound_type is not None
+        ):
+            outbound_type = self.mc.network_profile.outbound_type
+            read_from_mc = True
+
+        # skip dynamic completion & validation if option read_only is specified
+        if read_only:
+            return outbound_type
+
+        # dynamic completion
+        if (
+            not read_from_mc and
+            outbound_type != CONST_OUTBOUND_TYPE_MANAGED_NAT_GATEWAY and
+            outbound_type != CONST_OUTBOUND_TYPE_USER_ASSIGNED_NAT_GATEWAY and
+            outbound_type != CONST_OUTBOUND_TYPE_USER_DEFINED_ROUTING
+        ):
+            outbound_type = CONST_OUTBOUND_TYPE_LOAD_BALANCER
+
+        # validation
+        # Note: The parameters involved in the validation are not verified in their own getters.
+        if enable_validation:
+            if outbound_type in [
+                CONST_OUTBOUND_TYPE_MANAGED_NAT_GATEWAY,
+                CONST_OUTBOUND_TYPE_USER_ASSIGNED_NAT_GATEWAY,
+                CONST_OUTBOUND_TYPE_USER_DEFINED_ROUTING,
+            ]:
+                # Should not enable read_only for get_load_balancer_sku, since its default value is None, and it has
+                # not been decorated into the mc object at this time, only the value after dynamic completion is
+                # meaningful here.
+                if safe_lower(self._get_load_balancer_sku(enable_validation=False)) == "basic":
+                    raise InvalidArgumentValueError("{} doesn't support basic load balancer sku".format(outbound_type))
+                if outbound_type == CONST_OUTBOUND_TYPE_USER_ASSIGNED_NAT_GATEWAY:
+                    if self.get_vnet_subnet_id() in ["", None]:
+                        raise RequiredArgumentMissingError(
+                            "--vnet-subnet-id must be specified for userAssignedNATGateway and it must "
+                            "be pre-associated with a NAT gateway with outbound public IPs or IP prefixes"
+                        )
+                if outbound_type == CONST_OUTBOUND_TYPE_USER_DEFINED_ROUTING:
+                    if self.get_vnet_subnet_id() in ["", None]:
+                        raise RequiredArgumentMissingError(
+                            "--vnet-subnet-id must be specified for userDefinedRouting and it must "
+                            "be pre-configured with a route table with egress rules"
+                        )
+                    if load_balancer_profile:
+                        if (
+                            load_balancer_profile.managed_outbound_i_ps or
+                            load_balancer_profile.outbound_i_ps or
+                            load_balancer_profile.outbound_ip_prefixes
+                        ):
+                            raise MutuallyExclusiveArgumentError(
+                                "userDefinedRouting doesn't support customizing "
+                                "a standard load balancer with IP addresses"
+                            )
+                    else:
+                        if (
+                            self.get_load_balancer_managed_outbound_ip_count() or
+                            self.get_load_balancer_outbound_ips() or
+                            self.get_load_balancer_outbound_ip_prefixes()
+                        ):
+                            raise MutuallyExclusiveArgumentError(
+                                "userDefinedRouting doesn't support customizing "
+                                "a standard load balancer with IP addresses"
+                            )
+        return outbound_type
 
     # pylint: disable=unused-argument,no-self-use
     def __validate_gmsa_options(

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_decorator.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_decorator.py
@@ -29,6 +29,9 @@ from azext_aks_preview._consts import (
     CONST_MONITORING_LOG_ANALYTICS_WORKSPACE_RESOURCE_ID,
     CONST_MONITORING_USING_AAD_MSI_AUTH,
     CONST_OPEN_SERVICE_MESH_ADDON_NAME,
+    CONST_OUTBOUND_TYPE_MANAGED_NAT_GATEWAY,
+    CONST_OUTBOUND_TYPE_USER_ASSIGNED_NAT_GATEWAY,
+    CONST_OUTBOUND_TYPE_USER_DEFINED_ROUTING,
     CONST_ROTATION_POLL_INTERVAL,
     CONST_SECRET_ROTATION_ENABLED,
     CONST_VIRTUAL_NODE_ADDON_NAME,
@@ -47,13 +50,10 @@ from azure.cli.command_modules.acs._consts import (
     DecoratorMode,
 )
 from azure.cli.core.azclierror import (
-    ArgumentUsageError,
     CLIInternalError,
     InvalidArgumentValueError,
     MutuallyExclusiveArgumentError,
-    NoTTYError,
     RequiredArgumentMissingError,
-    UnknownError,
 )
 from msrestazure.azure_exceptions import CloudError
 
@@ -1007,6 +1007,128 @@ class AKSPreviewContextTestCase(unittest.TestCase):
         ):
             self.assertEqual(ctx_3.get_node_vm_size(), "custom_node_vm_size")
 
+    def test_test_get_outbound_type(self):
+        # default
+        ctx_1 = AKSPreviewContext(
+            self.cmd,
+            {
+                "outbound_type": None,
+            },
+            self.models,
+            decorator_mode=DecoratorMode.CREATE,
+        )
+        self.assertEqual(ctx_1._get_outbound_type(read_only=True), None)
+        self.assertEqual(ctx_1.get_outbound_type(), "loadBalancer")
+        network_profile_1 = self.models.ContainerServiceNetworkProfile(
+            outbound_type="test_outbound_type"
+        )
+        mc = self.models.ManagedCluster(
+            location="test_location", network_profile=network_profile_1
+        )
+        ctx_1.attach_mc(mc)
+        self.assertEqual(ctx_1.get_outbound_type(), "test_outbound_type")
+
+        # invalid parameter
+        ctx_2 = AKSPreviewContext(
+            self.cmd,
+            {
+                "outbound_type": CONST_OUTBOUND_TYPE_MANAGED_NAT_GATEWAY,
+                "load_balancer_sku": "basic",
+            },
+            self.models,
+            decorator_mode=DecoratorMode.CREATE,
+        )
+        # fail on invalid load_balancer_sku (basic) when outbound_type is CONST_OUTBOUND_TYPE_MANAGED_NAT_GATEWAY
+        with self.assertRaises(InvalidArgumentValueError):
+            ctx_2.get_outbound_type()
+
+        # invalid parameter
+        ctx_3 = AKSPreviewContext(
+            self.cmd,
+            {
+                "outbound_type": CONST_OUTBOUND_TYPE_USER_ASSIGNED_NAT_GATEWAY,
+                "load_balancer_sku": "basic",
+            },
+            self.models,
+            decorator_mode=DecoratorMode.CREATE,
+        )
+        # fail on invalid load_balancer_sku (basic) when outbound_type is CONST_OUTBOUND_TYPE_USER_ASSIGNED_NAT_GATEWAY
+        with self.assertRaises(InvalidArgumentValueError):
+            ctx_3.get_outbound_type()
+
+        # invalid parameter
+        ctx_4 = AKSPreviewContext(
+            self.cmd,
+            {
+                "outbound_type": CONST_OUTBOUND_TYPE_USER_ASSIGNED_NAT_GATEWAY,
+                "vnet_subnet_id": None,
+            },
+            self.models,
+            decorator_mode=DecoratorMode.CREATE,
+        )
+        # fail on vnet_subnet_id not specified
+        with self.assertRaises(RequiredArgumentMissingError):
+            ctx_4.get_outbound_type()
+
+        # invalid parameter
+        ctx_5 = AKSPreviewContext(
+            self.cmd,
+            {
+                "outbound_type": CONST_OUTBOUND_TYPE_USER_DEFINED_ROUTING,
+                "vnet_subnet_id": None,
+            },
+            self.models,
+            decorator_mode=DecoratorMode.CREATE,
+        )
+        # fail on vnet_subnet_id not specified
+        with self.assertRaises(RequiredArgumentMissingError):
+            ctx_5.get_outbound_type()
+
+        # invalid parameter
+        ctx_6 = AKSPreviewContext(
+            self.cmd,
+            {
+                "outbound_type": CONST_OUTBOUND_TYPE_USER_DEFINED_ROUTING,
+                "vnet_subnet_id": "test_vnet_subnet_id",
+                "load_balancer_managed_outbound_ip_count": 10,
+            },
+            self.models,
+            decorator_mode=DecoratorMode.CREATE,
+        )
+        # fail on mutually exclusive outbound_type and managed_outbound_ip_count/outbound_ips/outbound_ip_prefixes of
+        # load balancer
+        with self.assertRaises(MutuallyExclusiveArgumentError):
+            ctx_6.get_outbound_type()
+
+        # invalid parameter
+        ctx_7 = AKSPreviewContext(
+            self.cmd,
+            {
+                "outbound_type": CONST_OUTBOUND_TYPE_USER_DEFINED_ROUTING,
+                "vnet_subnet_id": "test_vnet_subnet_id",
+            },
+            self.models,
+            decorator_mode=DecoratorMode.CREATE,
+        )
+        load_balancer_profile = self.models.lb_models.get(
+            "ManagedClusterLoadBalancerProfile"
+        )(
+            outbound_ip_prefixes=self.models.lb_models.get(
+                "ManagedClusterLoadBalancerProfileOutboundIPPrefixes"
+            )(
+                public_ip_prefixes=[
+                    self.models.lb_models.get("ResourceReference")(
+                        id="test_public_ip_prefix"
+                    )
+                ]
+            )
+        )
+        # fail on mutually exclusive outbound_type and managed_outbound_ip_count/outbound_ips/outbound_ip_prefixes of
+        # load balancer
+        with self.assertRaises(MutuallyExclusiveArgumentError):
+            ctx_7.get_outbound_type(
+                load_balancer_profile=load_balancer_profile,
+            )
 
 class AKSPreviewCreateDecoratorTestCase(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

* Fix the getter for outbound_type in decorator pattern.

Unit Test Coverage:

- "covered_lines": 474,
- "num_statements": 480,
- "percent_covered": 98.75,
- "missing_lines": 6,
- "excluded_lines": 0

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
