### PR TITLE
{CI} Bump azure-core version to 1.21.1

### DIFF
--- a/scripts/ci/test_source.sh
+++ b/scripts/ci/test_source.sh
@@ -4,11 +4,10 @@ set -ex
 # Install CLI & CLI testsdk
 echo "Installing azure-cli-testsdk, azure-cli-core, azure-cli from source code"
 git clone https://github.com/Azure/azure-cli --depth 1
-# Because the new version has breaking change, so bump to 1.21.1
-pip install azure-core==1.21.1
-pip install -e azure-cli/src/azure-cli-testsdk
-pip install -e azure-cli/src/azure-cli-core
-pip install -e azure-cli/src/azure-cli
+pip install -e azure-cli/src/azure-cli-testsdk --no-deps
+pip install -e azure-cli/src/azure-cli-core --no-deps
+pip install -e azure-cli/src/azure-cli --no-deps
+pip install -r azure-cli/src/azure-cli/requirements.py3.$(uname).txt
 echo "Installed."
 
 pip list -v

--- a/scripts/ci/test_source.sh
+++ b/scripts/ci/test_source.sh
@@ -4,9 +4,7 @@ set -ex
 # Install CLI & CLI testsdk
 echo "Installing azure-cli-testsdk, azure-cli-core, azure-cli from source code"
 git clone https://github.com/Azure/azure-cli --depth 1
-pip install -e azure-cli/src/azure-cli-testsdk --no-deps
-pip install -e azure-cli/src/azure-cli-core --no-deps
-pip install -e azure-cli/src/azure-cli --no-deps
+find azure-cli/src/ -name setup.py -type f | xargs -I {} dirname {} | xargs pip install --no-deps
 pip install -r azure-cli/src/azure-cli/requirements.py3.$(uname).txt
 echo "Installed."
 

--- a/scripts/ci/test_source.sh
+++ b/scripts/ci/test_source.sh
@@ -4,6 +4,8 @@ set -ex
 # Install CLI & CLI testsdk
 echo "Installing azure-cli-testsdk, azure-cli-core, azure-cli from source code"
 git clone https://github.com/Azure/azure-cli --depth 1
+# Because the new version has breaking change, so bump to 1.21.1
+pip install azure-core==1.21.1
 pip install -e azure-cli/src/azure-cli-testsdk
 pip install -e azure-cli/src/azure-cli-core
 pip install -e azure-cli/src/azure-cli


### PR DESCRIPTION
---
Because 1.24.0 has breaking change with 1.21.1.
So we bump azure-core version to 1.21.1 to fix CI error:
https://dev.azure.com/azure-sdk/public/_build/results?buildId=1561389&view=logs&j=9c80867e-ccda-50f1-65bc-e11447f3cda9&t=8e28b004-aba6-5a56-67c2-9d40a66e3ed9

Test screenshot：
![image](https://user-images.githubusercontent.com/18628534/168202986-52cf9022-8f1f-4653-8946-f83e7c6c82b1.png)


This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repository and upgrade the version in the pull request but do not modify `src/index.json`. 
