### PR TITLE
[k8s-configuration] Bump `pycryptodome` to support Python 3.10

### DIFF
--- a/src/k8s-configuration/HISTORY.rst
+++ b/src/k8s-configuration/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+1.5.1
+++++++++++++++++++
+* Bump pycryptodome to 3.14.1 to support Python 3.10
+
 1.5.0
 ++++++++++++++++++
 * Update models to 2022-03-01 for GA

--- a/src/k8s-configuration/setup.py
+++ b/src/k8s-configuration/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
 
-VERSION = "1.5.0"
+VERSION = "1.5.1"
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
@@ -29,10 +29,12 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "License :: OSI Approved :: MIT License",
 ]
 
-DEPENDENCIES = ["pycryptodome~=3.9.8"]
+DEPENDENCIES = ["pycryptodome~=3.14.1"]
 
 with open("README.rst", "r", encoding="utf-8") as f:
     README = f.read()


### PR DESCRIPTION
Fix https://github.com/Azure/azure-cli/issues/21964

MSI's bundled Python has been updated to 3.10 (https://github.com/Azure/azure-cli/pull/21746). `k8s-configuration` and `connectedk8s` depend on `pycryptodome==3.9.8` which doesn't release wheels for Python 3.10:

https://pypi.org/project/pycryptodome/3.9.8/#files

![image](https://user-images.githubusercontent.com/4003950/162114904-3dca2e99-2d69-46c6-9de4-980b0fd4a874.png)

The latest `pycryptodome` 3.14.1 works with Python 3.10 using ABIs:

https://pypi.org/project/pycryptodome/#files

![image](https://user-images.githubusercontent.com/4003950/162115052-112cd2b5-deaa-41bd-a1fb-3f744c1df317.png)