### PR TITLE
Fix functionapp devops-pipeline create

### DIFF
--- a/src/functionapp/HISTORY.rst
+++ b/src/functionapp/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.1.1
+++++++
+* Fix bug when running `az functionapp devops-pipeline create`
+
 0.1.0
 ++++++
 * Initial release.

--- a/src/functionapp/azext_functionapp/azure_devops_build_interactive.py
+++ b/src/functionapp/azext_functionapp/azure_devops_build_interactive.py
@@ -30,7 +30,7 @@ from azure_functions_devops_build.exceptions import (
 )
 from azure.cli.command_modules.appservice.custom import (
     list_function_app,
-    show_functionapp,
+    show_webapp,
     get_app_settings)
 from azure.cli.command_modules.appservice.utils import str2bool
 from .azure_devops_build_provider import AzureDevopsBuildProvider
@@ -242,7 +242,7 @@ class AzureDevopsBuildInteractive():
         else:
             functionapp = self.cmd_selector.cmd_functionapp(self.functionapp_name)
 
-        kinds = show_functionapp(self.cmd, functionapp.resource_group, functionapp.name).kind.split(',')
+        kinds = show_webapp(self.cmd, functionapp.resource_group, functionapp.name).kind.split(',')
 
         # Get functionapp settings in Azure
         app_settings = get_app_settings(self.cmd, functionapp.resource_group, functionapp.name)

--- a/src/functionapp/azext_functionapp/tests/latest/test_devops_build_commands_thru_mock.py
+++ b/src/functionapp/azext_functionapp/tests/latest/test_devops_build_commands_thru_mock.py
@@ -130,7 +130,7 @@ class TestDevopsBuildCommandsMocked(unittest.TestCase):
         self._client.pre_checks_github()
 
     @patch(interactive_patch_path("get_app_settings"), MagicMock())
-    @patch(interactive_patch_path("show_functionapp"), MagicMock())
+    @patch(interactive_patch_path("show_webapp"), MagicMock())
     @patch(interactive_patch_path("AzureDevopsBuildInteractive._find_type"), MagicMock())
     @patch(interactive_patch_path("AzureDevopsBuildInteractive._get_functionapp_runtime_language"), MagicMock())
     @patch(interactive_patch_path("AzureDevopsBuildInteractive._get_functionapp_storage_name"), MagicMock())

--- a/src/functionapp/setup.py
+++ b/src/functionapp/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
-VERSION = '0.1.0'
+VERSION = '0.1.1'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
A customer reached about an error when trying to run `az functionapp devops-pipeline create` and this PR address it.

While working on this PR, looks like the dependency, [`azure-functions-devops-build`](https://github.com/Azure/azure-functions-devops-build), also requires a fix (not related to this error as such). I worked up [the PR](https://github.com/Azure/azure-functions-devops-build/pull/55) for that as well.

PS: There were a few `pylint` errors, mostly for considering using `f-strings` but with a 9+ score. I suppose I could fix them and push them in this PR itself. Would that be OK?

resolves #4497

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?