### PR TITLE
{AzureContainerApp} fixes Azure/azure-cli-extensions#5781 fix for 'NoneType' object does not support item assignment

### DIFF
--- a/src/containerapp/HISTORY.rst
+++ b/src/containerapp/HISTORY.rst
@@ -2,6 +2,10 @@
 
 Release History
 ===============
+Upcoming
+++++++
+* Fix for 'az containerapp dapr enable' cli command resulting in 'TypeError: 'NoneType' object does not support item assignment' exception.
+
 0.3.21
 ++++++
 * Fix the PermissionError caused for the Temporary files while running `az containerapp up` command on Windows

--- a/src/containerapp/azext_containerapp/custom.py
+++ b/src/containerapp/azext_containerapp/custom.py
@@ -2366,10 +2366,13 @@ def enable_dapr(cmd, name, resource_group_name,
     if 'configuration' not in containerapp_def['properties']:
         containerapp_def['properties']['configuration'] = {}
 
-    if 'dapr' not in containerapp_def['properties']['configuration']:
-        containerapp_def['properties']['configuration']['dapr'] = {}
+    if not safe_get(containerapp_def, "properties", "configuration", "dapr"):
+        if "dapr" not in containerapp_def['properties']['configuration']:
+            containerapp_def['properties']['configuration']['dapr'] = {}
 
-    if dapr_app_id:
+    if not safe_get(containerapp_def, "properties", "configuration", "dapr", "appId"):
+        if dapr_app_id not in containerapp_def['properties']['configuration']['dapr']:
+            containerapp_def['properties']['configuration']['dapr']['appId'] = {}
         containerapp_def['properties']['configuration']['dapr']['appId'] = dapr_app_id
 
     if dapr_app_port:

--- a/src/containerapp/azext_containerapp/custom.py
+++ b/src/containerapp/azext_containerapp/custom.py
@@ -2368,10 +2368,10 @@ def enable_dapr(cmd, name, resource_group_name,
 
     if not safe_get(containerapp_def, "properties", "configuration", "dapr"):
         if "dapr" not in containerapp_def['properties']['configuration']:
-            containerapp_def['properties']['configuration']['dapr'] = {}
+            safe_get(containerapp_def, "properties", "configuration", "dapr", default=[])
 
     if not safe_get(containerapp_def, "properties", "configuration", "dapr", "appId"):
-        if dapr_app_id not in containerapp_def['properties']['configuration']['dapr']:
+        if dapr_app_id not in safe_get(containerapp_def['properties']['configuration']['dapr'], default=[]):
             containerapp_def['properties']['configuration']['dapr']['appId'] = {}
         containerapp_def['properties']['configuration']['dapr']['appId'] = dapr_app_id
 

--- a/src/containerapp/azext_containerapp/tests/latest/test_containerapp_commands.py
+++ b/src/containerapp/azext_containerapp/tests/latest/test_containerapp_commands.py
@@ -617,8 +617,8 @@ class ContainerappDaprTests(ScenarioTest):
         ])
         
         self.cmd('containerapp dapr enable -g {} -n {} --dapr-app-id containerapp1 --dapr-app-port 80 --dapr-app-protocol http --dal --dhmrs 6 --dhrbs 60 --dapr-log-level warn'.format(resource_group, ca_name, env_name), checks=[
-            JMESPathCheck('appId', "containerapp1"),
-            JMESPathCheck('enabled', True)
+            JMESPathCheck('properties.configuration.dapr.appId', "containerapp1"),
+            JMESPathCheck('properties.configuration.dapr.enabled', True)
         ])
         
         self.cmd('containerapp show -g {} -n {}'.format(resource_group, ca_name), checks=[

--- a/src/containerapp/azext_containerapp/tests/latest/test_containerapp_commands.py
+++ b/src/containerapp/azext_containerapp/tests/latest/test_containerapp_commands.py
@@ -615,12 +615,7 @@ class ContainerappDaprTests(ScenarioTest):
             JMESPathCheck('logLevel', "warn"),
             JMESPathCheck('enableApiLogging', True),
         ])
