### PR TITLE
{ADO} Pin version `2.1.17` for cred scan

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,6 +23,7 @@ jobs:
     inputs:
       toolMajorVersion: V2
       suppressionsFile: './scripts/ci/credscan/CredScanSuppressions.json'
+      toolVersionV2: '2.1.17'
   - task: ms-codeanalysis.vss-microsoft-security-code-analysis-devops.build-task-postanalysis.PostAnalysis@1
     displayName: 'Post Analysis'
     inputs:


### PR DESCRIPTION
Same as https://github.com/Azure/azure-cli/pull/21230

Because package `Microsoft.Security.CredScan` in task `Run Credential Scanner` was upgraded from version `2.1.17` to the new version `2.2.7.8`, a large number of issues were scanned, resulting in CI blocking [pipeline link](https://dev.azure.com/azure-sdk/public/_build/results?buildId=1354072&view=logs&j=90b26e6a-5461-58d0-82ac-76aa6c69f0af&t=cb13b626-29b0-5981-0cad-2f2519bb3c97)

Therefore, pin the version of `Microsoft.Security.CredScan` to the last successfully version `2.1.17` to avoid blocking CI