### PR TITLE
Extending basic build support 

### DIFF
--- a/src/containerapp-compose/HISTORY.rst
+++ b/src/containerapp-compose/HISTORY.rst
@@ -6,3 +6,8 @@ Release History
 0.1.0
 ++++++
 * Initial release.
+
+0.2.0
+++++++
+* Add basic build support
+* Fix bug in specifying memory

--- a/src/containerapp-compose/HISTORY.rst
+++ b/src/containerapp-compose/HISTORY.rst
@@ -3,11 +3,11 @@
 Release History
 ===============
 
+0.2.0
+++++++
+* Add basic build support for compose services
+* Fix bug in specifying memory
+
 0.1.0
 ++++++
 * Initial release.
-
-0.2.0
-++++++
-* Add basic build support
-* Fix bug in specifying memory

--- a/src/containerapp-compose/azext_containerapp_compose/custom.py
+++ b/src/containerapp-compose/azext_containerapp_compose/custom.py
@@ -14,7 +14,9 @@ from pycomposefile import ComposeFile
 logger = get_logger(__name__)
 
 
-def resolve_configuration_element_list(compose_service, unsupported_configuration):
+def resolve_configuration_element_list(compose_service, unsupported_configuration, area=None):
+    if area is not None:
+        compose_service = getattr(compose_service, area)
     config_list = []
     for configuration_element in unsupported_configuration:
         try:
@@ -27,11 +29,18 @@ def resolve_configuration_element_list(compose_service, unsupported_configuratio
 
 
 def warn_about_unsupported_build_configuration(compose_service):
+    unsupported_configuration = ["args", "ssh", "cache_from", "cache_to", "extra_hosts",
+                                 "isolation", "labels", "no_cache", "pull", "shm_size",
+                                 "target", "secrets", "tags"]
     if compose_service.build is not None:
-        message = f"Build configuration for {compose_service.build.compose_path} is not currently supported."
-        message += " Work is planned to add that capability."
+        config_list = resolve_configuration_element_list(compose_service, unsupported_configuration, 'build')
+        message = "These build configuration settings from the docker-compose file are yet supported."
+        message += " Currently, we support supplying a build context and optionally target Dockerfile for a service."
         message += " See https://aka.ms/containerapp/compose/build_support for more information or to add feedback."
-        logger.warning(message)
+        if len(config_list) >= 1:
+            logger.warning(message)
+            for item in config_list:
+                logger.warning("     %s", item)
 
 
 def warn_about_unsupported_runtime_host_configuration(compose_service):
@@ -110,6 +119,7 @@ def create_containerapps_from_compose(cmd,  # pylint: disable=R0914
     from ._monkey_patch import (
         create_containerapp_from_service,
         create_containerapps_compose_environment,
+        build_containerapp_from_compose_service,
         load_yaml_file,
         show_managed_environment)
 
@@ -142,6 +152,7 @@ def create_containerapps_from_compose(cmd,  # pylint: disable=R0914
             message = "Unsupported platform found. "
             message += "Azure Container Apps only supports linux/amd64 container images."
             raise InvalidArgumentValueError(message)
+        image = service.image
         warn_about_unsupported_elements(service)
         logger.info(  # pylint: disable=W1203
             f"Creating the Container Apps instance for {service_name} under {resource_group_name} in {location}.")
@@ -161,11 +172,34 @@ def create_containerapps_from_compose(cmd,  # pylint: disable=R0914
         elif secret_env_ref is not None:
             environment = secret_env_ref
 
+        if service.build is not None:
+            logger.warning("Build configuration defined for this service.")
+            logger.warning("The build will be performed by Azure Container Registry.")
+            context = service.build.context
+            dockerfile = "Dockerfile"
+            if service.build.dockerfile is not None:
+                dockerfile = service.build.dockerfile
+            image, registry, registry_username, registry_password = build_containerapp_from_compose_service(
+                cmd,
+                service_name,
+                context,
+                dockerfile,
+                resource_group_name,
+                managed_env,
+                location,
+                image,
+                target_port,
+                ingress_type,
+                registry,
+                registry_username,
+                registry_password,
+                environment)
+
         containerapps_from_compose.append(
             create_containerapp_from_service(cmd,
                                              service_name,
                                              resource_group_name,
-                                             image=service.image,
+                                             image=image,
                                              container_name=service.container_name,
                                              managed_env=managed_environment["id"],
                                              ingress=ingress_type,

--- a/src/containerapp-compose/azext_containerapp_compose/tests/latest/common.py
+++ b/src/containerapp-compose/azext_containerapp_compose/tests/latest/common.py
@@ -22,5 +22,5 @@ def clean_up_test_file(filename):
 
 class ContainerappComposePreviewScenarioTest(ScenarioTest):
     def setUp(self):
-        self.cmd("extension add --name containerapp")
+        self.cmd("extension add --name containerapp --upgrade --yes")
         return super().setUp()

--- a/src/containerapp-compose/setup.py
+++ b/src/containerapp-compose/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
-VERSION = '0.1.0'
+VERSION = '0.2.0'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
@@ -32,7 +32,7 @@ CLASSIFIERS = [
     'License :: OSI Approved :: MIT License',
 ]
 
-DEPENDENCIES = ['pycomposefile>=0.0.26']
+DEPENDENCIES = ['pycomposefile>=0.0.29']
 
 with open('README.rst', 'r', encoding='utf-8') as f:
     README = f.read()


### PR DESCRIPTION

This PR adds basic build support (context and dockerfile) via Azure Container Registry (ACR) build tasks. If a service in the Compose file has the build key defined, either the provided ACR (or a new ACR which will be automatically provisioned) will be used to build the source container image.  The container registry will be mapped the container app to finish the deployment scenario.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
az containerapp compose


### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repository and upgrade the version in the pull request but do not modify `src/index.json`. 
