### PR TITLE
Fix UUID issue for data disk

### DIFF
--- a/src/vm-repair/HISTORY.rst
+++ b/src/vm-repair/HISTORY.rst
@@ -2,6 +2,10 @@
 Release History
 ===============
 
+0.4.2
+++++++
+Linux only: Fixing duplicated UUID issue. Data disk gets attached only after VM got created.
+
 0.4.1
 ++++++
 Fixing bug in preview parameter

--- a/src/vm-repair/azext_vm_repair/custom.py
+++ b/src/vm-repair/azext_vm_repair/custom.py
@@ -109,15 +109,13 @@ def create(cmd, vm_name, resource_group_name, repair_password=None, repair_usern
             if source_vm.zones:
                 zone = source_vm.zones[0]
                 copy_disk_command += ' --zone {zone}'.format(zone=zone)
-            
             # Copy OS Disk
             logger.info('Copying OS disk of source VM...')
             copy_disk_id = _call_az_command(copy_disk_command).strip('\n')
-            
+            # For Linux the disk gets not attached at VM creation time. To prevent an incorrect boot state it is required to attach the disk after the VM got created.
             if is_linux:
-                # For Linux the disk gets not attached at VM creation time. To prevent an incorrect boot state it is required to attach the disk after the VM got created.
                 pass
-            else:   
+            else:
                 # Add copied OS Disk to VM creat command so that the VM is created with the disk attached
                 create_repair_vm_command += ' --attach-data-disks {id}'.format(id=copy_disk_id)
             # Validate create vm create command to validate parameters before runnning copy disk command

--- a/src/vm-repair/azext_vm_repair/custom.py
+++ b/src/vm-repair/azext_vm_repair/custom.py
@@ -120,7 +120,6 @@ def create(cmd, vm_name, resource_group_name, repair_password=None, repair_usern
             else:   
                 # Add copied OS Disk to VM creat command so that the VM is created with the disk attached
                 create_repair_vm_command += ' --attach-data-disks {id}'.format(id=copy_disk_id)
-            
             # Validate create vm create command to validate parameters before runnning copy disk command
             validate_create_vm_command = create_repair_vm_command + ' --validate'
             logger.info('Validating VM template before continuing...')

--- a/src/vm-repair/azext_vm_repair/custom.py
+++ b/src/vm-repair/azext_vm_repair/custom.py
@@ -133,7 +133,7 @@ def create(cmd, vm_name, resource_group_name, repair_password=None, repair_usern
                 # Attach copied managed disk to new vm
                 logger.info('Attaching copied disk to repair VM as data disk...')
                 attach_disk_command = "az vm disk attach -g {g} --name {disk_id} --vm-name {vm_name} " \
-                               .format(g=repair_group_name, disk_id=copy_disk_id, vm_name=repair_vm_name)
+                                       .format(g=repair_group_name, disk_id=copy_disk_id, vm_name=repair_vm_name)
                 _call_az_command(attach_disk_command)
 
             # Handle encrypted VM cases

--- a/src/vm-repair/azext_vm_repair/custom.py
+++ b/src/vm-repair/azext_vm_repair/custom.py
@@ -132,8 +132,7 @@ def create(cmd, vm_name, resource_group_name, repair_password=None, repair_usern
             if is_linux:
                 # Attach copied managed disk to new vm
                 logger.info('Attaching copied disk to repair VM as data disk...')
-                attach_disk_command = "az vm disk attach -g {g} --name {disk_id} --vm-name {vm_name} " \
-                                       .format(g=repair_group_name, disk_id=copy_disk_id, vm_name=repair_vm_name)
+                attach_disk_command = "az vm disk attach -g {g} --name {disk_id} --vm-name {vm_name} ".format(g=repair_group_name, disk_id=copy_disk_id, vm_name=repair_vm_name)
                 _call_az_command(attach_disk_command)
 
             # Handle encrypted VM cases

--- a/src/vm-repair/azext_vm_repair/custom.py
+++ b/src/vm-repair/azext_vm_repair/custom.py
@@ -133,7 +133,7 @@ def create(cmd, vm_name, resource_group_name, repair_password=None, repair_usern
                 # Attach copied managed disk to new vm
                 logger.info('Attaching copied disk to repair VM as data disk...')
                 attach_disk_command = "az vm disk attach -g {g} --name {disk_id} --vm-name {vm_name} " \
-                                  .format(g=repair_group_name, disk_id=copy_disk_id, vm_name=repair_vm_name)
+                               .format(g=repair_group_name, disk_id=copy_disk_id, vm_name=repair_vm_name)
                 _call_az_command(attach_disk_command)
 
             # Handle encrypted VM cases

--- a/src/vm-repair/azext_vm_repair/custom.py
+++ b/src/vm-repair/azext_vm_repair/custom.py
@@ -113,9 +113,7 @@ def create(cmd, vm_name, resource_group_name, repair_password=None, repair_usern
             logger.info('Copying OS disk of source VM...')
             copy_disk_id = _call_az_command(copy_disk_command).strip('\n')
             # For Linux the disk gets not attached at VM creation time. To prevent an incorrect boot state it is required to attach the disk after the VM got created.
-            if is_linux:
-                pass
-            else:
+            if not is_linux:
                 # Add copied OS Disk to VM creat command so that the VM is created with the disk attached
                 create_repair_vm_command += ' --attach-data-disks {id}'.format(id=copy_disk_id)
             # Validate create vm create command to validate parameters before runnning copy disk command

--- a/src/vm-repair/setup.py
+++ b/src/vm-repair/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup, find_packages
 
-VERSION = "0.4.1"
+VERSION = "0.4.2"
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',


### PR DESCRIPTION
PR only
This PR fixes an UUID issue which may happen if the same Ubuntu 18 image, by both the recover VM created and the os-image, is in use.

With this PR the recover-vm boots from its own os-disk and not , which can happen by chance, from the disk to be recovered
Below lsblk output makes it clear how the double UUID issue may look like with this fix

repair-AZC-020:~$ lsblk -f
NAME    FSTYPE LABEL           UUID                                 MOUNTPOINT
sda
├─sda1  ext4   cloudimg-rootfs 5b1ab5d4-8b76-46c5-928f-8db42fbe3af6 /
├─sda14
└─sda15 vfat   UEFI            91B6-4BB7                            /boot/efi
sdb
└─sdb1  ext4                   644dfbda-f823-4427-9f08-4ca90bb189c5 /mnt
sdc
├─sdc1  ext4   cloudimg-rootfs 5b1ab5d4-8b76-46c5-928f-8db42fbe3af6
├─sdc14
└─sdc15 vfat   UEFI            91B6-4BB7

The recover VM does mount its root-fs from  /dev/sda1 and not from the data disk