### PR TITLE
[Fix] Log warning rather than throw exception when we by default create app insights

### DIFF
--- a/src/spring/HISTORY.md
+++ b/src/spring/HISTORY.md
@@ -1,5 +1,9 @@
 Release History
 ===============
+1.1.3
+---
+* Enhance Application Insights settings when create service instance.
+
 1.1.2
 ---
 * Support configure Germination Grace Period Seconds for deployments.

--- a/src/spring/setup.py
+++ b/src/spring/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
-VERSION = '1.1.2'
+VERSION = '1.1.3'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
### Background
When customer create Azure Spring Apps service instance with CLI, if customer didn't specify anything for application insights, we'll by default create an Application Insights, and associate it to the service instance. But create application insights can fail, we don't want to block customer's flow to create service instance, so log warning rather than throw exception and fail the command, just as was done in Basic and Standard tiers.

### Effect Preview
#### Warning when create application insights failed
![image](https://user-images.githubusercontent.com/22190245/176340851-8a1866f1-5a4a-4239-9f19-d876548dbe5c.png)

### ADO workitem
[Bug 13041269](https://msazure.visualstudio.com/AzureDMSS/_workitems/edit/13041269): [CLI][All tiers][Pilot]:Create service instance successfully，but application insights create failed

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

```
az spring create xxxxxxx
```


### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repository and upgrade the version in the pull request but do not modify `src/index.json`. 
