### PR TITLE
Fix error msg since secrets and env vars are space delimited 

### DIFF
--- a/src/containerapp/azext_containerapp/_utils.py
+++ b/src/containerapp/azext_containerapp/_utils.py
@@ -72,8 +72,8 @@ def parse_env_var_flags(env_list, is_update_containerapp=False):
         key_val = pair.split('=', 1)
         if len(key_val) != 2:
             if is_update_containerapp:
-                raise ValidationError("Environment variables must be in the format \"<key>=<value>\" \"<key>=secretref:<value>\" ...\".")
-            raise ValidationError("Environment variables must be in the format \"<key>=<value>\" \"<key>=secretref:<value>\" ...\".")
+                raise ValidationError("Environment variables must be in the format \"<key>=<value> <key>=secretref:<value> ...\".")
+            raise ValidationError("Environment variables must be in the format \"<key>=<value> <key>=secretref:<value> ...\".")
         if key_val[0] in env_pairs:
             raise ValidationError("Duplicate environment variable {env} found, environment variable names must be unique.".format(env=key_val[0]))
         value = key_val[1].split('secretref:')
@@ -101,9 +101,9 @@ def parse_secret_flags(secret_list):
     for pair in secret_list:
         key_val = pair.split('=', 1)
         if len(key_val) != 2:
-            raise ValidationError("--secrets: must be in format \"<key>=<value>,<key>=<value>,...\"")
+            raise ValidationError("Secrets must be in format \"<key>=<value> <key>=<value> ...\".")
         if key_val[0] in secret_pairs:
-            raise ValidationError("--secrets: duplicate secret {secret} found, secret names must be unique.".format(secret=key_val[0]))
+            raise ValidationError("Duplicate secret \"{secret}\" found, secret names must be unique.".format(secret=key_val[0]))
         secret_pairs[key_val[0]] = key_val[1]
 
     secret_var_def = []


### PR DESCRIPTION
- Small low hanging fruit I noticed: fix error msg since secrets and env vars are space delimited now, instead of comma delimited

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
