### PR TITLE
Revert "{UpdateExtCommandTree} Support aaz commands"

### DIFF
--- a/scripts/ci/update_ext_cmd_tree.py
+++ b/scripts/ci/update_ext_cmd_tree.py
@@ -44,7 +44,8 @@ def update_cmd_tree(ext_name):
     az_cli.invocation = invoker
 
     sys.path.append(ext_dir)
-    extension_command_table, _ = _load_extension_command_loader(invoker.commands_loader, None, ext_mod)
+    extension_command_table, _ = _load_extension_command_loader(invoker.commands_loader,
+                                                                "", ext_mod)
 
     EXT_CMD_TREE_TO_UPLOAD = Session()
     EXT_CMD_TREE_TO_UPLOAD.load(os.path.expanduser(os.path.join('~', '.azure', file_name)))


### PR DESCRIPTION
build_ext_cmd_tree.sh relies on released azure-cli.
https://github.com/Azure/azure-cli-extensions/blob/facef1105e533dfde286d33bda7c8f34962cdd66/scripts/ci/build_ext_cmd_tree.sh#L9

Revert the modification to unblock [CI](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1635268&view=logs&j=275f1d19-1bd8-5591-b06b-07d489ea915a&t=3178dee2-26ab-587a-4407-0f5d5c54e1f3), because it works only if https://github.com/Azure/azure-cli/pull/22709 in azure-cli-core is released.

Reverts Azure/azure-cli-extensions#4968