### PR TITLE
[Quantum] Expand help and error messages about Provider/SKU format

### DIFF
--- a/src/quantum/azext_quantum/_help.py
+++ b/src/quantum/azext_quantum/_help.py
@@ -203,10 +203,9 @@ helps['quantum workspace create'] = """
       - name: Create a new Azure Quantum workspace with a specific list of providers.
         text: |-
             az quantum workspace create -g MyResourceGroup -w MyWorkspace -l MyLocation \\
-                -r "MyProvider1 / MySKU1, MyProvider2 / MySKU2" -a MyStorageAccountName
-      - name: 'To display a list of available providers and their SKUs, use the following command:'
-        text: |-
-            az quantum offerings list -l MyLocation -o table
+                -r "MyProvider1 / MySKU1, MyProvider2 / MySKU2" -a MyStorageAccountName\n
+            To display a list of available providers and their SKUs, use the following command:
+                az quantum offerings list -l MyLocation -o table
 """
 
 helps['quantum workspace delete'] = """

--- a/src/quantum/azext_quantum/_help.py
+++ b/src/quantum/azext_quantum/_help.py
@@ -120,7 +120,7 @@ helps['quantum offerings list'] = """
     examples:
       - name: List offerings available in an Azure location.
         text: |-
-            az quantum offerings list -l MyLocation
+            az quantum offerings list -l MyLocation -o table
 """
 
 helps['quantum offerings show-terms'] = """
@@ -204,6 +204,9 @@ helps['quantum workspace create'] = """
         text: |-
             az quantum workspace create -g MyResourceGroup -w MyWorkspace -l MyLocation \\
                 -r "MyProvider1 / MySKU1, MyProvider2 / MySKU2" -a MyStorageAccountName
+      - name: 'To display a list of available providers and their SKUs, use the following command:'
+        text: |-
+            az quantum offerings list -l MyLocation -o table
 """
 
 helps['quantum workspace delete'] = """

--- a/src/quantum/azext_quantum/_params.py
+++ b/src/quantum/azext_quantum/_params.py
@@ -43,7 +43,7 @@ def load_arguments(self, _):
     skip_role_assignment_type = CLIArgumentType(help='Skip the role assignment step for the quantum workspace in the storage account.')
     provider_id_type = CLIArgumentType(options_list=['--provider-id', '-p'], help='Identifier of an Azure Quantum provider.')
     sku_type = CLIArgumentType(options_list=['--sku', '-k'], help='Identify a plan or SKU offered by an Azure Quantum provider.')
-    provider_sku_list_type = CLIArgumentType(options_list=['--provider-sku-list', '-r'], help='Comma separated list of Provider/SKU pairs.')
+    provider_sku_list_type = CLIArgumentType(options_list=['--provider-sku-list', '-r'], help='Comma separated list of Provider/SKU pairs. Separate the Provider and SKU with a slash. Enclose the entire list in quotes. Values from `az quantum offerings list -l <location> -o table`')
 
     with self.argument_context('quantum workspace') as c:
         c.argument('workspace_name', workspace_name_type)

--- a/src/quantum/azext_quantum/commands.py
+++ b/src/quantum/azext_quantum/commands.py
@@ -62,8 +62,8 @@ def transform_jobs(results):
 def transform_offerings(offerings):
     def one(offering):
         return OrderedDict([
-            ('Provider Id', offering['id']),
-            ('SKUs', ', '.join([s['id'] for s in offering['properties']['skus']])),
+            ('Provider ID', offering['id']),
+            ('SKU', ', '.join([s['id'] for s in offering['properties']['skus']])),
             ('Publisher ID', offering['properties']['managedApplication']['publisherId']),
             ('Offer ID', offering['properties']['managedApplication']['offerId'])
         ])

--- a/src/quantum/azext_quantum/operations/workspace.py
+++ b/src/quantum/azext_quantum/operations/workspace.py
@@ -178,7 +178,11 @@ def create(cmd, resource_group_name=None, workspace_name=None, location=None, st
     if not location:
         raise RequiredArgumentMissingError("A location for the new quantum workspace is required.")
     if provider_sku_list is None:
-        raise RequiredArgumentMissingError("A list of Azure Quantum providers and SKUs is required.")
+        raise RequiredArgumentMissingError("A list of Azure Quantum providers and SKUs is required.",
+                                           "Supply the missing -r parameter. For example:\n"
+                                           "\t-r \"Microsoft/Basic, Microsoft.FleetManagement/Basic\"\n"
+                                           "To display a list of Provider IDs and their SKUs, use the following command:\n"
+                                           "\taz quantum offerings list -l MyLocation -o table")
     info = WorkspaceInfo(cmd, resource_group_name, workspace_name, location)
     if not info.resource_group:
         raise ResourceNotFoundError("Please run 'az quantum workspace set' first to select a default resource group.")


### PR DESCRIPTION
Description of changes:

- Expanded the error message that’s issued when the `-r` parameter is missing in `az quantum create workspace` 
- Added an example of how to find Provider IDs and SKUs in workspace.py and help.py
- Added more details to the `--provider-sku-list -r` parameter help in params.py
- Modified `transform_offerings` in commands.py for consistency of column headings

---


This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?
