### PR TITLE
[DO NOT MERGE]Support set/update secrets with yaml file

### DIFF
--- a/src/containerapp/azext_containerapp/_clients.py
+++ b/src/containerapp/azext_containerapp/_clients.py
@@ -17,6 +17,7 @@ logger = get_logger(__name__)
 PREVIEW_API_VERSION = "2022-06-01-preview"
 CURRENT_API_VERSION = PREVIEW_API_VERSION
 MANAGED_CERTS_API_VERSION = '2022-11-01-preview'
+KV_SECRETS_API_VERSION = '2022-11-01-preview'
 POLLING_TIMEOUT = 600  # how many seconds before exiting
 POLLING_SECONDS = 2  # how many seconds between requests
 POLLING_TIMEOUT_FOR_MANAGED_CERTIFICATE = 1500  # how many seconds before exiting
@@ -75,7 +76,7 @@ class ContainerAppClient():
     @classmethod
     def create_or_update(cls, cmd, resource_group_name, name, container_app_envelope, no_wait=False):
         management_hostname = cmd.cli_ctx.cloud.endpoints.resource_manager
-        api_version = CURRENT_API_VERSION
+        api_version = KV_SECRETS_API_VERSION
         sub_id = get_subscription_id(cmd.cli_ctx)
         url_fmt = "{}/subscriptions/{}/resourceGroups/{}/providers/Microsoft.App/containerApps/{}?api-version={}"
         request_url = url_fmt.format(
@@ -244,7 +245,7 @@ class ContainerAppClient():
     def list_secrets(cls, cmd, resource_group_name, name):
 
         management_hostname = cmd.cli_ctx.cloud.endpoints.resource_manager
-        api_version = CURRENT_API_VERSION
+        api_version = KV_SECRETS_API_VERSION
         sub_id = get_subscription_id(cmd.cli_ctx)
         url_fmt = "{}/subscriptions/{}/resourceGroups/{}/providers/Microsoft.App/containerApps/{}/listSecrets?api-version={}"
         request_url = url_fmt.format(

--- a/src/containerapp/azext_containerapp/_models.py
+++ b/src/containerapp/azext_containerapp/_models.py
@@ -120,7 +120,9 @@ ScaleRule = {
 
 Secret = {
     "name": None,
-    "value": None
+    "value": None,
+    "keyVaultUrl": None,
+    "identity": None
 }
 
 Scale = {

--- a/src/containerapp/azext_containerapp/_params.py
+++ b/src/containerapp/azext_containerapp/_params.py
@@ -277,6 +277,14 @@ def load_arguments(self, _):
         c.argument('show_values', help='Show the secret values.')
         c.ignore('disable_max_length')
 
+    with self.argument_context('containerapp secret set') as c:
+        c.argument('yaml', type=file_type, help='Path to a .yaml file with the secrets configuration of a container app. All other parameters will be ignored. For an example, see  https://docs.microsoft.com/azure/container-apps/azure-resource-manager-api-spec#examples')
+        c.argument('secrets', nargs='+', options_list=['--secrets', '-s'], help="A list of secret(s) for the container app. Space-separated values in 'key=value' format (where 'key' cannot be longer than 20 characters).")
+        c.argument('secret_name', help="The name of the secret to show.")
+        c.argument('secret_names', nargs='+', help="A list of secret(s) for the container app. Space-separated secret values names.")
+        c.argument('show_values', help='Show the secret values.')
+        c.ignore('disable_max_length')
+
     with self.argument_context('containerapp env dapr-component') as c:
         c.argument('dapr_app_id', help="The Dapr app ID.")
         c.argument('dapr_app_port', help="The port of your app.")

--- a/src/containerapp/azext_containerapp/_sdk_models.py
+++ b/src/containerapp/azext_containerapp/_sdk_models.py
@@ -3033,11 +3033,17 @@ class Secret(Model):
     :type name: str
     :param value: Secret Value.
     :type value: str
+    :param keyVaultUrl: Secret KeyVaultUrl.
+    :type keyVaultUrl: str
+    :param identity: Identity talking to keyVault.
+    :type identity: str
     """
 
     _attribute_map = {
         'name': {'key': 'name', 'type': 'str'},
         'value': {'key': 'value', 'type': 'str'},
+        'keyVaultUrl': {'key': 'keyVaultUrl', 'type': 'str'},
+        'identity': {'key': 'identity', 'type': 'str'},
     }
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
This PR introduces KV secrets for containerapps. KV secrets can now updated/set using yml file.

When use `az containerapp secret set --yaml`, the file should be in format like below
![image](https://user-images.githubusercontent.com/79332479/220728980-cc8903f7-b027-4e12-b846-a0225970ee53.png)

When use `az containerapp create/update --yaml`, secrets should be following the contract like below
![image](https://user-images.githubusercontent.com/79332479/220729793-fc2e1f6b-ac5f-41f9-8d98-ad3f65b7e17a.png)

**This PR is still waiting for new release to be deployed to fully test.**
