### PR TITLE
[Quantum] Update version and history info for az quantum extension 0.18.0

### DIFF
--- a/src/quantum/HISTORY.rst
+++ b/src/quantum/HISTORY.rst
@@ -5,7 +5,7 @@ Release History
 
 0.18.0
 ++++++
-* [2023-02-07] Version intended to work with QDK version 0.27.253010 and Azure CLI 2.41.0 or greater.
+* [2023-02-08] Version intended to work with QDK version 0.27.253010 and Azure CLI 2.41.0 or greater.
 * You can now submit QIR and pass-through jobs using the CLI.
 * Fixed Azure/azure-cli-extensions Issue #5831 to eliminate some workspace creation errors.
 

--- a/src/quantum/HISTORY.rst
+++ b/src/quantum/HISTORY.rst
@@ -3,6 +3,12 @@
 Release History
 ===============
 
+0.18.0
+++++++
+* [2023-02-07] Version intended to work with QDK version 0.27.253010 and Azure CLI 2.41.0 or greater.
+* You can now submit QIR, QIO, and pass-through jobs using the CLI.
+* Fixed Azure/azure-cli-extensions Issue #5831 to eliminate some workspace creation errors.
+
 0.17.0
 ++++++
 * [2022-11-02] Update default QDK version to latest 0.27.238334 - See https://learn.microsoft.com/azure/quantum/release-notes.

--- a/src/quantum/HISTORY.rst
+++ b/src/quantum/HISTORY.rst
@@ -6,7 +6,7 @@ Release History
 0.18.0
 ++++++
 * [2023-02-07] Version intended to work with QDK version 0.27.253010 and Azure CLI 2.41.0 or greater.
-* You can now submit QIR, QIO, and pass-through jobs using the CLI.
+* You can now submit QIR and pass-through jobs using the CLI. QIO jobs for solvers that expect gzip input compression are also supported.
 * Fixed Azure/azure-cli-extensions Issue #5831 to eliminate some workspace creation errors.
 
 0.17.0

--- a/src/quantum/HISTORY.rst
+++ b/src/quantum/HISTORY.rst
@@ -6,7 +6,7 @@ Release History
 0.18.0
 ++++++
 * [2023-02-07] Version intended to work with QDK version 0.27.253010 and Azure CLI 2.41.0 or greater.
-* You can now submit QIR and pass-through jobs using the CLI. QIO jobs for solvers that expect gzip input compression are also supported.
+* You can now submit QIR and pass-through jobs using the CLI.
 * Fixed Azure/azure-cli-extensions Issue #5831 to eliminate some workspace creation errors.
 
 0.17.0

--- a/src/quantum/azext_quantum/__init__.py
+++ b/src/quantum/azext_quantum/__init__.py
@@ -11,7 +11,7 @@ import azext_quantum._help  # pylint: disable=unused-import
 # This is the version reported by the CLI to the service when submitting requests.
 # This should be in sync with the extension version in 'setup.py', unless we need to
 # submit using a different version.
-CLI_REPORTED_VERSION = "0.17.0"
+CLI_REPORTED_VERSION = "0.18.0"
 
 
 class QuantumCommandsLoader(AzCommandsLoader):

--- a/src/quantum/setup.py
+++ b/src/quantum/setup.py
@@ -17,7 +17,7 @@ except ImportError:
 # This version should match the latest entry in HISTORY.rst
 # Also, when updating this, please review the version used by the extension to
 # submit requests, which can be found at './azext_quantum/__init__.py'
-VERSION = '0.17.0'
+VERSION = '0.18.0'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Release PR for az quantum extension, version 0.18.0.

---

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?
