### PR TITLE
Display Asterisk in place of password

### DIFF
--- a/src/connectedvmware/HISTORY.rst
+++ b/src/connectedvmware/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.1.8
+++++++
+* Displaying asterisks (*****) for password input.
+
 0.1.7
 ++++++
 * Proxy support in vm guest agent.

--- a/src/connectedvmware/azext_connectedvmware/custom.py
+++ b/src/connectedvmware/azext_connectedvmware/custom.py
@@ -136,6 +136,10 @@ def connect_vcenter(
             creds['password'] = pwinput('Please provide vcenter password: ')
             if not creds['password']:
                 print('Parameter is required, please try again')
+            passwdConfim = pwinput('Please confirm vcenter password: ')
+            if creds['password'] != passwdConfim:
+                print('Passwords do not match, please try again')
+                creds['password'] = None
         print('Confirm vcenter details? [Y/n]: ', end='')
         res = input().lower()
         if res in ['y', '']:

--- a/src/connectedvmware/azext_connectedvmware/custom.py
+++ b/src/connectedvmware/azext_connectedvmware/custom.py
@@ -5,7 +5,7 @@
 # pylint: disable= too-many-lines, too-many-locals, unused-argument, too-many-branches, too-many-statements
 # pylint: disable= consider-using-dict-items, consider-using-f-string
 
-from getpass import getpass
+from pwinput import pwinput
 from knack.util import CLIError
 from azext_connectedvmware.vmware_utils import get_resource_id
 from azure.cli.core.util import sdk_no_wait
@@ -122,21 +122,23 @@ def connect_vcenter(
             'username': username,
             'password': password,
         }
-        if fqdn is None:
+        while not creds['fqdn']:
             print('Please provide vcenter FQDN or IP address: ', end='')
             creds['fqdn'] = input()
-        if username is None:
+            if not creds['fqdn']:
+                print('Parameter is required, please try again')
+        while not creds['username']:
             print('Please provide vcenter username: ', end='')
             creds['username'] = input()
-        if password is None:
-            creds['password'] = getpass('Please provide vcenter password: ')
+            if not creds['username']:
+                print('Parameter is required, please try again')
+        while not creds['password']:
+            creds['password'] = pwinput('Please provide vcenter password: ')
+            if not creds['password']:
+                print('Parameter is required, please try again')
         print('Confirm vcenter details? [Y/n]: ', end='')
         res = input().lower()
         if res in ['y', '']:
-            for cred_type, cred_val in creds.items():
-                if not cred_val:
-                    print(f'{cred_type} cannot be empty. Please try again.')
-                    continue
             fqdn, username, password = creds['fqdn'], creds['username'], creds['password']
             creds_ok = True
         elif res != 'n':

--- a/src/connectedvmware/setup.py
+++ b/src/connectedvmware/setup.py
@@ -19,7 +19,7 @@ except ImportError:
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
 
-VERSION = '0.1.7'
+VERSION = '0.1.8'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
@@ -36,7 +36,7 @@ CLASSIFIERS = [
 ]
 
 # TODO: Add any additional SDK dependencies here
-DEPENDENCIES = []
+DEPENDENCIES = ["pwinput"]
 
 with open('README.rst', 'r', encoding='utf-8') as f:
     README = f.read()

--- a/src/scvmm/HISTORY.rst
+++ b/src/scvmm/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.1.6
+++++++
+* Displaying asterisks (*****) for password input.
+
 0.1.5
 +++
 * Requesting VMMServer credentials from the user until they are non-empty.

--- a/src/scvmm/azext_scvmm/custom.py
+++ b/src/scvmm/azext_scvmm/custom.py
@@ -4,7 +4,6 @@
 # --------------------------------------------------------------------------------------------
 # pylint: disable=unused-argument,too-many-lines
 
-import sys
 from pwinput import pwinput
 from azure.cli.core.azclierror import (
     UnrecognizedArgumentError,

--- a/src/scvmm/azext_scvmm/custom.py
+++ b/src/scvmm/azext_scvmm/custom.py
@@ -5,7 +5,7 @@
 # pylint: disable=unused-argument,too-many-lines
 
 import sys
-from getpass import getpass
+from pwinput import pwinput
 from azure.cli.core.azclierror import (
     UnrecognizedArgumentError,
     RequiredArgumentMissingError,
@@ -122,19 +122,12 @@ def connect_vmmserver(
             if not creds['username']:
                 print('Parameter is required, please try again')
         while not creds['password']:
-            creds['password'] = getpass('Please provide vmmserver password: ')
+            creds['password'] = pwinput('Please provide vmmserver password: ')
             if not creds['password']:
                 print('Parameter is required, please try again')
         print('Confirm vmmserver details? [Y/n]: ', end='')
         res = input().lower()
         if res in ['y', '']:
-            for cred_type, cred_val in creds.items():
-                if not cred_val:
-                    print(
-                        f'{cred_type} cannot be empty. Please try again.',
-                        file=sys.stderr,
-                    )
-                    continue
             fqdn, port, username, password = (
                 creds['fqdn'],
                 creds['port'],

--- a/src/scvmm/azext_scvmm/custom.py
+++ b/src/scvmm/azext_scvmm/custom.py
@@ -124,6 +124,10 @@ def connect_vmmserver(
             creds['password'] = pwinput('Please provide vmmserver password: ')
             if not creds['password']:
                 print('Parameter is required, please try again')
+            passwdConfim = pwinput('Please confirm vmmserver password: ')
+            if creds['password'] != passwdConfim:
+                print('Passwords do not match, please try again')
+                creds['password'] = None
         print('Confirm vmmserver details? [Y/n]: ', end='')
         res = input().lower()
         if res in ['y', '']:

--- a/src/scvmm/setup.py
+++ b/src/scvmm/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
 
-VERSION = '0.1.5'
+VERSION = '0.1.6'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
@@ -32,7 +32,7 @@ CLASSIFIERS = [
     'License :: OSI Approved :: MIT License',
 ]
 
-DEPENDENCIES = []
+DEPENDENCIES = ["pwinput"]
 
 with open('README.rst', 'r', encoding='utf-8') as f:
     README = f.read()


### PR DESCRIPTION
---
Changes:
- Remove redundant empty checks
- Display asterisk(***) in place of password input for the following commands:
  + az connectedvmware vcenter connect
     ![image](https://user-images.githubusercontent.com/17731151/194807647-109f00ab-3fc0-4ac5-a998-a153ae5aa82f.png)
  + az scvmm vmmserver connect
     ![image](https://user-images.githubusercontent.com/17731151/194807660-d6f5943b-ff35-499d-a3b4-e43afe30c83a.png)

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
az connectedvmware vcenter connect
az scvmm vmmserver connect

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repository and upgrade the version in the pull request but do not modify `src/index.json`. 
