### PR TITLE
Fix conflicts for aks_preview index.json

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -5151,6 +5151,49 @@
                     "version": "0.5.65"
                 },
                 "sha256Digest": "df53989fd97f37b5feb6bd54dca9c11308cd8ac6c77e012efccfb4c0111c2f18"
+            },
+            {
+                "downloadUrl": "https://azcliprod.blob.core.windows.net/cli-extensions/aks_preview-0.5.66-py2.py3-none-any.whl",
+                "filename": "aks_preview-0.5.66-py2.py3-none-any.whl",
+                "metadata": {
+                    "azext.isPreview": true,
+                    "azext.minCliCoreVersion": "2.32.0",
+                    "classifiers": [
+                        "Development Status :: 4 - Beta",
+                        "Intended Audience :: Developers",
+                        "Intended Audience :: System Administrators",
+                        "Programming Language :: Python",
+                        "Programming Language :: Python :: 3",
+                        "Programming Language :: Python :: 3.6",
+                        "Programming Language :: Python :: 3.7",
+                        "Programming Language :: Python :: 3.8",
+                        "License :: OSI Approved :: MIT License"
+                    ],
+                    "extensions": {
+                        "python.details": {
+                            "contacts": [
+                                {
+                                    "email": "azpycli@microsoft.com",
+                                    "name": "Microsoft Corporation",
+                                    "role": "author"
+                                }
+                            ],
+                            "document_names": {
+                                "description": "DESCRIPTION.rst"
+                            },
+                            "project_urls": {
+                                "Home": "https://github.com/Azure/azure-cli-extensions/tree/main/src/aks-preview"
+                            }
+                        }
+                    },
+                    "generator": "bdist_wheel (0.30.0)",
+                    "license": "MIT",
+                    "metadata_version": "2.0",
+                    "name": "aks-preview",
+                    "summary": "Provides a preview for upcoming AKS features",
+                    "version": "0.5.66"
+                },
+                "sha256Digest": "82026c5aafd8f0c7f5e72524e708a4ed5c6485b574686d0cdded1104f20a82b3"
             }
         ],
         "alertsmanagement": [


### PR DESCRIPTION
Related PR: #4778

Since the `index.json` PR #4753 of the previous version `0.5.65` is merged later than the PR #4759 that changed the version to `0.5.66` from `setup.py`, so the code in `index.json` from PR #4759 does not contain the contents of version `0.5.65`, then the generated index.json for version `0.5.66` from this PR conflicts with the index.json for version `0.5.65`

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [x] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
