### PR TITLE
[Quantum] Do not display update message if version numbers are not available

### DIFF
--- a/src/quantum/azext_quantum/_version_check_helper.py
+++ b/src/quantum/azext_quantum/_version_check_helper.py
@@ -44,7 +44,7 @@ def check_version(config, reported_version, today):
         if latest_version_dict is not None:
             latest_version = latest_version_dict['version'].split(' ')[0]
 
-        if reported_version != latest_version:
+        if reported_version != latest_version and reported_version is not None and latest_version is not None:
             return (f"\nVersion {reported_version} of the quantum extension is installed locally,"
                     f" but version {latest_version} is now available.\n"
                     "You can use 'az extension update -n quantum' to upgrade.\n")

--- a/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
+++ b/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
@@ -104,11 +104,13 @@ class QuantumWorkspacesScenarioTest(ScenarioTest):
         test_config = None
 
         message = check_version(test_config, test_current_reported_version, test_old_date)
-        assert test_current_reported_version in message
+        assert message is None
+        # Note: list_versions("quantum") fails during these tests, so latest version number cannot be determined.
+        # No message is generated if either version number is unavailable. 
 
         message = check_version(test_config, test_old_reported_version, test_old_date)
-        assert test_old_reported_version in message
+        assert message is None
 
         message = check_version(test_config, test_none_version, test_today)
-        assert message is None  # Note: list_versions("quantum") fails during these tests
+        assert message is None
      


### PR DESCRIPTION
Added logic to suppress the update message if either version number is not available, and modified the unit tests accordingly. 

This bug fix primarily affects the presentation of the update message during testing, and as such will not change the user experience.  However, in the rare event of a transient connectivity glitch during version detection, this bug fix has the added benefit of preventing the user from ever seeing a spurious "None" in place of a valid version number in the message.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

