### PR TITLE
[AKS] Fix `aks kollect` command cannot read storage account from diagnostic settings

### DIFF
--- a/src/aks-preview/azext_aks_preview/custom.py
+++ b/src/aks-preview/azext_aks_preview/custom.py
@@ -2420,8 +2420,9 @@ def get_storage_account_from_diag_settings(cli_ctx, resource_group_name, name):
         '/managedClusters/{2}'.format(subscription_id,
                                       resource_group_name, name)
     diag_settings = diag_settings_client.list(aks_resource_id)
-    if diag_settings.value:
-        return diag_settings.value[0].storage_account_id
+    for _, diag_setting in enumerate(diag_settings):
+        if diag_setting:
+            return diag_setting.storage_account_id
 
     print("No diag settings specified")
     return None


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- Fix `aks kollect` command cannot read storage account from diagnostic settings. Issue [#4448](https://github.com/Azure/azure-cli-extensions/issues/4448).
  - The reason for the error is that in the latest api version (2021-05-01-preview) of the monitor management client, the result returned by the list operation for diagnostic settings becomes an [iterator](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/monitor/azure-mgmt-monitor/azure/mgmt/monitor/v2021_05_01_preview/operations/_diagnostic_settings_operations.py#L242), which used to be an object of type [DiagnosticSettingsResourceCollection](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/monitor/azure-mgmt-monitor/azure/mgmt/monitor/v2017_05_01_preview/operations/_diagnostic_settings_operations.py#L241).

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
