### PR TITLE
Correcting QDK version referenced by quantum extension

### DIFF
--- a/src/quantum/HISTORY.rst
+++ b/src/quantum/HISTORY.rst
@@ -5,7 +5,7 @@ Release History
 
 0.15.0
 ++++++
-* [2022-04-25] Version intended to work with QDK version v0.24.206417
+* [2022-04-25] Version intended to work with QDK version v0.24.208024
 * Extended error message and added help examples for provider/SKU '-r' parameter.
 * Fixed issue azure-cli-extensions/4697, which allows setting a polling interval when waiting for an Azure Quantum job to complete.
 * Outputting job submission progress messages to stderr so stdout will only contain valid JSON by default.


### PR DESCRIPTION
This pull request only corrects an entry in the az quantum extension history page on a reference version number.