### PR TITLE
[Quantum] [DRAFT - Do not merge] Convert provider name to lowercase

### DIFF
--- a/src/quantum/azext_quantum/operations/workspace.py
+++ b/src/quantum/azext_quantum/operations/workspace.py
@@ -126,7 +126,7 @@ def _add_quantum_providers(cmd, workspace, providers):
             raise InvalidArgumentValueError(f"Terms for Provider '{provider['provider_id']}' and SKU '{provider['sku']}' have not been accepted.\n"
                                             "Use command 'az quantum offerings accept-terms' to accept them.")
         p = Provider()
-        p.provider_id = provider['provider_id']
+        p.provider_id = provider['provider_id'].lower()
         p.provider_sku = provider['sku']
         workspace.providers.append(p)
 


### PR DESCRIPTION
When provider names were capitalized in the `as quantum workspace create` command, the providers did not appear in the portal.  Converting all provider names to lowercase before executing this command.

**OK, it’s not that simple:**
The lowercase conversion works great for "Quantinuum/test1", but I tested it with "Microsoft/Basic" and no providers showed in the portal! ☹

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?
