### PR TITLE
{AKS} `az aks update`: Fix command failing on updating the ssh key value if cluster was created without ssh key

### DIFF
--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -12,6 +12,7 @@ To release a new version, please select a new version number (usually plus 1 to 
 Pending
 +++++++
 
+* Fix `az aks update` command failing on updating the ssh key value if cluster was created without ssh key, see issue `\#5559 <https://github.com/Azure/azure-cli-extensions/issues/5559>`_.
 * Mark "--enable-pod-security-policy" deprecated
 
 0.5.115
@@ -28,7 +29,7 @@ Pending
 +++++++
 
 * Fix workload identity update error after oidc issure GA in azure-cli.
-* Fix `az aks update` command failing on SP-based cluster blocked by validation in AzureMonitorMetrics Addon, see issue `\#5336 <https://github.com/Azure/azure-cli-extensions/issues/5488>`_.
+* Fix `az aks update` command failing on SP-based cluster blocked by validation in AzureMonitorMetrics Addon, see issue `\#5488 <https://github.com/Azure/azure-cli-extensions/issues/5488>`_.
 * Fix `az aks update` command failing on changes not related to outbound type conversion, see issue `\#24430 https://github.com/Azure/azure-cli/issues/24430>`_.
 
 0.5.112

--- a/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
@@ -3176,14 +3176,21 @@ class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):
         ssh_key_value = self.context.get_ssh_key_value_for_update()
 
         if ssh_key_value:
-            mc.linux_profile.ssh = self.models.ContainerServiceSshConfiguration(
+            ssh_config = self.models.ContainerServiceSshConfiguration(
                 public_keys=[
                     self.models.ContainerServiceSshPublicKey(
                         key_data=ssh_key_value
                     )
                 ]
             )
-
+            # apply default linux profile if not set when created
+            if mc.linux_profile == None:
+                mc.linux_profile = self.models.ContainerServiceLinuxProfile(
+                    admin_username=self.context.get_admin_username(),
+                    ssh=ssh_config,
+                )
+            else:
+                mc.linux_profile.ssh = ssh_config
         return mc
 
     def update_mc_profile_preview(self) -> ManagedCluster:

--- a/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
@@ -3176,7 +3176,7 @@ class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):
         ssh_key_value = self.context.get_ssh_key_value_for_update()
 
         if ssh_key_value:
-            if mc.linux_profile == None:
+            if mc.linux_profile is None:
                 raise InvalidArgumentValueError("Updating the cluster with no ssh key set at creation is not supported")
             mc.linux_profile.ssh = self.models.ContainerServiceSshConfiguration(
                 public_keys=[

--- a/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
@@ -3176,21 +3176,15 @@ class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):
         ssh_key_value = self.context.get_ssh_key_value_for_update()
 
         if ssh_key_value:
-            ssh_config = self.models.ContainerServiceSshConfiguration(
+            if mc.linux_profile == None:
+                raise InvalidArgumentValueError("Updating the cluster with no ssh key set at creation is not supported")
+            mc.linux_profile.ssh = self.models.ContainerServiceSshConfiguration(
                 public_keys=[
                     self.models.ContainerServiceSshPublicKey(
                         key_data=ssh_key_value
                     )
                 ]
             )
-            # apply default linux profile if not set when created
-            if mc.linux_profile == None:
-                mc.linux_profile = self.models.ContainerServiceLinuxProfile(
-                    admin_username=self.context.get_admin_username(),
-                    ssh=ssh_config,
-                )
-            else:
-                mc.linux_profile.ssh = ssh_config
         return mc
 
     def update_mc_profile_preview(self) -> ManagedCluster:

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
@@ -5804,6 +5804,34 @@ class AKSPreviewManagedClusterUpdateDecoratorTestCase(unittest.TestCase):
         )
         self.assertEqual(dec_mc_1, ground_truth_mc_1)
 
+    def test_update_linux_profile(self):
+        dec_1 = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {"ssh_key_value": "test_key"},
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        mc_1 = self.models.ManagedCluster(
+            location="test_location",
+        )
+        dec_1.context.attach_mc(mc_1)
+        dec_mc_1 = dec_1.update_linux_profile(mc_1)
+
+        ground_truth_mc_1 = self.models.ManagedCluster(
+            location="test_location",
+            linux_profile=self.models.ContainerServiceLinuxProfile(
+                admin_username=None,
+                ssh=self.models.ContainerServiceSshConfiguration(
+                    public_keys=[
+                        self.models.ContainerServiceSshPublicKey(
+                            key_data="test_key"
+                        )
+                    ]
+                ),
+            ),
+        )
+        self.assertEqual(dec_mc_1, ground_truth_mc_1)
+
     def test_update_mc_profile_preview(self):
         import inspect
 

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
@@ -5815,22 +5815,9 @@ class AKSPreviewManagedClusterUpdateDecoratorTestCase(unittest.TestCase):
             location="test_location",
         )
         dec_1.context.attach_mc(mc_1)
-        dec_mc_1 = dec_1.update_linux_profile(mc_1)
-
-        ground_truth_mc_1 = self.models.ManagedCluster(
-            location="test_location",
-            linux_profile=self.models.ContainerServiceLinuxProfile(
-                admin_username=None,
-                ssh=self.models.ContainerServiceSshConfiguration(
-                    public_keys=[
-                        self.models.ContainerServiceSshPublicKey(
-                            key_data="test_key"
-                        )
-                    ]
-                ),
-            ),
-        )
-        self.assertEqual(dec_mc_1, ground_truth_mc_1)
+        # fail on cluster has no linux profile
+        with self.assertRaises(InvalidArgumentValueError):
+            dec_mc_1 = dec_1.update_linux_profile(mc_1)
 
     def test_update_mc_profile_preview(self):
         import inspect


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

Fix the NoneType error of updating the ssh key value if cluster was created without ssh key. This is not supported, would return an InvalidArgumentValueError.

Fix issue [#5559](https://github.com/Azure/azure-cli-extensions/issues/5559).

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

`az aks update`


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repository and upgrade the version in the pull request but do not modify `src/index.json`. 
