### PR TITLE
[Quantum] [DRAFT - Do not merge] Update QDK version in Release History

### DIFF
--- a/src/quantum/HISTORY.rst
+++ b/src/quantum/HISTORY.rst
@@ -5,7 +5,7 @@ Release History
 
 0.17.0
 ++++++
-* [2022-10-14] Version intended to work with QDK version 0.26.233415
+* [2022-10-14] Initial 0.17.0 release was intended to work with QDK version 0.26.233415, however additional functionality has been added to QDK version to 0.27.238334 that can be accessed by this CLI release. See https://learn.microsoft.com/azure/quantum/release-notes 
 * The `az quantum` reference documentation now indicates which command parameters are required, and missing-parameter error messages are more informative. See https://learn.microsoft.com/cli/azure/quantum
 * You can submit jobs to the microsoft.simulator.resources-estimator target using the CLI.
 


### PR DESCRIPTION
This PR only updates the QDK version number in the 0.17.0 Release History notes, and adds a link to the QDK release notes. 