### PR TITLE
{CI} Check cli core min version both remote and local

### DIFF
--- a/scripts/ci/test_index.py
+++ b/scripts/ci/test_index.py
@@ -47,7 +47,7 @@ def check_min_version_local(extension_name):
             if metadata.get('azext.minCliCoreVersion'):
                 return True
     except Exception as e:
-        logger.error(f'can not get minCliCoreVersion from local: {e}')
+        logger.error(f'{extension_name} can not get minCliCoreVersion from local: {e}')
         return False
 
 

--- a/scripts/ci/test_index.py
+++ b/scripts/ci/test_index.py
@@ -173,7 +173,7 @@ class TestIndex(unittest.TestCase):
 
             try:
                 # check key properties exists
-                self.assertIn('azext.minCliCoreVersion', metadata) or check_min_version(extension_name)
+                self.assertIn('azext.minCliCoreVersion', metadata) or check_min_version(ext_name)
             except AssertionError as ex:
                 if ext_name in historical_extensions:
                     threshold_version = historical_extensions[ext_name]

--- a/scripts/ci/test_index.py
+++ b/scripts/ci/test_index.py
@@ -31,13 +31,13 @@ def get_sha256sum(a_file):
     return sha256.hexdigest()
 
 
-def check_min_version(extension_name):
+def check_min_version_local(extension_name):
     try:
         azext_metadata = glob.glob(os.path.join(SRC_PATH, extension_name, 'azext_*', 'azext_metadata.json'))[0]
         with open(azext_metadata, 'r') as f:
             metadata = json.load(f)
-            self.assertIn('azext.minCliCoreVersion', metadata)
-            return True
+            if metadata.get('azext.minCliCoreVersion'):
+                return True
     except Exception as e:
         logger.error(f'can not get minCliCoreVersion: {e}')
         return False
@@ -173,7 +173,8 @@ class TestIndex(unittest.TestCase):
 
             try:
                 # check key properties exists
-                self.assertIn('azext.minCliCoreVersion', metadata) or check_min_version(ext_name)
+                if not check_min_version_local(ext_name):
+                    self.assertIn('azext.minCliCoreVersion', metadata) or check_min_version(ext_name)
             except AssertionError as ex:
                 if ext_name in historical_extensions:
                     threshold_version = historical_extensions[ext_name]

--- a/scripts/ci/test_index.py
+++ b/scripts/ci/test_index.py
@@ -12,6 +12,7 @@ from __future__ import print_function
 import glob
 import hashlib
 import json
+import logging
 import os
 import shutil
 import tempfile
@@ -22,6 +23,13 @@ from util import SRC_PATH
 from wheel.install import WHEEL_INFO_RE
 
 from util import get_ext_metadata, get_whl_from_url, get_index_data
+
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+ch = logging.StreamHandler()
+ch.setLevel(logging.DEBUG)
+logger.addHandler(ch)
 
 
 def get_sha256sum(a_file):
@@ -39,7 +47,7 @@ def check_min_version_local(extension_name):
             if metadata.get('azext.minCliCoreVersion'):
                 return True
     except Exception as e:
-        logger.error(f'can not get minCliCoreVersion: {e}')
+        logger.error(f'can not get minCliCoreVersion from local: {e}')
         return False
 
 
@@ -174,7 +182,7 @@ class TestIndex(unittest.TestCase):
             try:
                 # check key properties exists
                 if not check_min_version_local(ext_name):
-                    self.assertIn('azext.minCliCoreVersion', metadata) or check_min_version(ext_name)
+                    self.assertIn('azext.minCliCoreVersion', metadata)
             except AssertionError as ex:
                 if ext_name in historical_extensions:
                     threshold_version = historical_extensions[ext_name]

--- a/src/keyvault-preview/azext_keyvault_preview/azext_metadata.json
+++ b/src/keyvault-preview/azext_keyvault_preview/azext_metadata.json
@@ -1,4 +1,3 @@
 {
-    "azext.minCliCoreVersion": "2.15.0",
     "azext.isPreview": true
 }

--- a/src/keyvault-preview/azext_keyvault_preview/azext_metadata.json
+++ b/src/keyvault-preview/azext_keyvault_preview/azext_metadata.json
@@ -1,3 +1,4 @@
 {
+    "azext.minCliCoreVersion": "2.15.0",
     "azext.isPreview": true
 }


### PR DESCRIPTION
Now we download the wheel package from downloadUrl provided by index.json, then check whether the cli core min version is included in the azext_metadata.json file.
This PR will first search for the latest azext_metadata.json file in local git, and if it can't be found in local git, then search from the downloaded azext_metadata.json file.

Test screenshot:
![image](https://user-images.githubusercontent.com/18628534/205808419-919ac358-489c-4b13-9044-d65219febd14.png)