-        
-        self.cmd('containerapp dapr enable -g {} -n {} --dapr-app-id containerapp1 --dapr-app-port 80 --dapr-app-protocol http --dal --dhmrs 6 --dhrbs 60 --dapr-log-level warn'.format(resource_group, ca_name, env_name), checks=[
-            JMESPathCheck('properties.configuration.dapr.appId', "containerapp1"),
-            JMESPathCheck('properties.configuration.dapr.enabled', True)
-        ])
-        
+                
         self.cmd('containerapp show -g {} -n {}'.format(resource_group, ca_name), checks=[
             JMESPathCheck('properties.configuration.dapr.appId', "containerapp1"),
             JMESPathCheck('properties.configuration.dapr.appPort', 80),
@@ -653,6 +648,34 @@ class ContainerappDaprTests(ScenarioTest):
             JMESPathCheck('properties.configuration.dapr.logLevel', "warn"),
             JMESPathCheck('properties.configuration.dapr.enableApiLogging', True),
         ])
+
+    @AllowLargeResponse(8192)
+    @ResourceGroupPreparer(location="eastus2")
+    def test_containerapp_up_dapr_e2e(self, resource_group):
+        """ Ensure that dapr can be enabled if the app has been created using containerapp up """
+        location = os.getenv("CLITestLocation")
+        if not location:
+            location = 'eastus'
+
+        self.cmd('configure --defaults location={}'.format(location))
+
+        image = 'mcr.microsoft.com/azuredocs/aks-helloworld:v1'
+        env_name = self.create_random_name(prefix='containerapp-env', length=24)
+        ca_name = self.create_random_name(prefix='containerapp', length=24)
+
+        create_containerapp_env(self, env_name, resource_group)
+
+        self.cmd(
+            'containerapp up -g {} -n {} --environment {} --image {}'.format(
+                resource_group, ca_name, env_name, image))
+
+        self.cmd(
+            'containerapp dapr enable -g {} -n {} --dapr-app-id containerapp1 --dapr-app-port 80 '
+            '--dapr-app-protocol http --dal --dhmrs 6 --dhrbs 60 --dapr-log-level warn'.format(
+                resource_group, ca_name, env_name), checks=[
+                JMESPathCheck('appId', "containerapp1"),
+                JMESPathCheck('enabled', True)
+            ])
 
 
 class ContainerappEnvStorageTests(ScenarioTest):

--- a/src/containerapp/azext_containerapp/tests/latest/test_containerapp_commands.py
+++ b/src/containerapp/azext_containerapp/tests/latest/test_containerapp_commands.py
@@ -615,7 +615,12 @@ class ContainerappDaprTests(ScenarioTest):
             JMESPathCheck('logLevel', "warn"),
             JMESPathCheck('enableApiLogging', True),
         ])
-
+        
+        self.cmd('containerapp dapr enable -g {} -n {} --dapr-app-id containerapp1 --dapr-app-port 80 --dapr-app-protocol http --dal --dhmrs 6 --dhrbs 60 --dapr-log-level warn'.format(resource_group, ca_name, env_name), checks=[
+            JMESPathCheck('appId', "containerapp1"),
+            JMESPathCheck('enabled', True)
+        ])
+        
         self.cmd('containerapp show -g {} -n {}'.format(resource_group, ca_name), checks=[
             JMESPathCheck('properties.configuration.dapr.appId', "containerapp1"),
             JMESPathCheck('properties.configuration.dapr.appPort', 80),


### PR DESCRIPTION
fixes Azure/azure-cli-extensions#5781

fix for TypeError: 'NoneType' object does not support item assignment while running the `az containerapp dapr enable` command

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repository and upgrade the version in the pull request but do not modify `src/index.json`. 
