### PR TITLE
Shorten ssh connect timeout

### DIFF
--- a/src/ssh/azext_ssh/ssh_utils.py
+++ b/src/ssh/azext_ssh/ssh_utils.py
@@ -51,7 +51,9 @@ def start_ssh_connection(op_info, delete_keys, delete_cert):
         log_file, ssh_arg_list, cleanup_process = _start_cleanup(op_info.cert_file, op_info.private_key_file,
                                                                  op_info.public_key_file, op_info.delete_credentials,
                                                                  delete_keys, delete_cert, ssh_arg_list)
-        command = command + op_info.build_args() + ssh_arg_list
+        command = command + op_info.build_args() + [
+            "-o", "ConnectTimeout=10",  # To override the default 2-min timeout when target unreachable
+            ] + ssh_arg_list
 
         connection_duration = time.time()
         logger.debug("Running ssh command %s", ' '.join(command))


### PR DESCRIPTION
This would be useful when the target VM's port 22 is somehow unreachable.

I have tested the `time ssh -o ConnectTimeout=10 example.com` to see that option working. But I have not yet tested this in a real "az ssh vm ..." context.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repository and upgrade the version in the pull request but do not modify `src/index.json`. 
