### PR TITLE
fix no attribute 'gigabytes' error

### DIFF
--- a/src/containerapp-compose/azext_containerapp_compose/custom.py
+++ b/src/containerapp-compose/azext_containerapp_compose/custom.py
@@ -327,9 +327,9 @@ def resolve_memory_configuration_from_service(service):
     if service_deploy_resources_exists(service):
         resources = service.deploy.resources
         if resources.reservations is not None and resources.reservations.memory is not None:
-            memory = str(resources.reservations.memory.gigabytes())
+            memory = str(resources.reservations.memory.as_gigabytes())
     elif service.mem_reservation is not None:
-        memory = str(service.mem_reservation.gigabytes())
+        memory = str(service.mem_reservation.as_gigabytes())
     return memory
 
 


### PR DESCRIPTION
### Related command

```sh
az containerapp compose create 
```

docker-compose.yaml

```yaml
services:
  helloworld:
    image: mcr.microsoft.com/azuredocs/containerapps-helloworld:latest
    ports: 
     - 8080:80
    deploy:
      resources:
        reservations:
          cpus: '0.25'
          memory: 0.5GB
```

### General Guidelines

- [x] Have you run `azdev stylepwd <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?


### See

https://github.com/smurawski/docker-compose-examples/issues/1
