### PR TITLE
[Quantum] Fix "NoneType is not iterable" error

### DIFF
--- a/src/quantum/azext_quantum/operations/job.py
+++ b/src/quantum/azext_quantum/operations/job.py
@@ -269,7 +269,7 @@ def _submit_directly_to_service(cmd, resource_group_name, workspace_name, locati
         #   -  Include it as 'entryPoint':'MyEntryPoint' in a JSON --job-params string or file
         #   -  Include it in an "items" list in a JSON --job-params string or file
         found_entry_point_in_items = False
-        if "items" in job_params:
+        if job_params is not None and "items" in job_params:
             items_list = job_params["items"]
             if isinstance(items_list, type([])):    # "list" has been redefined as a function name
                 for item in items_list:


### PR DESCRIPTION
### One-line bug fix:

Found and fixed a bug where `job_params is not None` was needed in a logical expression in the `--job-params` parsing code for submitting QIR jobs.

### Affected commands:
```
az quantum run
az quantum execute
az quanrum job submit
```

---

### General Guidelines

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?
