### PR TITLE
{testsdk} Migrate `azure-devtools` to `azure-cli-testsdk`

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -21,7 +21,7 @@ disable=
 
 [TYPECHECK]
 # For Azure CLI extensions, we ignore some import errors as they'll be available in the environment of the CLI
-ignored-modules=azure,azure.cli,azure.cli.core,azure.cli.core.commands,knack,msrestazure,argcomplete,azure_devtools,isodate,OpenSSL
+ignored-modules=azure,azure.cli,azure.cli.core,azure.cli.core.commands,knack,msrestazure,argcomplete,azure.cli.testsdk,isodate,OpenSSL
 
 [FORMAT]
 max-line-length=120

--- a/src/account/azext_account/tests/latest/test_account_scenario.py
+++ b/src/account/azext_account/tests/latest/test_account_scenario.py
@@ -7,7 +7,7 @@ import os
 import unittest
 import time
 
-from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 from azure.cli.testsdk import (ScenarioTest, ResourceGroupPreparer)
 
 

--- a/src/ad/azext_ad/tests/latest/preparers.py
+++ b/src/ad/azext_ad/tests/latest/preparers.py
@@ -10,7 +10,7 @@
 
 import os
 from datetime import datetime
-from azure_devtools.scenario_tests import SingleValueReplacer
+from azure.cli.testsdk.scenario_tests import SingleValueReplacer
 from azure.cli.testsdk.preparers import NoTrafficRecordingPreparer
 from azure.cli.testsdk.exceptions import CliTestError
 from azure.cli.testsdk.reverse_dependency import get_dummy_cli

--- a/src/aem/azext_aem/tests/latest/test_aem_commands.py
+++ b/src/aem/azext_aem/tests/latest/test_aem_commands.py
@@ -6,7 +6,7 @@
 from azure.cli.testsdk import (ScenarioTest, ResourceGroupPreparer)
 from azure.cli.core.util import CLIError
 from azext_aem.custom import EnhancedMonitoring  # pylint: disable=unused-import
-from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 import os
 import sys
 # pylint: disable=unused-argument,too-few-public-methods

--- a/src/ai-examples/azext_ai_examples/tests/latest/test_ai_examples_scenario.py
+++ b/src/ai-examples/azext_ai_examples/tests/latest/test_ai_examples_scenario.py
@@ -9,7 +9,7 @@ import unittest
 from unittest import mock
 import requests
 
-from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 from azure.cli.testsdk import (ScenarioTest, ResourceGroupPreparer)
 from azext_ai_examples.custom import (call_aladdin_service, ping_aladdin_service,
                                       clean_from_http_answer, get_generated_examples)

--- a/src/aks-preview/azext_aks_preview/tests/latest/recording_processors.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/recording_processors.py
@@ -3,8 +3,8 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from azure_devtools.scenario_tests import RecordingProcessor
-from azure_devtools.scenario_tests.utilities import is_text_payload
+from azure.cli.testsdk.scenario_tests import RecordingProcessor
+from azure.cli.testsdk.scenario_tests.utilities import is_text_payload
 
 MOCK_GUID = '00000000-0000-0000-0000-000000000001'
 MOCK_SECRET = 'fake-secret'

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -10,7 +10,7 @@ import tempfile
 from azure.cli.testsdk import (
     ResourceGroupPreparer, RoleBasedServicePrincipalPreparer, ScenarioTest, live_only)
 from azure.cli.command_modules.acs._format import version_to_tuple
-from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 from knack.util import CLIError
 
 from .recording_processors import KeyReplacer

--- a/src/alertsmanagement/azext_alertsmanagement/tests/latest/test_alertsmanagement_scenario.py
+++ b/src/alertsmanagement/azext_alertsmanagement/tests/latest/test_alertsmanagement_scenario.py
@@ -6,7 +6,7 @@
 import os
 import unittest
 
-from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 from azure.cli.testsdk import (ScenarioTest, ResourceGroupPreparer)
 
 

--- a/src/application-insights/azext_applicationinsights/tests/latest/recording_processors.py
+++ b/src/application-insights/azext_applicationinsights/tests/latest/recording_processors.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from azure_devtools.scenario_tests import RecordingProcessor
+from azure.cli.testsdk.scenario_tests import RecordingProcessor
 
 
 def _py3_byte_to_str(byte_or_str):

