### PR TITLE
Update image tag used for "no Dockerfile" containerapp up scenario

### DIFF
--- a/src/containerapp/azext_containerapp/_constants.py
+++ b/src/containerapp/azext_containerapp/_constants.py
@@ -40,7 +40,7 @@ LOG_TYPE_SYSTEM = "system"
 
 ACR_TASK_TEMPLATE = """version: v1.1.0
 steps:
-  - cmd: mcr.microsoft.com/oryx/cli:20220811.1 oryx dockerfile --bind-port {{target_port}} --output ./Dockerfile .
+  - cmd: mcr.microsoft.com/oryx/cli:debian-buster-20230222.1 oryx dockerfile --bind-port {{target_port}} --output ./Dockerfile .
     timeout: 28800
   - build: -t $Registry/{{image_name}} -f Dockerfile .
     timeout: 28800


### PR DESCRIPTION
This PR aims to update the Oryx build image tag used by the `az containerapp up` command to construct a `Dockerfile` for the user when the provided `--source` code does not contain a `Dockerfile` itself.

The new image tag will enable the latest versions of supported Oryx platform binaries to be pulled down dynamically when building the `--source`, as well as enable telemetry on the Oryx end.
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command

`az containerapp up`


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

~- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).~


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repository and upgrade the version in the pull request but do not modify `src/index.json`. 
