### PR TITLE
[Interactive]Upgrade 'prompt_toolkit' to 3.0.32

### DIFF
--- a/src/interactive/azext_interactive/azclishell/az_completer.py
+++ b/src/interactive/azext_interactive/azclishell/az_completer.py
@@ -41,7 +41,7 @@ def sort_completions(completions_gen):
     def _get_weight(val):
         """ weights the completions with required things first the lexicographically"""
         priority = ''
-        if val.display_meta and val.display_meta.startswith(REQUIRED_TAG):
+        if val.display_meta and val.display_meta[0][1].startswith(REQUIRED_TAG):
             priority = ' '  # a space has the lowest ordinance
         return priority + val.text
 

--- a/src/interactive/azext_interactive/azclishell/color_styles.py
+++ b/src/interactive/azext_interactive/azclishell/color_styles.py
@@ -4,34 +4,34 @@
 # --------------------------------------------------------------------------------------------
 import platform
 
-from pygments.token import Token  # pylint: disable=import-error
-from prompt_toolkit.styles import style_from_dict  # pylint: disable=import-error
+from prompt_toolkit.styles import Style
+from prompt_toolkit.styles.pygments import style_from_pygments_dict  # pylint: disable=import-error
 
 
 def color_mapping(curr_completion, completion, prompt, command, subcommand,
                   param, text, line, example, toolbar):
 
-    return style_from_dict({
+    return Style.from_dict({
         # Completion colors
-        Token.Menu.Completions.Completion.Current: curr_completion,
-        Token.Menu.Completions.Completion: completion,
-        Token.Menu.Completions.ProgressButton: 'bg:#b78991',
-        Token.Menu.Completions.ProgressBar: 'bg:#ffc0cb',
+        'pygments.menu.completions.completion.current': curr_completion,
+        'pygments.menu.completions.completion': completion,
+        'pygments.menu.completions.progress_button': 'bg:#b78991',
+        'pygments.menu.completions.progress_bar': 'bg:#ffc0cb',
 
-        Token.Az: prompt,
-        Token.Prompt.Arg: prompt,
+        'pygments.az': prompt,
+        'pygments.prompt.arg': prompt,
 
         # Pretty Words
-        Token.Keyword: command,
-        Token.Keyword.Declaration: subcommand,
-        Token.Name.Class: param,
-        Token.Text: text,
+        'pygments.keyword': command,
+        'pygments.keyword.declaration': subcommand,
+        'pygments.name.class': param,
+        'pygments.text': text,
 
-        Token.Line: line,
-        Token.Number: example,
+        'pygments.line': line,
+        'pygments.number': example,
         # toolbar
-        Token.Operator: toolbar,
-        Token.Toolbar: toolbar
+        'pygments.operator': toolbar,
+        'pygments.toolbar': toolbar
     })
 
 

--- a/src/interactive/azext_interactive/azclishell/layout.py
+++ b/src/interactive/azext_interactive/azclishell/layout.py
@@ -2,22 +2,20 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
-
+from prompt_toolkit.layout import Layout
 # pylint: disable=import-error
-from pygments.token import Token
 from pygments.lexer import Lexer as PygLex
 from prompt_toolkit.enums import DEFAULT_BUFFER, SEARCH_BUFFER
 from prompt_toolkit.filters import Condition, Always, IsDone, HasFocus, RendererHeightIsKnown
 from prompt_toolkit.layout.containers import VSplit, HSplit, \
     Window, FloatContainer, Float, ConditionalContainer
-from prompt_toolkit.layout.controls import BufferControl, FillControl, TokenListControl
-from prompt_toolkit.layout.dimension import LayoutDimension
-from prompt_toolkit.layout.lexers import PygmentsLexer, Lexer as PromptLex
+from prompt_toolkit.layout.controls import BufferControl, FormattedTextControl
+from prompt_toolkit.layout.dimension import Dimension
+from prompt_toolkit.lexers import PygmentsLexer, Lexer as PromptLex
 from prompt_toolkit.layout.menus import CompletionsMenu
 from prompt_toolkit.layout.processors import HighlightSearchProcessor, \
     HighlightSelectionProcessor, \
-    ConditionalProcessor, AppendAutoSuggestion
-from prompt_toolkit.layout.prompt import DefaultPrompt
+    ConditionalProcessor, AppendAutoSuggestion, BeforeInput
 from prompt_toolkit.layout.screen import Char
 
 
@@ -30,25 +28,26 @@ MAX_COMPLETION = 16
 class LayoutManager(object):
     """ store information and conditions for the layout """
 
-    def __init__(self, shell_ctx):
+    def __init__(self, shell_ctx, buffers):
         self.shell_ctx = shell_ctx
+        self.buffers = buffers
 
         @Condition
-        def show_default(_):
+        def show_default():
             return self.shell_ctx.is_showing_default
 
         @Condition
-        def show_symbol(_):
+        def show_symbol():
             return self.shell_ctx.is_symbols
 
         @Condition
-        def show_progress(_):
+        def show_progress():
             progress = get_progress_message()
             done = get_done()
             return progress != '' and not done
 
         @Condition
-        def has_default_scope(_):
+        def has_default_scope():
             return self.shell_ctx.default_command == ''
 
         self.has_default_scope = has_default_scope
@@ -64,73 +63,74 @@ class LayoutManager(object):
                 # there is no search: the Vi 'n' binding for instance
                 # still allows to jump to the next match in
                 # navigation mode.)
-                HighlightSearchProcessor(preview_search=Always()),
+                HighlightSearchProcessor(),
                 HasFocus(SEARCH_BUFFER)),
             HighlightSelectionProcessor(),
-            ConditionalProcessor(AppendAutoSuggestion(), HasFocus(DEFAULT_BUFFER) & self.has_default_scope)
+            ConditionalProcessor(AppendAutoSuggestion(), HasFocus(self.buffers[DEFAULT_BUFFER]) & self.has_default_scope)
         ]
 
