### PR TITLE
chore(arcdata): arcdata version bump to 1.3.1

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -6425,7 +6425,7 @@
                     "summary": "Tools for managing ArcData.",
                     "version": "1.3.1"
                 },
-                "sha256Digest": "c28e45c08d1828b5d316e630242549ef2827d80c6f40ec2569434d25df8b0301"
+                "sha256Digest": "dc14939fd86a237e14ebd3cb0a6daebb08a58c0b758ee53505d79fc24f1cf030"
             },
             {
                 "downloadUrl": "https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.3.0-py2.py3-none-any.whl",

--- a/src/index.json
+++ b/src/index.json
@@ -6370,7 +6370,7 @@
         ],
         "arcdata": [
             {
-                "downloadUrl": "https://azextarcdataartifacts.blob.core.windows.net/azext-arcdata-build-artifacts/arcdata-1.3.1-py2.py3-none-any.whl",
+                "downloadUrl": "https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.3.1-py2.py3-none-any.whl",
                 "filename": "arcdata-1.3.1-py2.py3-none-any.whl",
                 "metadata": {
                     "azext.isExperimental": false,
@@ -6425,7 +6425,7 @@
                     "summary": "Tools for managing ArcData.",
                     "version": "1.3.1"
                 },
-                "sha256Digest": "dc14939fd86a237e14ebd3cb0a6daebb08a58c0b758ee53505d79fc24f1cf030"
+                "sha256Digest": "c7040d903665c23b592462225ad32bdff90af40a99fa73ba440b87857c3e1e5b"
             },
             {
                 "downloadUrl": "https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.3.0-py2.py3-none-any.whl",

--- a/src/index.json
+++ b/src/index.json
@@ -6370,6 +6370,64 @@
         ],
         "arcdata": [
             {
+                "downloadUrl": "https://azextarcdataartifacts.blob.core.windows.net/azext-arcdata-build-artifacts/arcdata-1.3.1-py2.py3-none-any.whl",
+                "filename": "arcdata-1.3.1-py2.py3-none-any.whl",
+                "metadata": {
+                    "azext.isExperimental": false,
+                    "azext.minCliCoreVersion": "2.3.1",
+                    "classifiers": [
+                        "Development Status :: 1 - Beta",
+                        "Intended Audience :: Developers",
+                        "Programming Language :: Python :: 3",
+                        "Programming Language :: Python :: 3.6",
+                        "Programming Language :: Python :: 3.7",
+                        "Programming Language :: Python :: 3.8",
+                        "License :: OSI Approved :: MIT License"
+                    ],
+                    "extensions": {
+                        "python.details": {
+                            "contacts": [
+                                {
+                                    "email": "dpgswdist@microsoft.com",
+                                    "name": "Microsoft Corporation",
+                                    "role": "author"
+                                }
+                            ],
+                            "document_names": {
+                                "description": "DESCRIPTION.rst"
+                            },
+                            "project_urls": {
+                                "Home": "https://docs.microsoft.com/en-us/azure/azure-arc/data/"
+                            }
+                        }
+                    },
+                    "extras": [],
+                    "generator": "bdist_wheel (0.30.0)",
+                    "license": "MIT",
+                    "license_file": "LICENSE",
+                    "metadata_version": "2.0",
+                    "name": "arcdata",
+                    "run_requires": [
+                        {
+                            "requires": [
+                                "colorama (==0.4.4)",
+                                "jinja2 (==3.0.3)",
+                                "jsonpatch (==1.24)",
+                                "jsonpath-ng (==1.4.3)",
+                                "jsonschema (==3.2.0)",
+                                "kubernetes (==12.0.1)",
+                                "ndjson (==0.3.1)",
+                                "pem (==21.2.0)",
+                                "pydash (==4.8.0)"
+                            ]
+                        }
+                    ],
+                    "summary": "Tools for managing ArcData.",
+                    "version": "1.3.1"
+                },
+                "sha256Digest": "c28e45c08d1828b5d316e630242549ef2827d80c6f40ec2569434d25df8b0301"
+            },
+            {
                 "downloadUrl": "https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.3.0-py2.py3-none-any.whl",
                 "filename": "arcdata-1.3.0-py2.py3-none-any.whl",
                 "metadata": {


### PR DESCRIPTION
chore(arcdata): arcdata version bump to 1.3.1

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?
