### PR TITLE
fix(spring-cloud): 🐛 App update warns when  active deployment not found

### DIFF
--- a/src/spring-cloud/azext_spring_cloud/_deployment_factory.py
+++ b/src/spring-cloud/azext_spring_cloud/_deployment_factory.py
@@ -50,7 +50,7 @@ class DefaultDeployment:
             memory=memory
         )
 
-    def _get_env(self, env, **_):
+    def _get_env(self, env=None, **_):
         return env
 
     def format_source(self, **kwargs):

--- a/src/spring-cloud/azext_spring_cloud/_utils.py
+++ b/src/spring-cloud/azext_spring_cloud/_utils.py
@@ -252,6 +252,14 @@ def get_spring_cloud_sku(client, resource_group, name):
     return client.services.get(resource_group, name).sku
 
 
+def convert_argument_to_parameter_list(args):
+    return ', '.join([convert_argument_to_parameter(x) for x in args])
+
+
+def convert_argument_to_parameter(arg):
+    return '--{}'.format(arg.replace('_', '-'))
+
+
 def wait_till_end(cmd, *pollers):
     if not pollers:
         return

--- a/src/spring-cloud/azext_spring_cloud/app.py
+++ b/src/spring-cloud/azext_spring_cloud/app.py
@@ -176,7 +176,7 @@ def app_update(cmd, client, resource_group, service, name,
         updated_deployment_kwargs = {k: v for k, v in deployment_kwargs.items() if v}
         if updated_deployment_kwargs:
             raise ArgumentUsageError('{} cannot be set when there is no active deployment.'
-                                      .format(convert_argument_to_parameter_list(updated_deployment_kwargs.keys())))
+                                     .format(convert_argument_to_parameter_list(updated_deployment_kwargs.keys())))
 
     deployment_factory = deployment_selector(**deployment_kwargs, **basic_kwargs)
     app_factory = app_selector(**basic_kwargs)

--- a/src/spring-cloud/azext_spring_cloud/app.py
+++ b/src/spring-cloud/azext_spring_cloud/app.py
@@ -176,7 +176,7 @@ def app_update(cmd, client, resource_group, service, name,
         updated_deployment_kwargs = {k: v for k, v in deployment_kwargs.items() if v}
         if updated_deployment_kwargs:
             raise InvalidArgumentValueError('{} cannot be set when there is no active deployment.'
-                                             .format(convert_argument_to_parameter_list(updated_deployment_kwargs.keys())))
+                                            .format(convert_argument_to_parameter_list(updated_deployment_kwargs.keys())))
 
     deployment_factory = deployment_selector(**deployment_kwargs, **basic_kwargs)
     app_factory = app_selector(**basic_kwargs)

--- a/src/spring-cloud/azext_spring_cloud/app.py
+++ b/src/spring-cloud/azext_spring_cloud/app.py
@@ -6,7 +6,7 @@
 # pylint: disable=wrong-import-order
 from knack.log import get_logger
 from azure.cli.core.util import sdk_no_wait