-    def get_prompt_tokens(self, _):
+    def get_prompt_tokens(self):
         """ returns prompt tokens """
         if self.shell_ctx.default_command:
             prompt = 'az {}>> '.format(self.shell_ctx.default_command)
         else:
             prompt = 'az>> '
-        return [(Token.Az, prompt)]
+        return [('class:pygments.az', prompt)]
 
     def create_tutorial_layout(self):
         """ layout for example tutorial """
         lexer, _, _ = get_lexers(self.shell_ctx.lexer, None, None)
+        main_window = Window(
+            BufferControl(
+                buffer=self.buffers[DEFAULT_BUFFER],
+                input_processors=self.input_processors,
+                lexer=lexer,
+                preview_search=Always()),
+            height=lambda: get_height(self.shell_ctx.application))
         layout_full = HSplit([
             FloatContainer(
-                Window(
-                    BufferControl(
-                        input_processors=self.input_processors,
-                        lexer=lexer,
-                        preview_search=Always()),
-                    get_height=get_height),
+                main_window,
                 [
                     Float(xcursor=True,
                           ycursor=True,
                           content=CompletionsMenu(
                               max_height=MAX_COMPLETION,
                               scroll_offset=1,
-                              extra_filter=(HasFocus(DEFAULT_BUFFER))))]),
+                              extra_filter=(HasFocus(self.buffers[DEFAULT_BUFFER]))))]),
             ConditionalContainer(
                 HSplit([
                     get_hline(),
-                    get_param(lexer),
+                    get_param(lexer, self.buffers),
                     get_hline(),
                     Window(
                         content=BufferControl(
-                            buffer_name='example_line',
+                            buffer=self.buffers['example_line'],
                             lexer=lexer
                         ),
                     ),
                     Window(
-                        TokenListControl(
-                            get_tutorial_tokens,
-                            default_char=Char(' ', Token.Toolbar)),
-                        height=LayoutDimension.exact(1)),
+                        FormattedTextControl(
+                            get_tutorial_tokens,),
+                        height=Dimension.exact(1)),
                 ]),
                 filter=~IsDone() & RendererHeightIsKnown()
             )
         ])
