### PR TITLE
{AKS} Fix enabled virtual node addon showing wrong status in `aks addon list`

### DIFF
--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -11,6 +11,12 @@ To release a new version, please select a new version number (usually plus 1 to 
 
 Pending
 +++++++
+0.5.89
+++++++
+
+* Fix for the az aks addon list command to return enable:true, if virtual-node addon is enabled for the AKS cluster.
+
++++++++
 0.5.88
 ++++++
 

--- a/src/aks-preview/azext_aks_preview/custom.py
+++ b/src/aks-preview/azext_aks_preview/custom.py
@@ -1383,6 +1383,7 @@ def aks_addon_list_available():
 def aks_addon_list(cmd, client, resource_group_name, name):
     mc = client.get(resource_group_name, name)
     current_addons = []
+    os_type = 'Linux'
 
     for name, addon_key in ADDONS.items():
         # web_application_routing is a special case, the configuration is stored in a separate profile
@@ -1400,6 +1401,13 @@ def aks_addon_list(cmd, client, resource_group_name, name):
                 if mc.addon_profiles and
                 addon_key in mc.addon_profiles and
                 mc.addon_profiles[addon_key].enabled
+                else False
+            )
+        if name == "virtual_node":
+            addon_key += os_type
+            enabled = (
+                True
+                if addon_key in mc.addon_profiles and mc.addon_profiles[addon_key].enabled
                 else False
             )
         current_addons.append({

--- a/src/aks-preview/setup.py
+++ b/src/aks-preview/setup.py
@@ -9,7 +9,7 @@ from codecs import open as open1
 
 from setuptools import setup, find_packages
 
-VERSION = "0.5.88"
+VERSION = "0.5.89"
 CLASSIFIERS = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",


### PR DESCRIPTION
fixes Azure/azure-cli-extensions#5098

az aks addon list command always returns "enable:false" for virtual-node addon. REST API returns "enable:true", but CLI displays result as "enable:false"

```
az aks addon list -g TestRG -n TestCluster --debug
# REST API returns the addon status to be "enabled:true" in debug trace.
   "addonProfiles": {
    "aciConnectorLinux": {
     "enabled": true,            <<<<<<<
     "config": {
      "SubnetName": "VirtualNodeSubnet"
     },


#However, CLI displays "enabled:false". It appears to be matching with "aciConnector" instead of "aciConnectorLinux".

  {
    "api_key": "aciConnector",
    "enabled": false,           <<<<<<<<<
    "name": "virtual-node"
  },
```

As per [this](https://github.com/Azure/azure-cli-extensions/blob/b02803b4bd7aee2ae9e707af1be8b6a9860559a7/src/aks-preview/azext_aks_preview/addonconfiguration.py#L107) and [this](https://github.com/Azure/azure-cli-extensions/blob/b02803b4bd7aee2ae9e707af1be8b6a9860559a7/src/aks-preview/azext_aks_preview/custom.py#L1667
)  source code we see that Linux is appended to the VirtualNode addon, so this check should be done while listing the addon:

```
os_type = 'Linux'
enable_virtual_node = False
if CONST_VIRTUAL_NODE_ADDON_NAME + os_type in instance.addon_profiles:
        enable_virtual_node = True
```

```
        addon = ADDONS[addon_arg]
        if addon == CONST_VIRTUAL_NODE_ADDON_NAME:
            # only linux is supported for now, in the future this will be a user flag
            addon += os_type
```



---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repository and upgrade the version in the pull request but do not modify `src/index.json`. 
