### PR TITLE
{AKS} `az aks update`: Fix command failure in validation of AzureMonitorMetrics Addon for SP-based cluster

### DIFF
--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -13,9 +13,6 @@ Pending
 +++++++
 
 * Fix workload identity update error after oidc issure GA in azure-cli.
-0.5.113
-+++++++
-
 * Fix `az aks update` command failing on SP-based cluster blocked by validation in AzureMonitorMetrics Addon, see issue `\#5336 <https://github.com/Azure/azure-cli-extensions/issues/5488>`_.
 
 0.5.112

--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -13,11 +13,15 @@ Pending
 +++++++
 
 * Fix workload identity update error after oidc issure GA in azure-cli.
+0.5.113
++++++++
+
+* Fix `az aks update` command failing on SP-based cluster blocked by validation in AzureMonitorMetrics Addon, see issue `\#5336 <https://github.com/Azure/azure-cli-extensions/issues/5488>`_.
 
 0.5.112
 +++++++
 
-* Add --outbound-type to update managed cluster command.
+* Add `--outbound-type` to update managed cluster command.
 
 0.5.111
 +++++++

--- a/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
@@ -1979,9 +1979,9 @@ class AKSPreviewManagedClusterContext(AKSManagedClusterContext):
         if enable_validation:
             if enable_azure_monitor_metrics and self._get_disable_azure_monitor_metrics(False):
                 raise MutuallyExclusiveArgumentError(
-                    "Cannot specify --enable-azuremonitormetrics and --enable-azuremonitormetrics at the same time."
+                    "Cannot specify --enable-azuremonitormetrics and --disable-azuremonitormetrics at the same time."
                 )
-            if not check_is_msi_cluster(self.mc):
+            if enable_azure_monitor_metrics and not check_is_msi_cluster(self.mc):
                 raise RequiredArgumentMissingError(
                     "--enable-azuremonitormetrics can only be specified for clusters with managed identity enabled"
                 )

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -1552,7 +1552,7 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             'aks delete -g {resource_group} -n {name} --yes --no-wait', checks=[self.is_empty()])
 
     @AllowLargeResponse()
-    @AKSCustomResourceGroupPreparer(random_name_length=17, name_prefix='clitest', location='eastus')
+    @AKSCustomResourceGroupPreparer(random_name_length=17, name_prefix='clitest', location='eastus', preserve_default_location=True)
     def test_aks_nodepool_add_with_disable_windows_outbound_nat(self, resource_group, resource_group_location):
         # reset the count so in replay mode the random names will start with 0
         self.test_resources_count = 0

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
@@ -5717,6 +5717,23 @@ class AKSPreviewManagedClusterUpdateDecoratorTestCase(unittest.TestCase):
         )
         self.assertEqual(dec_mc_3, ground_truth_mc_3)
 
+    def test_update_azure_monitor_profile(self):
+        dec_1 = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {},
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        mc_1 = self.models.ManagedCluster(
+            location="test_location",
+        )
+        dec_1.context.attach_mc(mc_1)
+        dec_mc_1 = dec_1.update_azure_monitor_profile(mc_1)
+        ground_truth_mc_1 = self.models.ManagedCluster(
+            location="test_location",
+        )
+        self.assertEqual(dec_mc_1, ground_truth_mc_1)
+
     def test_update_mc_profile_preview(self):
         import inspect
 

--- a/src/aks-preview/setup.py
+++ b/src/aks-preview/setup.py
@@ -9,7 +9,7 @@ from codecs import open as open1
 
 from setuptools import setup, find_packages
 
-VERSION = "0.5.113"
+VERSION = "0.5.112"
 
 CLASSIFIERS = [
     "Development Status :: 4 - Beta",

--- a/src/aks-preview/setup.py
+++ b/src/aks-preview/setup.py
@@ -9,7 +9,7 @@ from codecs import open as open1
 
 from setuptools import setup, find_packages
 
-VERSION = "0.5.112"
+VERSION = "0.5.113"
 
 CLASSIFIERS = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

Fix issue [#5488](https://github.com/Azure/azure-cli-extensions/issues/5488). Previously, in update code path, for an SP-based cluster, command would fail on the validation of AzureMonitorMetrics Addon.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

- `az aks update`

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repository and upgrade the version in the pull request but do not modify `src/index.json`. 
