### PR TITLE
Update diagnostics commands to work with clusters with local accounts disabled

### DIFF
--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -13,6 +13,7 @@ Pending
 +++++++
 
 * Mark "--enable-pod-security-policy" deprecated
+* Support AAD clusters for "az aks kollect"
 
 0.5.115
 +++++++

--- a/src/aks-preview/azext_aks_preview/aks_diagnostics.py
+++ b/src/aks-preview/azext_aks_preview/aks_diagnostics.py
@@ -245,7 +245,7 @@ def _get_temp_kubeconfig_path(cmd, client, resource_group_name: str, name: str, 
             if not prompt_y_n('Can not find kubelogin executable in PATH. Install now?', default="y"):
                 # The user doesn't want us to install kubelogin automatically, so we cannot continue.
                 raise CLIError('kubelogin not found. Use az aks install-cli to install.')
-            
+
             # Install kubelogin
             kubelogin_install_location = _get_default_install_location('kubelogin')
             k8s_install_kubelogin(cmd, 'latest', kubelogin_install_location)

--- a/src/aks-preview/azext_aks_preview/aks_diagnostics.py
+++ b/src/aks-preview/azext_aks_preview/aks_diagnostics.py
@@ -12,6 +12,8 @@ import tempfile
 import time
 
 from azure.cli.core.commands.client_factory import get_mgmt_service_client, get_subscription_id
+from azure.cli.command_modules.acs.custom import k8s_install_kubelogin
+from azure.cli.command_modules.acs._params import _get_default_install_location
 from enum import Flag, auto
 from knack.log import get_logger
 from knack.prompting import prompt_y_n
@@ -132,10 +134,7 @@ def aks_kollect_cmd(cmd,    # pylint: disable=too-many-statements,too-many-local
 
     print()
     print("Getting credentials for cluster %s " % name)
-    _, temp_kubeconfig_path = tempfile.mkstemp()
-    credentialResults = client.list_cluster_admin_credentials(resource_group_name, name, None)
-    kubeconfig = credentialResults.kubeconfigs[0].value.decode(encoding='UTF-8')
-    print_or_merge_credentials(temp_kubeconfig_path, kubeconfig, False, None)
+    temp_kubeconfig_path = _get_temp_kubeconfig_path(cmd, client, resource_group_name, name, mc.disable_local_accounts)
 
     print()
     print("Starts collecting diag info for cluster %s " % name)
@@ -221,17 +220,40 @@ def aks_kollect_cmd(cmd,    # pylint: disable=too-many-statements,too-many-local
         _display_diagnostics_report(temp_kubeconfig_path)
 
 
-def aks_kanalyze_cmd(client, resource_group_name: str, name: str) -> None:
+def aks_kanalyze_cmd(cmd, client, resource_group_name: str, name: str) -> None:
     colorama.init()
 
-    client.get(resource_group_name, name)
+    mc = client.get(resource_group_name, name)
 
+    temp_kubeconfig_path = _get_temp_kubeconfig_path(cmd, client, resource_group_name, name, mc.disable_local_accounts)
+
+    _display_diagnostics_report(temp_kubeconfig_path)
+
+
+def _get_temp_kubeconfig_path(cmd, client, resource_group_name: str, name: str, disable_local_accounts: bool) -> str:
     _, temp_kubeconfig_path = tempfile.mkstemp()
-    credentialResults = client.list_cluster_admin_credentials(resource_group_name, name, None)
+
+    # Use normal user credentials, not admin credentials (admin creds will not be supplied if local accounts are disabled).
+    credentialResults = client.list_cluster_user_credentials(resource_group_name, name, None)
     kubeconfig = credentialResults.kubeconfigs[0].value.decode(encoding='UTF-8')
     print_or_merge_credentials(temp_kubeconfig_path, kubeconfig, False, None)
 
-    _display_diagnostics_report(temp_kubeconfig_path)
+    if disable_local_accounts:
+        # The current credentials require interactive login. We need to use kubelogin to update the kubeconfig credential.
+        if not which('kubelogin'):
+            # No kubelogin found...but we can install it if the user wants.
+            if not prompt_y_n('Can not find kubelogin executable in PATH. Install now?', default="y"):
+                # The user doesn't want us to install kubelogin automatically, so we cannot continue.
+                raise CLIError('kubelogin not found. Use az aks install-cli to install.')
+            
+            # Install kubelogin
+            kubelogin_install_location = _get_default_install_location('kubelogin')
+            k8s_install_kubelogin(cmd, 'latest', kubelogin_install_location)
+
+        # kubelogin is installed. Run it to populate user credentials that don't require interactive login.
+        subprocess.check_output(["kubelogin", "convert-kubeconfig", "--kubeconfig", temp_kubeconfig_path, "--login", "azurecli"], stderr=subprocess.STDOUT)
+
+    return temp_kubeconfig_path
 
 
 def _get_kustomize_yaml(storage_account_name,

--- a/src/aks-preview/azext_aks_preview/aks_diagnostics.py
+++ b/src/aks-preview/azext_aks_preview/aks_diagnostics.py
@@ -134,7 +134,7 @@ def aks_kollect_cmd(cmd,    # pylint: disable=too-many-statements,too-many-local
 
     print()
     print("Getting credentials for cluster %s " % name)
-    temp_kubeconfig_path = _get_temp_kubeconfig_path(cmd, client, resource_group_name, name, mc.disable_local_accounts)
+    temp_kubeconfig_path = _get_temp_kubeconfig_path(cmd, client, resource_group_name, name, mc.aad_profile is not None)
 
     print()
     print("Starts collecting diag info for cluster %s " % name)
@@ -225,12 +225,12 @@ def aks_kanalyze_cmd(cmd, client, resource_group_name: str, name: str) -> None:
 
     mc = client.get(resource_group_name, name)
 
-    temp_kubeconfig_path = _get_temp_kubeconfig_path(cmd, client, resource_group_name, name, mc.disable_local_accounts)
+    temp_kubeconfig_path = _get_temp_kubeconfig_path(cmd, client, resource_group_name, name, mc.aad_profile is not None)
 
     _display_diagnostics_report(temp_kubeconfig_path)
 
 
-def _get_temp_kubeconfig_path(cmd, client, resource_group_name: str, name: str, disable_local_accounts: bool) -> str:
+def _get_temp_kubeconfig_path(cmd, client, resource_group_name: str, name: str, has_aad_profile: bool) -> str:
     _, temp_kubeconfig_path = tempfile.mkstemp()
 
     # Use normal user credentials, not admin credentials (admin creds will not be supplied if local accounts are disabled).
@@ -238,7 +238,7 @@ def _get_temp_kubeconfig_path(cmd, client, resource_group_name: str, name: str, 
     kubeconfig = credentialResults.kubeconfigs[0].value.decode(encoding='UTF-8')
     print_or_merge_credentials(temp_kubeconfig_path, kubeconfig, False, None)
 
-    if disable_local_accounts:
+    if has_aad_profile:
         # The current credentials require interactive login. We need to use kubelogin to update the kubeconfig credential.
         if not which('kubelogin'):
             # No kubelogin found...but we can install it if the user wants.

--- a/src/aks-preview/azext_aks_preview/custom.py
+++ b/src/aks-preview/azext_aks_preview/custom.py
@@ -1966,8 +1966,8 @@ def aks_kollect(cmd,    # pylint: disable=too-many-statements,too-many-locals
                     container_logs, kube_objects, node_logs, node_logs_windows)
 
 
-def aks_kanalyze(client, resource_group_name, name):
-    aks_kanalyze_cmd(client, resource_group_name, name)
+def aks_kanalyze(cmd, client, resource_group_name, name):
+    aks_kanalyze_cmd(cmd, client, resource_group_name, name)
 
 
 def aks_pod_identity_add(cmd, client, resource_group_name, cluster_name,

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -5714,6 +5714,12 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             self.check('provisioningState', 'Succeeded')
         ])
 
+        # Install kubectl (required by the 'kollect' command).
+        try:
+            subprocess.call(['az', 'aks', 'install-cli'])
+        except subprocess.CalledProcessError as err:
+            raise CliTestError(f"Failed to install kubectl with error: '{err}'")
+
         self.assert_kollect_deploys_periscope(resource_group, aks_name, stg_acct_name)
 
     @live_only() # because we're downloading a binary, and we're not testing the output of any ARM requests.
@@ -5754,6 +5760,12 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         sp_oid = sp["id"]
         print(f'objectid of service principal is {sp_oid}')
 
+        # Install kubectl (for setting up service principal permissions, and required by the 'kollect' command).
+        try:
+            subprocess.call(['az', 'aks', 'install-cli'])
+        except subprocess.CalledProcessError as err:
+            raise CliTestError(f"Failed to install kubectl with error: '{err}'")
+
         # Grant the service principal cluster-admin access using the admin account
         # (it'd be nice if `az aks command invoke` had an --admin option, but it appears not to, so we have to download admin credentials)
         fd, admin_kubeconfig_path = tempfile.mkstemp()
@@ -5784,12 +5796,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         self.assert_kollect_deploys_periscope(resource_group, aks_name, stg_acct_name)
 
     def assert_kollect_deploys_periscope(self, resource_group, aks_name, stg_acct_name):
-        # Install kubectl (required by the 'kollect' command).
-        try:
-            subprocess.call(['az', 'aks', 'install-cli'])
-        except subprocess.CalledProcessError as err:
-            raise CliTestError(f"Failed to install kubectl with error: '{err}'")
-
         # The kollect command is interactive, with two prompts requiring 'y|n' followed by newline.
         # The prompting library used by the CLI checks for the presence of a TTY, so just passing these as input is not
         # sufficient and will raise an exception; we also need to attach a pseudo-TTY to the process.

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -5827,7 +5827,7 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
 
         # Invoke kubectl to get the daemonsets deployed to the cluster
         invoke_get_daemonset_cmd = "aks command invoke --resource-group={resource_group} --name={aks_name} --command 'kubectl get daemonset -n aks-periscope -o name'"
-        get_daemonset_output = self.cmd(invoke_get_daemonset_cmd)
+        get_daemonset_output = self.cmd(invoke_get_daemonset_cmd).output
 
         # Check expected output of 'kubectl get daemonset' command
         for pattern in [

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -5826,7 +5826,7 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
                 raise CliTestError(f"Output from kollect did not contain '{pattern}'. Output:\n{kollect_output}")
 
         # Invoke kubectl to get the daemonsets deployed to the cluster
-        invoke_get_daemonset_cmd = "aks command invoke --resource-group={resource_group} --name={stg_acct_name} --command 'kubectl get daemonset -n aks-periscope -o name'"
+        invoke_get_daemonset_cmd = "aks command invoke --resource-group={resource_group} --name={aks_name} --command 'kubectl get daemonset -n aks-periscope -o name'"
         get_daemonset_output = self.cmd(invoke_get_daemonset_cmd)
 
         # Check expected output of 'kubectl get daemonset' command

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -5826,16 +5826,16 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
                 raise CliTestError(f"Output from kollect did not contain '{pattern}'. Output:\n{kollect_output}")
 
         # Invoke kubectl to get the daemonsets deployed to the cluster
-        invoke_get_daemonset_cmd = "aks command invoke --resource-group={resource_group} --name={aks_name} --command 'kubectl get daemonset -n aks-periscope -o name'"
-        get_daemonset_output = self.cmd(invoke_get_daemonset_cmd).output
+        k_get_daemonset_cmd = ["az", "aks", "command", "invoke", "--resource-group", resource_group, "--name", aks_name, "--command", "kubectl get daemonset -n aks-periscope -o name"]
+        k_get_daemonset_output = subprocess.check_output(k_get_daemonset_cmd, text=True)
 
         # Check expected output of 'kubectl get daemonset' command
         for pattern in [
             "daemonset.apps/aks-periscope",
             "daemonset.apps/aks-periscope-win"
         ]:
-            if not pattern in get_daemonset_output:
-                raise CliTestError(f"Output from 'kubectl get daemonset' did not contain '{pattern}'. Output:\n{get_daemonset_output}")
+            if not pattern in k_get_daemonset_output:
+                raise CliTestError(f"Output from 'kubectl get daemonset' did not contain '{pattern}'. Output:\n{k_get_daemonset_output}")
 
     @AllowLargeResponse()
     @AKSCustomResourceGroupPreparer(random_name_length=17, name_prefix='clitest', location='eastus', preserve_default_location=True)


### PR DESCRIPTION
Previously the `kollect` and `kanalyze` commands attempted to gain cluster access by listing admin credentials. This does not work if the cluster has local accounts disabled.

These changes make use of normal non-admin user credentials. However, if a cluster is AAD-enabled, these credentials will initially require interactive login. We can make use of `kubelogin` to convert the credentials to allow non-interactive use. The bulk of the code changes here are to check whether this binary is accessible to the user and either downloading or failing with an appropriate error.

cc: @Tatsinnit 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repository and upgrade the version in the pull request but do not modify `src/index.json`. 