--- a/src/application-insights/azext_applicationinsights/tests/latest/test_applicationinsights_mgmt.py
+++ b/src/application-insights/azext_applicationinsights/tests/latest/test_applicationinsights_mgmt.py
@@ -6,7 +6,7 @@
 # pylint: disable=line-too-long
 from azure.cli.testsdk import ResourceGroupPreparer, ScenarioTest, StorageAccountPreparer
 from .recording_processors import StorageAccountSASReplacer
-from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 
 
 class ApplicationInsightsManagementClientTests(ScenarioTest):

--- a/src/appservice-kube/azext_appservice_kube/tests/latest/test_appservice_kube_scenario.py
+++ b/src/appservice-kube/azext_appservice_kube/tests/latest/test_appservice_kube_scenario.py
@@ -7,7 +7,7 @@ import os
 import unittest
 import base64
 
-from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 from azure.cli.testsdk import (ScenarioTest, ResourceGroupPreparer, RoleBasedServicePrincipalPreparer, live_only)
 
 TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))

--- a/src/attestation/azext_attestation/tests/latest/preparers.py
+++ b/src/attestation/azext_attestation/tests/latest/preparers.py
@@ -10,7 +10,7 @@
 
 import os
 from datetime import datetime
-from azure_devtools.scenario_tests import SingleValueReplacer
+from azure.cli.testsdk.scenario_tests import SingleValueReplacer
 from azure.cli.testsdk.preparers import NoTrafficRecordingPreparer
 from azure.cli.testsdk.exceptions import CliTestError
 from azure.cli.testsdk.reverse_dependency import get_dummy_cli

--- a/src/authV2/azext_authV2/tests/latest/test_authV2_scenario.py
+++ b/src/authV2/azext_authV2/tests/latest/test_authV2_scenario.py
@@ -6,7 +6,7 @@
 import os
 import unittest
 
-from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 from azure.cli.testsdk import (ScenarioTest, ResourceGroupPreparer, JMESPathCheck)
 
 TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))

--- a/src/blockchain/azext_blockchain/tests/latest/preparers.py
+++ b/src/blockchain/azext_blockchain/tests/latest/preparers.py
@@ -10,7 +10,7 @@
 
 import os
 from datetime import datetime
-from azure_devtools.scenario_tests import SingleValueReplacer
+from azure.cli.testsdk.scenario_tests import SingleValueReplacer
 
 from azure.cli.testsdk.preparers import NoTrafficRecordingPreparer
 from azure.cli.testsdk.exceptions import CliTestError

--- a/src/blockchain/azext_blockchain/tests/latest/test_blockchain_scenario.py
+++ b/src/blockchain/azext_blockchain/tests/latest/test_blockchain_scenario.py
@@ -11,7 +11,7 @@
 import os
 import unittest
 
-from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 from azure.cli.testsdk import ScenarioTest
 from .. import try_manual
 from azure.cli.testsdk import ResourceGroupPreparer

--- a/src/blueprint/azext_blueprint/tests/latest/test_blueprint_scenario.py
+++ b/src/blueprint/azext_blueprint/tests/latest/test_blueprint_scenario.py
@@ -10,7 +10,7 @@ import filecmp
 from pathlib import Path
 import shutil
 
-from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 from azure.cli.testsdk import (ScenarioTest, ResourceGroupPreparer,
                                JMESPathCheck, JMESPathCheckExists,
                                NoneCheck)

--- a/src/codespaces/azext_codespaces/tests/latest/test_codespaces_scenario.py
+++ b/src/codespaces/azext_codespaces/tests/latest/test_codespaces_scenario.py
@@ -6,7 +6,7 @@
 import os
 import unittest
 
-from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 from azure.cli.testsdk import (ScenarioTest, ResourceGroupPreparer, live_only)
 
 

--- a/src/confluent/azext_confluent/tests/latest/test_confluent_scenario.py
+++ b/src/confluent/azext_confluent/tests/latest/test_confluent_scenario.py
@@ -20,7 +20,7 @@ from .example_steps import step_organization_list
 from .example_steps import step_organization_list2
 from .example_steps import step_organization_update
 from .example_steps import step_organization_delete
