### PR TITLE
Updated logic for Vm Repair Reset Nic cmd(ResourceNotFound)

### DIFF
--- a/src/vm-repair/azext_vm_repair/custom.py
+++ b/src/vm-repair/azext_vm_repair/custom.py
@@ -573,6 +573,7 @@ def reset_nic(cmd, vm_name, resource_group_name, yes=False):
         subnet_id_tokens = subnet_id.split('/')
         subnet_name = subnet_id_tokens[-1]
         vnet_name = subnet_id_tokens[-3]
+        vnet_resource_group = subnet_id_tokens[-7]
         ipconfig_name = ip_config_object['name']
         orig_ip_address = ip_config_object['privateIpAddress']
         # Dynamic | Static
@@ -580,7 +581,7 @@ def reset_nic(cmd, vm_name, resource_group_name, yes=False):
 
         # Get aviailable ip address within subnet
         get_available_ip_command = 'az network vnet subnet list-available-ips -g {g} --vnet-name {vnet} --name {subnet} --query [0] -o tsv' \
-                                   .format(g=resource_group_name, vnet=vnet_name, subnet=subnet_name)
+                                   .format(g=vnet_resource_group, vnet=vnet_name, subnet=subnet_name)
         swap_ip_address = _call_az_command(get_available_ip_command)
         if not swap_ip_address:
             # Raise available IP not found

--- a/src/vm-repair/setup.py
+++ b/src/vm-repair/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup, find_packages
 
-VERSION = "0.4.9"
+VERSION = "0.4.10"
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.
- Updated logic for Reset Nic "ResourceNotFound" bug.
- Reset Nic Script now correctly picks `VNet ResourceGroup` for fetching `IpAddress` instead of using `ResourceGroup of VM`.
- Tested logic on several Test VM's.
### Related command
` az vm repair reset-nic -RgName $rgname  -VMName $name --subscription $SubId --verbose`
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repository and upgrade the version in the pull request but do not modify `src/index.json`. 
