### PR TITLE
{CI} Add resolve issues logic

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -720,6 +720,407 @@
           "operator": "and",
           "operands": [
             {
+              "name": "labelAdded",
+              "parameters": {
+                "label": "issue-addressed"
+              }
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[Resolve Workflow] Issue Addressed Label Applied",
+        "actions": [
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "Hi @${issueAuthor}.  Thank you for opening this issue and giving us the opportunity to assist.  We believe that this has been addressed.  If you feel that further discussion is needed, please add a comment with the text “`/unresolve`” to remove the “issue-addressed” label and continue the conversation."
+            }
+          },
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "needs-triage"
+            }
+          },
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "needs-team-triage"
+            }
+          },
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "needs-team-attention"
+            }
+          },
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "needs-author-feedback"
+            }
+          },
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "no-recent-activity"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "scheduled",
+      "capabilityId": "ScheduledSearch",
+      "subCapability": "ScheduledSearch",
+      "version": "1.1",
+      "config": {
+        "frequency": [
+          {
+            "weekDay": 0,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ],
+            "timezoneOffset": -4
+          },
+          {
+            "weekDay": 1,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ],
+            "timezoneOffset": -4
+          },
+          {
+            "weekDay": 2,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ],
+            "timezoneOffset": -4
+          },
+          {
+            "weekDay": 3,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ],
+            "timezoneOffset": -4
+          },
+          {
+            "weekDay": 4,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ],
+            "timezoneOffset": -4
+          },
+          {
+            "weekDay": 5,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ],
+            "timezoneOffset": -4
+          },
+          {
+            "weekDay": 6,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ],
+            "timezoneOffset": -4
+          }
+        ],
+        "searchTerms": [
+          {
+            "name": "isIssue",
+            "parameters": {}
+          },
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "issue-addressed"
+            }
+          },
+          {
+            "name": "noActivitySince",
+            "parameters": {
+              "days": 7
+            }
+          }
+        ],
+        "taskName": "[Resolve Workflow] Close Addressed Issues",
+        "actions": [
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "Hi @${issueAuthor}, since you haven’t asked that we “`/unresolve`” the issue, we’ll close this out. If you believe further discussion is needed, please add a comment “`/unresolve`” to reopen the issue."
+            }
+          },
+          {
+            "name": "closeIssue",
+            "parameters": {}
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssueCommentResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "issue-addressed"
+              }
+            },
+            {
+              "name": "commentContains",
+              "parameters": {
+                "commentPattern": "/unresolve"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": {
+                      "type": "author"
+                    }
+                  }
+                },
+                {
+                  "name": "activitySenderHasPermissions",
+                  "parameters": {
+                    "permissions": "admin"
+                  }
+                },
+                {
+                  "name": "activitySenderHasPermissions",
+                  "parameters": {
+                    "permissions": "write"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issue_comment"
+        ],
+        "taskName": "[Resolve Workflow] Unresolve Command by Author",
+        "actions": [
+          {
+            "name": "reopenIssue",
+            "parameters": {}
+          },
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "issue-addressed"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "needs-team-attention"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssueCommentResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "issue-addressed"
+              }
+            },
+            {
+              "name": "commentContains",
+              "parameters": {
+                "commentPattern": "/unresolve"
+              }
+            },
+            {
+              "operator": "and",
+              "operands": [
+                {
+                  "operator": "not",
+                  "operands": [
+                    {
+                      "name": "isActivitySender",
+                      "parameters": {
+                        "user": {
+                          "type": "author"
+                        }
+                      }
+                    }
+                  ]
+                },
+                {
+                  "operator": "not",
+                  "operands": [
+                    {
+                      "name": "activitySenderHasPermissions",
+                      "parameters": {
+                        "permissions": "admin"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "operator": "not",
+                  "operands": [
+                    {
+                      "name": "activitySenderHasPermissions",
+                      "parameters": {
+                        "permissions": "write"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issue_comment"
+        ],
+        "taskName": "[Resolve Workflow] Unresolve Command Without Permissions",
+        "actions": [
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "Hi ${contextualAuthor}, only the original author of the issue can ask that it be unresolved.  Please open a new issue with your scenario and details if you would like to discuss this topic with the team."
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isOpen",
+              "parameters": {}
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "issue-addressed"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "labelAdded",
+                  "parameters": {
+                    "label": "needs-team-attention"
+                  }
+                },
+                {
+                  "name": "labelAdded",
+                  "parameters": {
+                    "label": "needs-author-feedback"
+                  }
+                },
+                {
+                  "name": "labelAdded",
+                  "parameters": {
+                    "label": "Service Attention"
+                  }
+                },
+                {
+                  "name": "labelAdded",
+                  "parameters": {
+                    "label": "needs-triage"
+                  }
+                },
+                {
+                  "name": "labelAdded",
+                  "parameters": {
+                    "label": "needs-team-triage"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[Resolve Workflow] Unresolve on WIP Labels",
+        "actions": [
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "issue-addressed"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
               "name": "isOpen",
               "parameters": {}
             },

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -207,49 +207,49 @@
             "hours": [
               1
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 1,
             "hours": [
               1
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 2,
             "hours": [
               1
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 3,
             "hours": [
               1
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 4,
             "hours": [
               1
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 5,
             "hours": [
               1
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 6,
             "hours": [
               1
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           }
         ],
         "searchTerms": [
@@ -304,7 +304,7 @@
               13,
               19
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 1,
@@ -314,7 +314,7 @@
               13,
               19
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 2,
@@ -324,7 +324,7 @@
               13,
               19
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 3,
@@ -334,7 +334,7 @@
               13,
               19
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 4,
@@ -344,7 +344,7 @@
               13,
               19
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 5,
@@ -354,7 +354,7 @@
               13,
               19
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 6,
@@ -364,7 +364,7 @@
               13,
               19
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           }
         ],
         "searchTerms": [
@@ -788,7 +788,7 @@
               12,
               18
             ],
-            "timezoneOffset": -4
+            "timezoneOffset": 8
           },
           {
             "weekDay": 1,
@@ -798,7 +798,7 @@
               12,
               18
             ],
-            "timezoneOffset": -4
+            "timezoneOffset": 8
           },
           {
             "weekDay": 2,
@@ -808,7 +808,7 @@
               12,
               18
             ],
-            "timezoneOffset": -4
+            "timezoneOffset": 8
           },
           {
             "weekDay": 3,
@@ -818,7 +818,7 @@
               12,
               18
             ],
-            "timezoneOffset": -4
+            "timezoneOffset": 8
           },
           {
             "weekDay": 4,
@@ -828,7 +828,7 @@
               12,
               18
             ],
-            "timezoneOffset": -4
+            "timezoneOffset": 8
           },
           {
             "weekDay": 5,
@@ -838,7 +838,7 @@
               12,
               18
             ],
-            "timezoneOffset": -4
+            "timezoneOffset": 8
           },
           {
             "weekDay": 6,
@@ -848,7 +848,7 @@
               12,
               18
             ],
-            "timezoneOffset": -4
+            "timezoneOffset": 8
           }
         ],
         "searchTerms": [
@@ -1173,7 +1173,7 @@
               19,
               22
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 1,
@@ -1187,7 +1187,7 @@
               19,
               22
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 2,
@@ -1201,7 +1201,7 @@
               19,
               22
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 3,
@@ -1215,7 +1215,7 @@
               19,
               22
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 4,
@@ -1229,7 +1229,7 @@
               19,
               22
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 5,
@@ -1243,7 +1243,7 @@
               19,
               22
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 6,
@@ -1257,7 +1257,7 @@
               19,
               22
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           }
         ],
         "searchTerms": [
@@ -1312,7 +1312,7 @@
               20,
               23
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 1,
@@ -1326,7 +1326,7 @@
               20,
               23
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 2,
@@ -1340,7 +1340,7 @@
               20,
               23
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 3,
@@ -1354,7 +1354,7 @@
               20,
               23
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 4,
@@ -1368,7 +1368,7 @@
               20,
               23
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 5,
@@ -1382,7 +1382,7 @@
               20,
               23
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 6,
@@ -1396,7 +1396,7 @@
               20,
               23
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           }
         ],
         "searchTerms": [


### PR DESCRIPTION
Add [automated workflows](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/490/Resolving-Issues) to align with the .NET SDK repo：

1. When work on an issue is believed to be complete, the Azure SDK team member responsible for communicating that status may apply the issue-addressed label.

2. When the bot that monitors the repository detects the issue-addressed label, it will respond with the message:
“Hi @issue-author. Thank you for opening this issue and giving us the opportunity to assist. We believe that this has been resolved. If you believe that further discussion is needed, please add a comment with the text “/unresolve” to remove the "issue-addressed” label and continue the conversation.”

3. For issues where the issue-addressed label was applied:
    a. If no action is taken, the issue is closed by the bot after 7 days of no activity with the message:
“Hi @issue-author, since you haven’t asked that we “/unresolve” the issue, we’ll close this out. If you believe further discussion is needed, please add a comment “/unresolve” to reopen the issue.”

    b. If the original author of the issue uses the /unresolve command to remove the issue-addressed label, the issue is left open for continued discussion and the “needs-team-attention” label is applied.

    c. If a comment is left with the /unresolve command by a person other than the original author of the issue or an internal team member, the bot responds with the message:
“Please open a new issue with your scenario and details if you would like to discuss this topic with the team.”

    d. If the issue-addressed label is removed by an Azure SDK team member directly, the issue is left open but no additional label is applied.

    e. If an Azure SDK team member adds a label that indicates work is ongoing for the issue, the issue-addressed label is removed. The following labels are considered:
         -  needs-team-attention
         - needs-author-feedback
         - Service Attention
         - needs-triage
         - needs-team-triage