-from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 from .. import (
     try_manual,
     raise_if,

--- a/src/confluent/azext_confluent/tests/latest/test_confluent_term_accept_flow.py
+++ b/src/confluent/azext_confluent/tests/latest/test_confluent_term_accept_flow.py
@@ -12,7 +12,7 @@ from unittest import mock
 import time
 
 from azure.cli.testsdk import ScenarioTest, ResourceGroupPreparer
-from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 
 from .test_confluent_scenario import mock_jwt_decode, mock_list_role_assignments
 

--- a/src/connectedk8s/azext_connectedk8s/tests/latest/test_connectedk8s_scenario.py
+++ b/src/connectedk8s/azext_connectedk8s/tests/latest/test_connectedk8s_scenario.py
@@ -7,7 +7,7 @@ import os
 import unittest
 
 from azure.cli.testsdk import (LiveScenarioTest, ResourceGroupPreparer)  # pylint: disable=import-error
-from azure_devtools.scenario_tests import AllowLargeResponse  # pylint: disable=import-error
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse  # pylint: disable=import-error
 
 
 TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))

--- a/src/connectedvmware/azext_connectedvmware/tests/latest/test_connectedvmware_scenario.py
+++ b/src/connectedvmware/azext_connectedvmware/tests/latest/test_connectedvmware_scenario.py
@@ -6,7 +6,7 @@
 import os
 import unittest
 
-from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 from azure.cli.testsdk import ScenarioTest, ResourceGroupPreparer
 from knack.util import CLIError
 from azure.cli.testsdk import ScenarioTest

--- a/src/connection-monitor-preview/azext_connection_monitor_preview/tests/latest/test_connection_monitor_preview.py
+++ b/src/connection-monitor-preview/azext_connection_monitor_preview/tests/latest/test_connection_monitor_preview.py
@@ -5,7 +5,7 @@
 
 from knack.util import CLIError
 
-from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 from azure.cli.testsdk import (ScenarioTest, ResourceGroupPreparer)
 
 

--- a/src/cosmosdb-preview/azext_cosmosdb_preview/tests/latest/test_cosmosdb-cassandrami_scenario.py
+++ b/src/cosmosdb-preview/azext_cosmosdb_preview/tests/latest/test_cosmosdb-cassandrami_scenario.py
@@ -7,7 +7,7 @@ import os
 from unittest import mock
 
 from azure.cli.testsdk import (ScenarioTest, ResourceGroupPreparer)
-from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 
 
 TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))

--- a/src/costmanagement/azext_costmanagement/tests/latest/preparers.py
+++ b/src/costmanagement/azext_costmanagement/tests/latest/preparers.py
@@ -11,7 +11,7 @@
 import os
 from datetime import datetime
 from azure.cli.testsdk.preparers import NoTrafficRecordingPreparer
-from azure_devtools.scenario_tests import SingleValueReplacer
+from azure.cli.testsdk.scenario_tests import SingleValueReplacer
 from azure.cli.testsdk.exceptions import CliTestError
 from azure.cli.testsdk.reverse_dependency import get_dummy_cli
 

--- a/src/costmanagement/azext_costmanagement/tests/latest/test_costmanagement_scenario.py
+++ b/src/costmanagement/azext_costmanagement/tests/latest/test_costmanagement_scenario.py
@@ -11,7 +11,7 @@
 # import os
 # import unittest
 
-# from azure_devtools.scenario_tests import AllowLargeResponse
+# from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 # from azure.cli.testsdk import ScenarioTest
 # from .. import try_manual
 # from azure.cli.testsdk import ResourceGroupPreparer

--- a/src/databricks/azext_databricks/tests/latest/test_databricks_scenario.py
+++ b/src/databricks/azext_databricks/tests/latest/test_databricks_scenario.py
@@ -7,7 +7,7 @@ import os
 import time
 import unittest
 
-from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 from azure.cli.testsdk import (ScenarioTest, ResourceGroupPreparer, KeyVaultPreparer)
 from msrestazure.tools import resource_id
 

--- a/src/datadog/azext_datadog/tests/latest/test_datadog_scenario.py
+++ b/src/datadog/azext_datadog/tests/latest/test_datadog_scenario.py
@@ -12,7 +12,7 @@ import os
 from unittest import mock
 from azure.cli.testsdk import ScenarioTest
 from azure.cli.testsdk import ResourceGroupPreparer
