### PR TITLE
chore: remove git.io

### DIFF
--- a/src/scvmm/setup.md
+++ b/src/scvmm/setup.md
@@ -86,7 +86,7 @@ pyenv install 3.8.10
 2. [Lightweight nodejs version manager](https://github.com/mklement0/n-install)
 
 ```
-curl -L https://git.io/n-install | bash -s -- -y lts
+curl -L https://bit.ly/n-install | bash -s -- -y lts
 exec $SHELL
 ```
 


### PR DESCRIPTION
All links on git.io will stop redirecting after April 29, 2022.

- https://github.blog/changelog/2022-04-25-git-io-deprecation/

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
