### PR TITLE
{CI} Fix Azure CLI Extensions Sync to MicrosoftDocs error

### DIFF
--- a/scripts/ci/avail-ext-doc/requirements.txt
+++ b/scripts/ci/avail-ext-doc/requirements.txt
@@ -1,3 +1,4 @@
 Jinja2~=2.10.1
-wheel==0.31.1
+MarkupSafe==2.0.1
 requests
+wheel==0.31.1

--- a/scripts/ci/avail-ext-doc/requirements.txt
+++ b/scripts/ci/avail-ext-doc/requirements.txt
@@ -1,4 +1,3 @@
-Jinja2~=2.10.1
-MarkupSafe==2.0.1
+Jinja2==3.0.3
 requests
 wheel==0.31.1


### PR DESCRIPTION
The pipeline (Azure CLI Extensions Sync to MicrosoftDocs）didn't work since July 5th.
![image](https://user-images.githubusercontent.com/18628534/182507930-5e5785d6-7cb9-4829-9a6b-3a02d4fe9727.png)
Here is the error message:
![image](https://user-images.githubusercontent.com/18628534/182504714-f7ba236d-c285-4885-8943-1ea773e749dc.png)
~~Since MarkupSafe remove soft_unicode in version 2.1.0~~
~~So we use MarkupSafe == 2.0.1 to fix this error.~~
And we use jinja2 == 3.0.3 in azure-cli which already drops the soft_unicode.
https://github.com/Azure/azure-cli/blob/75f7048672cf8198bb8f073262caa9e706b68699/scripts/ci/test_ref_doc.sh#L17
So we also upgrade jinja2 to 3.0.3 in azure-cli-extensions.
Test result:
![image](https://user-images.githubusercontent.com/18628534/182511662-455409c6-d8f9-4bda-aeab-fa0c0099f1bf.png)