### PR TITLE
Also allow --hostname in az ssh config

### DIFF
--- a/src/ssh/azext_ssh/_params.py
+++ b/src/ssh/azext_ssh/_params.py
@@ -24,7 +24,7 @@ def load_arguments(self, _):
     with self.argument_context('ssh config') as c:
         c.argument('config_path', options_list=['--file', '-f'], help='The file path to write the SSH config to')
         c.argument('vm_name', options_list=['--vm-name', '--name', '-n'], help='The name of the VM')
-        c.argument('ssh_ip', options_list=['--ip'], help='The public IP address (or hostname) of the VM')
+        c.argument('ssh_ip', options_list=['--ip', '--hostname'], help='The public IP address (or hostname) of the VM')
         c.argument('public_key_file', options_list=['--public-key-file', '-p'], help='The RSA public key file path')
         c.argument('private_key_file', options_list=['--private-key-file', '-i'], help='The RSA private key file path')
         c.argument('use_private_ip', options_list=['--prefer-private-ip'],


### PR DESCRIPTION
Similarly to `az ssh vm`, `az ssh config` should also accept using the `--hostname` form of the argument as well as `--ip`. See: https://github.com/Azure/azure-cli-extensions/blob/5f4873831fb690b30a266fb36e7f9e153da585bf/src/ssh/azext_ssh/_params.py#L11-L12

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
