### PR TITLE
Pyre type error fixed

### DIFF
--- a/scripts/ci/index_ref_doc.py
+++ b/scripts/ci/index_ref_doc.py
@@ -71,7 +71,7 @@ class TestIndexRefDocsMeta(type):
         return type.__new__(mcs, name, bases, _dict)
 
 
-class IndexRefDocs(with_metaclass(TestIndexRefDocsMeta, unittest.TestCase)):
+class IndexRefDocs(TestIndexRefDocsMeta, unittest.TestCase):
 
     def setUp(self):
         self.whl_dir = tempfile.mkdtemp()


### PR DESCRIPTION
"filename": "scripts/ci/index_ref_doc.py"
"warning_type": "Invalid type [31]"
"warning_message": " Expression `six.with_metaclass(scripts.ci.index_ref_doc.TestIndexRefDocsMeta, unittest.TestCase)` is not a valid type."
"warning_line": 74
"fix": remove six.with_metaclass(