### PR TITLE
[rdbms-connect] Use compatible release for `setproctitle` to support Python 3.10

### DIFF
--- a/src/rdbms-connect/HISTORY.rst
+++ b/src/rdbms-connect/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+1.0.2
+++++++
++ Use compatible release for `setproctitle` to support Python 3.10
+
 1.0.1
 ++++++
 + Add rdbms-module to cloud shell
@@ -17,7 +21,7 @@ Release History
 
 0.1.3
 ++++++
-* Introduce query/sql file execution command as 'flexible server execute' command. 
+* Introduce query/sql file execution command as 'flexible server execute' command.
 * [BREKAING CHANGE] Move query execution of the 'flexible server connect' command to 'flexible server execute' command.
 
 0.1.2

--- a/src/rdbms-connect/setup.py
+++ b/src/rdbms-connect/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
-VERSION = '1.0.1'
+VERSION = '1.0.2'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
@@ -33,7 +33,7 @@ CLASSIFIERS = [
 ]
 
 DEPENDENCIES = [
-    'setproctitle==1.2.2',
+    'setproctitle~=1.2.2',
     'mycli==1.22.2',
     'pgcli==3.0.0'
 ]


### PR DESCRIPTION
Similar to #4643

Windows MSI package's bundled Python has been updated to 3.10 (https://github.com/Azure/azure-cli/pull/21746). `rdbms-connect` depends on `setproctitle==1.2.2` which doesn't release wheels for Python 3.10.

`setproctitle` starts to support Python 3.10 in 1.2.3. We use [compatible release](https://peps.python.org/pep-0440/#compatible-release) for `setproctitle` so that 1.2.3 can be installed.

Note: It is not a good practice to use a pinned version in `setup.py`.
