### PR TITLE
Fix for Draft CLI 1:n release issue and failing tests. ☕️🙏🚀

### DIFF
--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -12,6 +12,12 @@ To release a new version, please select a new version number (usually plus 1 to 
 Pending
 +++++++
 
+0.5.98
+++++++
+
+* Fix auto download issue for Draft CLI.
+* Remove host and certificates as draft tools update command no longer uses it.
+
 0.5.97
 ++++++
 

--- a/src/aks-preview/azext_aks_preview/_consts.py
+++ b/src/aks-preview/azext_aks_preview/_consts.py
@@ -184,3 +184,8 @@ CONST_PERISCOPE_NAMESPACE = "aks-periscope"
 
 CONST_AZURE_KEYVAULT_NETWORK_ACCESS_PUBLIC = "Public"
 CONST_AZURE_KEYVAULT_NETWORK_ACCESS_PRIVATE = "Private"
+
+# refer https://api.github.com/repos/Azure/draft/releases/latest
+# tag_name gives latest version released.
+# Moving away from 1:n release to avoid unwanted breaking changes with auto upgrades.
+CONST_DRAFT_CLI_VERSION = "v0.0.23"

--- a/src/aks-preview/azext_aks_preview/_help.py
+++ b/src/aks-preview/azext_aks_preview/_help.py
@@ -2104,5 +2104,5 @@ helps['aks draft update'] = """
       - name: Prompt to update the application to be internet accessible in a specific project directory.
         text: az aks draft update --destination=/projects/some_project
       - name: Update the application to be internet accessible with a host of the ingress resource and a Keyvault certificate in a specific project directory.
-        text: az aks draft update --host=some_host --certificate=some_certificate --destination=/projects/some_project
+        text: az aks draft update --destination=/projects/some_project
 """

--- a/src/aks-preview/azext_aks_preview/_help.py
+++ b/src/aks-preview/azext_aks_preview/_help.py
@@ -2086,12 +2086,6 @@ helps['aks draft update'] = """
     long-summary: This command automatically updates your yaml files as necessary so that your
                   application will be able to receive external requests.
     parameters:
-        - name: --host
-          type: string
-          short-summary: Specify the host of the ingress resource.
-        - name: --certificate
-          type: string
-          short-summary: Specify the URI of the Keyvault certificate to present.
         - name: --destination
           type: string
           short-summary: Specify the path to the project directory (default is .).
@@ -2102,7 +2096,5 @@ helps['aks draft update'] = """
       - name: Prompt to update the application to be internet accessible.
         text: az aks draft update
       - name: Prompt to update the application to be internet accessible in a specific project directory.
-        text: az aks draft update --destination=/projects/some_project
-      - name: Update the application to be internet accessible with a host of the ingress resource and a Keyvault certificate in a specific project directory.
         text: az aks draft update --destination=/projects/some_project
 """

--- a/src/aks-preview/azext_aks_preview/aks_draft/commands.py
+++ b/src/aks-preview/azext_aks_preview/aks_draft/commands.py
@@ -14,10 +14,10 @@ import platform
 from pathlib import Path
 from knack.prompting import prompt_y_n
 import logging
-
 from azext_aks_preview._consts import (
     CONST_DRAFT_CLI_VERSION
 )
+
 
 # `az aks draft create` function
 def aks_draft_cmd_create(destination: str,
@@ -123,8 +123,8 @@ def aks_draft_cmd_up(app: str,
 
 
 # `az aks draft update` function
-def aks_draft_cmd_update(host: str, certificate: str, destination: str, download_path: str) -> None:
-    file_path, arguments = _pre_run(download_path, host=host, certificate=certificate, destination=destination)
+def aks_draft_cmd_update(destination: str, download_path: str) -> None:
+    file_path, arguments = _pre_run(download_path, destination=destination)
     run_successful = _run(file_path, 'update', arguments)
     if run_successful:
         _run_finish()
@@ -201,8 +201,6 @@ def _binary_pre_check(download_path: str) -> Optional[str]:
 
 # Returns True if the local binary is the latest version, False otherwise
 def _is_latest_version(binary_path: str) -> bool:
-    # We should run this from some kind of config, but since there is none 
-    # lets pass this sttaic from here to fix failing tests, periscope does same.
     latest_version = CONST_DRAFT_CLI_VERSION
     process = subprocess.Popen([binary_path, 'version'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout, stderr = process.communicate()

--- a/src/aks-preview/azext_aks_preview/aks_draft/commands.py
+++ b/src/aks-preview/azext_aks_preview/aks_draft/commands.py
@@ -15,6 +15,9 @@ from pathlib import Path
 from knack.prompting import prompt_y_n
 import logging
 
+from azext_aks_preview._consts import (
+    CONST_DRAFT_CLI_VERSION
+)
 
 # `az aks draft create` function
 def aks_draft_cmd_create(destination: str,
@@ -196,16 +199,11 @@ def _binary_pre_check(download_path: str) -> Optional[str]:
         return _download_binary()
 
 
-# Returns the latest version str of Draft on Github
-def _get_latest_version() -> str:
-    response = requests.get('https://api.github.com/repos/Azure/draft/releases/latest')
-    response_json = json.loads(response.text)
-    return response_json.get('tag_name')
-
-
 # Returns True if the local binary is the latest version, False otherwise
 def _is_latest_version(binary_path: str) -> bool:
-    latest_version = _get_latest_version()
+    # We should run this from some kind of config, but since there is none 
+    # lets pass this sttaic from here to fix failing tests, periscope does same.
+    latest_version = CONST_DRAFT_CLI_VERSION
     process = subprocess.Popen([binary_path, 'version'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout, stderr = process.communicate()
     if stderr.decode():

--- a/src/aks-preview/azext_aks_preview/custom.py
+++ b/src/aks-preview/azext_aks_preview/custom.py
@@ -1910,8 +1910,8 @@ def aks_draft_up(app=None,
                      cluster_name, registry_name, container_name, destination, branch, path)
 
 
-def aks_draft_update(host=None, certificate=None, destination=None, path=None):
-    aks_draft_cmd_update(host, certificate, destination, path)
+def aks_draft_update(destination=None, path=None):
+    aks_draft_cmd_update(destination, path)
 
 
 def aks_kollect(cmd,    # pylint: disable=too-many-statements,too-many-locals

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -5258,7 +5258,7 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             assert os.path.isfile(f'{tmp_dir}/charts/production.yaml') and os.path.isfile(f'{tmp_dir}/.github/workflows/azure-kubernetes-service-helm.yml')
 
             # test `update`
-            update_cmd = f'aks draft update --path={tmp_dir} --destination={tmp_dir} --host=testHost --certificate=testKV'
+            update_cmd = f'aks draft update --path={tmp_dir} --destination={tmp_dir}'
             self.cmd(update_cmd)
             assert os.path.isfile(f'{tmp_dir}/charts/production.yaml')
 
@@ -5283,7 +5283,7 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             assert os.path.isfile(f'{tmp_dir}/overlays/production/deployment.yaml') and os.path.isfile(f'{tmp_dir}/.github/workflows/azure-kubernetes-service-kustomize.yml')
 
             # test `update`
-            update_cmd = f'aks draft update --path={tmp_dir} --destination={tmp_dir} --host=testHost --certificate=testKV'
+            update_cmd = f'aks draft update --path={tmp_dir} --destination={tmp_dir}'
             self.cmd(update_cmd)
             assert os.path.isfile(f'{tmp_dir}/overlays/production/service.yaml')
 
@@ -5308,7 +5308,7 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             assert os.path.isfile(f'{tmp_dir}/.github/workflows/azure-kubernetes-service.yml')
 
             # test `update`
-            update_cmd = f'aks draft update --path={tmp_dir} --destination={tmp_dir} --host=testHost --certificate=testKV'
+            update_cmd = f'aks draft update --path={tmp_dir} --destination={tmp_dir}'
             self.cmd(update_cmd)
             assert os.path.isfile(f'{tmp_dir}/manifests/service.yaml')
 

--- a/src/aks-preview/setup.py
+++ b/src/aks-preview/setup.py
@@ -9,7 +9,7 @@ from codecs import open as open1
 
 from setuptools import setup, find_packages
 
-VERSION = "0.5.97"
+VERSION = "0.5.98"
 CLASSIFIERS = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command

Following changes is for fixing failing test and the `1:n` release issue which needs to be fixed with `1:1` release  because currently there was a function auto downloading the latest version and `DRAFT CLI` had a breaking change in `v0.0.23` from `v0.0.22` and even if `AZ CLI` was in old version this auto download code would have broken the existing user.

This PR fixes:

* `1:n` to `1:1` release issue for az cli and draft.
* Fix test by removing `--host and --certificate` which was removed under this PR: https://github.com/Azure/draft/pull/136
    * **Question**: I see that 2 new parameters are added in the new `draft` PR, will those parameter required parameters fr update command to work?
    * Also, if will be good to test this locally with someone who is familiar with Draft commands more so that there is no side effects getting shipped with this. Thanks in advance.

Thanks and FYI: @karenychen , @gambtho , @FumingZhang , @imiller31 , @davidgamero , @qpetraroia , @sabbour, @bfoley13  ❤️🙏☕️


### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repository and upgrade the version in the pull request but do not modify `src/index.json`. 
