### PR TITLE
{Subscription} Update supported  `--offer-types` of `az account create`

### DIFF
--- a/src/subscription/azext_subscription/_params.py
+++ b/src/subscription/azext_subscription/_params.py
@@ -4,13 +4,14 @@
 # --------------------------------------------------------------------------------------------
 
 from azure.cli.core.commands.parameters import get_enum_type
+from .subscription.models import OfferType
 
 
 # pylint: disable=line-too-long
 def load_arguments(self, _):
     with self.argument_context('account create') as c:
         c.argument('enrollment_account_name', options_list=('--enrollment-account-name', '--enrollment-account-object-id'), required=True, help='The name of the enrollment account which should be used to create a subscription.')
-        c.argument('offer_type', required=True, help='The offer type of the subscription. For example, MS-AZR-0017P (EnterpriseAgreement) and MS-AZR-0148P (EnterpriseAgreement devTest) are available.', arg_type=get_enum_type(['MS-AZR-0017P', 'MS-AZR-0148P']))
+        c.argument('offer_type', required=True, help='The offer type of the subscription. For example, MS-AZR-0017P (EnterpriseAgreement) and MS-AZR-0148P (EnterpriseAgreement devTest) are available.', arg_type=get_enum_type(OfferType))
         c.argument('display_name', help='The display name of the subscription.')
         c.argument('owner_object_id', help='The object id(s) of the owner(s) which should be granted access to the new subscription.')
         c.argument('owner_spn', help='The service principal name(s) of the owner(s) which should be granted access to the new subscription.')

--- a/src/subscription/azext_subscription/subscription/models/subscription_client_enums.py
+++ b/src/subscription/azext_subscription/subscription/models/subscription_client_enums.py
@@ -18,6 +18,8 @@ class OfferType(str, Enum):
     ms_azr_0148_p = "MS-AZR-0148P"
     ms_azr_usgov_0017p = "MS-AZR-USGOV-0017P"
     ms_azr_usgov_0003p = "MS-AZR-USGOV-0003P"
+    ms_azr_usgov_0015p = "MS-AZR-USGOV-0015P"
+    ms_azr_usgov_0148p = "MS-AZR-USGOV-0148P"
 
 
 class SubscriptionState(str, Enum):

--- a/src/subscription/azext_subscription/subscription/models/subscription_client_enums.py
+++ b/src/subscription/azext_subscription/subscription/models/subscription_client_enums.py
@@ -17,7 +17,6 @@ class OfferType(str, Enum):
     ms_azr_0017_p = "MS-AZR-0017P"
     ms_azr_0148_p = "MS-AZR-0148P"
     ms_azr_usgov_0017p = "MS-AZR-USGOV-0017P"
-    ms_azr_usgov_0003p = "MS-AZR-USGOV-0003P"
     ms_azr_usgov_0015p = "MS-AZR-USGOV-0015P"
     ms_azr_usgov_0148p = "MS-AZR-USGOV-0148P"
 

--- a/src/subscription/azext_subscription/subscription/models/subscription_client_enums.py
+++ b/src/subscription/azext_subscription/subscription/models/subscription_client_enums.py
@@ -16,6 +16,8 @@ class OfferType(str, Enum):
 
     ms_azr_0017_p = "MS-AZR-0017P"
     ms_azr_0148_p = "MS-AZR-0148P"
+    MS_AZR_USGOV_0017P = "MS-AZR-USGOV-0017P"
+    MS_AZR_USGOV_0003P = "MS-AZR-USGOV-0003P"
 
 
 class SubscriptionState(str, Enum):

--- a/src/subscription/azext_subscription/subscription/models/subscription_client_enums.py
+++ b/src/subscription/azext_subscription/subscription/models/subscription_client_enums.py
@@ -16,8 +16,8 @@ class OfferType(str, Enum):
 
     ms_azr_0017_p = "MS-AZR-0017P"
     ms_azr_0148_p = "MS-AZR-0148P"
-    MS_AZR_USGOV_0017P = "MS-AZR-USGOV-0017P"
-    MS_AZR_USGOV_0003P = "MS-AZR-USGOV-0003P"
+    ms_azr_usgov_0017p = "MS-AZR-USGOV-0017P"
+    ms_azr_usgov_0003p = "MS-AZR-USGOV-0003P"
 
 
 class SubscriptionState(str, Enum):


### PR DESCRIPTION
Fix: https://github.com/Azure/azure-cli-extensions/issues/4766

Update supported argument value for `--offer-types` of command `az account create`



---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
`az account create`


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repository and upgrade the version in the pull request but do not modify `src/index.json`. 
