### PR TITLE
metadata update

### DIFF
--- a/scripts/ci/avail-ext-doc/list-template.md
+++ b/scripts/ci/avail-ext-doc/list-template.md
@@ -6,9 +6,9 @@ ms.author: jianzen
 manager: yonzhan,yungezz
 ms.date: {{ date }}
 ms.topic: article
-ms.prod: azure
-ms.technology: azure-cli
+ms.service: azure-cli
 ms.devlang: azure-cli
+ms.tool: azure-cli
 ms.custom: devx-track-azurecli
 keywords: az extension, azure cli extensions, azure extensions
 ---


### PR DESCRIPTION
This PR is a metadata update to replace https://github.com/MicrosoftDocs/azure-docs-cli/pull/3367.  This update is being requested by ...

"
This Pull Request was generated automatically as part of a global effort to improve metadata quality. Please review and merge this Pull Request within 5 days. If you have any questions or concerns about these metadata updates, please contact [docs-allowlist-mgmt@microsoft.com](mailto:docs-allowlist-mgmt@microsoft.com). If you are not the correct contact for this content and repository, please notify [Metadata-Management@microsoft.com](mailto:Metadata-Management@microsoft.com).

Fixing[#559143 Remove ms.technology value azure-cli](https://dev.azure.com/ceapex/Content%20Learning%20Content%20Architecture/_workitems/edit/559143)
"