### PR TITLE
[aks-preview] make sure securityProfile.azureKeyVaultKms doesn't exist in kms test case

### DIFF
--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -3695,7 +3695,7 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
                      '--ssh-key-value={ssh_key_value} -o json'
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
-            self.check('securityProfile', None)
+            self.not_exists('securityProfile.azureKeyVaultKms')
         ])
 
         update_cmd = 'aks update --resource-group={resource_group} --name={name} ' \


### PR DESCRIPTION
self.not_exists('securityProfile.azureKeyVaultKms') can check:
* securityProfile does not exist
* if securityProfile exists, azureKeyVaultKms does not exist