### PR TITLE
[Quantum] Output job progress messages with Knack logger

### DIFF
--- a/src/quantum/azext_quantum/operations/job.py
+++ b/src/quantum/azext_quantum/operations/job.py
@@ -6,6 +6,7 @@
 # pylint: disable=redefined-builtin,bare-except,inconsistent-return-statements
 
 import logging
+import knack.log
 
 from azure.cli.core.azclierror import (FileOperationError, AzureInternalError,
                                        InvalidArgumentValueError, AzureResponseError)
@@ -15,6 +16,7 @@ from .workspace import WorkspaceInfo
 from .target import TargetInfo
 
 logger = logging.getLogger(__name__)
+knack_logger = knack.log.get_logger(__name__)
 
 
 def list(cmd, resource_group_name=None, workspace_name=None, location=None):
@@ -70,7 +72,7 @@ def build(cmd, target_id=None, project=None):
     logger.debug("Building project with arguments:")
     logger.debug(args)
 
-    print("Building project...")
+    knack_logger.warning('Building project...')
 
     import subprocess
     result = subprocess.run(args, stdout=subprocess.PIPE, check=False)
@@ -183,7 +185,7 @@ def submit(cmd, program_args, resource_group_name=None, workspace_name=None, loc
     args = _generate_submit_args(program_args, ws, target, token, project, job_name, shots, storage, job_params)
     _set_cli_version()
 
-    print("Submitting job...")
+    knack_logger.warning('Submitting job...')
 
     import subprocess
     result = subprocess.run(args, stdout=subprocess.PIPE, check=False)

--- a/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
+++ b/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
@@ -138,7 +138,7 @@ class QuantumWorkspacesScenarioTest(ScenarioTest):
         assert message is None
 
         message = check_version(test_config, test_old_reported_version, test_old_date)
-        assert message is f"\nVersion {test_old_reported_version} of the quantum extension is installed locally, but version {test_current_reported_version} is now available.\nYou can use 'az extension update -n quantum' to upgrade.\n"
+        assert message == f"\nVersion {test_old_reported_version} of the quantum extension is installed locally, but version {test_current_reported_version} is now available.\nYou can use 'az extension update -n quantum' to upgrade.\n"
 
         # No message is generated if either version number is unavailable. 
         message = check_version(test_config, test_none_version, test_today)

--- a/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
+++ b/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
@@ -136,12 +136,11 @@ class QuantumWorkspacesScenarioTest(ScenarioTest):
 
         message = check_version(test_config, test_current_reported_version, test_old_date)
         assert message is None
-        # Note: list_versions("quantum") fails during these tests, so latest version number cannot be determined.
-        # No message is generated if either version number is unavailable. 
 
         message = check_version(test_config, test_old_reported_version, test_old_date)
-        assert message is None
+        assert message is f"\nVersion {test_old_reported_version} of the quantum extension is installed locally, but version {test_current_reported_version} is now available.\nYou can use 'az extension update -n quantum' to upgrade.\n"
 
+        # No message is generated if either version number is unavailable. 
         message = check_version(test_config, test_none_version, test_today)
         assert message is None
 


### PR DESCRIPTION
The job submission progress messages added for [PR 4480](https://github.com/Azure/azure-cli-extensions/pull/4480) broke the CLI integration tests in the E2E validation pipeline.  Only JSON output is expected in stdout during the tests.  By using the Knack logger and displaying the messages as warnings, the progress messages are output to stderr instead of stdout in a way that PowerShell will not treat them as errors. 

Also updated test_version_check in test_quantum_workspace.py to remediate another E2E validation pipeline test failure.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?