-from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 from .. import try_manual, raise_if, calc_coverage
 
 

--- a/src/datashare/azext_datashare/tests/latest/test_datashare_scenario.py
+++ b/src/datashare/azext_datashare/tests/latest/test_datashare_scenario.py
@@ -6,7 +6,7 @@
 import os
 import unittest
 
-from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 from azure.cli.testsdk import (ScenarioTest, ResourceGroupPreparer, StorageAccountPreparer)
 
 TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))

--- a/src/diskpool/azext_diskpool/tests/latest/preparers.py
+++ b/src/diskpool/azext_diskpool/tests/latest/preparers.py
@@ -8,7 +8,7 @@
 # regenerated.
 # --------------------------------------------------------------------------
 
-from azure_devtools.scenario_tests import SingleValueReplacer
+from azure.cli.testsdk.scenario_tests import SingleValueReplacer
 from azure.cli.testsdk.preparers import NoTrafficRecordingPreparer
 from azure.cli.testsdk.reverse_dependency import get_dummy_cli
 

--- a/src/dnc/azext_dnc/manual/tests/latest/preparers.py
+++ b/src/dnc/azext_dnc/manual/tests/latest/preparers.py
@@ -10,7 +10,7 @@
 
 import os
 from datetime import datetime
-from azure_devtools.scenario_tests import SingleValueReplacer
+from azure.cli.testsdk.scenario_tests import SingleValueReplacer
 from azure.cli.testsdk.preparers import NoTrafficRecordingPreparer
 from azure.cli.testsdk.exceptions import CliTestError
 from azure.cli.testsdk.reverse_dependency import get_dummy_cli

--- a/src/dnc/azext_dnc/tests/latest/preparers.py
+++ b/src/dnc/azext_dnc/tests/latest/preparers.py
@@ -10,7 +10,7 @@
 
 import os
 from datetime import datetime
-from azure_devtools.scenario_tests import SingleValueReplacer
+from azure.cli.testsdk.scenario_tests import SingleValueReplacer
 from azure.cli.testsdk.preparers import NoTrafficRecordingPreparer
 from azure.cli.testsdk.exceptions import CliTestError
 from azure.cli.testsdk.reverse_dependency import get_dummy_cli

--- a/src/hardware-security-modules/azext_hardware_security_modules/tests/latest/test_hardwaresecuritymodules_scenario.py
+++ b/src/hardware-security-modules/azext_hardware_security_modules/tests/latest/test_hardwaresecuritymodules_scenario.py
@@ -11,7 +11,7 @@
 import os
 import unittest
 
-from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 from azure.cli.testsdk import ScenarioTest
 from .. import try_manual
 from azure.cli.testsdk import ResourceGroupPreparer

--- a/src/healthcareapis/azext_healthcareapis/tests/latest/preparers.py
+++ b/src/healthcareapis/azext_healthcareapis/tests/latest/preparers.py
@@ -13,7 +13,7 @@ from datetime import datetime
 from azure.cli.testsdk.exceptions import CliTestError
 from azure.cli.testsdk.preparers import NoTrafficRecordingPreparer
 from azure.cli.testsdk.reverse_dependency import get_dummy_cli
-from azure_devtools.scenario_tests import SingleValueReplacer
+from azure.cli.testsdk.scenario_tests import SingleValueReplacer
 
 
 KEY_RESOURCE_GROUP = 'rg'

--- a/src/hpc-cache/azext_hpc_cache/tests/latest/test_hpc_cache_scenario.py
+++ b/src/hpc-cache/azext_hpc_cache/tests/latest/test_hpc_cache_scenario.py
@@ -6,7 +6,7 @@
 import os
 from unittest import mock
 
-from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 from azure.cli.testsdk import ScenarioTest, ResourceGroupPreparer, StorageAccountPreparer
 
 

--- a/src/internet-analyzer/azext_internet_analyzer/tests/latest/test_internet-analyzer_scenario.py
+++ b/src/internet-analyzer/azext_internet_analyzer/tests/latest/test_internet-analyzer_scenario.py
@@ -6,7 +6,7 @@
 import os
 import unittest
 
