### PR TITLE
chore(arcdata): arcdata version bump to 1.2.1

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -6026,8 +6026,8 @@
         ],
         "arcdata": [
             {
-                "downloadUrl": "https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.2.0-py2.py3-none-any.whl",
-                "filename": "arcdata-1.2.0-py2.py3-none-any.whl",
+                "downloadUrl": "https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.2.1-py2.py3-none-any.whl",
+                "filename": "arcdata-1.2.1-py2.py3-none-any.whl",
                 "metadata": {
                     "azext.isExperimental": false,
                     "azext.minCliCoreVersion": "2.3.1",
@@ -6080,9 +6080,9 @@
                         }
                     ],
                     "summary": "Tools for managing ArcData.",
-                    "version": "1.2.0"
+                    "version": "1.2.1"
                 },
-                "sha256Digest": "308d953ecabc7b59fa6b3e545404279bc18376b8c129580124c443e866e3cb54"
+                "sha256Digest": "0d5bfcbed4e418f5ce79377a2e392f5f61abb0d5e6f8ce164940b83b5cfdbcd5"
             },
             {
                 "downloadUrl": "https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.1.3-py2.py3-none-any.whl",

--- a/src/index.json
+++ b/src/index.json
@@ -6068,7 +6068,7 @@
                         {
                             "requires": [
                                 "colorama (==0.4.4)",
-                                "jinja2 (==2.10.3)",
+                                "jinja2 (==3.0.3)",
                                 "jsonpatch (==1.24)",
                                 "jsonpath-ng (==1.4.3)",
                                 "jsonschema (==3.2.0)",


### PR DESCRIPTION
chore(arcdata): arcdata version bump to 1.2.1

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?
