### PR TITLE
Hide spring 1.1.6 from customers since not compatible with old CLI core

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -33954,49 +33954,6 @@
                     "version": "1.1.5"
                 },
                 "sha256Digest": "091004e8bfea9c39fbb192065b2355018f6a3ab1041e914ace26f8c02ef14687"
-            },
-            {
-                "downloadUrl": "https://azcliprod.blob.core.windows.net/cli-extensions/spring-1.1.6-py3-none-any.whl",
-                "filename": "spring-1.1.6-py3-none-any.whl",
-                "metadata": {
-                    "azext.isPreview": false,
-                    "azext.minCliCoreVersion": "2.30.0",
-                    "classifiers": [
-                        "Development Status :: 4 - Beta",
-                        "Intended Audience :: Developers",
-                        "Intended Audience :: System Administrators",
-                        "Programming Language :: Python",
-                        "Programming Language :: Python :: 3",
-                        "Programming Language :: Python :: 3.6",
-                        "Programming Language :: Python :: 3.7",
-                        "Programming Language :: Python :: 3.8",
-                        "License :: OSI Approved :: MIT License"
-                    ],
-                    "extensions": {
-                        "python.details": {
-                            "contacts": [
-                                {
-                                    "email": "azpycli@microsoft.com",
-                                    "name": "Microsoft Corporation",
-                                    "role": "author"
-                                }
-                            ],
-                            "document_names": {
-                                "description": "DESCRIPTION.rst"
-                            },
-                            "project_urls": {
-                                "Home": "https://github.com/Azure/azure-cli-extensions/tree/main/src/spring"
-                            }
-                        }
-                    },
-                    "generator": "bdist_wheel (0.30.0)",
-                    "license": "MIT",
-                    "metadata_version": "2.0",
-                    "name": "spring",
-                    "summary": "Microsoft Azure Command-Line Tools spring Extension",
-                    "version": "1.1.6"
-                },
-                "sha256Digest": "e742de1759ee15ca635b86df1ec54db1327bfb146f4c4945bd7f355d245b3ff1"
             }
         ],
         "spring-cloud": [


### PR DESCRIPTION
Hide spring 1.1.6 from customers since not compatible with old CLI core
spring 1.1.6 has minCliCoreVersion at 2.30, but it's not compatible with CLI core < 2.38.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
az spring


### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repository and upgrade the version in the pull request but do not modify `src/index.json`. 
