### PR TITLE
Quantum: Update Data-Plane client generate script to delete previous output folder contents

### DIFF
--- a/src/quantum/eng/Generate-DataPlane-Client.ps1
+++ b/src/quantum/eng/Generate-DataPlane-Client.ps1
@@ -41,6 +41,13 @@ Param (
 
 $OutputFolder = Join-Path $PSScriptRoot "../azext_quantum/vendored_sdks/azure_quantum/"
 
+Write-Verbose "Output folder: $OutputFolder"
+
+Write-Verbose "Deleting previous output folder contents"
+if (Test-Path $OutputFolder) {
+    Remove-Item $OutputFolder -Recurse | Write-Verbose
+}
+
 $AutoRestConfig = "$SwaggerRepoUrl/blob/$SwaggerRepoBranch/specification/quantum/data-plane/readme.md"
 
 Write-Verbose "Installing latest AutoRest client"


### PR DESCRIPTION
Simple PR to update Data-Plane client generation script to delete previous output folder contents.
No changes in the actual extension.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
