### PR TITLE
{AzContainerApp} fixes Azure/azure-cli-extensions#5067

### DIFF
--- a/src/containerapp/azext_containerapp/custom.py
+++ b/src/containerapp/azext_containerapp/custom.py
@@ -504,6 +504,11 @@ def update_containerapp_logic(cmd,
                               from_revision=None):
     _validate_subscription_registered(cmd, CONTAINER_APPS_RP)
 
+    # Validate that max_replicas is set to 0-30"""
+    if max_replicas is not None:
+        if max_replicas < 1 or max_replicas > 30:
+            raise CLIError('--max_replicas must be in the range [1,30]')
+            
     if yaml:
         if image or min_replicas or max_replicas or\
            set_env_vars or remove_env_vars or replace_env_vars or remove_all_env_vars or cpu or memory or\


### PR DESCRIPTION
az containerapp update -n ContainerAppName -g ResourceGroup --min-replicas 0 --max-replicas 0 finishes without throwing any error, however scaling configuration is not updated as max replicas cannot be zero.

This PR should include a fix to validate the --max-replicas field while the value is sent as Zero and raise CLIError

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repository and upgrade the version in the pull request but do not modify `src/index.json`. 
