### PR TITLE
Fix kollect bug with inconsistent container name for private clusters

### DIFF
--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -14,6 +14,7 @@ Pending
 
 * Update the minimum required cli core version to `2.37.0`.
 * Enable v2 decorator pattern.
+* Fix container name inconsistency for private clusters in kollect command.
 
 0.5.82
 +++++++

--- a/src/aks-preview/azext_aks_preview/aks_diagnostics.py
+++ b/src/aks-preview/azext_aks_preview/aks_diagnostics.py
@@ -133,16 +133,8 @@ def aks_kollect_cmd(cmd,    # pylint: disable=too-many-statements,too-many-local
     print()
     print("Starts collecting diag info for cluster %s " % name)
 
-    # Form containerName from fqdn, as it was previously jsut the location of code is changed.
-    # https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata#container-names
-    maxContainerNameLength = 63
-    fqdn = mc.fqdn if mc.fqdn is not None else mc.private_fqdn
-    normalized_container_name = fqdn.replace('.', '-')
-    len_of_container_name = normalized_container_name.index("-hcp-")
-    if len_of_container_name == -1:
-        len_of_container_name = maxContainerNameLength
-    container_name = normalized_container_name[:len_of_container_name]
-
+    # Base the container name on the fqdn (or private fqdn) of the managed cluster
+    container_name = _generate_container_name(mc.fqdn, mc.private_fqdn)
     sas_token = sas_token.strip('?')
 
     kustomize_yaml = _get_kustomize_yaml(storage_account_name, sas_token, container_name, container_logs, kube_objects, node_logs, node_logs_windows)
@@ -201,7 +193,7 @@ def aks_kollect_cmd(cmd,    # pylint: disable=too-many-statements,too-many-local
 
     token_in_storage_account_url = readonly_sas_token if readonly_sas_token is not None else sas_token
     log_storage_account_url = f"https://{storage_account_name}.blob.core.windows.net/" \
-                              f"{_trim_fqdn_name_containing_hcp(container_name)}?{token_in_storage_account_url}"
+                              f"{container_name}?{token_in_storage_account_url}"
 
     print(f'{colorama.Fore.GREEN}Your logs are being uploaded to storage account {_format_bright(storage_account_name)}')
 
@@ -298,22 +290,27 @@ def _get_storage_account_from_diag_settings(cli_ctx, resource_group_name, name):
     return None
 
 
-def _trim_fqdn_name_containing_hcp(normalized_fqdn: str) -> str:
+def _generate_container_name(fqdn: str, private_fqdn: str) -> str:
     """
-    Trims the storage blob name and takes everything prior to "-hcp-".
-    Currently it is displayed wrong: i.e. at time of creation cli has
-    following limitation:
-    https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/
-    error-storage-account-name
+    Generates a container name unique to the specified managed cluster, that
+    conforms to the Azure naming restrictions defined here:
+    https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata#container-names
 
-    :param normalized_fqdn: storage blob name
-    :return: storage_name_without_hcp: Storage name without the hcp value
-    attached
+    This is done based on fqdn (falling back to private_fqdn), and shortened
+    to strip everything including and after ".hcp.".
+    In case the result is excessively long, and also for private clusters which
+    may not contain "-hcp-", the resulting name is truncated at 63 characters,
+    with any trailing hyphens removed.
+
+    :param fqdn: FQDN of managed cluster
+    :param private_fqdn: Private FQDN of managed cluster
+    :return: container_name: Compliant Azure Storage container name for the cluster
     """
-    storage_name_without_hcp, _, _ = normalized_fqdn.partition('-hcp-')
-    if len(storage_name_without_hcp) > CONST_CONTAINER_NAME_MAX_LENGTH:
-        storage_name_without_hcp = storage_name_without_hcp[:CONST_CONTAINER_NAME_MAX_LENGTH]
-    return storage_name_without_hcp.rstrip('-')
+    container_name = fqdn if fqdn is not None else private_fqdn
+    container_name = container_name[:container_name.find(".hcp.")]
+    container_name = container_name.replace('.', '-')
+    container_name = container_name[:CONST_CONTAINER_NAME_MAX_LENGTH].rstrip('-')
+    return container_name
 
 
 def _display_diagnostics_report(temp_kubeconfig_path):   # pylint: disable=too-many-statements

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_diagnostics.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_diagnostics.py
@@ -7,22 +7,21 @@ import unittest
 import azext_aks_preview.aks_diagnostics as commands
 
 
-class TestTrimContainerName(unittest.TestCase):
-    def test_trim_fqdn_name_containing_hcp(self):
-        container_name = 'abcdef-dns-ed55ba6d-hcp-centralus-azmk8s-io'
+class TestGenerateContainerName(unittest.TestCase):
+    def test_generate_container_name_containing_hcp(self):
+        fqdn = 'abcdef-dns-ed55ba6d.hcp.centralus.azmk8s.io'
         expected_container_name = 'abcdef-dns-ed55ba6d'
-        trim_container_name = commands._trim_fqdn_name_containing_hcp(container_name)
+        trim_container_name = commands._generate_container_name(fqdn, None)
         self.assertEqual(expected_container_name, trim_container_name)
 
-    def test_trim_fqdn_name_trailing_dash(self):
-        container_name = 'dns-ed55ba6ad-e48fe2bd-b4bc-4aac-bc23-29bc44154fe1-privatelink-centralus-azmk8s-io'
+    def test_generate_container_name_trailing_dash(self):
+        private_fqdn = 'dns-ed55ba6ad.e48fe2bd-b4bc-4aac-bc23-29bc44154fe1.privatelink.centralus.azmk8s.io'
         expected_container_name = 'dns-ed55ba6ad-e48fe2bd-b4bc-4aac-bc23-29bc44154fe1-privatelink'
-        trim_container_name = commands._trim_fqdn_name_containing_hcp(
-            container_name)
+        trim_container_name = commands._generate_container_name(None, private_fqdn)
         self.assertEqual(expected_container_name, trim_container_name)
 
-    def test_trim_fqdn_name_not_containing_hcp(self):
-        container_name = 'abcdef-dns-ed55ba6d-e48fe2bd-b4bc-4aac-bc23-29bc44154fe1-privatelink-centralus-azmk8s-io'
+    def test_generate_container_name_not_containing_hcp(self):
+        private_fqdn = 'abcdef-dns-ed55ba6d.e48fe2bd-b4bc-4aac-bc23-29bc44154fe1.privatelink.centralus.azmk8s.io'
         expected_container_name = 'abcdef-dns-ed55ba6d-e48fe2bd-b4bc-4aac-bc23-29bc44154fe1-privat'
-        trim_container_name = commands._trim_fqdn_name_containing_hcp(container_name)
+        trim_container_name = commands._generate_container_name(None, private_fqdn)
         self.assertEqual(expected_container_name, trim_container_name)


### PR DESCRIPTION
This fixes a bug in which the storage container used to retrieve Periscope logs is not the same as the one they are uploaded to.

The change is to put all the logic for determining the container name into one function, rather than spreading it throughout the kollect function.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repository and upgrade the version in the pull request but do not modify `src/index.json`. 
