### PR TITLE
{CI} drop python 3.6

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,9 +71,9 @@ jobs:
     vmImage: 'ubuntu-20.04'
   steps:
     - task: UsePythonVersion@0
-      displayName: 'Use Python 3.8'
+      displayName: 'Use Python 3.6'
       inputs:
-        versionSpec: 3.8
+        versionSpec: 3.6
     - bash: pip install wheel==0.30.0 pylint==1.9.5 flake8==3.5.0 requests
       displayName: 'Install wheel, pylint, flake8, requests'
     - bash: python scripts/ci/source_code_static_analysis.py

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,9 +71,9 @@ jobs:
     vmImage: 'ubuntu-20.04'
   steps:
     - task: UsePythonVersion@0
-      displayName: 'Use Python 3.6'
+      displayName: 'Use Python 3.8'
       inputs:
-        versionSpec: 3.6
+        versionSpec: 3.8
     - bash: pip install wheel==0.30.0 pylint==1.9.5 flake8==3.5.0 requests
       displayName: 'Install wheel, pylint, flake8, requests'
     - bash: python scripts/ci/source_code_static_analysis.py
@@ -102,8 +102,6 @@ jobs:
     vmImage: 'ubuntu-20.04'
   strategy:
     matrix:
-      Python36:
-        python.version: '3.6'
       Python38:
         python.version: '3.8'
       Python39:


### PR DESCRIPTION
---
By default, the end-of-life is scheduled 5 years after the first release.

![image](https://user-images.githubusercontent.com/18628534/183668634-ebf52bf7-e434-4ccf-827d-58d9a5301a24.png)

And the python SDK has already dropped python 3.6.
But we still use python 3.6 in our test enviroment, that will cause some error like these:

![image](https://user-images.githubusercontent.com/18628534/183669746-b61c358b-12d8-4644-a280-7baa39fab5e9.png)

The root cause is that azure-mgmt-monitor no longer supports python3.6, so the latest azure-mgmt-monitor cannot be installed in the python3.6 test environment.

![image](https://user-images.githubusercontent.com/18628534/183670196-88856d0b-538b-4d83-864a-3576e2f22c51.png)
This pull request will drop python 3.6 in our pipeline.

And I will bump pylint to 2.11.1 in this [PR](https://github.com/Azure/azure-cli-extensions/pull/4645) when I have time.