-from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 from azure.cli.testsdk import (ScenarioTest, ResourceGroupPreparer)
 
 

--- a/src/ip-group/azext_ip_group/tests/latest/test_ip_group_scenario.py
+++ b/src/ip-group/azext_ip_group/tests/latest/test_ip_group_scenario.py
@@ -6,7 +6,7 @@
 import os
 import unittest
 
-from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 from azure.cli.testsdk import (ScenarioTest, ResourceGroupPreparer)
 
 

--- a/src/kusto/azext_kusto/manual/tests/latest/test_kusto_scenario.py
+++ b/src/kusto/azext_kusto/manual/tests/latest/test_kusto_scenario.py
@@ -12,7 +12,7 @@ import os
 from azure.cli.testsdk import ScenarioTest
 from azure.cli.testsdk import ResourceGroupPreparer
 from azure.cli.testsdk import StorageAccountPreparer
-from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 from .. import (
     try_manual,
     raise_if,

--- a/src/kusto/azext_kusto/tests/latest/test_kusto_scenario.py
+++ b/src/kusto/azext_kusto/tests/latest/test_kusto_scenario.py
@@ -12,7 +12,7 @@ import os
 from azure.cli.testsdk import ScenarioTest
 from azure.cli.testsdk import ResourceGroupPreparer
 from azure.cli.testsdk import StorageAccountPreparer
-from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 from .. import (
     try_manual,
     raise_if,

--- a/src/log-analytics-solution/azext_log_analytics_solution/tests/latest/test_log_analytics_solution_scenario.py
+++ b/src/log-analytics-solution/azext_log_analytics_solution/tests/latest/test_log_analytics_solution_scenario.py
@@ -6,7 +6,7 @@
 import os
 import unittest
 
-from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 from azure.cli.testsdk import (ScenarioTest, ResourceGroupPreparer)
 from knack.util import CLIError
 

--- a/src/logic/azext_logic/tests/latest/test_logic_scenario.py
+++ b/src/logic/azext_logic/tests/latest/test_logic_scenario.py
@@ -7,7 +7,7 @@ import os
 import unittest
 
 from azure.cli.testsdk import JMESPathCheck
-from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 from azure.cli.testsdk import ScenarioTest
 from azure.cli.testsdk import ResourceGroupPreparer
 

--- a/src/logz/azext_logz/tests/latest/test_logz_commands.py
+++ b/src/logz/azext_logz/tests/latest/test_logz_commands.py
@@ -9,11 +9,11 @@ from azure.cli.testsdk import (
     ResourceGroupPreparer,
     ScenarioTest
 )
-from azure_devtools.scenario_tests import (
+from azure.cli.testsdk.scenario_tests import (
     RecordingProcessor,
     live_only
 )
-from azure_devtools.scenario_tests.utilities import is_text_payload
+from azure.cli.testsdk.scenario_tests.utilities import is_text_payload
 
 
 class CredentialReplacer(RecordingProcessor):

--- a/src/mixed-reality/azext_mixed_reality/tests/latest/recording_processors.py
+++ b/src/mixed-reality/azext_mixed_reality/tests/latest/recording_processors.py
@@ -3,8 +3,8 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from azure_devtools.scenario_tests import RecordingProcessor
-from azure_devtools.scenario_tests.utilities import is_text_payload
+from azure.cli.testsdk.scenario_tests import RecordingProcessor
+from azure.cli.testsdk.scenario_tests.utilities import is_text_payload
 
 MOCK_KEY = 'mock_key'
 

--- a/src/network-manager/azext_network_manager/tests/latest/preparers.py
+++ b/src/network-manager/azext_network_manager/tests/latest/preparers.py
@@ -10,7 +10,7 @@
 
 import os
 from datetime import datetime
-from azure_devtools.scenario_tests import SingleValueReplacer
+from azure.cli.testsdk.scenario_tests import SingleValueReplacer
 from azure.cli.testsdk.preparers import NoTrafficRecordingPreparer
 from azure.cli.testsdk.exceptions import CliTestError
 from azure.cli.testsdk.reverse_dependency import get_dummy_cli

--- a/src/notification-hub/azext_notification_hub/tests/latest/test_notificationhubs_scenario.py
+++ b/src/notification-hub/azext_notification_hub/tests/latest/test_notificationhubs_scenario.py
@@ -7,7 +7,7 @@ import os
 import unittest
 import time
 
-from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 from azure.cli.testsdk import (ScenarioTest, ResourceGroupPreparer, JMESPathCheck, JMESPathCheckExists)
 
 

--- a/src/peering/azext_peering/tests/latest/preparers.py
+++ b/src/peering/azext_peering/tests/latest/preparers.py
@@ -12,7 +12,7 @@
 
 import os
 from datetime import datetime
-from azure_devtools.scenario_tests import SingleValueReplacer
+from azure.cli.testsdk.scenario_tests import SingleValueReplacer
 from azure.cli.testsdk.preparers import NoTrafficRecordingPreparer
 from azure.cli.testsdk.exceptions import CliTestError
 from azure.cli.testsdk.reverse_dependency import get_dummy_cli

--- a/src/peering/azext_peering/tests/latest/test_peering_scenario.py
+++ b/src/peering/azext_peering/tests/latest/test_peering_scenario.py
@@ -11,7 +11,7 @@
 # import os
 # import unittest
 #
-# from azure_devtools.scenario_tests import AllowLargeResponse
+# from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 # from azure.cli.testsdk import ScenarioTest
 # from .. import try_manual
 # from azure.cli.testsdk import ResourceGroupPreparer

--- a/src/portal/azext_portal/tests/latest/preparers.py
+++ b/src/portal/azext_portal/tests/latest/preparers.py
@@ -6,7 +6,7 @@
 import os
 from datetime import datetime
 from azure.cli.testsdk.preparers import NoTrafficRecordingPreparer
-from azure_devtools.scenario_tests import SingleValueReplacer
+from azure.cli.testsdk.scenario_tests import SingleValueReplacer
 from azure.cli.testsdk.exceptions import CliTestError
 from azure.cli.testsdk.reverse_dependency import get_dummy_cli
 

--- a/src/portal/azext_portal/tests/latest/test_portal_scenario.py
+++ b/src/portal/azext_portal/tests/latest/test_portal_scenario.py
@@ -6,7 +6,7 @@
 import os
 import unittest
 
-from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 from azure.cli.testsdk import JMESPathCheck
 from azure.cli.testsdk import JMESPathCheckExists
 from azure.cli.testsdk import NoneCheck

--- a/src/providerhub/azext_providerhub/tests/latest/example_steps.py
+++ b/src/providerhub/azext_providerhub/tests/latest/example_steps.py
@@ -9,7 +9,7 @@
 # --------------------------------------------------------------------------
 
 from azure.cli.testsdk import (live_only)
-from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 from .. import try_manual
 
 

--- a/src/quantum/azext_quantum/tests/latest/test_quantum_jobs.py
+++ b/src/quantum/azext_quantum/tests/latest/test_quantum_jobs.py
@@ -7,7 +7,7 @@ import json
 import os
 import unittest
 
-from azure_devtools.scenario_tests import AllowLargeResponse, live_only
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse, live_only
 from azure.cli.testsdk import (ScenarioTest, ResourceGroupPreparer)
 
 from .utils import get_test_subscription_id, get_test_resource_group, get_test_workspace, get_test_workspace_location

--- a/src/quantum/azext_quantum/tests/latest/test_quantum_targets.py
+++ b/src/quantum/azext_quantum/tests/latest/test_quantum_targets.py
@@ -6,7 +6,7 @@
 import os
 import unittest
 
-from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 from azure.cli.testsdk import (ScenarioTest, ResourceGroupPreparer)
 
 from .utils import get_test_resource_group, get_test_workspace, get_test_workspace_location

--- a/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
+++ b/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
@@ -6,7 +6,7 @@
 import os
 import unittest
 
-from azure_devtools.scenario_tests import AllowLargeResponse, live_only
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse, live_only
 from azure.cli.testsdk import (ScenarioTest, ResourceGroupPreparer)
 from azure.cli.core.azclierror import RequiredArgumentMissingError, ResourceNotFoundError
 

--- a/src/rdbms-connect/azext_rdbms_connect/tests/latest/test_rdbms-connect_scenario.py
+++ b/src/rdbms-connect/azext_rdbms_connect/tests/latest/test_rdbms-connect_scenario.py
@@ -6,7 +6,7 @@
 import os
 import unittest
 
-from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 from azure.cli.testsdk import (
     JMESPathCheck,
     NoneCheck,

--- a/src/resource-graph/azext_resourcegraph/tests/latest/test_resourcegraph_commands.py
+++ b/src/resource-graph/azext_resourcegraph/tests/latest/test_resourcegraph_commands.py
@@ -5,7 +5,7 @@
 
 # pylint: disable=line-too-long
 from azure.cli.testsdk import ScenarioTest, ResourceGroupPreparer
-from azure_devtools.scenario_tests.const import MOCKED_SUBSCRIPTION_ID
+from azure.cli.testsdk.scenario_tests.const import MOCKED_SUBSCRIPTION_ID
 from knack.util import CLIError
 from six import string_types
 import json

--- a/src/resource-mover/azext_resource_mover/tests/latest/test_resourcemover_scenarios.py
+++ b/src/resource-mover/azext_resource_mover/tests/latest/test_resourcemover_scenarios.py
@@ -8,7 +8,7 @@ import json
 import time
 
 from azure.cli.testsdk import (ScenarioTest, ResourceGroupPreparer)
-from azure_devtools.scenario_tests import RecordingProcessor
+from azure.cli.testsdk.scenario_tests import RecordingProcessor
 
 
 class RoleAssignmentReplacer(RecordingProcessor):

--- a/src/securityinsight/azext_sentinel/tests/latest/test_sentinel_scenario.py
+++ b/src/securityinsight/azext_sentinel/tests/latest/test_sentinel_scenario.py
@@ -12,7 +12,7 @@ import os
 from azure.cli.testsdk import ScenarioTest
 from .. import try_manual, raise_if, calc_coverage
 from azure.cli.testsdk import ResourceGroupPreparer
-from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 
 
 TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))

--- a/src/serial-console/azext_serialconsole/tests/latest/test_serialconsole_scenario.py
+++ b/src/serial-console/azext_serialconsole/tests/latest/test_serialconsole_scenario.py
@@ -18,7 +18,7 @@ from azure.cli.core.azclierror import ForbiddenError, ResourceNotFoundError
 from azure.cli.core.azclierror import AzureConnectionError
 from azure.cli.core.azclierror import ForbiddenError
 from azure.core.exceptions import ResourceNotFoundError as ComputeClientResourceNotFoundError
-from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 
 TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))
 

