### PR TITLE
[Quantum] Show progress messages and dots before executing commands

### DIFF
--- a/src/quantum/azext_quantum/operations/job.py
+++ b/src/quantum/azext_quantum/operations/job.py
@@ -70,6 +70,8 @@ def build(cmd, target_id=None, project=None):
     logger.debug("Building project with arguments:")
     logger.debug(args)
 
+    print(f"Building project...")
+
     import subprocess
     result = subprocess.run(args, stdout=subprocess.PIPE, check=False)
 
@@ -180,6 +182,8 @@ def submit(cmd, program_args, resource_group_name=None, workspace_name=None, loc
 
     args = _generate_submit_args(program_args, ws, target, token, project, job_name, shots, storage, job_params)
     _set_cli_version()
+
+    print("Submitting job...")
 
     import subprocess
     result = subprocess.run(args, stdout=subprocess.PIPE, check=False)

--- a/src/quantum/azext_quantum/operations/job.py
+++ b/src/quantum/azext_quantum/operations/job.py
@@ -70,7 +70,7 @@ def build(cmd, target_id=None, project=None):
     logger.debug("Building project with arguments:")
     logger.debug(args)
 
-    print(f"Building project...")
+    print("Building project...")
 
     import subprocess
     result = subprocess.run(args, stdout=subprocess.PIPE, check=False)

--- a/src/quantum/azext_quantum/operations/workspace.py
+++ b/src/quantum/azext_quantum/operations/workspace.py
@@ -207,6 +207,9 @@ def create(cmd, resource_group_name=None, workspace_name=None, location=None, st
     credentials = _get_data_credentials(cmd.cli_ctx, info.subscription)
     arm_client = ResourceManagementClient(credentials, info.subscription)
 
+    # Show the first progress indicator dot before starting ARM template deployment
+    print('.', end='', flush=True)
+
     deployment_async_operation = arm_client.deployments.begin_create_or_update(
         info.resource_group,
         workspace_name,     # Note: This is actually specifying a the deployment name, but workspace_name is used here in test_quantum_workspace.py


### PR DESCRIPTION
When running the`az quantum execute`command, there is a delay of several seconds between entering the command and anything happening on the screen. This also occurs with the`az quantum job submit`and`az quantum workspace create`commands.

The changes in this PR cause progress messages (or dots) to appear immediately, to address feedback that "something should happen on the screen as soon as the command is entered."

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?