-        return layout_full
+        return Layout(layout_full, main_window)
 
     def create_layout(self, exam_lex, toolbar_lex):
         """ creates the layout """
         lexer, exam_lex, toolbar_lex = get_lexers(self.shell_ctx.lexer, exam_lex, toolbar_lex)
 
-        if not any(isinstance(processor, DefaultPrompt) for processor in self.input_processors):
-            self.input_processors.append(DefaultPrompt(self.get_prompt_tokens))
+        if not any(isinstance(processor, BeforeInput) for processor in self.input_processors):
+            self.input_processors.append(BeforeInput(self.get_prompt_tokens))
 
         layout_lower = ConditionalContainer(
             HSplit([
                 get_anyhline(self.shell_ctx.config),
-                get_descriptions(self.shell_ctx.config, exam_lex, lexer),
+                get_descriptions(self.shell_ctx.config, exam_lex, lexer, self.buffers),
                 get_examplehline(self.shell_ctx.config),
-                get_example(self.shell_ctx.config, exam_lex),
+                get_example(self.shell_ctx.config, exam_lex, self.buffers),
 
                 ConditionalContainer(
                     get_hline(),
@@ -139,7 +139,7 @@ class LayoutManager(object):
                 ConditionalContainer(
                     Window(
                         content=BufferControl(
-                            buffer_name='default_values',
+                            buffer=self.buffers['default_values'],
                             lexer=lexer
                         )
                     ),
@@ -152,7 +152,7 @@ class LayoutManager(object):
                 ConditionalContainer(
                     Window(
                         content=BufferControl(
-                            buffer_name='symbols',
+                            buffer=self.buffers['symbols'],
                             lexer=exam_lex
                         )
                     ),
@@ -161,7 +161,7 @@ class LayoutManager(object):
                 ConditionalContainer(
                     Window(
                         content=BufferControl(
-                            buffer_name='progress',
+                            buffer=self.buffers['progress'],
                             lexer=lexer
                         )
                     ),
@@ -169,7 +169,7 @@ class LayoutManager(object):
                 ),
                 Window(
                     content=BufferControl(
-                        buffer_name='bottom_toolbar',
+                        buffer=self.buffers['bottom_toolbar'],
                         lexer=toolbar_lex
                     ),
                 ),
@@ -177,38 +177,40 @@ class LayoutManager(object):
             filter=~IsDone() & RendererHeightIsKnown()
         )
 
+        main_window = Window(
+            BufferControl(
+                buffer=self.buffers[DEFAULT_BUFFER],
+                input_processors=self.input_processors,
+                lexer=lexer,
+                preview_search=Always()),
+            height=lambda: get_height(self.shell_ctx.application),
+        )
         layout_full = HSplit([
             FloatContainer(
-                Window(
-                    BufferControl(
-                        input_processors=self.input_processors,
-                        lexer=lexer,
-                        preview_search=Always()),
-                    get_height=get_height,
-                ),
+                main_window,
                 [
                     Float(xcursor=True,
                           ycursor=True,
                           content=CompletionsMenu(
                               max_height=MAX_COMPLETION,
                               scroll_offset=1,
-                              extra_filter=(HasFocus(DEFAULT_BUFFER))))]),
+                              extra_filter=(HasFocus(self.buffers[DEFAULT_BUFFER]))))]),
             layout_lower
         ])
 
-        return layout_full
+        return Layout(layout_full, main_window)
 
 
-def get_height(cli):
+def get_height(application):
     """ gets the height of the cli """
-    if not cli.is_done:
-        return LayoutDimension(min=8)
+    if not application.is_done:
+        return Dimension(min=8)
     return None
 
 
 def get_tutorial_tokens(_):
     """ tutorial tokens """
-    return [(Token.Toolbar, 'In Tutorial Mode: Press [Enter] after typing each part')]
+    return [('class:pygments.toolbar', 'In Tutorial Mode: Press [Enter] after typing each part')]
 
 
 def get_lexers(main_lex, exam_lex, tool_lex):
@@ -238,34 +240,35 @@ def get_anyhline(config):
     if config.BOOLEAN_STATES[config.config.get('Layout', 'command_description')] or\
        config.BOOLEAN_STATES[config.config.get('Layout', 'param_description')]:
         return Window(
-            width=LayoutDimension.exact(1),
-            height=LayoutDimension.exact(1),
-            content=FillControl('-', token=Token.Line))
+            width=Dimension.exact(1),
+            height=Dimension.exact(1),
+            char='-',
+            style='class:pygments.line',)
     return get_empty()
 
 