--- a/src/service_name.json
+++ b/src/service_name.json
@@ -10,6 +10,11 @@
     "URL": "https://docs.microsoft.com/azure/container-registry/"
   },
   {
+    "Command": "az ad",
+    "AzureServiceName": "Azure Active Directory",
+    "URL": "https://docs.microsoft.com/en-us/azure/active-directory/"
+  },
+  {
     "Command": "az ai-examples",
     "AzureServiceName": "Microsoft AI",
     "URL": "https://docs.microsoft.com/archive/msdn-magazine/2017/connect/artificial-intelligence-getting-started-with-microsoft-ai"

--- a/src/spring-cloud/azext_spring_cloud/tests/latest/test_asc_scenario.py
+++ b/src/spring-cloud/azext_spring_cloud/tests/latest/test_asc_scenario.py
@@ -7,7 +7,7 @@ import os
 import unittest
 
 from knack.util import CLIError
-from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 from azure.cli.testsdk import (ScenarioTest, ResourceGroupPreparer, StorageAccountPreparer, record_only)
 
 # pylint: disable=line-too-long

--- a/src/stack-hci/azext_stack_hci/tests/latest/preparers.py
+++ b/src/stack-hci/azext_stack_hci/tests/latest/preparers.py
@@ -10,7 +10,7 @@
 
 import os
 from datetime import datetime
-from azure_devtools.scenario_tests import SingleValueReplacer
+from azure.cli.testsdk.scenario_tests import SingleValueReplacer
 from azure.cli.testsdk.preparers import NoTrafficRecordingPreparer
 from azure.cli.testsdk.exceptions import CliTestError
 from azure.cli.testsdk.reverse_dependency import get_dummy_cli

--- a/src/storage-blob-preview/azext_storage_blob_preview/tests/latest/test_storage_blob_scenarios.py
+++ b/src/storage-blob-preview/azext_storage_blob_preview/tests/latest/test_storage_blob_scenarios.py
@@ -11,7 +11,7 @@ from azure.cli.testsdk import (ScenarioTest, ResourceGroupPreparer, StorageAccou
                                JMESPathCheck, JMESPathCheckExists, NoneCheck, api_version_constraint)
 from knack.util import CLIError
 from azure.cli.core.profiles import ResourceType
-from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 
 from ..storage_test_util import StorageScenarioMixin
 

--- a/src/storage-preview/azext_storage_preview/tests/latest/test_storage_account_scenarios.py
+++ b/src/storage-preview/azext_storage_preview/tests/latest/test_storage_account_scenarios.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 from azure.cli.testsdk import (ScenarioTest, JMESPathCheck, ResourceGroupPreparer, StorageAccountPreparer,
                                api_version_constraint)
-from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 from .storage_test_util import StorageScenarioMixin
 from ...profiles import CUSTOM_MGMT_PREVIEW_STORAGE
 from knack.util import CLIError

--- a/src/stream-analytics/azext_stream_analytics/tests/latest/test_stream_analytics_commands.py
+++ b/src/stream-analytics/azext_stream_analytics/tests/latest/test_stream_analytics_commands.py
@@ -13,7 +13,7 @@ from azure.cli.testsdk import (
     ScenarioTest,
     StorageAccountPreparer
 )
-from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 
 
 class StreamAnalyticsClientTest(ScenarioTest):

--- a/src/support/azext_support/tests/latest/test_support_scenario.py
+++ b/src/support/azext_support/tests/latest/test_support_scenario.py
@@ -10,7 +10,7 @@ from datetime import date, timedelta
 
 from azure.cli.core.commands.client_factory import get_subscription_id
 from azure.cli.testsdk import ScenarioTest
-from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 
 
 class SupportScenarioTest(ScenarioTest):

--- a/src/virtual-wan/azext_vwan/tests/latest/credential_replacer.py
+++ b/src/virtual-wan/azext_vwan/tests/latest/credential_replacer.py
@@ -5,7 +5,7 @@
 
 import re
 
-from azure_devtools.scenario_tests import RecordingProcessor
+from azure.cli.testsdk.scenario_tests import RecordingProcessor
 
 
 class VpnClientGeneratedURLReplacer(RecordingProcessor):

--- a/src/webpubsub/azext_webpubsub/tests/latest/recording_processors.py
+++ b/src/webpubsub/azext_webpubsub/tests/latest/recording_processors.py
@@ -3,8 +3,8 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from azure_devtools.scenario_tests import RecordingProcessor
-from azure_devtools.scenario_tests.utilities import is_text_payload
+from azure.cli.testsdk.scenario_tests import RecordingProcessor
+from azure.cli.testsdk.scenario_tests.utilities import is_text_payload
 
 MOCK_KEY = 'mock_key'
 

--- a/src/webpubsub/azext_webpubsub/tests/latest/test_webpubsub_event_handler.py
+++ b/src/webpubsub/azext_webpubsub/tests/latest/test_webpubsub_event_handler.py
@@ -7,7 +7,7 @@
 import os
 import unittest
 
-from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 from azure.cli.testsdk import (ScenarioTest, ResourceGroupPreparer)
 from .recording_processors import KeyReplacer
 

--- a/src/webpubsub/azext_webpubsub/tests/latest/test_webpubsub_scenario.py
+++ b/src/webpubsub/azext_webpubsub/tests/latest/test_webpubsub_scenario.py
@@ -7,7 +7,7 @@
 import os
 import unittest
 
-from azure_devtools.scenario_tests import AllowLargeResponse
+from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 from azure.cli.testsdk import (ScenarioTest, ResourceGroupPreparer)
 from .recording_processors import KeyReplacer
 


### PR DESCRIPTION
Since  CLI recently migrated `azure-devtools` code to `azure-cli-testsdk` and drop the dependency of `azure-devtools`. Related PR: [#20601](https://github.com/Azure/azure-cli/pull/20601) Therefore, CLI extension also needs to be migrated.
Because too many modules are involved, in order to fix the issue as soon as possible to avoid blocking CI, so I modified them uniformly

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [x] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
