### PR TITLE
remove vmware 5.0.0 from index

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -45472,39 +45472,6 @@
                 "sha256Digest": "05a8c52125bcd12250201a2ef0a1eb637e2b28f8b30aa4df014036f403584131"
             },
             {
-                "downloadUrl": "https://azcliprod.blob.core.windows.net/cli-extensions/vmware-5.0.0-py2.py3-none-any.whl",
-                "filename": "vmware-5.0.0-py2.py3-none-any.whl",
-                "metadata": {
-                    "azext.isPreview": false,
-                    "azext.minCliCoreVersion": "2.11.0",
-                    "description_content_type": "text/markdown",
-                    "extensions": {
-                        "python.details": {
-                            "contacts": [
-                                {
-                                    "email": "azpycli@microsoft.com",
-                                    "name": "Microsoft",
-                                    "role": "author"
-                                }
-                            ],
-                            "document_names": {
-                                "description": "DESCRIPTION.rst"
-                            },
-                            "project_urls": {
-                                "Home": "https://github.com/Azure/azure-cli-extensions/tree/main/src/vmware"
-                            }
-                        }
-                    },
-                    "generator": "bdist_wheel (0.30.0)",
-                    "license": "MIT",
-                    "metadata_version": "2.0",
-                    "name": "vmware",
-                    "summary": "Azure VMware Solution commands.",
-                    "version": "5.0.0"
-                },
-                "sha256Digest": "0c3982253c79cb00575353e71dd4ee308c4b5375af1fbf198c02ba46b4e9b11e"
-            },
-            {
                 "downloadUrl": "https://azcliprod.blob.core.windows.net/cli-extensions/vmware-5.0.1-py2.py3-none-any.whl",
                 "filename": "vmware-5.0.1-py2.py3-none-any.whl",
                 "metadata": {


### PR DESCRIPTION
This reverts commit bb4907f17b74365f35f975460699f6b589f230c3 to remove vmware 5.0.0 from the index. It is a bad build. See https://github.com/Azure/azure-cli-extensions/pull/5619 for the fix to make 5.0.1.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repository and upgrade the version in the pull request but do not modify `src/index.json`. 