-from azure.cli.core.azclierror import (ValidationError, InvalidArgumentValueError)
+from azure.cli.core.azclierror import (ValidationError, ArgumentUsageError)
 from .custom import app_get
 from ._utils import (get_spring_cloud_sku, wait_till_end, convert_argument_to_parameter_list)
 from ._deployment_factory import (deployment_selector,
@@ -175,8 +175,8 @@ def app_update(cmd, client, resource_group, service, name,
     if deployment is None:
         updated_deployment_kwargs = {k: v for k, v in deployment_kwargs.items() if v}
         if updated_deployment_kwargs:
-            raise InvalidArgumentValueError('{} cannot be set when there is no active deployment.'
-                                            .format(convert_argument_to_parameter_list(updated_deployment_kwargs.keys())))
+            raise ArgumentUsageError ('{} cannot be set when there is no active deployment.'
+                                      .format(convert_argument_to_parameter_list(updated_deployment_kwargs.keys())))
 
     deployment_factory = deployment_selector(**deployment_kwargs, **basic_kwargs)
     app_factory = app_selector(**basic_kwargs)

--- a/src/spring-cloud/azext_spring_cloud/app.py
+++ b/src/spring-cloud/azext_spring_cloud/app.py
@@ -175,7 +175,7 @@ def app_update(cmd, client, resource_group, service, name,
     if deployment is None:
         updated_deployment_kwargs = {k: v for k, v in deployment_kwargs.items() if v}
         if updated_deployment_kwargs:
-            raise ArgumentUsageError ('{} cannot be set when there is no active deployment.'
+            raise ArgumentUsageError('{} cannot be set when there is no active deployment.'
                                       .format(convert_argument_to_parameter_list(updated_deployment_kwargs.keys())))
 
     deployment_factory = deployment_selector(**deployment_kwargs, **basic_kwargs)

--- a/src/spring-cloud/azext_spring_cloud/app.py
+++ b/src/spring-cloud/azext_spring_cloud/app.py
@@ -6,9 +6,9 @@
 # pylint: disable=wrong-import-order
 from knack.log import get_logger
 from azure.cli.core.util import sdk_no_wait
-from azure.cli.core.azclierror import ValidationError
+from azure.cli.core.azclierror import (ValidationError, InvalidArgumentValueError)
 from .custom import app_get
-from ._utils import (get_spring_cloud_sku, wait_till_end)
+from ._utils import (get_spring_cloud_sku, wait_till_end, convert_argument_to_parameter_list)
 from ._deployment_factory import (deployment_selector,
                                   deployment_settings_options_from_resource,
                                   deployment_source_options_from_resource,
@@ -149,9 +149,9 @@ def app_update(cmd, client, resource_group, service, name,
         'resource_group': resource_group,
         'service': service,
         'app': name,
-        'deployment': deployment.name,
+        'sku': deployment.sku if deployment else get_spring_cloud_sku(client, resource_group, service),
+        'deployment': deployment.name if deployment else None,
         'deployment_resource': deployment,
-        'sku': deployment.sku
     }
 
     deployment_kwargs = {
@@ -160,8 +160,9 @@ def app_update(cmd, client, resource_group, service, name,
         'runtime_version': runtime_version,
         'jvm_options': jvm_options,
         'main_entry': main_entry,
-        'source_type': deployment.properties.source.type
+        'source_type': deployment.properties.source.type if deployment else None
     }
+
     app_kwargs = {
         'public': assign_endpoint,
         'enable_persistent_storage': enable_persistent_storage,
@@ -171,6 +172,12 @@ def app_update(cmd, client, resource_group, service, name,
         'https_only': https_only,
     }
 
+    if deployment is None:
+        updated_deployment_kwargs = {k: v for k, v in deployment_kwargs.items() if v}
+        if updated_deployment_kwargs:
+            raise InvalidArgumentValueError('{} cannot be set when there is no active deployment.'
+                                             .format(convert_argument_to_parameter_list(updated_deployment_kwargs.keys())))
+
     deployment_factory = deployment_selector(**deployment_kwargs, **basic_kwargs)
     app_factory = app_selector(**basic_kwargs)
     deployment_kwargs.update(deployment_factory.source_factory
@@ -179,15 +186,18 @@ def app_update(cmd, client, resource_group, service, name,
     app_resource = app_factory.format_resource(**app_kwargs, **basic_kwargs)
     deployment_resource = deployment_factory.format_resource(**deployment_kwargs, **basic_kwargs)
 
-    app_poller = client.apps.begin_update(resource_group, service, name, app_resource)
-    poller = client.deployments.begin_update(resource_group,
-                                             service,
-                                             name,
-                                             DEFAULT_DEPLOYMENT_NAME,
-                                             deployment_resource)
+    pollers = [
+        client.apps.begin_update(resource_group, service, name, app_resource)
+    ]
+    if deployment_kwargs:
+        pollers.append(client.deployments.begin_update(resource_group,
+                                                       service,
+                                                       name,
+                                                       DEFAULT_DEPLOYMENT_NAME,
+                                                       deployment_resource))
     if no_wait:
         return
-    wait_till_end(cmd, app_poller, poller)
+    wait_till_end(cmd, *pollers)
     return app_get(cmd, client, resource_group, service, name)
 
 

--- a/src/spring-cloud/azext_spring_cloud/custom.py
+++ b/src/spring-cloud/azext_spring_cloud/custom.py
@@ -347,7 +347,7 @@ def app_scale(cmd, client, resource_group, service, name,
                        resource_group, service, name, deployment.name, deployment_resource)
 
 
-def app_get_build_log(cmd, client, resource_group, service, name, deployment):
+def app_get_build_log(cmd, client, resource_group, service, name, deployment=None):
     if deployment.properties.source.type != "Source":
         raise CLIError("{} deployment has no build logs.".format(deployment.properties.source.type))
     return stream_logs(client.deployments, resource_group, service, name, deployment.name)

--- a/src/spring-cloud/azext_spring_cloud/tests/latest/test_asc_app_validator.py
+++ b/src/spring-cloud/azext_spring_cloud/tests/latest/test_asc_app_validator.py
@@ -7,7 +7,7 @@ from argparse import Namespace
 from azure.cli.core.azclierror import InvalidArgumentValueError
 from msrestazure.azure_exceptions import CloudError
 from azure.core.exceptions import ResourceNotFoundError
-from ..._app_validator import (fulfill_deployment_param, active_deployment_exist, active_deployment_exist_under_app,
+from ..._app_validator import (fulfill_deployment_param, active_deployment_exist,
                                validate_cpu, validate_memory, validate_deloyment_create_path, validate_deloy_path)
 
 


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

Previously wrongly fatal the `az spring-cloud app update` when there is no active deployment under it. It should just set a warning if user just want to update the app properties

Will upgrade version in #4294 

### General Guidelines

- [X] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [X] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
