### PR TITLE
[Spring-cloud] Remove 3.1.0 of Spring-Cloud extension from index.json

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -27652,49 +27652,6 @@
                 "sha256Digest": "1142951621ab8ae41759275261cdd0507d11544ba03ad57e02c880e074eabafd"
             },
             {
-                "downloadUrl": "https://azcliprod.blob.core.windows.net/cli-extensions/spring_cloud-3.1.0-py3-none-any.whl",
-                "filename": "spring_cloud-3.1.0-py3-none-any.whl",
-                "metadata": {
-                    "azext.isPreview": false,
-                    "azext.minCliCoreVersion": "2.25.0",
-                    "classifiers": [
-                        "Development Status :: 4 - Beta",
-                        "Intended Audience :: Developers",
-                        "Intended Audience :: System Administrators",
-                        "Programming Language :: Python",
-                        "Programming Language :: Python :: 3",
-                        "Programming Language :: Python :: 3.6",
-                        "Programming Language :: Python :: 3.7",
-                        "Programming Language :: Python :: 3.8",
-                        "License :: OSI Approved :: MIT License"
-                    ],
-                    "extensions": {
-                        "python.details": {
-                            "contacts": [
-                                {
-                                    "email": "azpycli@microsoft.com",
-                                    "name": "Microsoft Corporation",
-                                    "role": "author"
-                                }
-                            ],
-                            "document_names": {
-                                "description": "DESCRIPTION.rst"
-                            },
-                            "project_urls": {
-                                "Home": "https://github.com/Azure/azure-cli-extensions/tree/main/src/spring-cloud"
-                            }
-                        }
-                    },
-                    "generator": "bdist_wheel (0.30.0)",
-                    "license": "MIT",
-                    "metadata_version": "2.0",
-                    "name": "spring-cloud",
-                    "summary": "Microsoft Azure Command-Line Tools spring-cloud Extension",
-                    "version": "3.1.0"
-                },
-                "sha256Digest": "a979236cad4f10e12e190c97848495f21dc2d066652366e1a728c0b6db2fb567"
-            },
-            {
                 "downloadUrl": "https://azcliprod.blob.core.windows.net/cli-extensions/spring_cloud-3.1.1-py3-none-any.whl",
                 "filename": "spring_cloud-3.1.1-py3-none-any.whl",
                 "metadata": {


### PR DESCRIPTION
---
### What does this PR do?
remove `3.1.0` of spring-cloud extension from index.json

### Background
See #4621 

### Follow ups
Delete from history of spring-cloud extension with next release

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
