### PR TITLE
[Spring-cloud] Upgrade min version requirement of azure cli for spring-cloud

### DIFF
--- a/src/spring-cloud/HISTORY.md
+++ b/src/spring-cloud/HISTORY.md
@@ -1,5 +1,9 @@
 Release History
 ===============
+3.1.1
+---
+* Fix min version requirement for Azure CLI Core.
+
 3.1.0
 ---
 * Add support for user-assigned managed identity on App (Preview).

--- a/src/spring-cloud/azext_spring_cloud/azext_metadata.json
+++ b/src/spring-cloud/azext_spring_cloud/azext_metadata.json
@@ -1,4 +1,4 @@
 {
     "azext.isPreview": false,
-    "azext.minCliCoreVersion": "2.25.0"
+    "azext.minCliCoreVersion": "2.34.1"
 }

--- a/src/spring-cloud/setup.py
+++ b/src/spring-cloud/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
-VERSION = '3.1.0'
+VERSION = '3.1.1'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
---

### What does this PR do?
1. We released spring-cloud CLI extension `3.1.0` with below PRs:
    - [Vendor AppPlatform 2022-03-01-preview SDK](https://github.com/Azure/azure-cli-extensions/pull/4552)
    - [Add support for AppMSI](https://github.com/Azure/azure-cli-extensions/pull/4598)
2. Later we find this CLI extension is not compatible with Azure CLI version 2.26.0, the error is "No module named 'azure.core.rest'", see below screenshot.
    - <img width="1284" alt="image" src="https://user-images.githubusercontent.com/22190245/161374384-6c980002-46dc-4bf7-bc9d-daef53cd7984.png">
3. Impact: all customers use old version of CLI and spring-cloud cli extension `3.1.0` will be failed to execute any `spring-cloud` commands.
4. Based on that most of the testing spring-cloud extension `3.1.0` is carried out with CLI `2.34.1`, we update minimal requirement for azure-cli from `2.25.0` to `2.34.1` to quick mitigate this problem.
5. Release a new version of CLI 3.1.1 as fix.


### Follow ups
1. Verify the suitable min version of azure cli.


---
This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