-def get_descript(lexer):
+def get_descript(lexer, buffers):
     """ command description window """
     return Window(
         content=BufferControl(
-            buffer_name="description",
+            buffer=buffers["description"],
             lexer=lexer))
 
 
-def get_param(lexer):
+def get_param(lexer, buffers):
     """ parameter description window """
     return Window(
         content=BufferControl(
-            buffer_name="parameter",
+            buffer=buffers["parameter"],
             lexer=lexer))
 
 
-def get_example(config, exam_lex):
+def get_example(config, exam_lex, buffers):
     """ example description window """
     if config.BOOLEAN_STATES[config.config.get('Layout', 'examples')]:
         return Window(
             content=BufferControl(
-                buffer_name="examples",
+                buffer=buffers["examples"],
                 lexer=exam_lex))
     return get_empty()
 
@@ -280,36 +283,38 @@ def get_examplehline(config):
 def get_empty():
     """ returns an empty window because of syntaxical issues """
     return Window(
-        content=FillControl(' ')
+        char=' ',
     )
 
 
 def get_hline():
     """ gets a horiztonal line """
     return Window(
-        width=LayoutDimension.exact(1),
-        height=LayoutDimension.exact(1),
-        content=FillControl('-', token=Token.Line))
+        width=Dimension.exact(1),
+        height=Dimension.exact(1),
+        char='-',
+        style='class:pygments.line',)
 
 
 def get_vline():
     """ gets a vertical line """
     return Window(
-        width=LayoutDimension.exact(1),
-        height=LayoutDimension.exact(1),
-        content=FillControl('*', token=Token.Line))
+        width=Dimension.exact(1),
+        height=Dimension.exact(1),
+        char='*',
+        style='class:pygments.line',)
 
 
-def get_descriptions(config, exam_lex, lexer):
+def get_descriptions(config, exam_lex, lexer, buffers):
     """ based on the configuration settings determines which windows to include """
     if config.BOOLEAN_STATES[config.config.get('Layout', 'command_description')]:
         if config.BOOLEAN_STATES[config.config.get('Layout', 'param_description')]:
             return VSplit([
-                get_descript(exam_lex),
+                get_descript(exam_lex, buffers),
                 get_vline(),
-                get_param(lexer),
+                get_param(lexer, buffers),
             ])
-        return get_descript(exam_lex)
+        return get_descript(exam_lex, buffers)
     if config.BOOLEAN_STATES[config.config.get('Layout', 'param_description')]:
-        return get_param(lexer)
+        return get_param(lexer, buffers)
     return get_empty()

--- a/src/interactive/setup.py
+++ b/src/interactive/setup.py
@@ -32,7 +32,7 @@ CLASSIFIERS = [
 ]
 
 DEPENDENCIES = [
-    'prompt_toolkit~=1.0.15'
+    'prompt_toolkit~=3.0.32'
 ]
 
 with open('README.rst', 'r', encoding='utf-8') as f:


### PR DESCRIPTION
The upgrade of prompt_toolkit can refer to [Upgrading to prompt_toolkit 2.0](https://python-prompt-toolkit.readthedocs.io/en/master/pages/upgrading/2.0.html). 

## Problems

- A callback parameter `on_input_timeout` is removed from `Application` constructor. I replace it with callback `before_redraw` but it may cause a loop because we will call `invalidate`(a redraw method) in `before_redraw`. 
- It seems that `KeyboardInterrupt` cannot be triggered after upgrading. We need to add a new keybinding for `CtrlC` in `KeyBinding`.
---

This checklist is used to make sure that common guidelines for a pull request are followed.

## Problems

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repository and upgrade the version in the pull request but do not modify `src/index.json`. 
