### PR TITLE
[appservice-kube] `az webapp scale` scope clarification

### DIFF
--- a/src/appservice-kube/azext_appservice_kube/_help.py
+++ b/src/appservice-kube/azext_appservice_kube/_help.py
@@ -9,7 +9,7 @@ from knack.help_files import helps
 
 helps['webapp scale'] = """
 type: command
-short-summary: Modify the number of instances of a webapp.
+short-summary: Modify the number of instances of a webapp on an Azure Arc-enabled Kubernetes cluster.
 examples:
   - name: Change the number of instances of MyApp to 2.
     text: >


### PR DESCRIPTION
closes https://github.com/Azure/azure-cli/issues/24808

updating help text description to clarify that this command is for arc enabled app service apps on kube environment
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
az webapp scale

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repository and upgrade the version in the pull request but do not modify `src/index.json`. 
