### PR TITLE
{CI} Add check __init__.py file in all extensions

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -194,12 +194,12 @@ jobs:
 
 - job: CheckInit
   displayName: "Check Init Files"
-    pool:
-      name: 'pool-ubuntu-2004'
-    steps:
-    - task: UsePythonVersion@0
-      displayName: 'Use Python 3.x'
-      inputs:
-        versionSpec: 3.x
-    - bash: |
-      python scripts/ci/check_init.py -v
+  pool:
+    name: 'pool-ubuntu-2004'
+  steps:
+  - task: UsePythonVersion@0
+    displayName: 'Use Python 3.x'
+    inputs:
+      versionSpec: 3.x
+  - bash: |
+    python scripts/ci/test_init.py -v

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -191,3 +191,15 @@ jobs:
     inputs:
       targetType: 'filePath'
       filePath: scripts/ci/test_index_ref_doc.sh
+
+- job: CheckInit
+  displayName: "Check Init Files"
+    pool:
+      name: 'pool-ubuntu-2004'
+    steps:
+    - task: UsePythonVersion@0
+      displayName: 'Use Python 3.x'
+      inputs:
+        versionSpec: 3.x
+    - bash: |
+      python scripts/ci/check_init.py -v

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -202,4 +202,4 @@ jobs:
     inputs:
       versionSpec: 3.x
   - bash: |
-    python scripts/ci/test_init.py -v
+      python scripts/ci/test_init.py -v

--- a/scripts/ci/test_init.py
+++ b/scripts/ci/test_init.py
@@ -37,10 +37,10 @@ def check_init_files():
 
 def check_init_recursive(root_dir):
     """ Check if a extension contains __init__.py
-    :param root_dir: azure-cli-extensions\\src\\account\\azext_account
-    :param dirpath: azure-cli-extensions\\src\\account\\azext_account
-    :param dirnames: ['generated', 'manual', 'tests', 'vendored_sdks']
-    :param filenames: ['.flake8', 'action.py', 'azext_metadata.json', 'custom.py', '__init__.py']
+    :param root_dir: azure-cli-extensions\src\{ext_name}\azext_{ext_name}
+    :param dirpath: azure-cli-extensions\src\{ext_name}\azext_{ext_name}
+    :param dirnames: all directories under dirpath, type: List[str]
+    :param filenames: all files under dirpath, type: List[str]
     """
     error_flag = False
     for (dirpath, dirnames, filenames) in os.walk(root_dir):

--- a/scripts/ci/test_init.py
+++ b/scripts/ci/test_init.py
@@ -5,9 +5,10 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-import os
 from util import SRC_PATH
 import logging
+import os
+import sys
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -21,6 +22,7 @@ check_path = 'vendored_sdks'
 
 def check_init_files():
     """ Check if the vendored_sdks directory contains __init__.py in all extensions """
+    ref = []
     # SRC_PATH: azure-cli-extensions\src
     for src_d in os.listdir(SRC_PATH):
         # src_d: azure-cli-extensions\src\ext_name
@@ -29,7 +31,8 @@ def check_init_files():
             for d in os.listdir(src_d_full):
                 if d.startswith('azext_'):
                     # root_dir: azure-cli-extensions\src\ext_name\azext_ext_name
-                    check_init_recursive(os.path.join(src_d_full, d))
+                    ref.append(check_init_recursive(os.path.join(src_d_full, d)))
+    return ref
 
 
 def check_init_recursive(root_dir):
@@ -39,11 +42,14 @@ def check_init_recursive(root_dir):
     :param dirnames: ['generated', 'manual', 'tests', 'vendored_sdks']
     :param filenames: ['.flake8', 'action.py', 'azext_metadata.json', 'custom.py', '__init__.py']
     """
+    error_flag = False
     for (dirpath, dirnames, filenames) in os.walk(root_dir):
         if dirpath.endswith(check_path):
             # Check __init__.py not exists in the vendored_sdks dir and it contains at least one file
             if '__init__.py' not in filenames and not is_empty_dir(dirpath):
-                logger.error(f'Directory {dirpath} does not contain __init__.py')
+                logger.error(f'Directory {dirpath} does not contain __init__.py, please add it.')
+                error_flag = True
+    return error_flag
 
 
 def is_empty_dir(root_dir):
@@ -55,4 +61,5 @@ def is_empty_dir(root_dir):
 
 
 if __name__ == '__main__':
-    check_init_files()
+    ref = check_init_files()
+    sys.exit(1) if any(ref) else sys.exit(0)

--- a/scripts/ci/test_init.py
+++ b/scripts/ci/test_init.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import os
+from util import SRC_PATH
+import logging
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+ch = logging.StreamHandler()
+ch.setLevel(logging.DEBUG)
+logger.addHandler(ch)
+
+
+check_path = 'vendored_sdks'
+
+
+def check_init_files():
+    """ Check if the vendored_sdks directory contains __init__.py in all extensions"""
+    # SRC_PATH: azure-cli-extensions\src
+    for src_d in os.listdir(SRC_PATH):
+        # src_d: azure-cli-extensions\src\ext_name
+        src_d_full = os.path.join(SRC_PATH, src_d)
+        if os.path.isdir(src_d_full):
+            for d in os.listdir(src_d_full):
+                if d.startswith('azext_'):
+                    # root_dir: azure-cli-extensions\src\ext_name\azext_ext_name
+                    check_init_recursive(os.path.join(src_d_full, d))
+
+
+def check_init_recursive(root_dir):
+    """ Check if a extension contains __init__.py
+    :param root_dir: azure-cli-extensions\\src\\account\\azext_account
+    :param dirpath: azure-cli-extensions\\src\\account\\azext_account
+    :param dirnames: ['generated', 'manual', 'tests', 'vendored_sdks']
+    :param filenames: ['.flake8', 'action.py', 'azext_metadata.json', 'custom.py', '__init__.py']
+    """
+    for (dirpath, dirnames, filenames) in os.walk(root_dir):
+        if dirpath.endswith(check_path):
+            # Check __init__.py not exists in the vendored_sdks dir and it contains at least one file
+            if '__init__.py' not in filenames and not is_empty_dir(dirpath):
+                logger.error(f'Directory {dirpath} does not contain __init__.py')
+
+
+def is_empty_dir(root_dir):
+    """ Check if the directory did not contain any file """
+    for (dirpath, dirnames, filenames) in os.walk(root_dir):
+        if filenames:
+            return False
+    return True
+
+
+if __name__ == '__main__':
+    check_init_files()

--- a/scripts/ci/test_init.py
+++ b/scripts/ci/test_init.py
@@ -20,7 +20,7 @@ check_path = 'vendored_sdks'
 
 
 def check_init_files():
-    """ Check if the vendored_sdks directory contains __init__.py in all extensions"""
+    """ Check if the vendored_sdks directory contains __init__.py in all extensions """
     # SRC_PATH: azure-cli-extensions\src
     for src_d in os.listdir(SRC_PATH):
         # src_d: azure-cli-extensions\src\ext_name


### PR DESCRIPTION
Check if the vendored_sdks directory contains `__init__.py` in all extensions.
Will exclude empty vendored_sdks dir, for example:
`azure-cli-extensions\src\containerapp-preview\azext_containerapp_preview\vendored_sdks` is a empty dir that didn't contain any files.

Test screenshot:
![image](https://user-images.githubusercontent.com/18628534/206637454-2eceb20b-6310-45e6-ac5d-c1a37d047ef7.png)
![image](https://user-images.githubusercontent.com/18628534/206638494-ac6a096c-906c-4e67-a718-b5440ee0dfab.png)
