### PR TITLE
Move cli contents to production subscription

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -8702,7 +8702,7 @@
         ],
         "azurestackhci": [
             {
-                "downloadUrl": "https://akshcistorage.z5.web.core.windows.net/SelfServiceVM/CLI/azurestackhci-0.2.0-py3-none-any.whl",
+                "downloadUrl": "https://hybridaksstorage.z13.web.core.windows.net/SelfServiceVM/CLI/azurestackhci-0.2.0-py3-none-any.whl",
                 "filename": "azurestackhci-0.2.0-py3-none-any.whl",
                 "metadata": {
                     "azext.isExperimental": true,
@@ -8742,7 +8742,7 @@
                 "sha256Digest": "27fba7f0a2c2fd97e4cc0e815a7de4ec9493e7ef99816d577da5046588f7977a"
             },
             {
-                "downloadUrl": "https://akshcistorage-secondary.z5.web.core.windows.net/SelfServiceVM/CLI/azurestackhci-0.2.1-py3-none-any.whl",
+                "downloadUrl": "https://hybridaksstorage.z13.web.core.windows.net/SelfServiceVM/CLI/azurestackhci-0.2.1-py3-none-any.whl",
                 "filename": "azurestackhci-0.2.1-py3-none-any.whl",
                 "metadata": {
                     "azext.isExperimental": true,
@@ -8785,7 +8785,7 @@
                 "sha256Digest": "3d6220cffd5b45383c16b9cdd43393e1d4e07bebf3b2bbca9eabed21049c197c"
             },
             {
-                "downloadUrl": "https://akshcistorage.z5.web.core.windows.net/SelfServiceVM/CLI/azurestackhci-0.2.2-py3-none-any.whl",
+                "downloadUrl": "https://hybridaksstorage.z13.web.core.windows.net/SelfServiceVM/CLI/azurestackhci-0.2.2-py3-none-any.whl",
                 "filename": "azurestackhci-0.2.2-py3-none-any.whl",
                 "metadata": {
                     "azext.isExperimental": true,
@@ -8828,7 +8828,7 @@
                 "sha256Digest": "2de905d3adc714745ee92bf81c237ea3dd61cb4a6e87d2a840f4047aba352a73"
             },
             {
-                "downloadUrl": "https://akshcistorage.z5.web.core.windows.net/SelfServiceVM/CLI/azurestackhci-0.2.3-py3-none-any.whl",
+                "downloadUrl": "https://hybridaksstorage.z13.web.core.windows.net/SelfServiceVM/CLI/azurestackhci-0.2.3-py3-none-any.whl",
                 "filename": "azurestackhci-0.2.3-py3-none-any.whl",
                 "metadata": {
                     "azext.isExperimental": true,


### PR DESCRIPTION
azurestackhci

Moving cli contents to a production subscription, more suitable for release.

cc @JocelynBerrendonner 