### PR TITLE
{AKS} Fix `az aks draft` command crashed on windows during binary check

### DIFF
--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -12,6 +12,10 @@ To release a new version, please select a new version number (usually plus 1 to 
 Pending
 +++++++
 
+0.5.101
++++++++
+
+* Fix `az aks draft` command crashed on windows during binary check, see issue `\#5336 <https://github.com/Azure/azure-cli-extensions/issues/5336>`_.
 * Update to use 2022-08-02-preview api version.
 
 0.5.100

--- a/src/aks-preview/azext_aks_preview/aks_draft/commands.py
+++ b/src/aks-preview/azext_aks_preview/aks_draft/commands.py
@@ -223,7 +223,8 @@ def _get_filename() -> Optional[str]:
         logging.error('Cannot find a suitable download for the current system architecture. Draft only supports AMD64 and ARM64.')
         return None
 
-    return f'draft-{operating_system}-{architecture}'
+    file_suffix = ".exe" if operating_system == "windows" else ""
+    return f'draft-{operating_system}-{architecture}{file_suffix}'
 
 
 # Returns path to existing draft binary, None otherwise

--- a/src/aks-preview/setup.py
+++ b/src/aks-preview/setup.py
@@ -9,7 +9,7 @@ from codecs import open as open1
 
 from setuptools import setup, find_packages
 
-VERSION = "0.5.100"
+VERSION = "0.5.101"
 CLASSIFIERS = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

{AKS} Fix `az aks draft` command crashed on windows during binary check. 

When the binary file of aks-draft does not exist, it will be downloaded from GitHub release. Since the file corresponding to the Windows platform ends with `.exe`, and the url used for downloading does not contain the suffix, an error occurs.

Fix issues [#5336](https://github.com/Azure/azure-cli-extensions/issues/5336), [#5310](https://github.com/Azure/azure-cli-extensions/issues/5310).

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

`az aks draft`


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repository and upgrade the version in the pull request but do not modify `src/index.json`. 
