### PR TITLE
add support for arm64 Helm binaries.

### DIFF
--- a/src/connectedk8s/azext_connectedk8s/custom.py
+++ b/src/connectedk8s/azext_connectedk8s/custom.py
@@ -383,9 +383,15 @@ def install_helm_client():
         install_location_string = f'.azure\\helm\\{consts.HELM_VERSION}\\{operating_system}-amd64\\helm.exe'
         requestUri = f'{consts.HELM_STORAGE_URL}/helm/helm-{consts.HELM_VERSION}-{operating_system}-amd64.zip'
     elif(operating_system == 'linux' or operating_system == 'darwin'):
-        download_location_string = f'.azure/helm/{consts.HELM_VERSION}/helm-{consts.HELM_VERSION}-{operating_system}-amd64.tar.gz'
-        install_location_string = f'.azure/helm/{consts.HELM_VERSION}/{operating_system}-amd64/helm'
-        requestUri = f'{consts.HELM_STORAGE_URL}/helm/helm-{consts.HELM_VERSION}-{operating_system}-amd64.tar.gz'
+        # Set the right platform values for Linux
+        if(machine_type == 'aarch64'):
+            machine_type = 'arch64'
+        elif(machine_type == 'x86_64'):
+            machine_type = 'amd64'
+        download_location_string = f'.azure/helm/{consts.HELM_VERSION}/helm-{consts.HELM_VERSION}-{operating_system}-{machine_type}.tar.gz'
+        install_location_string = f'.azure/helm/{consts.HELM_VERSION}/{operating_system}-{machine_type}/helm'
+        requestUri = f'{consts.HELM_STORAGE_URL}/helm/helm-{consts.HELM_VERSION}-{operating_system}-{machine_type}.tar.gz'
+        logger.warning("Helm URI", requestUri)
     else:
         telemetry.set_exception(exception='Unsupported OS for installing helm client', fault_type=consts.Helm_Unsupported_OS_Fault_Type,
                                 summary=f'{operating_system} is not supported for installing helm client')


### PR DESCRIPTION
add a condition to check what architecture we will be executing Helm (arm64 or amd64). This will ensure that we download the correct binaries for that platform. Currently, on a arm64 Mac (M1/M2 processors) we are downloading the amd64 helm binary and are using Rosetta for the translation. This breaks on any other OS (e.g.: Linux) running on aarch64.

this is a WIP as the https://k8connecthelm.azureedge.net/helm/ only contains the amd64 version of helm.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repository and upgrade the version in the pull request but do not modify `src/index.json`. 
