### PR TITLE
[Quantum] Shorten long workspace name in test

### DIFF
--- a/src/quantum/azext_quantum/tests/latest/utils.py
+++ b/src/quantum/azext_quantum/tests/latest/utils.py
@@ -45,7 +45,7 @@ def get_test_workspace_random_name():
     return "e2e-test-w" + str(random.randint(1000000, 9999999))
 
 def get_test_workspace_random_long_name():
-    return get_test_workspace_random_name() + "-54-char-name123456789012345678901234"
+    return get_test_workspace_random_name() + "-53-char-name12345678901234567890123"
 
 def all_providers_are_in_capabilities(provider_sku_string, capabilities_string):
     for provide_sku_pair in provider_sku_string.split(';'):


### PR DESCRIPTION
One of the live tests generates a maximum-length managed application name that includes the provider's name.  When "quantinuum" was automatically added (instead of "honeywell") the name became one character too long.  This PR shortens the name used in the test to a valid length.

---

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?
