### PR TITLE
[Spring-cloud] Find min version requirement of Azure CLI

### DIFF
--- a/src/spring-cloud/HISTORY.md
+++ b/src/spring-cloud/HISTORY.md
@@ -1,11 +1,12 @@
 Release History
 ===============
+3.1.2
+---
+* Find min version requirement for Azure CLI Core.
+
 3.1.1
 ---
 * Fix min version requirement for Azure CLI Core.
-
-3.1.0
----
 * Add support for user-assigned managed identity on App (Preview).
 
 3.0.1

--- a/src/spring-cloud/azext_spring_cloud/azext_metadata.json
+++ b/src/spring-cloud/azext_spring_cloud/azext_metadata.json
@@ -1,4 +1,4 @@
 {
     "azext.isPreview": false,
-    "azext.minCliCoreVersion": "2.34.1"
+    "azext.minCliCoreVersion": "2.30.0"
 }

--- a/src/spring-cloud/setup.py
+++ b/src/spring-cloud/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
-VERSION = '3.1.1'
+VERSION = '3.1.2'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
---
### What does this PR do
1. We released spring-cloud CLI extension `3.1.0` with below PRs:
    - [Vendor AppPlatform 2022-03-01-preview SDK](https://github.com/Azure/azure-cli-extensions/pull/4552)
    - [Add support for AppMSI](https://github.com/Azure/azure-cli-extensions/pull/4598)
 2. We find spring-cloud extension `3.1.0` is not compatible with Azure CLI `2.26.0`. It's caused by SDK introduced in earlier PR.
 3. We release spring-cloud `3.1.1` to add min Azure CLI version from `2.25.0` to latest `2.34.1` with below PR
   - [Upgrade min version requirement of azure cli for spring-cloud](https://github.com/Azure/azure-cli-extensions/pull/4621)
 4. We also deleted spring-cloud `3.1.0` from `index.json` manually with below PR, so that customer will not be able to install it.
   - [Remove 3.1.0 of Spring-Cloud extension from index.json](https://github.com/Azure/azure-cli-extensions/pull/4623)
 5. **In this PR**, we verified that min supported Azure CLI version is `2.30.0`, and the extension is compatible from all versions of azure cli since `2.30.0`. So this pr:
  - Release CLI `3.1.2`
  - Update min cli core version requirement to `2.30.0`
  - Update the spring-cloud release history to remove `3.1.0`


### What tests I've carries out
- Running integration test with `3.1.2` version of spring-cloud extension with different Azure CLI versions with below pipelines((Azure Spring Cloud team's pipeline) ): 
  - 2.30.0: https://msazure.visualstudio.com/AzureDMSS/_build/results?buildId=53792070&view=results
  - 2.31.0: https://msazure.visualstudio.com/AzureDMSS/_build/results?buildId=53792069&view=results
  - 2.32.0: https://msazure.visualstudio.com/AzureDMSS/_build/results?buildId=53792067&view=results
  - 2.33.1: https://msazure.visualstudio.com/AzureDMSS/_build/results?buildId=53792062&view=results
  - 2.34.1: https://msazure.visualstudio.com/AzureDMSS/_build/results?buildId=53792061&view=results
- Running unit test and scenario tests locally with different versions of azure-cli and azure-cli-core
  - 2.30.0
  - 2.31.0
  - 2.32.0
  - 2.33.1
  - 2.34.1
- Incompatibility for azure cli `2.29.2` and spring-cloud extension
  - ![image](https://user-images.githubusercontent.com/22190245/161435048-8b467724-96ea-4bb3-a832-38534097cbd5.png)


### A minor problem with recording test is:
In `src/spring-cloud/azext_spring_cloud/tests/latest/test_asc_scenario.py::ByosTest::test_persistent_storage`, there is an annotation `@StorageAccountPreparer()`,  when running the test, with azure-cli `2.34.1`, it's calling to storage account with apiVersion `2020-08-01`, where older azure-cli is using `2020-06-01`, which mean cannot find the request in recording file. However, it's the unit test self failure, not the extension failure.
```python
class ByosTest(ScenarioTest):

    @ResourceGroupPreparer()
    @StorageAccountPreparer()
    def test_persistent_storage(self, resource_group, storage_account):
        template = 'storage account keys list -n {} -g {} --query "[0].value" -otsv'
        accountkey = self.cmd(template.format(storage_account, resource_group)).output
```

### Follow-ups
- How to test such the compatibility among Azure CLI extension and Azure CLI properly?

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
