### PR TITLE
{CI} Migrate azure cli extensions pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,8 @@ jobs:
 - job: CredScan
   displayName: "Credential Scan"
   pool:
-    vmImage: "windows-2019"
+    name: 'azure-cli-pool-windows-2019'
+    vmImage: 'windows-2019'
   steps:
   - task: ms-codeanalysis.vss-microsoft-security-code-analysis-devops.build-task-credscan.CredScan@2
     displayName: 'Run Credential Scanner'
@@ -37,6 +38,7 @@ jobs:
 - job: CheckLicenseHeader
   displayName: "Check License"
   pool:
+    name: 'azure-cli-pool-ubuntu-2004'
     vmImage: 'ubuntu-20.04'
   steps:
   - task: UsePythonVersion@0
@@ -68,6 +70,7 @@ jobs:
 - job: StaticAnalysis
   displayName: "Static Analysis"
   pool:
+    name: 'azure-cli-pool-ubuntu-2004'
     vmImage: 'ubuntu-20.04'
   steps:
     - task: UsePythonVersion@0
@@ -82,6 +85,7 @@ jobs:
 - job: IndexVerify
   displayName: "Verify Extensions Index"
   pool:
+    name: 'azure-cli-pool-ubuntu-2004'
     vmImage: 'ubuntu-20.04'
   steps:
   - task: UsePythonVersion@0
@@ -99,6 +103,7 @@ jobs:
 - job: SourceTests
   displayName: "Integration Tests, Build Tests"
   pool:
+    name: 'azure-cli-pool-ubuntu-2004'
     vmImage: 'ubuntu-20.04'
   strategy:
     matrix:
@@ -127,6 +132,7 @@ jobs:
   displayName: "CLI Linter on Modified Extensions"
   condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
   pool:
+    name: 'azure-cli-pool-ubuntu-2004'
     vmImage: 'ubuntu-20.04'
   steps:
     - task: UsePythonVersion@0
@@ -163,6 +169,7 @@ jobs:
 - job: IndexRefDocVerify
   displayName: "Verify Ref Docs"
   pool:
+    name: 'azure-cli-pool-ubuntu-2004'
     vmImage: 'ubuntu-20.04'
   steps:
   - task: UsePythonVersion@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,8 +16,7 @@ jobs:
 - job: CredScan
   displayName: "Credential Scan"
   pool:
-    name: 'azure-cli-pool-windows-2019'
-    vmImage: 'windows-2019'
+    name: 'pool-windows-2019'
   steps:
   - task: ms-codeanalysis.vss-microsoft-security-code-analysis-devops.build-task-credscan.CredScan@2
     displayName: 'Run Credential Scanner'
@@ -38,8 +37,7 @@ jobs:
 - job: CheckLicenseHeader
   displayName: "Check License"
   pool:
-    name: 'azure-cli-pool-ubuntu-2004'
-    vmImage: 'ubuntu-20.04'
+    name: 'pool-ubuntu-2004'
   steps:
   - task: UsePythonVersion@0
     displayName: 'Use Python 3.10'
@@ -70,8 +68,7 @@ jobs:
 - job: StaticAnalysis
   displayName: "Static Analysis"
   pool:
-    name: 'azure-cli-pool-ubuntu-2004'
-    vmImage: 'ubuntu-20.04'
+    name: 'pool-ubuntu-2004'
   steps:
     - task: UsePythonVersion@0
       displayName: 'Use Python 3.6'
@@ -85,8 +82,7 @@ jobs:
 - job: IndexVerify
   displayName: "Verify Extensions Index"
   pool:
-    name: 'azure-cli-pool-ubuntu-2004'
-    vmImage: 'ubuntu-20.04'
+    name: 'pool-ubuntu-2004'
   steps:
   - task: UsePythonVersion@0
     displayName: 'Use Python 3.10'
@@ -103,8 +99,7 @@ jobs:
 - job: SourceTests
   displayName: "Integration Tests, Build Tests"
   pool:
-    name: 'azure-cli-pool-ubuntu-2004'
-    vmImage: 'ubuntu-20.04'
+    name: 'pool-ubuntu-2004'
   strategy:
     matrix:
       Python36:
@@ -132,8 +127,7 @@ jobs:
   displayName: "CLI Linter on Modified Extensions"
   condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
   pool:
-    name: 'azure-cli-pool-ubuntu-2004'
-    vmImage: 'ubuntu-20.04'
+    name: 'pool-ubuntu-2004'
   steps:
     - task: UsePythonVersion@0
       displayName: 'Use Python 3.10'
@@ -169,8 +163,7 @@ jobs:
 - job: IndexRefDocVerify
   displayName: "Verify Ref Docs"
   pool:
-    name: 'azure-cli-pool-ubuntu-2004'
-    vmImage: 'ubuntu-20.04'
+    name: 'pool-ubuntu-2004'
   steps:
   - task: UsePythonVersion@0
     displayName: 'Use Python 3.10'


### PR DESCRIPTION
Migrate Azure.azure-cli-extensions pipeline to azclitools org.
[Azure.azure-cli-extensions](https://dev.azure.com/azclitools/public/_build?definitionId=59)
[Azure CLI Extensions Release](https://dev.azure.com/azclitools/internal/_build?definitionId=197)
[Azure CLI Extensions Sync After Release](https://dev.azure.com/azclitools/internal/_build?definitionId=198)
[Azure CLI Extensions Sync to MicrosoftDocs](https://dev.azure.com/azclitools/internal/_build?definitionId=196)


![image](https://user-images.githubusercontent.com/18628534/185286016-2f8ba8b6-9a85-4345-9b12-cadf69892b98.png)
