### PR TITLE
Disabling pwinput till the azure-cli 2.42 issue gets fixed

### DIFF
--- a/src/scvmm/HISTORY.rst
+++ b/src/scvmm/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+
+0.1.7
+++++++
+* [Hotfix] Disabling pwinput till the issue here gets fixed: https://github.com/Azure/azure-cli/issues/24781 
+
 0.1.6
 ++++++
 * Displaying asterisks (*****) for password input.

--- a/src/scvmm/azext_scvmm/custom.py
+++ b/src/scvmm/azext_scvmm/custom.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 # pylint: disable=unused-argument,too-many-lines
 
-from pwinput import pwinput
+from getpass import getpass
 from azure.cli.core.azclierror import (
     UnrecognizedArgumentError,
     RequiredArgumentMissingError,
@@ -121,10 +121,10 @@ def connect_vmmserver(
             if not creds['username']:
                 print('Parameter is required, please try again')
         while not creds['password']:
-            creds['password'] = pwinput('Please provide vmmserver password: ')
+            creds['password'] = getpass('Please provide vmmserver password: ')
             if not creds['password']:
                 print('Parameter is required, please try again')
-            passwdConfim = pwinput('Please confirm vmmserver password: ')
+            passwdConfim = getpass('Please confirm vmmserver password: ')
             if creds['password'] != passwdConfim:
                 print('Passwords do not match, please try again')
                 creds['password'] = None

--- a/src/scvmm/setup.py
+++ b/src/scvmm/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
 
-VERSION = '0.1.6'
+VERSION = '0.1.7'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/src/scvmm/setup.py
+++ b/src/scvmm/setup.py
@@ -32,7 +32,7 @@ CLASSIFIERS = [
     'License :: OSI Approved :: MIT License',
 ]
 
-DEPENDENCIES = ["pwinput"]
+DEPENDENCIES = []
 
 with open('README.rst', 'r', encoding='utf-8') as f:
     README = f.read()


### PR DESCRIPTION
Az cli version 2.42.0 on Windows installed using MSI is not able to install the dependency pwinput.
Issue opened and being tracked : https://github.com/Azure/azure-cli/issues/24781 

As a hotfix, disabling the dependency for now.
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repository and upgrade the version in the pull request but do not modify `src/index.json`. 
