### PR TITLE
{CI} Fix tests not belonging to the changed extension are running 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -116,7 +116,7 @@ jobs:
     - bash: ./scripts/ci/test_source.sh
       displayName: 'Run integration test and build test'
       env:
-        ADO_PULL_REQUEST_LATEST_COMMIT: HEAD
+        ADO_PULL_REQUEST_LATEST_COMMIT: 'HEAD'
         ADO_PULL_REQUEST_TARGET_BRANCH: $(System.PullRequest.TargetBranch)
 
 - job: LintModifiedExtensions

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -116,7 +116,7 @@ jobs:
     - bash: ./scripts/ci/test_source.sh
       displayName: 'Run integration test and build test'
       env:
-        ADO_PULL_REQUEST_LATEST_COMMIT: 'HEAD'
+        ADO_PULL_REQUEST_LATEST_COMMIT: HEAD
         ADO_PULL_REQUEST_TARGET_BRANCH: $(System.PullRequest.TargetBranch)
 
 - job: LintModifiedExtensions

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -116,7 +116,7 @@ jobs:
     - bash: ./scripts/ci/test_source.sh
       displayName: 'Run integration test and build test'
       env:
-        ADO_PULL_REQUEST_LATEST_COMMIT: $(System.PullRequest.SourceCommitId)
+        ADO_PULL_REQUEST_LATEST_COMMIT: HEAD
         ADO_PULL_REQUEST_TARGET_BRANCH: $(System.PullRequest.TargetBranch)
 
 - job: LintModifiedExtensions
@@ -153,7 +153,7 @@ jobs:
         AZURE_EXTENSION_DIR=~/.azure/cliextensions python scripts/ci/verify_linter.py
       displayName: "CLI Linter on Modified Extension"
       env:
-        ADO_PULL_REQUEST_LATEST_COMMIT: $(System.PullRequest.SourceCommitId)
+        ADO_PULL_REQUEST_LATEST_COMMIT: HEAD
         ADO_PULL_REQUEST_TARGET_BRANCH: $(System.PullRequest.TargetBranch)
 
 - job: IndexRefDocVerify

--- a/scripts/ci/test_source.py
+++ b/scripts/ci/test_source.py
@@ -7,6 +7,7 @@
 
 from __future__ import print_function
 
+import logging
 import os
 import sys
 import tempfile
@@ -21,6 +22,7 @@ from six import with_metaclass
 
 from util import SRC_PATH
 
+logger = logging.getLogger(__name__)
 
 ALL_TESTS = []
 
@@ -39,8 +41,9 @@ for src_d in os.listdir(SRC_PATH):
     cmd_tpl = 'git --no-pager diff --name-only origin/{commit_start} {commit_end} -- {code_dir}'
     ado_branch_last_commit = os.environ.get('ADO_PULL_REQUEST_LATEST_COMMIT')
     ado_target_branch = os.environ.get('ADO_PULL_REQUEST_TARGET_BRANCH')
+    logger.warning(f'ado_branch_last_commit: {ado_branch_last_commit}, ado_target_branch: {ado_target_branch}')
     if ado_branch_last_commit and ado_target_branch:
-        if ado_branch_last_commit == '$(System.PullRequest.SourceCommitId)':
+        if ado_branch_last_commit == 'HEAD':
             # default value if ADO_PULL_REQUEST_LATEST_COMMIT not set in ADO
             continue
         elif ado_target_branch == '$(System.PullRequest.TargetBranch)':

--- a/scripts/ci/test_source.py
+++ b/scripts/ci/test_source.py
@@ -42,7 +42,7 @@ for src_d in os.listdir(SRC_PATH):
     ado_branch_last_commit = os.environ.get('ADO_PULL_REQUEST_LATEST_COMMIT')
     ado_target_branch = os.environ.get('ADO_PULL_REQUEST_TARGET_BRANCH')
     if ado_branch_last_commit and ado_target_branch:
-        if ado_branch_last_commit == 'HEAD':
+        if ado_branch_last_commit == '$(System.PullRequest.SourceCommitId)':
             # default value if ADO_PULL_REQUEST_LATEST_COMMIT not set in ADO
             continue
         elif ado_target_branch == '$(System.PullRequest.TargetBranch)':

--- a/scripts/ci/test_source.py
+++ b/scripts/ci/test_source.py
@@ -41,7 +41,6 @@ for src_d in os.listdir(SRC_PATH):
     cmd_tpl = 'git --no-pager diff --name-only origin/{commit_start} {commit_end} -- {code_dir}'
     ado_branch_last_commit = os.environ.get('ADO_PULL_REQUEST_LATEST_COMMIT')
     ado_target_branch = os.environ.get('ADO_PULL_REQUEST_TARGET_BRANCH')
-    logger.warning(f'ado_branch_last_commit: {ado_branch_last_commit}, ado_target_branch: {ado_target_branch}')
     if ado_branch_last_commit and ado_target_branch:
         if ado_branch_last_commit == 'HEAD':
             # default value if ADO_PULL_REQUEST_LATEST_COMMIT not set in ADO
@@ -58,6 +57,9 @@ for src_d in os.listdir(SRC_PATH):
     if pkg_name and os.path.isdir(os.path.join(src_d_full, pkg_name, 'tests')):
         ALL_TESTS.append((pkg_name, src_d_full))
 
+logger.warning(f'ado_branch_last_commit: {ado_branch_last_commit}, '
+               f'ado_target_branch: {ado_target_branch}, '
+               f'ALL_TESTS: {ALL_TESTS}.')
 
 class TestExtensionSourceMeta(type):
     def __new__(mcs, name, bases, _dict):

--- a/scripts/ci/test_source.py
+++ b/scripts/ci/test_source.py
@@ -61,6 +61,7 @@ logger.warning(f'ado_branch_last_commit: {ado_branch_last_commit}, '
                f'ado_target_branch: {ado_target_branch}, '
                f'ALL_TESTS: {ALL_TESTS}.')
 
+
 class TestExtensionSourceMeta(type):
     def __new__(mcs, name, bases, _dict):
 


### PR DESCRIPTION
According to #4565, we should use HEAD as the ADO_PULL_REQUEST_LATEST_COMMIT.

This problem happens again at #4486.

See [Error log](https://dev.azure.com/azure-sdk/public/_build/results?buildId=1475781&view=logs&j=d7b07fa6-1884-5260-cab7-367baa6ff6f2&t=2a8d4b0b-b34e-5683-c586-83d0d6277b9a).

In azext_vm_repair's PR our CI run appservice-kube test. 

![image](https://user-images.githubusercontent.com/18628534/161933753-77ba2c33-30f2-4771-8b11-1f877a4e82f0.png)
