### PR TITLE
{CI} Pin `Jinja2` to 3.0.3

### DIFF
--- a/scripts/ci/test_index_ref_doc.sh
+++ b/scripts/ci/test_index_ref_doc.sh
@@ -5,7 +5,7 @@ set -ex
 echo "Installing azure-cli..."
 
 pip install --pre azure-cli --extra-index-url https://azurecliprod.blob.core.windows.net/edge -q
-pip install "sphinx==1.7.0" -q
+pip install sphinx==1.7.0 Jinja2==3.0.3
 echo "Installed."
 
 python ./scripts/ci/index_ref_doc.py -v


### PR DESCRIPTION
Same as https://github.com/Azure/azure-cli/pull/21798

CI failed:

https://dev.azure.com/azure-sdk/public/_build/results?buildId=1459023&view=logs&j=a49103b8-20d1-5a8c-534b-bda9ab69fa51&t=f07883fb-9b2e-5ef1-366a-e8e57e798ca5&l=1338

```
Could not import extension sphinx.builders.latex (exception: cannot import name 'contextfunction' from 'jinja2' (/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/jinja2/__init__.py))
```
