### PR TITLE
[Attestation] Fix #3937 #4120: `az attestation policy set` and `az attestation policy show` fails when execution

### DIFF
--- a/src/attestation/azext_attestation/manual/custom.py
+++ b/src/attestation/azext_attestation/manual/custom.py
@@ -188,7 +188,7 @@ def get_policy(cmd, client, attestation_type, resource_group_name=None, provider
 
     if token:
         import jwt
-        policy = jwt.decode(token, verify=False).get('x-ms-policy', '')
+        policy = jwt.decode(token, algorithms=['RS256'], options={"verify_signature": False}).get('x-ms-policy', '')
         result['Jwt'] = policy
         result['JwtLength'] = len(policy)
         result['Algorithm'] = None
@@ -248,9 +248,7 @@ def set_policy(cmd, client, attestation_type, new_attestation_policy=None, new_a
             new_attestation_policy = \
                 base64.urlsafe_b64encode(new_attestation_policy.encode('ascii')).decode('ascii').strip('=')
             new_attestation_policy = {'AttestationPolicy': new_attestation_policy}
-            new_attestation_policy = jwt.encode(
-                new_attestation_policy, key='', algorithm='none'
-            ).decode('ascii')
+            new_attestation_policy = jwt.encode(new_attestation_policy, 'ascii', algorithms=['RS256'], options={"verify_signature": False})
 
         except TypeError as e:
             print(e)

--- a/src/attestation/azext_attestation/manual/custom.py
+++ b/src/attestation/azext_attestation/manual/custom.py
@@ -129,7 +129,7 @@ def add_signer(cmd, client, signer=None, signer_file=None, resource_group_name=N
             'Algorithm': header.get('alg', ''),
             'JKU': header.get('jku', '')
         })
-        body = jwt.decode(token, verify=False)
+        body = jwt.decode(token, algorithms=['RS256'], options={"verify_signature": False})
         result['Certificates'] = body.get('aas-policyCertificates', {}).get('keys', [])
         result['CertificateCount'] = len(result['Certificates'])
 
@@ -171,7 +171,7 @@ def list_signers(cmd, client, resource_group_name=None, provider_name=None):
             'Algorithm': header.get('alg', ''),
             'JKU': header.get('jku', '')
         })
-        body = jwt.decode(token, verify=False)
+        body = jwt.decode(token, algorithms=['RS256'], options={"verify_signature": False})
         result['Certificates'] = body.get('x-ms-policy-certificates', {}).get('keys', [])
         result['CertificateCount'] = len(result['Certificates'])
 
@@ -195,7 +195,7 @@ def get_policy(cmd, client, attestation_type, resource_group_name=None, provider
 
         if policy:
             try:
-                decoded_policy = jwt.decode(policy, verify=False)
+                decoded_policy = jwt.decode(policy, algorithms=['RS256'], options={"verify_signature": False})
                 decoded_policy = decoded_policy.get('AttestationPolicy', '')
                 try:
                     new_decoded_policy = base64.b64decode(_b64url_to_b64(decoded_policy)).decode('ascii')

--- a/src/attestation/azext_attestation/manual/custom.py
+++ b/src/attestation/azext_attestation/manual/custom.py
@@ -248,7 +248,7 @@ def set_policy(cmd, client, attestation_type, new_attestation_policy=None, new_a
             new_attestation_policy = \
                 base64.urlsafe_b64encode(new_attestation_policy.encode('ascii')).decode('ascii').strip('=')
             new_attestation_policy = {'AttestationPolicy': new_attestation_policy}
-            new_attestation_policy = jwt.encode(new_attestation_policy, 'ascii', algorithms=['RS256'], options={"verify_signature": False})
+            new_attestation_policy = jwt.decode(new_attestation_policy, 'ascii', algorithms=['RS256'], options={"verify_signature": False})
 
         except TypeError as e:
             print(e)


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-cli-extensions/issues/3937
Fixes: https://github.com/Azure/azure-cli-extensions/issues/4120

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repository and upgrade the version in the pull request but do not modify `src/index.json`. 
