### PR TITLE
[Quantum] Left align histogram

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -5002,6 +5002,65 @@
         ],
         "arcdata": [
             {
+                "downloadUrl": "https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.1.2-py2.py3-none-any.whl",
+                "filename": "arcdata-1.1.2-py2.py3-none-any.whl",
+                "metadata": {
+                    "azext.isExperimental": false,
+                    "azext.minCliCoreVersion": "2.3.1",
+                    "classifiers": [
+                        "Development Status :: 1 - Beta",
+                        "Intended Audience :: Developers",
+                        "Programming Language :: Python",
+                        "Programming Language :: Python :: 3",
+                        "Programming Language :: Python :: 3.6",
+                        "Programming Language :: Python :: 3.7",
+                        "Programming Language :: Python :: 3.8",
+                        "License :: OSI Approved :: MIT License"
+                    ],
+                    "extensions": {
+                        "python.details": {
+                            "contacts": [
+                                {
+                                    "email": "dpgswdist@microsoft.com",
+                                    "name": "Microsoft Corporation",
+                                    "role": "author"
+                                }
+                            ],
+                            "document_names": {
+                                "description": "DESCRIPTION.rst"
+                            },
+                            "project_urls": {
+                                "Home": "https://docs.microsoft.com/en-us/azure/azure-arc/data/"
+                            }
+                        }
+                    },
+                    "extras": [],
+                    "generator": "bdist_wheel (0.30.0)",
+                    "license": "MIT",
+                    "license_file": "LICENSE",
+                    "metadata_version": "2.0",
+                    "name": "arcdata",
+                    "run_requires": [
+                        {
+                            "requires": [
+                                "colorama (==0.4.4)",
+                                "jinja2 (==2.10.3)",
+                                "jsonpatch (==1.24)",
+                                "jsonpath-ng (==1.4.3)",
+                                "jsonschema (==3.2.0)",
+                                "kubernetes (==12.0.1)",
+                                "ndjson (==0.3.1)",
+                                "pem (==21.2.0)",
+                                "pydash (==4.8.0)"
+                            ]
+                        }
+                    ],
+                    "summary": "Tools for managing ArcData.",
+                    "version": "1.1.2"
+                },
+                "sha256Digest": "ffcb38d3653195dc30ce93066b5aff3ff7037be81232db4afcb11ef99f3de844"
+            },
+            {
                 "downloadUrl": "https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.1.1-py2.py3-none-any.whl",
                 "filename": "arcdata-1.1.1-py2.py3-none-any.whl",
                 "metadata": {

--- a/src/quantum/azext_quantum/commands.py
+++ b/src/quantum/azext_quantum/commands.py
@@ -64,7 +64,7 @@ def transform_output(results):
         return OrderedDict([
             ('Result', key),
             ('Frequency', f"{value:10.8f}"),
-            ('', f"\u007C{barra:^20}\u007C")
+            ('', f"\u007C{barra:<20}\u007C")
         ])
 
     if 'Histogram' in results:

--- a/src/quantum/azext_quantum/tests/latest/test_quantum_jobs.py
+++ b/src/quantum/azext_quantum/tests/latest/test_quantum_jobs.py
@@ -93,14 +93,15 @@ class QuantumJobsScenarioTest(ScenarioTest):
 
     def test_transform_output(self):
         # Call with a good histogram
-        test_job_results = '{"Histogram":["[0,0,0]",0.125,"[1,0,0]",0.125,"[0,1,0]",0.125,"[1,1,0]",0.125,"[0,0,1]",0.125,"[1,0,1]",0.125,"[0,1,1]",0.125,"[1,1,1]",0.125]}'
-        table = transform_output(json.loads(test_job_results))   # Returns an array of OrderedDict. '' is the key for the histogram row.
+        test_job_results = '{"Histogram":["[0,0,0]",0.125,"[1,0,0]",0.125,"[0,1,0]",0.125,"[1,1,0]",0.125]}'
+        table = transform_output(json.loads(test_job_results))
         table_row = table[0]
         hist_row = table_row['']
         second_char = hist_row[1]
-        #self.assertEquals(second_char, " ")        # This would have worked before the bug fix 
-        self.assertEquals(second_char, "\u2588")    # This character is also hard-coded in commands.py 
+        self.assertEquals(second_char, "\u2588")    # Expecting a "Full Block" character here 
 
         # Give it a malformed histogram
-        #TODO 
+        test_job_results = '{"Histogram":["[0,0,0]",0.125,"[1,0,0]",0.125,"[0,1,0]",0.125,"[1,1,0]"]}'
+        table = transform_output(json.loads(test_job_results))
+        self.assertEquals(table, json.loads(test_job_results))    # No transform should be done if input param is bad
         


### PR DESCRIPTION
The left-align string-formatting option "<" was applied to histogram rows in the job-results console output.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?
