### PR TITLE
[Quantum] Add "Microsoft.AzureQuantum-" prefix to deployment name

### DIFF
--- a/src/quantum/azext_quantum/operations/workspace.py
+++ b/src/quantum/azext_quantum/operations/workspace.py
@@ -254,7 +254,7 @@ def create(cmd, resource_group_name=None, workspace_name=None, location=None, st
 
     deployment_async_operation = arm_client.deployments.begin_create_or_update(
         info.resource_group,
-        DEPLOYMENT_NAME_PREFIX + workspace_name,
+        (DEPLOYMENT_NAME_PREFIX + workspace_name)[:64],
         {'properties': deployment_properties}
     )
 

--- a/src/quantum/azext_quantum/operations/workspace.py
+++ b/src/quantum/azext_quantum/operations/workspace.py
@@ -30,6 +30,7 @@ DEFAULT_STORAGE_SKU_TIER = 'Standard'
 DEFAULT_STORAGE_KIND = 'Storage'
 SUPPORTED_STORAGE_SKU_TIERS = ['Standard']
 SUPPORTED_STORAGE_KINDS = ['Storage', 'StorageV2']
+DEPLOYMENT_NAME_PREFIX = 'Microsoft.AzureQuantum-'
 
 POLLING_TIME_DURATION = 3  # Seconds
 MAX_RETRIES_ROLE_ASSIGNMENT = 20
@@ -253,7 +254,7 @@ def create(cmd, resource_group_name=None, workspace_name=None, location=None, st
 
     deployment_async_operation = arm_client.deployments.begin_create_or_update(
         info.resource_group,
-        workspace_name,     # Note: This is actually specifying a the deployment name, but workspace_name is used here in test_quantum_workspace.py
+        DEPLOYMENT_NAME_PREFIX + workspace_name,
         {'properties': deployment_properties}
     )
 

--- a/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
+++ b/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
@@ -58,7 +58,7 @@ class QuantumWorkspacesScenarioTest(ScenarioTest):
         test_storage_account = get_test_workspace_storage()
         test_storage_account_grs = get_test_workspace_storage_grs()
         test_provider_sku_list = get_test_workspace_provider_sku_list()
-        
+
         if all_providers_are_in_capabilities(test_provider_sku_list, get_test_capabilities()):
             # create
             self.cmd(f'az quantum workspace create -g {test_resource_group} -w {test_workspace_temp} -l {test_location} -a {test_storage_account} -r {test_provider_sku_list} -o json --skip-role-assignment', checks=[

--- a/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
+++ b/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
@@ -13,7 +13,7 @@ from .utils import get_test_resource_group, get_test_workspace, get_test_workspa
 from ..._version_check_helper import check_version
 from datetime import datetime
 from ...__init__ import CLI_REPORTED_VERSION
-from ...operations.workspace import _validate_storage_account, SUPPORTED_STORAGE_SKU_TIERS, SUPPORTED_STORAGE_KINDS
+from ...operations.workspace import _validate_storage_account, SUPPORTED_STORAGE_SKU_TIERS, SUPPORTED_STORAGE_KINDS, DEPLOYMENT_NAME_PREFIX
 
 TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))
 
@@ -58,6 +58,7 @@ class QuantumWorkspacesScenarioTest(ScenarioTest):
         test_storage_account = get_test_workspace_storage()
         test_storage_account_grs = get_test_workspace_storage_grs()
         test_provider_sku_list = get_test_workspace_provider_sku_list()
+        #test_deployment_name = f"Microsoft.AzureQuantum-{test_workspace_temp}"
 
         if all_providers_are_in_capabilities(test_provider_sku_list, get_test_capabilities()):
             # create
@@ -77,7 +78,7 @@ class QuantumWorkspacesScenarioTest(ScenarioTest):
 
             # create
             self.cmd(f'az quantum workspace create -g {test_resource_group} -w {test_workspace_temp} -l {test_location} -a {test_storage_account} -r {test_provider_sku_list} -o json', checks=[
-            self.check("name", test_workspace_temp),
+            self.check("name", DEPLOYMENT_NAME_PREFIX + test_workspace_temp),
             # >>>>>self.check("provisioningState", "Succeeded")  # Status is "Succeeded" since we are linking the storage account this time.
             ])
 
@@ -92,7 +93,7 @@ class QuantumWorkspacesScenarioTest(ScenarioTest):
 
             # create
             self.cmd(f'az quantum workspace create -g {test_resource_group} -w {test_workspace_temp} -l {test_location} -a {test_storage_account_grs} -r {test_provider_sku_list} -o json', checks=[
-            self.check("name", test_workspace_temp),
+            self.check("name", DEPLOYMENT_NAME_PREFIX + test_workspace_temp),
             # >>>>>self.check("provisioningState", "Succeeded")  # Status is "Succeeded" since we are linking the storage account this time.
             ])
 
@@ -140,7 +141,7 @@ class QuantumWorkspacesScenarioTest(ScenarioTest):
         # No message is generated if either version number is unavailable. 
 
         message = check_version(test_config, test_old_reported_version, test_old_date)
-        assert message is None
+        assert message == f"\nVersion {test_old_reported_version} of the quantum extension is installed locally, but version {test_current_reported_version} is now available.\nYou can use 'az extension update -n quantum' to upgrade.\n"
 
         message = check_version(test_config, test_none_version, test_today)
         assert message is None

--- a/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
+++ b/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
@@ -58,8 +58,7 @@ class QuantumWorkspacesScenarioTest(ScenarioTest):
         test_storage_account = get_test_workspace_storage()
         test_storage_account_grs = get_test_workspace_storage_grs()
         test_provider_sku_list = get_test_workspace_provider_sku_list()
-        #test_deployment_name = f"Microsoft.AzureQuantum-{test_workspace_temp}"
-
+        
         if all_providers_are_in_capabilities(test_provider_sku_list, get_test_capabilities()):
             # create
             self.cmd(f'az quantum workspace create -g {test_resource_group} -w {test_workspace_temp} -l {test_location} -a {test_storage_account} -r {test_provider_sku_list} -o json --skip-role-assignment', checks=[
@@ -79,7 +78,6 @@ class QuantumWorkspacesScenarioTest(ScenarioTest):
             # create
             self.cmd(f'az quantum workspace create -g {test_resource_group} -w {test_workspace_temp} -l {test_location} -a {test_storage_account} -r {test_provider_sku_list} -o json', checks=[
             self.check("name", DEPLOYMENT_NAME_PREFIX + test_workspace_temp),
-            # >>>>>self.check("provisioningState", "Succeeded")  # Status is "Succeeded" since we are linking the storage account this time.
             ])
 
             # delete
@@ -94,7 +92,6 @@ class QuantumWorkspacesScenarioTest(ScenarioTest):
             # create
             self.cmd(f'az quantum workspace create -g {test_resource_group} -w {test_workspace_temp} -l {test_location} -a {test_storage_account_grs} -r {test_provider_sku_list} -o json', checks=[
             self.check("name", DEPLOYMENT_NAME_PREFIX + test_workspace_temp),
-            # >>>>>self.check("provisioningState", "Succeeded")  # Status is "Succeeded" since we are linking the storage account this time.
             ])
 
             # delete

--- a/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
+++ b/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
@@ -9,7 +9,7 @@ import unittest
 from azure.cli.testsdk.scenario_tests import AllowLargeResponse, live_only
 from azure.cli.testsdk import (ScenarioTest, ResourceGroupPreparer)
 from azure.cli.core.azclierror import RequiredArgumentMissingError, ResourceNotFoundError, InvalidArgumentValueError
-from .utils import get_test_resource_group, get_test_workspace, get_test_workspace_location, get_test_workspace_storage, get_test_workspace_storage_grs, get_test_workspace_random_name, get_test_capabilities, get_test_workspace_provider_sku_list, all_providers_are_in_capabilities
+from .utils import get_test_resource_group, get_test_workspace, get_test_workspace_location, get_test_workspace_storage, get_test_workspace_storage_grs, get_test_workspace_random_name, get_test_workspace_random_long_name, get_test_capabilities, get_test_workspace_provider_sku_list, all_providers_are_in_capabilities
 from ..._version_check_helper import check_version
 from datetime import datetime
 from ...__init__ import CLI_REPORTED_VERSION
@@ -92,6 +92,20 @@ class QuantumWorkspacesScenarioTest(ScenarioTest):
             # create
             self.cmd(f'az quantum workspace create -g {test_resource_group} -w {test_workspace_temp} -l {test_location} -a {test_storage_account_grs} -r {test_provider_sku_list} -o json', checks=[
             self.check("name", DEPLOYMENT_NAME_PREFIX + test_workspace_temp),
+            ])
+
+            # delete
+            self.cmd(f'az quantum workspace delete -g {test_resource_group} -w {test_workspace_temp} -o json', checks=[
+            self.check("name", test_workspace_temp),
+            self.check("provisioningState", "Deleting")
+            ])
+
+            # Create a workspace with a maximum length name, but make sure the deployment name was truncated to a valid length
+            test_workspace_temp = get_test_workspace_random_long_name()
+
+            # create
+            self.cmd(f'az quantum workspace create -g {test_resource_group} -w {test_workspace_temp} -l {test_location} -a {test_storage_account_grs} -r {test_provider_sku_list} -o json', checks=[
+            self.check("name", (DEPLOYMENT_NAME_PREFIX + test_workspace_temp)[:64]),
             ])
 
             # delete

--- a/src/quantum/azext_quantum/tests/latest/utils.py
+++ b/src/quantum/azext_quantum/tests/latest/utils.py
@@ -44,6 +44,9 @@ def get_test_workspace_random_name():
     import random
     return "e2e-test-w" + str(random.randint(1000000, 9999999))
 
+def get_test_workspace_random_long_name():
+    return get_test_workspace_random_name() + "-54-char-name123456789012345678901234"
+
 def all_providers_are_in_capabilities(provider_sku_string, capabilities_string):
     for provide_sku_pair in provider_sku_string.split(';'):
         provider = "new." + provide_sku_pair.split('/')[0].lower()


### PR DESCRIPTION
To follow our telemetry naming convention and standardize queries, the ARM deployment name should begin with “Microsoft.AzureQuantum-“ when creating a quantum workspace.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?