### PR TITLE
Fix conflicts for aks_preview index.json

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -5624,6 +5624,92 @@
                     "version": "0.5.77"
                 },
                 "sha256Digest": "35008db1e3d6e9ae6c409ed0749a37f6fddec6223aa8cefa0e7245af5f81c95a"
+            },
+            {
+                "downloadUrl": "https://azcliprod.blob.core.windows.net/cli-extensions/aks_preview-0.5.78-py2.py3-none-any.whl",
+                "filename": "aks_preview-0.5.78-py2.py3-none-any.whl",
+                "metadata": {
+                    "azext.isPreview": true,
+                    "azext.minCliCoreVersion": "2.35.0",
+                    "classifiers": [
+                        "Development Status :: 4 - Beta",
+                        "Intended Audience :: Developers",
+                        "Intended Audience :: System Administrators",
+                        "Programming Language :: Python",
+                        "Programming Language :: Python :: 3",
+                        "Programming Language :: Python :: 3.6",
+                        "Programming Language :: Python :: 3.7",
+                        "Programming Language :: Python :: 3.8",
+                        "License :: OSI Approved :: MIT License"
+                    ],
+                    "extensions": {
+                        "python.details": {
+                            "contacts": [
+                                {
+                                    "email": "azpycli@microsoft.com",
+                                    "name": "Microsoft Corporation",
+                                    "role": "author"
+                                }
+                            ],
+                            "document_names": {
+                                "description": "DESCRIPTION.rst"
+                            },
+                            "project_urls": {
+                                "Home": "https://github.com/Azure/azure-cli-extensions/tree/main/src/aks-preview"
+                            }
+                        }
+                    },
+                    "generator": "bdist_wheel (0.30.0)",
+                    "license": "MIT",
+                    "metadata_version": "2.0",
+                    "name": "aks-preview",
+                    "summary": "Provides a preview for upcoming AKS features",
+                    "version": "0.5.78"
+                },
+                "sha256Digest": "a98ecf3b74dae40025d90c8fa152341897682b3647964fd4876545c71b1aa186"
+            },
+            {
+                "downloadUrl": "https://azcliprod.blob.core.windows.net/cli-extensions/aks_preview-0.5.79-py2.py3-none-any.whl",
+                "filename": "aks_preview-0.5.79-py2.py3-none-any.whl",
+                "metadata": {
+                    "azext.isPreview": true,
+                    "azext.minCliCoreVersion": "2.35.0",
+                    "classifiers": [
+                        "Development Status :: 4 - Beta",
+                        "Intended Audience :: Developers",
+                        "Intended Audience :: System Administrators",
+                        "Programming Language :: Python",
+                        "Programming Language :: Python :: 3",
+                        "Programming Language :: Python :: 3.6",
+                        "Programming Language :: Python :: 3.7",
+                        "Programming Language :: Python :: 3.8",
+                        "License :: OSI Approved :: MIT License"
+                    ],
+                    "extensions": {
+                        "python.details": {
+                            "contacts": [
+                                {
+                                    "email": "azpycli@microsoft.com",
+                                    "name": "Microsoft Corporation",
+                                    "role": "author"
+                                }
+                            ],
+                            "document_names": {
+                                "description": "DESCRIPTION.rst"
+                            },
+                            "project_urls": {
+                                "Home": "https://github.com/Azure/azure-cli-extensions/tree/main/src/aks-preview"
+                            }
+                        }
+                    },
+                    "generator": "bdist_wheel (0.30.0)",
+                    "license": "MIT",
+                    "metadata_version": "2.0",
+                    "name": "aks-preview",
+                    "summary": "Provides a preview for upcoming AKS features",
+                    "version": "0.5.79"
+                },
+                "sha256Digest": "e00adb76107a1daf813b7469392cc42f54dfe37a13f300e0e3f5fb59604a1a7a"
             }
         ],
         "alertsmanagement": [


### PR DESCRIPTION
Related PR: 
https://github.com/Azure/azure-cli-extensions/pull/4934

Since the index.json PR (https://github.com/Azure/azure-cli-extensions/pull/4912) of the previous version 0.5.77 is merged later than the version 0.5.78 PR (https://github.com/Azure/azure-cli-extensions/pull/4868) and the version 0.5.79 PR (https://github.com/Azure/azure-cli-extensions/pull/4905),
so the code in index.json from PR (https://github.com/Azure/azure-cli-extensions/pull/4934) does not contain the contents of version 0.5.77 and 0.5.78, then the generated index.json for version 0.5.79 from this PR conflicts with the index.json for version 0.5.77.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repository and upgrade the version in the pull request but do not modify `src/index.json`. 
