### PR TITLE
Retrieve the correct resource group based on the storage account

### DIFF
--- a/src/serial-console/HISTORY.rst
+++ b/src/serial-console/HISTORY.rst
@@ -1,6 +1,10 @@
 Release History
 ===============
 
+0.1.5
+++++++
+* Fix resource group for custom storage account
+
 0.1.4
 ++++++
 * Fix repeating loading message

--- a/src/serial-console/azext_serialconsole/custom.py
+++ b/src/serial-console/azext_serialconsole/custom.py
@@ -702,7 +702,7 @@ def get_region_from_storage_account(cli_ctx, resource_group_name, vm_vmss_name, 
             logger.debug(result.boot_diagnostics)
             if result.boot_diagnostics.console_screenshot_blob_uri is not None:
                 storage_account_url = result.boot_diagnostics.console_screenshot_blob_uri
-                storage_account_region = get_storage_account_info(storage_account_url, resource_group_name, scf)
+                storage_account_region = get_storage_account_info(storage_account_url, scf)
     else:
         try:
             result_data = client.virtual_machines.get(
@@ -731,12 +731,12 @@ def get_region_from_storage_account(cli_ctx, resource_group_name, vm_vmss_name, 
         if result.diagnostics_profile is not None:
             if result.diagnostics_profile.boot_diagnostics is not None:
                 storage_account_url = result.diagnostics_profile.boot_diagnostics.storage_uri
-                storage_account_region = get_storage_account_info(storage_account_url, resource_group_name, scf)
+                storage_account_region = get_storage_account_info(storage_account_url, scf)
 
     return result, storage_account_region
 
 
-def get_storage_account_info(storage_account_url, resource_group_name, scf):
+def get_storage_account_info(storage_account_url, scf):
     from azext_serialconsole._arm_endpoints import ArmEndpoints
 
     if storage_account_url is not None:
@@ -766,6 +766,7 @@ def resource_group_from_storage_account_name(storage_account_name, scf):
     for storage_account in storage_accounts:
         storage_account_id = storage_account.id
         if storage_account_id.endswith("Microsoft.Storage/storageAccounts/" + storage_account_name):
-            rg = re.search(r"resourceGroups/(.+)/providers/Microsoft.Storage/storageAccounts", storage_account_id).group(1)
+            rg = re.search(r"resourceGroups/(.+)/providers/Microsoft.Storage/storageAccounts",
+                           storage_account_id).group(1)
             return rg
     return None

--- a/src/serial-console/azext_serialconsole/custom.py
+++ b/src/serial-console/azext_serialconsole/custom.py
@@ -740,23 +740,32 @@ def get_storage_account_info(storage_account_url, resource_group_name, scf):
     from azext_serialconsole._arm_endpoints import ArmEndpoints
 
     if storage_account_url is not None:
-        storage_account = parse_storage_account_url(storage_account_url)
+        storage_account, storage_account_resource_group = parse_storage_account_url(storage_account_url, scf)
         if storage_account is not None:
-            sa_result = scf.storage_accounts.get_properties(resource_group_name, storage_account)
+            sa_result = scf.storage_accounts.get_properties(storage_account_resource_group, storage_account)
             if (sa_result is not None and
                     sa_result.network_rule_set is not None and
                     len(sa_result.network_rule_set.ip_rules) > 0):
                 return ArmEndpoints.region_prefix_pairings[sa_result.location]
-
     return None
 
 
-def parse_storage_account_url(url):
+def parse_storage_account_url(url, scf):
     if url is not None:
         sa_list = url.split('.')
         if len(sa_list) > 0:
             sa_url = sa_list[0]
-            sa_url = sa_url.replace("https://", "")
-            return sa_url
+            sa_name = sa_url.replace("https://", "")
+            sa_resource_group = resource_group_from_storage_account_name(sa_name, scf)
+            return sa_name, sa_resource_group
+    return None, None
 
+
+def resource_group_from_storage_account_name(storage_account_name, scf):
+    storage_accounts = scf.storage_accounts.list()
+    for storage_account in storage_accounts:
+        storage_account_id = storage_account.id
+        if storage_account_id.endswith("Microsoft.Storage/storageAccounts/" + storage_account_name):
+            rg = re.search(r"resourceGroups/(.+)/providers/Microsoft.Storage/storageAccounts", storage_account_id).group(1)
+            return rg
     return None

--- a/src/serial-console/azext_serialconsole/tests/latest/recordings/test_check_resource_VM.yaml
+++ b/src/serial-console/azext_serialconsole/tests/latest/recordings/test_check_resource_VM.yaml
@@ -11,9 +11,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?$expand=instanceView&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?$expand=instanceView&api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Compute/virtualMachines/cli000003''
@@ -27,7 +27,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:51:38 GMT
+      - Mon, 06 Mar 2023 14:54:44 GMT
       expires:
       - '-1'
       pragma:
@@ -53,9 +53,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Compute/virtualMachineScaleSets/cli000003''
@@ -69,7 +69,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:51:38 GMT
+      - Mon, 06 Mar 2023 14:54:44 GMT
       expires:
       - '-1'
       pragma:
@@ -95,9 +95,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/0/instanceView?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/0/instanceView?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"ParentResourceNotFound","message":"Can not perform
@@ -111,7 +111,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:51:38 GMT
+      - Mon, 06 Mar 2023 14:54:44 GMT
       expires:
       - '-1'
       pragma:
@@ -135,7 +135,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.28.1
+      - python-requests/2.26.0
     method: GET
     uri: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/arm-compute/quickstart-templates/aliases.json
   response:
@@ -202,11 +202,11 @@ interactions:
       content-type:
       - text/plain; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:51:40 GMT
+      - Mon, 06 Mar 2023 14:54:46 GMT
       etag:
       - W/"41b202f4dc5098d126019dc00721a4c5e30df0c5196794514fadc3710ee2a5cb"
       expires:
-      - Tue, 13 Dec 2022 22:56:40 GMT
+      - Mon, 06 Mar 2023 14:59:46 GMT
       source-age:
       - '0'
       strict-transport-security:
@@ -216,21 +216,21 @@ interactions:
       via:
       - 1.1 varnish
       x-cache:
-      - MISS
+      - HIT
       x-cache-hits:
-      - '0'
+      - '1'
       x-content-type-options:
       - nosniff
       x-fastly-request-id:
-      - 48ec8db47af211ad6c24da7db7eb4907dfc50d87
+      - 0896e7fa97402d8f83fbb89be7912979e4b4e7b6
       x-frame-options:
       - deny
       x-github-request-id:
-      - 42FE:0D55:4E604:6620A:639901FC
+      - 2404:0661:52C8DE:6E0168:6405FB51
       x-served-by:
-      - cache-pao17421-PAO
+      - cache-dal21277-DAL
       x-timer:
-      - S1670971900.496800,VS0,VE94
+      - S1678114487.737419,VS0,VE1
       x-xss-protection:
       - 1; mode=block
     status:
@@ -250,13 +250,13 @@ interactions:
       ParameterSetName:
       - -g -n --image -l --generate-ssh-keys
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/publishers/Canonical/artifacttypes/vmimage/offers/UbuntuServer/skus/18.04-LTS/versions?$top=1&$orderby=name%20desc&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/publishers/Canonical/artifacttypes/vmimage/offers/UbuntuServer/skus/18.04-LTS/versions?$top=1&$orderby=name%20desc&api-version=2022-11-01
   response:
     body:
-      string: "[\r\n  {\r\n    \"location\": \"westus2\",\r\n    \"name\": \"18.04.202212090\",\r\n
-        \   \"id\": \"/Subscriptions/00000000-0000-0000-0000-000000000000/Providers/Microsoft.Compute/Locations/westus2/Publishers/Canonical/ArtifactTypes/VMImage/Offers/UbuntuServer/Skus/18.04-LTS/Versions/18.04.202212090\"\r\n
+      string: "[\r\n  {\r\n    \"location\": \"westus2\",\r\n    \"name\": \"18.04.202302100\",\r\n
+        \   \"id\": \"/Subscriptions/00000000-0000-0000-0000-000000000000/Providers/Microsoft.Compute/Locations/westus2/Publishers/Canonical/ArtifactTypes/VMImage/Offers/UbuntuServer/Skus/18.04-LTS/Versions/18.04.202302100\"\r\n
         \ }\r\n]"
     headers:
       cache-control:
@@ -266,7 +266,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:51:40 GMT
+      - Mon, 06 Mar 2023 14:54:47 GMT
       expires:
       - '-1'
       pragma:
@@ -283,7 +283,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/ListVMImagesVersionsFromLocation3Min;15999,Microsoft.Compute/ListVMImagesVersionsFromLocation30Min;43999
+      - Microsoft.Compute/ListVMImagesVersionsFromLocation3Min;15997,Microsoft.Compute/ListVMImagesVersionsFromLocation30Min;43988
     status:
       code: 200
       message: OK
@@ -301,9 +301,9 @@ interactions:
       ParameterSetName:
       - -g -n --image -l --generate-ssh-keys
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/publishers/Canonical/artifacttypes/vmimage/offers/UbuntuServer/skus/18.04-LTS/versions/18.04.202212090?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/publishers/Canonical/artifacttypes/vmimage/offers/UbuntuServer/skus/18.04-LTS/versions/18.04.202302100?api-version=2022-11-01
   response:
     body:
       string: "{\r\n  \"properties\": {\r\n    \"hyperVGeneration\": \"V1\",\r\n    \"architecture\":
@@ -317,8 +317,8 @@ interactions:
         \"IsHibernateSupported\",\r\n        \"value\": \"True\"\r\n      }\r\n    ],\r\n
         \   \"osDiskImage\": {\r\n      \"operatingSystem\": \"Linux\",\r\n      \"sizeInGb\":
         31,\r\n      \"sizeInBytes\": 32213303808\r\n    },\r\n    \"dataDiskImages\":
-        []\r\n  },\r\n  \"location\": \"westus2\",\r\n  \"name\": \"18.04.202212090\",\r\n
-        \ \"id\": \"/Subscriptions/00000000-0000-0000-0000-000000000000/Providers/Microsoft.Compute/Locations/westus2/Publishers/Canonical/ArtifactTypes/VMImage/Offers/UbuntuServer/Skus/18.04-LTS/Versions/18.04.202212090\"\r\n}"
+        []\r\n  },\r\n  \"location\": \"westus2\",\r\n  \"name\": \"18.04.202302100\",\r\n
+        \ \"id\": \"/Subscriptions/00000000-0000-0000-0000-000000000000/Providers/Microsoft.Compute/Locations/westus2/Publishers/Canonical/ArtifactTypes/VMImage/Offers/UbuntuServer/Skus/18.04-LTS/Versions/18.04.202302100\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -327,7 +327,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:51:40 GMT
+      - Mon, 06 Mar 2023 14:54:47 GMT
       expires:
       - '-1'
       pragma:
@@ -344,7 +344,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetVMImageFromLocation3Min;12999,Microsoft.Compute/GetVMImageFromLocation30Min;73999
+      - Microsoft.Compute/GetVMImageFromLocation3Min;12996,Microsoft.Compute/GetVMImageFromLocation30Min;73992
     status:
       code: 200
       message: OK
@@ -362,7 +362,7 @@ interactions:
       ParameterSetName:
       - -g -n --image -l --generate-ssh-keys
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-network/21.0.1 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-network/21.0.1 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks?api-version=2022-01-01
   response:
@@ -376,7 +376,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:51:41 GMT
+      - Mon, 06 Mar 2023 14:54:47 GMT
       expires:
       - '-1'
       pragma:
@@ -400,7 +400,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.28.1
+      - python-requests/2.26.0
     method: GET
     uri: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/arm-compute/quickstart-templates/aliases.json
   response:
@@ -467,13 +467,13 @@ interactions:
       content-type:
       - text/plain; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:51:41 GMT
+      - Mon, 06 Mar 2023 14:54:48 GMT
       etag:
       - W/"41b202f4dc5098d126019dc00721a4c5e30df0c5196794514fadc3710ee2a5cb"
       expires:
-      - Tue, 13 Dec 2022 22:56:41 GMT
+      - Mon, 06 Mar 2023 14:59:48 GMT
       source-age:
-      - '1'
+      - '2'
       strict-transport-security:
       - max-age=31536000
       vary:
@@ -487,15 +487,15 @@ interactions:
       x-content-type-options:
       - nosniff
       x-fastly-request-id:
-      - 49f1e56a46245956b4bf8e7394986a622e0cebb4
+      - fef67b7095eb01a152aea6c331106d4070da187b
       x-frame-options:
       - deny
       x-github-request-id:
-      - 42FE:0D55:4E604:6620A:639901FC
+      - 2404:0661:52C8DE:6E0168:6405FB51
       x-served-by:
-      - cache-pao17420-PAO
+      - cache-dal2120116-DAL
       x-timer:
-      - S1670971902.697913,VS0,VE1
+      - S1678114488.085066,VS0,VE1
       x-xss-protection:
       - 1; mode=block
     status:
@@ -515,13 +515,13 @@ interactions:
       ParameterSetName:
       - -g -n --image -l --generate-ssh-keys
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/publishers/Canonical/artifacttypes/vmimage/offers/UbuntuServer/skus/18.04-LTS/versions?$top=1&$orderby=name%20desc&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/publishers/Canonical/artifacttypes/vmimage/offers/UbuntuServer/skus/18.04-LTS/versions?$top=1&$orderby=name%20desc&api-version=2022-11-01
   response:
     body:
-      string: "[\r\n  {\r\n    \"location\": \"westus2\",\r\n    \"name\": \"18.04.202212090\",\r\n
-        \   \"id\": \"/Subscriptions/00000000-0000-0000-0000-000000000000/Providers/Microsoft.Compute/Locations/westus2/Publishers/Canonical/ArtifactTypes/VMImage/Offers/UbuntuServer/Skus/18.04-LTS/Versions/18.04.202212090\"\r\n
+      string: "[\r\n  {\r\n    \"location\": \"westus2\",\r\n    \"name\": \"18.04.202302100\",\r\n
+        \   \"id\": \"/Subscriptions/00000000-0000-0000-0000-000000000000/Providers/Microsoft.Compute/Locations/westus2/Publishers/Canonical/ArtifactTypes/VMImage/Offers/UbuntuServer/Skus/18.04-LTS/Versions/18.04.202302100\"\r\n
         \ }\r\n]"
     headers:
       cache-control:
@@ -531,7 +531,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:51:41 GMT
+      - Mon, 06 Mar 2023 14:54:47 GMT
       expires:
       - '-1'
       pragma:
@@ -548,7 +548,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/ListVMImagesVersionsFromLocation3Min;15998,Microsoft.Compute/ListVMImagesVersionsFromLocation30Min;43998
+      - Microsoft.Compute/ListVMImagesVersionsFromLocation3Min;15993,Microsoft.Compute/ListVMImagesVersionsFromLocation30Min;43984
     status:
       code: 200
       message: OK
@@ -566,9 +566,9 @@ interactions:
       ParameterSetName:
       - -g -n --image -l --generate-ssh-keys
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/publishers/Canonical/artifacttypes/vmimage/offers/UbuntuServer/skus/18.04-LTS/versions/18.04.202212090?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/publishers/Canonical/artifacttypes/vmimage/offers/UbuntuServer/skus/18.04-LTS/versions/18.04.202302100?api-version=2022-11-01
   response:
     body:
       string: "{\r\n  \"properties\": {\r\n    \"hyperVGeneration\": \"V1\",\r\n    \"architecture\":
@@ -582,8 +582,8 @@ interactions:
         \"IsHibernateSupported\",\r\n        \"value\": \"True\"\r\n      }\r\n    ],\r\n
         \   \"osDiskImage\": {\r\n      \"operatingSystem\": \"Linux\",\r\n      \"sizeInGb\":
         31,\r\n      \"sizeInBytes\": 32213303808\r\n    },\r\n    \"dataDiskImages\":
-        []\r\n  },\r\n  \"location\": \"westus2\",\r\n  \"name\": \"18.04.202212090\",\r\n
-        \ \"id\": \"/Subscriptions/00000000-0000-0000-0000-000000000000/Providers/Microsoft.Compute/Locations/westus2/Publishers/Canonical/ArtifactTypes/VMImage/Offers/UbuntuServer/Skus/18.04-LTS/Versions/18.04.202212090\"\r\n}"
+        []\r\n  },\r\n  \"location\": \"westus2\",\r\n  \"name\": \"18.04.202302100\",\r\n
+        \ \"id\": \"/Subscriptions/00000000-0000-0000-0000-000000000000/Providers/Microsoft.Compute/Locations/westus2/Publishers/Canonical/ArtifactTypes/VMImage/Offers/UbuntuServer/Skus/18.04-LTS/Versions/18.04.202302100\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -592,7 +592,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:51:41 GMT
+      - Mon, 06 Mar 2023 14:54:48 GMT
       expires:
       - '-1'
       pragma:
@@ -609,7 +609,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetVMImageFromLocation3Min;12998,Microsoft.Compute/GetVMImageFromLocation30Min;73998
+      - Microsoft.Compute/GetVMImageFromLocation3Min;12993,Microsoft.Compute/GetVMImageFromLocation30Min;73989
     status:
       code: 200
       message: OK
@@ -627,13 +627,13 @@ interactions:
       ParameterSetName:
       - -g -n --image -l --generate-ssh-keys
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/publishers/Canonical/artifacttypes/vmimage/offers/UbuntuServer/skus/18.04-LTS/versions?$top=1&$orderby=name%20desc&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/publishers/Canonical/artifacttypes/vmimage/offers/UbuntuServer/skus/18.04-LTS/versions?$top=1&$orderby=name%20desc&api-version=2022-11-01
   response:
     body:
-      string: "[\r\n  {\r\n    \"location\": \"westus2\",\r\n    \"name\": \"18.04.202212090\",\r\n
-        \   \"id\": \"/Subscriptions/00000000-0000-0000-0000-000000000000/Providers/Microsoft.Compute/Locations/westus2/Publishers/Canonical/ArtifactTypes/VMImage/Offers/UbuntuServer/Skus/18.04-LTS/Versions/18.04.202212090\"\r\n
+      string: "[\r\n  {\r\n    \"location\": \"westus2\",\r\n    \"name\": \"18.04.202302100\",\r\n
+        \   \"id\": \"/Subscriptions/00000000-0000-0000-0000-000000000000/Providers/Microsoft.Compute/Locations/westus2/Publishers/Canonical/ArtifactTypes/VMImage/Offers/UbuntuServer/Skus/18.04-LTS/Versions/18.04.202302100\"\r\n
         \ }\r\n]"
     headers:
       cache-control:
@@ -643,7 +643,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:51:41 GMT
+      - Mon, 06 Mar 2023 14:54:48 GMT
       expires:
       - '-1'
       pragma:
@@ -660,7 +660,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/ListVMImagesVersionsFromLocation3Min;15997,Microsoft.Compute/ListVMImagesVersionsFromLocation30Min;43997
+      - Microsoft.Compute/ListVMImagesVersionsFromLocation3Min;15989,Microsoft.Compute/ListVMImagesVersionsFromLocation30Min;43980
     status:
       code: 200
       message: OK
@@ -678,9 +678,9 @@ interactions:
       ParameterSetName:
       - -g -n --image -l --generate-ssh-keys
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/publishers/Canonical/artifacttypes/vmimage/offers/UbuntuServer/skus/18.04-LTS/versions/18.04.202212090?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/publishers/Canonical/artifacttypes/vmimage/offers/UbuntuServer/skus/18.04-LTS/versions/18.04.202302100?api-version=2022-11-01
   response:
     body:
       string: "{\r\n  \"properties\": {\r\n    \"hyperVGeneration\": \"V1\",\r\n    \"architecture\":
@@ -694,8 +694,8 @@ interactions:
         \"IsHibernateSupported\",\r\n        \"value\": \"True\"\r\n      }\r\n    ],\r\n
         \   \"osDiskImage\": {\r\n      \"operatingSystem\": \"Linux\",\r\n      \"sizeInGb\":
         31,\r\n      \"sizeInBytes\": 32213303808\r\n    },\r\n    \"dataDiskImages\":
-        []\r\n  },\r\n  \"location\": \"westus2\",\r\n  \"name\": \"18.04.202212090\",\r\n
-        \ \"id\": \"/Subscriptions/00000000-0000-0000-0000-000000000000/Providers/Microsoft.Compute/Locations/westus2/Publishers/Canonical/ArtifactTypes/VMImage/Offers/UbuntuServer/Skus/18.04-LTS/Versions/18.04.202212090\"\r\n}"
+        []\r\n  },\r\n  \"location\": \"westus2\",\r\n  \"name\": \"18.04.202302100\",\r\n
+        \ \"id\": \"/Subscriptions/00000000-0000-0000-0000-000000000000/Providers/Microsoft.Compute/Locations/westus2/Publishers/Canonical/ArtifactTypes/VMImage/Offers/UbuntuServer/Skus/18.04-LTS/Versions/18.04.202302100\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -704,7 +704,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:51:41 GMT
+      - Mon, 06 Mar 2023 14:54:49 GMT
       expires:
       - '-1'
       pragma:
@@ -721,7 +721,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetVMImageFromLocation3Min;12997,Microsoft.Compute/GetVMImageFromLocation30Min;73997
+      - Microsoft.Compute/GetVMImageFromLocation3Min;12988,Microsoft.Compute/GetVMImageFromLocation30Min;73984
     status:
       code: 200
       message: OK
@@ -747,7 +747,7 @@ interactions:
       {"privateIPAllocationMethod": "Dynamic", "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET/subnets/cli000003Subnet"},
       "publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/publicIPAddresses/cli000003PublicIP"}}}],
       "networkSecurityGroup": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkSecurityGroups/cli000003NSG"}}},
-      {"apiVersion": "2022-08-01", "type": "Microsoft.Compute/virtualMachines", "name":
+      {"apiVersion": "2022-11-01", "type": "Microsoft.Compute/virtualMachines", "name":
       "cli000003", "location": "westus2", "tags": {}, "dependsOn": ["Microsoft.Network/networkInterfaces/cli000003VMNic"],
       "properties": {"hardwareProfile": {"vmSize": "Standard_DS1_v2"}, "networkProfile":
       {"networkInterfaces": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic",
@@ -755,10 +755,10 @@ interactions:
       "fromImage", "name": null, "caching": "ReadWrite", "managedDisk": {"storageAccountType":
       null}}, "imageReference": {"publisher": "Canonical", "offer": "UbuntuServer",
       "sku": "18.04-LTS", "version": "latest"}}, "osProfile": {"computerName": "cli000003",
-      "adminUsername": "rhl", "linuxConfiguration": {"disablePasswordAuthentication":
-      true, "ssh": {"publicKeys": [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h",
-      "path": "/home/rhl/.ssh/authorized_keys"}]}}}}}], "outputs": {}}, "parameters":
-      {}, "mode": "incremental"}}'
+      "adminUsername": "rhoover", "linuxConfiguration": {"disablePasswordAuthentication":
+      true, "ssh": {"publicKeys": [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+      REDMOND+rhoover@DESKTOP-XVFR7ID\n", "path": "/home/rhoover/.ssh/authorized_keys"}]}}}}}],
+      "outputs": {}}, "parameters": {}, "mode": "incremental"}}'
     headers:
       Accept:
       - application/json
@@ -769,29 +769,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '3604'
+      - '3818'
       Content-Type:
       - application/json
       ParameterSetName:
       - -g -n --image -l --generate-ssh-keys
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_serialconsole000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2021-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Resources/deployments/vm_deploy_wODhdZyNJnDHyD4uBeotYkfJB63Oaeqx","name":"vm_deploy_wODhdZyNJnDHyD4uBeotYkfJB63Oaeqx","type":"Microsoft.Resources/deployments","properties":{"templateHash":"12991909321417793164","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2022-12-13T22:51:45.0603248Z","duration":"PT0.000512S","correlationId":"ac4a1363-9d62-43ae-8dfe-45da9449b143","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus2"]},{"resourceType":"networkSecurityGroups","locations":["westus2"]},{"resourceType":"publicIPAddresses","locations":["westus2"]},{"resourceType":"networkInterfaces","locations":["westus2"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus2"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"cli000003VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkSecurityGroups/cli000003NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"cli000003NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/publicIPAddresses/cli000003PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"cli000003PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"cli000003VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"cli000003VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"cli000003"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Resources/deployments/vm_deploy_enG16AZR2oQ6uJMv0NAOrzPAuDb9eYIt","name":"vm_deploy_enG16AZR2oQ6uJMv0NAOrzPAuDb9eYIt","type":"Microsoft.Resources/deployments","properties":{"templateHash":"10496909535467993346","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2023-03-06T14:54:51.7854151Z","duration":"PT0.0007293S","correlationId":"2e90cf2b-4e0d-47fc-9483-71aa69a8b8f6","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus2"]},{"resourceType":"networkSecurityGroups","locations":["westus2"]},{"resourceType":"publicIPAddresses","locations":["westus2"]},{"resourceType":"networkInterfaces","locations":["westus2"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus2"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"cli000003VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkSecurityGroups/cli000003NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"cli000003NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/publicIPAddresses/cli000003PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"cli000003PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"cli000003VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"cli000003VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"cli000003"}]}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_serialconsole000001/providers/Microsoft.Resources/deployments/vm_deploy_wODhdZyNJnDHyD4uBeotYkfJB63Oaeqx/operationStatuses/08585306349818955675?api-version=2021-04-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_serialconsole000001/providers/Microsoft.Resources/deployments/vm_deploy_enG16AZR2oQ6uJMv0NAOrzPAuDb9eYIt/operationStatuses/08585234923949369219?api-version=2021-04-01
       cache-control:
       - no-cache
       content-length:
-      - '2490'
+      - '2491'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:51:44 GMT
+      - Mon, 06 Mar 2023 14:54:51 GMT
       expires:
       - '-1'
       pragma:
@@ -801,7 +801,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
     status:
       code: 201
       message: Created
@@ -819,51 +819,9 @@ interactions:
       ParameterSetName:
       - -g -n --image -l --generate-ssh-keys
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_serialconsole000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585306349818955675?api-version=2021-04-01
-  response:
-    body:
-      string: '{"status":"Accepted"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 13 Dec 2022 22:51:45 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vm create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --image -l --generate-ssh-keys
-      User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_serialconsole000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585306349818955675?api-version=2021-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_serialconsole000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585234923949369219?api-version=2021-04-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -875,7 +833,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:52:14 GMT
+      - Mon, 06 Mar 2023 14:55:22 GMT
       expires:
       - '-1'
       pragma:
@@ -903,9 +861,9 @@ interactions:
       ParameterSetName:
       - -g -n --image -l --generate-ssh-keys
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_serialconsole000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585306349818955675?api-version=2021-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_serialconsole000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585234923949369219?api-version=2021-04-01
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -917,7 +875,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:52:44 GMT
+      - Mon, 06 Mar 2023 14:55:51 GMT
       expires:
       - '-1'
       pragma:
@@ -945,21 +903,21 @@ interactions:
       ParameterSetName:
       - -g -n --image -l --generate-ssh-keys
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_serialconsole000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2021-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Resources/deployments/vm_deploy_wODhdZyNJnDHyD4uBeotYkfJB63Oaeqx","name":"vm_deploy_wODhdZyNJnDHyD4uBeotYkfJB63Oaeqx","type":"Microsoft.Resources/deployments","properties":{"templateHash":"12991909321417793164","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2022-12-13T22:52:26.3422308Z","duration":"PT41.282418S","correlationId":"ac4a1363-9d62-43ae-8dfe-45da9449b143","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus2"]},{"resourceType":"networkSecurityGroups","locations":["westus2"]},{"resourceType":"publicIPAddresses","locations":["westus2"]},{"resourceType":"networkInterfaces","locations":["westus2"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus2"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"cli000003VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkSecurityGroups/cli000003NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"cli000003NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/publicIPAddresses/cli000003PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"cli000003PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"cli000003VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"cli000003VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"cli000003"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkSecurityGroups/cli000003NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/publicIPAddresses/cli000003PublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Resources/deployments/vm_deploy_enG16AZR2oQ6uJMv0NAOrzPAuDb9eYIt","name":"vm_deploy_enG16AZR2oQ6uJMv0NAOrzPAuDb9eYIt","type":"Microsoft.Resources/deployments","properties":{"templateHash":"10496909535467993346","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2023-03-06T14:55:34.2193327Z","duration":"PT42.4346469S","correlationId":"2e90cf2b-4e0d-47fc-9483-71aa69a8b8f6","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus2"]},{"resourceType":"networkSecurityGroups","locations":["westus2"]},{"resourceType":"publicIPAddresses","locations":["westus2"]},{"resourceType":"networkInterfaces","locations":["westus2"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus2"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"cli000003VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkSecurityGroups/cli000003NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"cli000003NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/publicIPAddresses/cli000003PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"cli000003PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"cli000003VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"cli000003VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"cli000003"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkSecurityGroups/cli000003NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/publicIPAddresses/cli000003PublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET"}]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3350'
+      - '3351'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:52:44 GMT
+      - Mon, 06 Mar 2023 14:55:52 GMT
       expires:
       - '-1'
       pragma:
@@ -987,65 +945,65 @@ interactions:
       ParameterSetName:
       - -g -n --image -l --generate-ssh-keys
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?$expand=instanceView&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?$expand=instanceView&api-version=2022-11-01
   response:
     body:
       string: "{\r\n  \"name\": \"cli000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003\",\r\n
         \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westus2\",\r\n
         \ \"tags\": {\r\n    \"azsecpack\": \"nonprod\",\r\n    \"platformsettings.host_environment.service.platform_optedin_for_rootcerts\":
-        \"true\"\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"d54f150a-5634-4201-b5af-271e2cd52432\",\r\n
+        \"true\"\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"94bb0e59-1bcd-493b-aa53-580e2ad730d7\",\r\n
         \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
         \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
         \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
         \"18.04-LTS\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
-        \"18.04.202212090\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\",\r\n
+        \"18.04.202302100\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\",\r\n
         \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
         \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\"\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\"\r\n
         \       },\r\n        \"deleteOption\": \"Detach\",\r\n        \"diskSizeGB\":
         30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
-        {\r\n      \"computerName\": \"cli000003\",\r\n      \"adminUsername\": \"rhl\",\r\n
+        {\r\n      \"computerName\": \"cli000003\",\r\n      \"adminUsername\": \"rhoover\",\r\n
         \     \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
         true,\r\n        \"ssh\": {\r\n          \"publicKeys\": [\r\n            {\r\n
-        \             \"path\": \"/home/rhl/.ssh/authorized_keys\",\r\n              \"keyData\":
-        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h\"\r\n
-        \           }\r\n          ]\r\n        },\r\n        \"provisionVMAgent\":
-        true,\r\n        \"patchSettings\": {\r\n          \"patchMode\": \"ImageDefault\",\r\n
-        \         \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n        \"enableVMAgentPlatformUpdates\":
-        false\r\n      },\r\n      \"secrets\": [],\r\n      \"allowExtensionOperations\":
-        true,\r\n      \"requireGuestProvisionSignal\": true\r\n    },\r\n    \"networkProfile\":
-        {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
+        \             \"path\": \"/home/rhoover/.ssh/authorized_keys\",\r\n              \"keyData\":
+        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+        REDMOND+rhoover@DESKTOP-XVFR7ID\\n\"\r\n            }\r\n          ]\r\n        },\r\n
+        \       \"provisionVMAgent\": true,\r\n        \"patchSettings\": {\r\n          \"patchMode\":
+        \"ImageDefault\",\r\n          \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n
+        \       \"enableVMAgentPlatformUpdates\": false\r\n      },\r\n      \"secrets\":
+        [],\r\n      \"allowExtensionOperations\": true,\r\n      \"requireGuestProvisionSignal\":
+        true\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
         \   \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\": {\r\n      \"computerName\":
         \"cli000003\",\r\n      \"osName\": \"ubuntu\",\r\n      \"osVersion\": \"18.04\",\r\n
         \     \"vmAgent\": {\r\n        \"vmAgentVersion\": \"2.9.0.4\",\r\n        \"statuses\":
         [\r\n          {\r\n            \"code\": \"ProvisioningState/succeeded\",\r\n
         \           \"level\": \"Info\",\r\n            \"displayStatus\": \"Ready\",\r\n
         \           \"message\": \"Guest Agent is running\",\r\n            \"time\":
-        \"2022-12-13T22:52:37+00:00\"\r\n          }\r\n        ],\r\n        \"extensionHandlers\":
-        []\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\",\r\n
+        \"2023-03-06T14:55:40+00:00\"\r\n          }\r\n        ],\r\n        \"extensionHandlers\":
+        []\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\",\r\n
         \         \"statuses\": [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n
         \             \"level\": \"Info\",\r\n              \"displayStatus\": \"Provisioning
-        succeeded\",\r\n              \"time\": \"2022-12-13T22:51:55.9397619+00:00\"\r\n
+        succeeded\",\r\n              \"time\": \"2023-03-06T14:55:03.5039962+00:00\"\r\n
         \           }\r\n          ]\r\n        }\r\n      ],\r\n      \"hyperVGeneration\":
         \"V1\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2022-12-13T22:52:24.9865038+00:00\"\r\n
+        succeeded\",\r\n          \"time\": \"2023-03-06T14:55:32.0038923+00:00\"\r\n
         \       },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\n
-        \       }\r\n      ]\r\n    },\r\n    \"timeCreated\": \"2022-12-13T22:51:52.3460253+00:00\"\r\n
+        \       }\r\n      ]\r\n    },\r\n    \"timeCreated\": \"2023-03-06T14:55:01.5508486+00:00\"\r\n
         \ }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '4034'
+      - '4248'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:52:45 GMT
+      - Mon, 06 Mar 2023 14:55:52 GMT
       expires:
       - '-1'
       pragma:
@@ -1062,7 +1020,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/LowCostGet3Min;3997,Microsoft.Compute/LowCostGet30Min;31997
+      - Microsoft.Compute/LowCostGet3Min;3995,Microsoft.Compute/LowCostGet30Min;31989
     status:
       code: 200
       message: OK
@@ -1080,18 +1038,18 @@ interactions:
       ParameterSetName:
       - -g -n --image -l --generate-ssh-keys
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-network/21.0.1 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-network/21.0.1 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic?api-version=2022-01-01
   response:
     body:
       string: "{\r\n  \"name\": \"cli000003VMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\",\r\n
-        \ \"etag\": \"W/\\\"5efe6693-8c5e-4aa1-b374-853d3c23bfc0\\\"\",\r\n  \"tags\":
+        \ \"etag\": \"W/\\\"195bbb90-e7d0-463e-8bc8-da845b58c4e8\\\"\",\r\n  \"tags\":
         {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"93fa5a25-0c32-4e6e-8164-2f574b57c721\",\r\n    \"ipConfigurations\":
+        \   \"resourceGuid\": \"b62843c1-739d-4770-8213-804bb9514703\",\r\n    \"ipConfigurations\":
         [\r\n      {\r\n        \"name\": \"ipconfigcli000003\",\r\n        \"id\":
         \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic/ipConfigurations/ipconfigcli000003\",\r\n
-        \       \"etag\": \"W/\\\"5efe6693-8c5e-4aa1-b374-853d3c23bfc0\\\"\",\r\n
+        \       \"etag\": \"W/\\\"195bbb90-e7d0-463e-8bc8-da845b58c4e8\\\"\",\r\n
         \       \"type\": \"Microsoft.Network/networkInterfaces/ipConfigurations\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\":
@@ -1100,8 +1058,8 @@ interactions:
         \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
         \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
         [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\":
-        \"p3eydcckeunermmp15escwacae.xx.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
-        \"00-22-48-BF-10-11\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
+        \"y03vf0ig2cxudefxvezcko31zg.xx.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
+        \"00-22-48-BE-A7-BF\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
         \   \"vnetEncryptionSupported\": false,\r\n    \"enableIPForwarding\": false,\r\n
         \   \"networkSecurityGroup\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkSecurityGroups/cli000003NSG\"\r\n
         \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
@@ -1118,9 +1076,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:52:45 GMT
+      - Mon, 06 Mar 2023 14:55:53 GMT
       etag:
-      - W/"5efe6693-8c5e-4aa1-b374-853d3c23bfc0"
+      - W/"195bbb90-e7d0-463e-8bc8-da845b58c4e8"
       expires:
       - '-1'
       pragma:
@@ -1137,7 +1095,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - c6600a81-4c8c-4e91-a2fc-03c77ec4f0b0
+      - 966abf28-31bc-44a5-927b-a74021f797de
     status:
       code: 200
       message: OK
@@ -1155,16 +1113,16 @@ interactions:
       ParameterSetName:
       - -g -n --image -l --generate-ssh-keys
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-network/21.0.1 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-network/21.0.1 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/publicIPAddresses/cli000003PublicIP?api-version=2022-01-01
   response:
     body:
       string: "{\r\n  \"name\": \"cli000003PublicIP\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/publicIPAddresses/cli000003PublicIP\",\r\n
-        \ \"etag\": \"W/\\\"d0b3b4ef-9fa3-49fd-bb03-c51ac5770882\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"d0a56808-1a6a-4eb9-8bf3-aee6572ce2bb\\\"\",\r\n  \"location\":
         \"westus2\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":
-        \"Succeeded\",\r\n    \"resourceGuid\": \"e28d06e0-7795-418d-ac79-e8673afcb5a6\",\r\n
-        \   \"ipAddress\": \"20.9.168.70\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n
+        \"Succeeded\",\r\n    \"resourceGuid\": \"7fb39d32-d47e-490d-83b5-2053aa110005\",\r\n
+        \   \"ipAddress\": \"20.3.93.238\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n
         \   \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
         4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic/ipConfigurations/ipconfigcli000003\"\r\n
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
@@ -1178,9 +1136,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:52:46 GMT
+      - Mon, 06 Mar 2023 14:55:53 GMT
       etag:
-      - W/"d0b3b4ef-9fa3-49fd-bb03-c51ac5770882"
+      - W/"d0a56808-1a6a-4eb9-8bf3-aee6572ce2bb"
       expires:
       - '-1'
       pragma:
@@ -1197,7 +1155,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 7464927e-1706-463b-ba2e-8089b4fbe1c1
+      - 6d876143-9993-47b3-a5a3-4dbb15c389f3
     status:
       code: 200
       message: OK
@@ -1215,65 +1173,65 @@ interactions:
       ParameterSetName:
       - -g -n --image -l --generate-ssh-keys
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?$expand=instanceView&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?$expand=instanceView&api-version=2022-11-01
   response:
     body:
       string: "{\r\n  \"name\": \"cli000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003\",\r\n
         \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westus2\",\r\n
         \ \"tags\": {\r\n    \"azsecpack\": \"nonprod\",\r\n    \"platformsettings.host_environment.service.platform_optedin_for_rootcerts\":
-        \"true\"\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"d54f150a-5634-4201-b5af-271e2cd52432\",\r\n
+        \"true\"\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"94bb0e59-1bcd-493b-aa53-580e2ad730d7\",\r\n
         \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
         \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
         \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
         \"18.04-LTS\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
-        \"18.04.202212090\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\",\r\n
+        \"18.04.202302100\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\",\r\n
         \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
         \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\"\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\"\r\n
         \       },\r\n        \"deleteOption\": \"Detach\",\r\n        \"diskSizeGB\":
         30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
-        {\r\n      \"computerName\": \"cli000003\",\r\n      \"adminUsername\": \"rhl\",\r\n
+        {\r\n      \"computerName\": \"cli000003\",\r\n      \"adminUsername\": \"rhoover\",\r\n
         \     \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
         true,\r\n        \"ssh\": {\r\n          \"publicKeys\": [\r\n            {\r\n
-        \             \"path\": \"/home/rhl/.ssh/authorized_keys\",\r\n              \"keyData\":
-        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h\"\r\n
-        \           }\r\n          ]\r\n        },\r\n        \"provisionVMAgent\":
-        true,\r\n        \"patchSettings\": {\r\n          \"patchMode\": \"ImageDefault\",\r\n
-        \         \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n        \"enableVMAgentPlatformUpdates\":
-        false\r\n      },\r\n      \"secrets\": [],\r\n      \"allowExtensionOperations\":
-        true,\r\n      \"requireGuestProvisionSignal\": true\r\n    },\r\n    \"networkProfile\":
-        {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
+        \             \"path\": \"/home/rhoover/.ssh/authorized_keys\",\r\n              \"keyData\":
+        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+        REDMOND+rhoover@DESKTOP-XVFR7ID\\n\"\r\n            }\r\n          ]\r\n        },\r\n
+        \       \"provisionVMAgent\": true,\r\n        \"patchSettings\": {\r\n          \"patchMode\":
+        \"ImageDefault\",\r\n          \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n
+        \       \"enableVMAgentPlatformUpdates\": false\r\n      },\r\n      \"secrets\":
+        [],\r\n      \"allowExtensionOperations\": true,\r\n      \"requireGuestProvisionSignal\":
+        true\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
         \   \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\": {\r\n      \"computerName\":
         \"cli000003\",\r\n      \"osName\": \"ubuntu\",\r\n      \"osVersion\": \"18.04\",\r\n
         \     \"vmAgent\": {\r\n        \"vmAgentVersion\": \"2.9.0.4\",\r\n        \"statuses\":
         [\r\n          {\r\n            \"code\": \"ProvisioningState/succeeded\",\r\n
         \           \"level\": \"Info\",\r\n            \"displayStatus\": \"Ready\",\r\n
         \           \"message\": \"Guest Agent is running\",\r\n            \"time\":
-        \"2022-12-13T22:52:37+00:00\"\r\n          }\r\n        ],\r\n        \"extensionHandlers\":
-        []\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\",\r\n
+        \"2023-03-06T14:55:40+00:00\"\r\n          }\r\n        ],\r\n        \"extensionHandlers\":
+        []\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\",\r\n
         \         \"statuses\": [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n
         \             \"level\": \"Info\",\r\n              \"displayStatus\": \"Provisioning
-        succeeded\",\r\n              \"time\": \"2022-12-13T22:51:55.9397619+00:00\"\r\n
+        succeeded\",\r\n              \"time\": \"2023-03-06T14:55:03.5039962+00:00\"\r\n
         \           }\r\n          ]\r\n        }\r\n      ],\r\n      \"hyperVGeneration\":
         \"V1\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2022-12-13T22:52:24.9865038+00:00\"\r\n
+        succeeded\",\r\n          \"time\": \"2023-03-06T14:55:32.0038923+00:00\"\r\n
         \       },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\n
-        \       }\r\n      ]\r\n    },\r\n    \"timeCreated\": \"2022-12-13T22:51:52.3460253+00:00\"\r\n
+        \       }\r\n      ]\r\n    },\r\n    \"timeCreated\": \"2023-03-06T14:55:01.5508486+00:00\"\r\n
         \ }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '4034'
+      - '4248'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:52:46 GMT
+      - Mon, 06 Mar 2023 14:55:53 GMT
       expires:
       - '-1'
       pragma:
@@ -1290,7 +1248,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/LowCostGet3Min;3996,Microsoft.Compute/LowCostGet30Min;31996
+      - Microsoft.Compute/LowCostGet3Min;3993,Microsoft.Compute/LowCostGet30Min;31987
     status:
       code: 200
       message: OK
@@ -1308,48 +1266,48 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?api-version=2022-11-01
   response:
     body:
       string: "{\r\n  \"name\": \"cli000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003\",\r\n
         \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westus2\",\r\n
         \ \"tags\": {\r\n    \"azsecpack\": \"nonprod\",\r\n    \"platformsettings.host_environment.service.platform_optedin_for_rootcerts\":
-        \"true\"\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"d54f150a-5634-4201-b5af-271e2cd52432\",\r\n
+        \"true\"\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"94bb0e59-1bcd-493b-aa53-580e2ad730d7\",\r\n
         \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
         \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
         \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
         \"18.04-LTS\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
-        \"18.04.202212090\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\",\r\n
+        \"18.04.202302100\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\",\r\n
         \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
         \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\"\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\"\r\n
         \       },\r\n        \"deleteOption\": \"Detach\",\r\n        \"diskSizeGB\":
         30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
-        {\r\n      \"computerName\": \"cli000003\",\r\n      \"adminUsername\": \"rhl\",\r\n
+        {\r\n      \"computerName\": \"cli000003\",\r\n      \"adminUsername\": \"rhoover\",\r\n
         \     \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
         true,\r\n        \"ssh\": {\r\n          \"publicKeys\": [\r\n            {\r\n
-        \             \"path\": \"/home/rhl/.ssh/authorized_keys\",\r\n              \"keyData\":
-        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h\"\r\n
-        \           }\r\n          ]\r\n        },\r\n        \"provisionVMAgent\":
-        true,\r\n        \"patchSettings\": {\r\n          \"patchMode\": \"ImageDefault\",\r\n
-        \         \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n        \"enableVMAgentPlatformUpdates\":
-        false\r\n      },\r\n      \"secrets\": [],\r\n      \"allowExtensionOperations\":
-        true,\r\n      \"requireGuestProvisionSignal\": true\r\n    },\r\n    \"networkProfile\":
-        {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
-        \   \"provisioningState\": \"Succeeded\",\r\n    \"timeCreated\": \"2022-12-13T22:51:52.3460253+00:00\"\r\n
+        \             \"path\": \"/home/rhoover/.ssh/authorized_keys\",\r\n              \"keyData\":
+        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+        REDMOND+rhoover@DESKTOP-XVFR7ID\\n\"\r\n            }\r\n          ]\r\n        },\r\n
+        \       \"provisionVMAgent\": true,\r\n        \"patchSettings\": {\r\n          \"patchMode\":
+        \"ImageDefault\",\r\n          \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n
+        \       \"enableVMAgentPlatformUpdates\": false\r\n      },\r\n      \"secrets\":
+        [],\r\n      \"allowExtensionOperations\": true,\r\n      \"requireGuestProvisionSignal\":
+        true\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
+        \   \"provisioningState\": \"Succeeded\",\r\n    \"timeCreated\": \"2023-03-06T14:55:01.5508486+00:00\"\r\n
         \ }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '2729'
+      - '2943'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:52:47 GMT
+      - Mon, 06 Mar 2023 14:55:53 GMT
       expires:
       - '-1'
       pragma:
@@ -1366,24 +1324,24 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/LowCostGet3Min;3995,Microsoft.Compute/LowCostGet30Min;31995
+      - Microsoft.Compute/LowCostGet3Min;3992,Microsoft.Compute/LowCostGet30Min;31986
     status:
       code: 200
       message: OK
 - request:
     body: '{"location": "westus2", "tags": {"azsecpack": "nonprod", "platformsettings.host_environment.service.platform_optedin_for_rootcerts":
       "true"}, "properties": {"hardwareProfile": {"vmSize": "Standard_DS1_v2"}, "storageProfile":
-      {"osDisk": {"osType": "Linux", "name": "cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e",
+      {"osDisk": {"osType": "Linux", "name": "cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f",
       "caching": "ReadWrite", "createOption": "FromImage", "diskSizeGB": 30, "managedDisk":
-      {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e",
+      {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f",
       "storageAccountType": "Premium_LRS"}, "deleteOption": "Detach"}, "dataDisks":
-      []}, "osProfile": {"computerName": "cli000003", "adminUsername": "rhl", "linuxConfiguration":
-      {"disablePasswordAuthentication": true, "ssh": {"publicKeys": [{"path": "/home/rhl/.ssh/authorized_keys",
-      "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h"}]},
-      "provisionVMAgent": true, "patchSettings": {"patchMode": "ImageDefault", "assessmentMode":
-      "ImageDefault"}, "enableVMAgentPlatformUpdates": false}, "secrets": [], "allowExtensionOperations":
-      true, "requireGuestProvisionSignal": true}, "networkProfile": {"networkInterfaces":
-      [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic"}]},
+      []}, "osProfile": {"computerName": "cli000003", "adminUsername": "rhoover",
+      "linuxConfiguration": {"disablePasswordAuthentication": true, "ssh": {"publicKeys":
+      [{"path": "/home/rhoover/.ssh/authorized_keys", "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+      REDMOND+rhoover@DESKTOP-XVFR7ID\n"}]}, "provisionVMAgent": true, "patchSettings":
+      {"patchMode": "ImageDefault", "assessmentMode": "ImageDefault"}, "enableVMAgentPlatformUpdates":
+      false}, "secrets": [], "allowExtensionOperations": true, "requireGuestProvisionSignal":
+      true}, "networkProfile": {"networkInterfaces": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic"}]},
       "diagnosticsProfile": {"bootDiagnostics": {"enabled": true}}}}'
     headers:
       Accept:
@@ -1395,59 +1353,59 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1781'
+      - '1995'
       Content-Type:
       - application/json
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?api-version=2022-11-01
   response:
     body:
       string: "{\r\n  \"name\": \"cli000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003\",\r\n
         \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westus2\",\r\n
         \ \"tags\": {\r\n    \"azsecpack\": \"nonprod\",\r\n    \"platformsettings.host_environment.service.platform_optedin_for_rootcerts\":
-        \"true\"\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"d54f150a-5634-4201-b5af-271e2cd52432\",\r\n
+        \"true\"\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"94bb0e59-1bcd-493b-aa53-580e2ad730d7\",\r\n
         \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
         \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
         \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
         \"18.04-LTS\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
-        \"18.04.202212090\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\",\r\n
+        \"18.04.202302100\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\",\r\n
         \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
         \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\"\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\"\r\n
         \       },\r\n        \"deleteOption\": \"Detach\",\r\n        \"diskSizeGB\":
         30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
-        {\r\n      \"computerName\": \"cli000003\",\r\n      \"adminUsername\": \"rhl\",\r\n
+        {\r\n      \"computerName\": \"cli000003\",\r\n      \"adminUsername\": \"rhoover\",\r\n
         \     \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
         true,\r\n        \"ssh\": {\r\n          \"publicKeys\": [\r\n            {\r\n
-        \             \"path\": \"/home/rhl/.ssh/authorized_keys\",\r\n              \"keyData\":
-        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h\"\r\n
-        \           }\r\n          ]\r\n        },\r\n        \"provisionVMAgent\":
-        true,\r\n        \"patchSettings\": {\r\n          \"patchMode\": \"ImageDefault\",\r\n
-        \         \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n        \"enableVMAgentPlatformUpdates\":
-        false\r\n      },\r\n      \"secrets\": [],\r\n      \"allowExtensionOperations\":
-        true,\r\n      \"requireGuestProvisionSignal\": true\r\n    },\r\n    \"networkProfile\":
-        {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
+        \             \"path\": \"/home/rhoover/.ssh/authorized_keys\",\r\n              \"keyData\":
+        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+        REDMOND+rhoover@DESKTOP-XVFR7ID\\n\"\r\n            }\r\n          ]\r\n        },\r\n
+        \       \"provisionVMAgent\": true,\r\n        \"patchSettings\": {\r\n          \"patchMode\":
+        \"ImageDefault\",\r\n          \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n
+        \       \"enableVMAgentPlatformUpdates\": false\r\n      },\r\n      \"secrets\":
+        [],\r\n      \"allowExtensionOperations\": true,\r\n      \"requireGuestProvisionSignal\":
+        true\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
         \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
         true\r\n      }\r\n    },\r\n    \"provisioningState\": \"Updating\",\r\n
-        \   \"timeCreated\": \"2022-12-13T22:51:52.3460253+00:00\"\r\n  }\r\n}"
+        \   \"timeCreated\": \"2023-03-06T14:55:01.5508486+00:00\"\r\n  }\r\n}"
     headers:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/5a354800-5044-4d82-9fc5-91567a9f0574?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/1c5c8e64-eb83-44a7-b392-aa99e1ab8937?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
       cache-control:
       - no-cache
       content-length:
-      - '2827'
+      - '3041'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:52:48 GMT
+      - Mon, 06 Mar 2023 14:55:55 GMT
       expires:
       - '-1'
       pragma:
@@ -1464,7 +1422,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/PutVM3Min;600,Microsoft.Compute/PutVM30Min;3009
+      - Microsoft.Compute/PutVM3Min;615,Microsoft.Compute/PutVM30Min;3091
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
     status:
@@ -1484,64 +1442,14 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/5a354800-5044-4d82-9fc5-91567a9f0574?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/1c5c8e64-eb83-44a7-b392-aa99e1ab8937?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T22:52:48.5333222+00:00\",\r\n  \"status\":
-        \"InProgress\",\r\n  \"name\": \"5a354800-5044-4d82-9fc5-91567a9f0574\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '134'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 13 Dec 2022 22:52:48 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14998,Microsoft.Compute/GetOperation30Min;29998
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vm boot-diagnostics enable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n
-      User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/5a354800-5044-4d82-9fc5-91567a9f0574?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
-  response:
-    body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T22:52:48.5333222+00:00\",\r\n  \"endTime\":
-        \"2022-12-13T22:52:57.5801392+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"name\": \"5a354800-5044-4d82-9fc5-91567a9f0574\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T14:55:55.2070149+00:00\",\r\n  \"endTime\":
+        \"2023-03-06T14:55:58.3632002+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"name\": \"1c5c8e64-eb83-44a7-b392-aa99e1ab8937\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -1550,7 +1458,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:53:18 GMT
+      - Mon, 06 Mar 2023 14:56:25 GMT
       expires:
       - '-1'
       pragma:
@@ -1567,7 +1475,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14997,Microsoft.Compute/GetOperation30Min;29997
+      - Microsoft.Compute/GetOperation3Min;14991,Microsoft.Compute/GetOperation30Min;29929
     status:
       code: 200
       message: OK
@@ -1585,49 +1493,49 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?api-version=2022-11-01
   response:
     body:
       string: "{\r\n  \"name\": \"cli000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003\",\r\n
         \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westus2\",\r\n
         \ \"tags\": {\r\n    \"azsecpack\": \"nonprod\",\r\n    \"platformsettings.host_environment.service.platform_optedin_for_rootcerts\":
-        \"true\"\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"d54f150a-5634-4201-b5af-271e2cd52432\",\r\n
+        \"true\"\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"94bb0e59-1bcd-493b-aa53-580e2ad730d7\",\r\n
         \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
         \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
         \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
         \"18.04-LTS\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
-        \"18.04.202212090\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\",\r\n
+        \"18.04.202302100\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\",\r\n
         \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
         \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\"\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\"\r\n
         \       },\r\n        \"deleteOption\": \"Detach\",\r\n        \"diskSizeGB\":
         30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
-        {\r\n      \"computerName\": \"cli000003\",\r\n      \"adminUsername\": \"rhl\",\r\n
+        {\r\n      \"computerName\": \"cli000003\",\r\n      \"adminUsername\": \"rhoover\",\r\n
         \     \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
         true,\r\n        \"ssh\": {\r\n          \"publicKeys\": [\r\n            {\r\n
-        \             \"path\": \"/home/rhl/.ssh/authorized_keys\",\r\n              \"keyData\":
-        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h\"\r\n
-        \           }\r\n          ]\r\n        },\r\n        \"provisionVMAgent\":
-        true,\r\n        \"patchSettings\": {\r\n          \"patchMode\": \"ImageDefault\",\r\n
-        \         \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n        \"enableVMAgentPlatformUpdates\":
-        false\r\n      },\r\n      \"secrets\": [],\r\n      \"allowExtensionOperations\":
-        true,\r\n      \"requireGuestProvisionSignal\": true\r\n    },\r\n    \"networkProfile\":
-        {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
+        \             \"path\": \"/home/rhoover/.ssh/authorized_keys\",\r\n              \"keyData\":
+        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+        REDMOND+rhoover@DESKTOP-XVFR7ID\\n\"\r\n            }\r\n          ]\r\n        },\r\n
+        \       \"provisionVMAgent\": true,\r\n        \"patchSettings\": {\r\n          \"patchMode\":
+        \"ImageDefault\",\r\n          \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n
+        \       \"enableVMAgentPlatformUpdates\": false\r\n      },\r\n      \"secrets\":
+        [],\r\n      \"allowExtensionOperations\": true,\r\n      \"requireGuestProvisionSignal\":
+        true\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
         \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
         true\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"timeCreated\": \"2022-12-13T22:51:52.3460253+00:00\"\r\n  }\r\n}"
+        \   \"timeCreated\": \"2023-03-06T14:55:01.5508486+00:00\"\r\n  }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '2828'
+      - '3042'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:53:18 GMT
+      - Mon, 06 Mar 2023 14:56:26 GMT
       expires:
       - '-1'
       pragma:
@@ -1644,7 +1552,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/LowCostGet3Min;3992,Microsoft.Compute/LowCostGet30Min;31992
+      - Microsoft.Compute/LowCostGet3Min;3987,Microsoft.Compute/LowCostGet30Min;31981
     status:
       code: 200
       message: OK
@@ -1662,37 +1570,37 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?$expand=instanceView&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?$expand=instanceView&api-version=2022-11-01
   response:
     body:
       string: "{\r\n  \"name\": \"cli000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003\",\r\n
         \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westus2\",\r\n
         \ \"tags\": {\r\n    \"azsecpack\": \"nonprod\",\r\n    \"platformsettings.host_environment.service.platform_optedin_for_rootcerts\":
-        \"true\"\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"d54f150a-5634-4201-b5af-271e2cd52432\",\r\n
+        \"true\"\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"94bb0e59-1bcd-493b-aa53-580e2ad730d7\",\r\n
         \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
         \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
         \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
         \"18.04-LTS\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
-        \"18.04.202212090\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\",\r\n
+        \"18.04.202302100\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\",\r\n
         \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
         \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\"\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\"\r\n
         \       },\r\n        \"deleteOption\": \"Detach\",\r\n        \"diskSizeGB\":
         30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
-        {\r\n      \"computerName\": \"cli000003\",\r\n      \"adminUsername\": \"rhl\",\r\n
+        {\r\n      \"computerName\": \"cli000003\",\r\n      \"adminUsername\": \"rhoover\",\r\n
         \     \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
         true,\r\n        \"ssh\": {\r\n          \"publicKeys\": [\r\n            {\r\n
-        \             \"path\": \"/home/rhl/.ssh/authorized_keys\",\r\n              \"keyData\":
-        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h\"\r\n
-        \           }\r\n          ]\r\n        },\r\n        \"provisionVMAgent\":
-        true,\r\n        \"patchSettings\": {\r\n          \"patchMode\": \"ImageDefault\",\r\n
-        \         \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n        \"enableVMAgentPlatformUpdates\":
-        false\r\n      },\r\n      \"secrets\": [],\r\n      \"allowExtensionOperations\":
-        true,\r\n      \"requireGuestProvisionSignal\": true\r\n    },\r\n    \"networkProfile\":
-        {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
+        \             \"path\": \"/home/rhoover/.ssh/authorized_keys\",\r\n              \"keyData\":
+        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+        REDMOND+rhoover@DESKTOP-XVFR7ID\\n\"\r\n            }\r\n          ]\r\n        },\r\n
+        \       \"provisionVMAgent\": true,\r\n        \"patchSettings\": {\r\n          \"patchMode\":
+        \"ImageDefault\",\r\n          \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n
+        \       \"enableVMAgentPlatformUpdates\": false\r\n      },\r\n      \"secrets\":
+        [],\r\n      \"allowExtensionOperations\": true,\r\n      \"requireGuestProvisionSignal\":
+        true\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
         \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
         true\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n
         \   \"instanceView\": {\r\n      \"computerName\": \"cli000003\",\r\n      \"osName\":
@@ -1700,30 +1608,30 @@ interactions:
         \       \"vmAgentVersion\": \"2.9.0.4\",\r\n        \"statuses\": [\r\n          {\r\n
         \           \"code\": \"ProvisioningState/succeeded\",\r\n            \"level\":
         \"Info\",\r\n            \"displayStatus\": \"Ready\",\r\n            \"message\":
-        \"Guest Agent is running\",\r\n            \"time\": \"2022-12-13T22:52:55+00:00\"\r\n
+        \"Guest Agent is running\",\r\n            \"time\": \"2023-03-06T14:55:58+00:00\"\r\n
         \         }\r\n        ],\r\n        \"extensionHandlers\": []\r\n      },\r\n
-        \     \"disks\": [\r\n        {\r\n          \"name\": \"cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\",\r\n
+        \     \"disks\": [\r\n        {\r\n          \"name\": \"cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\",\r\n
         \         \"statuses\": [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n
         \             \"level\": \"Info\",\r\n              \"displayStatus\": \"Provisioning
-        succeeded\",\r\n              \"time\": \"2022-12-13T22:52:49.2051571+00:00\"\r\n
+        succeeded\",\r\n              \"time\": \"2023-03-06T14:55:55.8319572+00:00\"\r\n
         \           }\r\n          ]\r\n        }\r\n      ],\r\n      \"bootDiagnostics\":
         {},\r\n      \"hyperVGeneration\": \"V1\",\r\n      \"statuses\": [\r\n        {\r\n
         \         \"code\": \"ProvisioningState/succeeded\",\r\n          \"level\":
         \"Info\",\r\n          \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \         \"time\": \"2022-12-13T22:52:57.5645074+00:00\"\r\n        },\r\n
+        \         \"time\": \"2023-03-06T14:55:58.3319893+00:00\"\r\n        },\r\n
         \       {\r\n          \"code\": \"PowerState/running\",\r\n          \"level\":
         \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\n        }\r\n
-        \     ]\r\n    },\r\n    \"timeCreated\": \"2022-12-13T22:51:52.3460253+00:00\"\r\n
+        \     ]\r\n    },\r\n    \"timeCreated\": \"2023-03-06T14:55:01.5508486+00:00\"\r\n
         \ }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '4163'
+      - '4377'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:53:19 GMT
+      - Mon, 06 Mar 2023 14:56:26 GMT
       expires:
       - '-1'
       pragma:
@@ -1740,7 +1648,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/LowCostGet3Min;3991,Microsoft.Compute/LowCostGet30Min;31991
+      - Microsoft.Compute/LowCostGet3Min;3986,Microsoft.Compute/LowCostGet30Min;31980
     status:
       code: 200
       message: OK
@@ -1758,8 +1666,8 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
-        (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.SerialConsole/consoleServices/default?api-version=2018-05-01
   response:
@@ -1773,7 +1681,7 @@ interactions:
       content-type:
       - application/json; charset=UTF-8
       date:
-      - Tue, 13 Dec 2022 22:53:20 GMT
+      - Mon, 06 Mar 2023 14:56:26 GMT
       expires:
       - '-1'
       pragma:
@@ -1809,9 +1717,9 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003/deallocate?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003/deallocate?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -1819,17 +1727,17 @@ interactions:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/deb9632e-2635-4f53-bd77-6ae88557e43f?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/fddf7569-6fd9-4e68-8799-e6090646cbaf?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Tue, 13 Dec 2022 22:53:21 GMT
+      - Mon, 06 Mar 2023 14:56:28 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/deb9632e-2635-4f53-bd77-6ae88557e43f?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/fddf7569-6fd9-4e68-8799-e6090646cbaf?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-11-01
       pragma:
       - no-cache
       server:
@@ -1860,13 +1768,13 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/deb9632e-2635-4f53-bd77-6ae88557e43f?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/fddf7569-6fd9-4e68-8799-e6090646cbaf?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T22:53:21.0800474+00:00\",\r\n  \"status\":
-        \"InProgress\",\r\n  \"name\": \"deb9632e-2635-4f53-bd77-6ae88557e43f\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T14:56:28.0037527+00:00\",\r\n  \"status\":
+        \"InProgress\",\r\n  \"name\": \"fddf7569-6fd9-4e68-8799-e6090646cbaf\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -1875,7 +1783,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:53:21 GMT
+      - Mon, 06 Mar 2023 14:56:38 GMT
       expires:
       - '-1'
       pragma:
@@ -1892,7 +1800,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14996,Microsoft.Compute/GetOperation30Min;29996
+      - Microsoft.Compute/GetOperation3Min;14992,Microsoft.Compute/GetOperation30Min;29928
     status:
       code: 200
       message: OK
@@ -1910,14 +1818,14 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/deb9632e-2635-4f53-bd77-6ae88557e43f?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/fddf7569-6fd9-4e68-8799-e6090646cbaf?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T22:53:21.0800474+00:00\",\r\n  \"endTime\":
-        \"2022-12-13T22:53:52.3923762+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"name\": \"deb9632e-2635-4f53-bd77-6ae88557e43f\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T14:56:28.0037527+00:00\",\r\n  \"endTime\":
+        \"2023-03-06T14:56:57.1130086+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"name\": \"fddf7569-6fd9-4e68-8799-e6090646cbaf\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -1926,7 +1834,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:53:57 GMT
+      - Mon, 06 Mar 2023 14:57:07 GMT
       expires:
       - '-1'
       pragma:
@@ -1943,7 +1851,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14991,Microsoft.Compute/GetOperation30Min;29991
+      - Microsoft.Compute/GetOperation3Min;14982,Microsoft.Compute/GetOperation30Min;29918
     status:
       code: 200
       message: OK
@@ -1961,9 +1869,9 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/deb9632e-2635-4f53-bd77-6ae88557e43f?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/fddf7569-6fd9-4e68-8799-e6090646cbaf?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-11-01
   response:
     body:
       string: ''
@@ -1973,7 +1881,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 13 Dec 2022 22:53:57 GMT
+      - Mon, 06 Mar 2023 14:57:07 GMT
       expires:
       - '-1'
       pragma:
@@ -1986,7 +1894,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14990,Microsoft.Compute/GetOperation30Min;29990
+      - Microsoft.Compute/GetOperation3Min;14981,Microsoft.Compute/GetOperation30Min;29917
     status:
       code: 200
       message: OK
@@ -2004,60 +1912,60 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?$expand=instanceView&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?$expand=instanceView&api-version=2022-11-01
   response:
     body:
       string: "{\r\n  \"name\": \"cli000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003\",\r\n
         \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westus2\",\r\n
         \ \"tags\": {\r\n    \"azsecpack\": \"nonprod\",\r\n    \"platformsettings.host_environment.service.platform_optedin_for_rootcerts\":
-        \"true\"\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"d54f150a-5634-4201-b5af-271e2cd52432\",\r\n
+        \"true\"\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"94bb0e59-1bcd-493b-aa53-580e2ad730d7\",\r\n
         \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
         \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
         \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
         \"18.04-LTS\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
-        \"18.04.202212090\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\",\r\n
+        \"18.04.202302100\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\",\r\n
         \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
-        \       \"managedDisk\": {\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\"\r\n
+        \       \"managedDisk\": {\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\"\r\n
         \       },\r\n        \"deleteOption\": \"Detach\"\r\n      },\r\n      \"dataDisks\":
         []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"cli000003\",\r\n
-        \     \"adminUsername\": \"rhl\",\r\n      \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
-        true,\r\n        \"ssh\": {\r\n          \"publicKeys\": [\r\n            {\r\n
-        \             \"path\": \"/home/rhl/.ssh/authorized_keys\",\r\n              \"keyData\":
-        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h\"\r\n
-        \           }\r\n          ]\r\n        },\r\n        \"provisionVMAgent\":
-        true,\r\n        \"patchSettings\": {\r\n          \"patchMode\": \"ImageDefault\",\r\n
-        \         \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n        \"enableVMAgentPlatformUpdates\":
-        false\r\n      },\r\n      \"secrets\": [],\r\n      \"allowExtensionOperations\":
-        true,\r\n      \"requireGuestProvisionSignal\": true\r\n    },\r\n    \"networkProfile\":
-        {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
+        \     \"adminUsername\": \"rhoover\",\r\n      \"linuxConfiguration\": {\r\n
+        \       \"disablePasswordAuthentication\": true,\r\n        \"ssh\": {\r\n
+        \         \"publicKeys\": [\r\n            {\r\n              \"path\": \"/home/rhoover/.ssh/authorized_keys\",\r\n
+        \             \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+        REDMOND+rhoover@DESKTOP-XVFR7ID\\n\"\r\n            }\r\n          ]\r\n        },\r\n
+        \       \"provisionVMAgent\": true,\r\n        \"patchSettings\": {\r\n          \"patchMode\":
+        \"ImageDefault\",\r\n          \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n
+        \       \"enableVMAgentPlatformUpdates\": false\r\n      },\r\n      \"secrets\":
+        [],\r\n      \"allowExtensionOperations\": true,\r\n      \"requireGuestProvisionSignal\":
+        true\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
         \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
         true\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n
         \   \"instanceView\": {\r\n      \"disks\": [\r\n        {\r\n          \"name\":
-        \"cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\",\r\n          \"statuses\":
+        \"cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\",\r\n          \"statuses\":
         [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n
         \             \"level\": \"Info\",\r\n              \"displayStatus\": \"Provisioning
-        succeeded\",\r\n              \"time\": \"2022-12-13T22:53:52.2049054+00:00\"\r\n
+        succeeded\",\r\n              \"time\": \"2023-03-06T14:56:56.9411976+00:00\"\r\n
         \           }\r\n          ]\r\n        }\r\n      ],\r\n      \"bootDiagnostics\":
         {},\r\n      \"hyperVGeneration\": \"V1\",\r\n      \"statuses\": [\r\n        {\r\n
         \         \"code\": \"ProvisioningState/succeeded\",\r\n          \"level\":
         \"Info\",\r\n          \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \         \"time\": \"2022-12-13T22:53:52.2204678+00:00\"\r\n        },\r\n
+        \         \"time\": \"2023-03-06T14:56:56.9567536+00:00\"\r\n        },\r\n
         \       {\r\n          \"code\": \"PowerState/deallocated\",\r\n          \"level\":
         \"Info\",\r\n          \"displayStatus\": \"VM deallocated\"\r\n        }\r\n
-        \     ]\r\n    },\r\n    \"timeCreated\": \"2022-12-13T22:51:52.3460253+00:00\"\r\n
+        \     ]\r\n    },\r\n    \"timeCreated\": \"2023-03-06T14:55:01.5508486+00:00\"\r\n
         \ }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3622'
+      - '3836'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:53:57 GMT
+      - Mon, 06 Mar 2023 14:57:08 GMT
       expires:
       - '-1'
       pragma:
@@ -2074,7 +1982,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/LowCostGet3Min;3987,Microsoft.Compute/LowCostGet30Min;31987
+      - Microsoft.Compute/LowCostGet3Min;3977,Microsoft.Compute/LowCostGet30Min;31971
     status:
       code: 200
       message: OK
@@ -2092,8 +2000,8 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
-        (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.SerialConsole/consoleServices/default?api-version=2018-05-01
   response:
@@ -2107,7 +2015,7 @@ interactions:
       content-type:
       - application/json; charset=UTF-8
       date:
-      - Tue, 13 Dec 2022 22:53:57 GMT
+      - Mon, 06 Mar 2023 14:57:08 GMT
       expires:
       - '-1'
       pragma:
@@ -2143,9 +2051,9 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003/start?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003/start?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -2153,1077 +2061,17 @@ interactions:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/4406abc9-3d4b-407c-8953-986972c84165?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/1d2958fc-ef91-4d87-92dd-93d69bcbda2f?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Tue, 13 Dec 2022 22:53:59 GMT
+      - Mon, 06 Mar 2023 14:57:09 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/4406abc9-3d4b-407c-8953-986972c84165?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-08-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/UpdateVM3Min;237,Microsoft.Compute/UpdateVM30Min;1197
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vm start
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n
-      User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/4406abc9-3d4b-407c-8953-986972c84165?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
-  response:
-    body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T22:53:59.2048421+00:00\",\r\n  \"status\":
-        \"InProgress\",\r\n  \"name\": \"4406abc9-3d4b-407c-8953-986972c84165\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '134'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 13 Dec 2022 22:53:59 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14989,Microsoft.Compute/GetOperation30Min;29989
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vm start
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n
-      User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/4406abc9-3d4b-407c-8953-986972c84165?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
-  response:
-    body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T22:53:59.2048421+00:00\",\r\n  \"status\":
-        \"InProgress\",\r\n  \"name\": \"4406abc9-3d4b-407c-8953-986972c84165\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '134'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 13 Dec 2022 22:54:08 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14988,Microsoft.Compute/GetOperation30Min;29988
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vm start
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n
-      User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/4406abc9-3d4b-407c-8953-986972c84165?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
-  response:
-    body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T22:53:59.2048421+00:00\",\r\n  \"endTime\":
-        \"2022-12-13T22:54:15.9391793+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"name\": \"4406abc9-3d4b-407c-8953-986972c84165\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '184'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 13 Dec 2022 22:54:38 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14984,Microsoft.Compute/GetOperation30Min;29984
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vm start
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n
-      User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/4406abc9-3d4b-407c-8953-986972c84165?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-08-01
-  response:
-    body:
-      string: ''
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Tue, 13 Dec 2022 22:54:38 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14983,Microsoft.Compute/GetOperation30Min;29983
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vm stop
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      ParameterSetName:
-      - -g -n
-      User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003/powerOff?skipShutdown=false&api-version=2022-08-01
-  response:
-    body:
-      string: ''
-    headers:
-      azure-asyncnotification:
-      - Enabled
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/3a08358c-f83d-429a-af51-6590bcdb1c23?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Tue, 13 Dec 2022 22:54:39 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/3a08358c-f83d-429a-af51-6590bcdb1c23?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-08-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/UpdateVM3Min;236,Microsoft.Compute/UpdateVM30Min;1196
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vm stop
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n
-      User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/3a08358c-f83d-429a-af51-6590bcdb1c23?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
-  response:
-    body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T22:54:39.7515637+00:00\",\r\n  \"status\":
-        \"InProgress\",\r\n  \"name\": \"3a08358c-f83d-429a-af51-6590bcdb1c23\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '134'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 13 Dec 2022 22:54:39 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14982,Microsoft.Compute/GetOperation30Min;29982
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vm stop
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n
-      User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/3a08358c-f83d-429a-af51-6590bcdb1c23?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
-  response:
-    body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T22:54:39.7515637+00:00\",\r\n  \"endTime\":
-        \"2022-12-13T22:54:46.8452719+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"name\": \"3a08358c-f83d-429a-af51-6590bcdb1c23\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '184'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 13 Dec 2022 22:55:09 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14980,Microsoft.Compute/GetOperation30Min;29979
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vm stop
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n
-      User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/3a08358c-f83d-429a-af51-6590bcdb1c23?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-08-01
-  response:
-    body:
-      string: ''
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Tue, 13 Dec 2022 22:55:09 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14979,Microsoft.Compute/GetOperation30Min;29978
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vm stop
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n
-      User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?$expand=instanceView&api-version=2022-08-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"cli000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003\",\r\n
-        \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westus2\",\r\n
-        \ \"tags\": {\r\n    \"azsecpack\": \"nonprod\",\r\n    \"platformsettings.host_environment.service.platform_optedin_for_rootcerts\":
-        \"true\"\r\n  },\r\n  \"identity\": {\r\n    \"type\": \"UserAssigned\",\r\n
-        \   \"userAssignedIdentities\": {\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/AzSecPackAutoConfigUA-westus2\":
-        {\r\n        \"principalId\": \"684d55e2-8922-4966-a660-2d38ca4a1711\",\r\n
-        \       \"clientId\": \"6d45cf55-f311-4228-97b0-c22ae418aad6\"\r\n      }\r\n
-        \   }\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"d54f150a-5634-4201-b5af-271e2cd52432\",\r\n
-        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
-        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
-        \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
-        \"18.04-LTS\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
-        \"18.04.202212090\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\",\r\n
-        \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
-        \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_SERIALCONSOLELMXZIWWK5PS5Z6A7GSGJPKCGAUTWUFSF6S5STLYYHQ6COP3BWYY27/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\"\r\n
-        \       },\r\n        \"deleteOption\": \"Detach\",\r\n        \"diskSizeGB\":
-        30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
-        {\r\n      \"computerName\": \"cli000003\",\r\n      \"adminUsername\": \"rhl\",\r\n
-        \     \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
-        true,\r\n        \"ssh\": {\r\n          \"publicKeys\": [\r\n            {\r\n
-        \             \"path\": \"/home/rhl/.ssh/authorized_keys\",\r\n              \"keyData\":
-        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h\"\r\n
-        \           }\r\n          ]\r\n        },\r\n        \"provisionVMAgent\":
-        true,\r\n        \"patchSettings\": {\r\n          \"patchMode\": \"ImageDefault\",\r\n
-        \         \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n        \"enableVMAgentPlatformUpdates\":
-        false\r\n      },\r\n      \"secrets\": [],\r\n      \"allowExtensionOperations\":
-        true,\r\n      \"requireGuestProvisionSignal\": true\r\n    },\r\n    \"networkProfile\":
-        {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
-        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
-        true\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"instanceView\": {\r\n      \"computerName\": \"cli000003\",\r\n      \"osName\":
-        \"ubuntu\",\r\n      \"osVersion\": \"18.04\",\r\n      \"vmAgent\": {\r\n
-        \       \"vmAgentVersion\": \"2.9.0.4\",\r\n        \"statuses\": [\r\n          {\r\n
-        \           \"code\": \"ProvisioningState/succeeded\",\r\n            \"level\":
-        \"Info\",\r\n            \"displayStatus\": \"Ready\",\r\n            \"message\":
-        \"Guest Agent is running\",\r\n            \"time\": \"2022-12-13T22:54:35+00:00\"\r\n
-        \         }\r\n        ],\r\n        \"extensionHandlers\": []\r\n      },\r\n
-        \     \"disks\": [\r\n        {\r\n          \"name\": \"cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\",\r\n
-        \         \"statuses\": [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n
-        \             \"level\": \"Info\",\r\n              \"displayStatus\": \"Provisioning
-        succeeded\",\r\n              \"time\": \"2022-12-13T22:54:30.8297292+00:00\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      ],\r\n      \"bootDiagnostics\":
-        {},\r\n      \"hyperVGeneration\": \"V1\",\r\n      \"statuses\": [\r\n        {\r\n
-        \         \"code\": \"ProvisioningState/succeeded\",\r\n          \"level\":
-        \"Info\",\r\n          \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \         \"time\": \"2022-12-13T22:54:46.8452719+00:00\"\r\n        },\r\n
-        \       {\r\n          \"code\": \"PowerState/stopped\",\r\n          \"level\":
-        \"Info\",\r\n          \"displayStatus\": \"VM stopped\"\r\n        }\r\n
-        \     ]\r\n    },\r\n    \"timeCreated\": \"2022-12-13T22:51:52.3460253+00:00\"\r\n
-        \ }\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '4625'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 13 Dec 2022 22:55:10 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/LowCostGet3Min;3982,Microsoft.Compute/LowCostGet30Min;31980
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vm stop
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n
-      User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
-        (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.SerialConsole/consoleServices/default?api-version=2018-05-01
-  response:
-    body:
-      string: "{\n \"properties\": {\n  \"disabled\": false\n }\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '43'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Tue, 13 Dec 2022 22:55:11 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - nginx
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - deny
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vm boot-diagnostics disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n
-      User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?api-version=2022-08-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"cli000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003\",\r\n
-        \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westus2\",\r\n
-        \ \"tags\": {\r\n    \"azsecpack\": \"nonprod\",\r\n    \"platformsettings.host_environment.service.platform_optedin_for_rootcerts\":
-        \"true\"\r\n  },\r\n  \"identity\": {\r\n    \"type\": \"UserAssigned\",\r\n
-        \   \"userAssignedIdentities\": {\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/AzSecPackAutoConfigUA-westus2\":
-        {\r\n        \"principalId\": \"684d55e2-8922-4966-a660-2d38ca4a1711\",\r\n
-        \       \"clientId\": \"6d45cf55-f311-4228-97b0-c22ae418aad6\"\r\n      }\r\n
-        \   }\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"d54f150a-5634-4201-b5af-271e2cd52432\",\r\n
-        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
-        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
-        \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
-        \"18.04-LTS\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
-        \"18.04.202212090\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\",\r\n
-        \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
-        \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_SERIALCONSOLELMXZIWWK5PS5Z6A7GSGJPKCGAUTWUFSF6S5STLYYHQ6COP3BWYY27/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\"\r\n
-        \       },\r\n        \"deleteOption\": \"Detach\",\r\n        \"diskSizeGB\":
-        30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
-        {\r\n      \"computerName\": \"cli000003\",\r\n      \"adminUsername\": \"rhl\",\r\n
-        \     \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
-        true,\r\n        \"ssh\": {\r\n          \"publicKeys\": [\r\n            {\r\n
-        \             \"path\": \"/home/rhl/.ssh/authorized_keys\",\r\n              \"keyData\":
-        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h\"\r\n
-        \           }\r\n          ]\r\n        },\r\n        \"provisionVMAgent\":
-        true,\r\n        \"patchSettings\": {\r\n          \"patchMode\": \"ImageDefault\",\r\n
-        \         \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n        \"enableVMAgentPlatformUpdates\":
-        false\r\n      },\r\n      \"secrets\": [],\r\n      \"allowExtensionOperations\":
-        true,\r\n      \"requireGuestProvisionSignal\": true\r\n    },\r\n    \"networkProfile\":
-        {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
-        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
-        true\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"timeCreated\": \"2022-12-13T22:51:52.3460253+00:00\"\r\n  }\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '3290'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 13 Dec 2022 22:55:11 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/LowCostGet3Min;3981,Microsoft.Compute/LowCostGet30Min;31979
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"location": "westus2", "tags": {"azsecpack": "nonprod", "platformsettings.host_environment.service.platform_optedin_for_rootcerts":
-      "true"}, "identity": {"type": "UserAssigned", "userAssignedIdentities": {"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/AzSecPackAutoConfigUA-westus2":
-      {}}}, "properties": {"hardwareProfile": {"vmSize": "Standard_DS1_v2"}, "storageProfile":
-      {"osDisk": {"osType": "Linux", "name": "cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e",
-      "caching": "ReadWrite", "createOption": "FromImage", "diskSizeGB": 30, "managedDisk":
-      {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_SERIALCONSOLELMXZIWWK5PS5Z6A7GSGJPKCGAUTWUFSF6S5STLYYHQ6COP3BWYY27/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e",
-      "storageAccountType": "Premium_LRS"}, "deleteOption": "Detach"}, "dataDisks":
-      []}, "osProfile": {"computerName": "cli000003", "adminUsername": "rhl", "linuxConfiguration":
-      {"disablePasswordAuthentication": true, "ssh": {"publicKeys": [{"path": "/home/rhl/.ssh/authorized_keys",
-      "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h"}]},
-      "provisionVMAgent": true, "patchSettings": {"patchMode": "ImageDefault", "assessmentMode":
-      "ImageDefault"}, "enableVMAgentPlatformUpdates": false}, "secrets": [], "allowExtensionOperations":
-      true, "requireGuestProvisionSignal": true}, "networkProfile": {"networkInterfaces":
-      [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic"}]},
-      "diagnosticsProfile": {"bootDiagnostics": {"enabled": false}}}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vm boot-diagnostics disable
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '2080'
-      Content-Type:
-      - application/json
-      ParameterSetName:
-      - -g -n
-      User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?api-version=2022-08-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"cli000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003\",\r\n
-        \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westus2\",\r\n
-        \ \"tags\": {\r\n    \"azsecpack\": \"nonprod\",\r\n    \"platformsettings.host_environment.service.platform_optedin_for_rootcerts\":
-        \"true\"\r\n  },\r\n  \"identity\": {\r\n    \"type\": \"UserAssigned\",\r\n
-        \   \"userAssignedIdentities\": {\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/AzSecPackAutoConfigUA-westus2\":
-        {\r\n        \"principalId\": \"684d55e2-8922-4966-a660-2d38ca4a1711\",\r\n
-        \       \"clientId\": \"6d45cf55-f311-4228-97b0-c22ae418aad6\"\r\n      }\r\n
-        \   }\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"d54f150a-5634-4201-b5af-271e2cd52432\",\r\n
-        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
-        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
-        \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
-        \"18.04-LTS\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
-        \"18.04.202212090\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\",\r\n
-        \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
-        \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_SERIALCONSOLELMXZIWWK5PS5Z6A7GSGJPKCGAUTWUFSF6S5STLYYHQ6COP3BWYY27/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\"\r\n
-        \       },\r\n        \"deleteOption\": \"Detach\",\r\n        \"diskSizeGB\":
-        30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
-        {\r\n      \"computerName\": \"cli000003\",\r\n      \"adminUsername\": \"rhl\",\r\n
-        \     \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
-        true,\r\n        \"ssh\": {\r\n          \"publicKeys\": [\r\n            {\r\n
-        \             \"path\": \"/home/rhl/.ssh/authorized_keys\",\r\n              \"keyData\":
-        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h\"\r\n
-        \           }\r\n          ]\r\n        },\r\n        \"provisionVMAgent\":
-        true,\r\n        \"patchSettings\": {\r\n          \"patchMode\": \"ImageDefault\",\r\n
-        \         \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n        \"enableVMAgentPlatformUpdates\":
-        false\r\n      },\r\n      \"secrets\": [],\r\n      \"allowExtensionOperations\":
-        true,\r\n      \"requireGuestProvisionSignal\": true\r\n    },\r\n    \"networkProfile\":
-        {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
-        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
-        false\r\n      }\r\n    },\r\n    \"provisioningState\": \"Updating\",\r\n
-        \   \"timeCreated\": \"2022-12-13T22:51:52.3460253+00:00\"\r\n  }\r\n}"
-    headers:
-      azure-asyncnotification:
-      - Enabled
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/6cfea4cf-69c9-4f0e-8f60-578281267c8d?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '3290'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 13 Dec 2022 22:55:13 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/PutVM3Min;599,Microsoft.Compute/PutVM30Min;3007
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vm boot-diagnostics disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n
-      User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/6cfea4cf-69c9-4f0e-8f60-578281267c8d?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
-  response:
-    body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T22:55:13.8451773+00:00\",\r\n  \"status\":
-        \"InProgress\",\r\n  \"name\": \"6cfea4cf-69c9-4f0e-8f60-578281267c8d\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '134'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 13 Dec 2022 22:55:13 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14978,Microsoft.Compute/GetOperation30Min;29977
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vm boot-diagnostics disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n
-      User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/6cfea4cf-69c9-4f0e-8f60-578281267c8d?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
-  response:
-    body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T22:55:13.8451773+00:00\",\r\n  \"endTime\":
-        \"2022-12-13T22:55:15.9857437+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"name\": \"6cfea4cf-69c9-4f0e-8f60-578281267c8d\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '184'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 13 Dec 2022 22:55:43 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14977,Microsoft.Compute/GetOperation30Min;29975
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vm boot-diagnostics disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n
-      User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?api-version=2022-08-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"cli000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003\",\r\n
-        \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westus2\",\r\n
-        \ \"tags\": {\r\n    \"azsecpack\": \"nonprod\",\r\n    \"platformsettings.host_environment.service.platform_optedin_for_rootcerts\":
-        \"true\"\r\n  },\r\n  \"identity\": {\r\n    \"type\": \"UserAssigned\",\r\n
-        \   \"userAssignedIdentities\": {\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/AzSecPackAutoConfigUA-westus2\":
-        {\r\n        \"principalId\": \"684d55e2-8922-4966-a660-2d38ca4a1711\",\r\n
-        \       \"clientId\": \"6d45cf55-f311-4228-97b0-c22ae418aad6\"\r\n      }\r\n
-        \   }\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"d54f150a-5634-4201-b5af-271e2cd52432\",\r\n
-        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
-        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
-        \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
-        \"18.04-LTS\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
-        \"18.04.202212090\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\",\r\n
-        \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
-        \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_SERIALCONSOLELMXZIWWK5PS5Z6A7GSGJPKCGAUTWUFSF6S5STLYYHQ6COP3BWYY27/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\"\r\n
-        \       },\r\n        \"deleteOption\": \"Detach\",\r\n        \"diskSizeGB\":
-        30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
-        {\r\n      \"computerName\": \"cli000003\",\r\n      \"adminUsername\": \"rhl\",\r\n
-        \     \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
-        true,\r\n        \"ssh\": {\r\n          \"publicKeys\": [\r\n            {\r\n
-        \             \"path\": \"/home/rhl/.ssh/authorized_keys\",\r\n              \"keyData\":
-        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h\"\r\n
-        \           }\r\n          ]\r\n        },\r\n        \"provisionVMAgent\":
-        true,\r\n        \"patchSettings\": {\r\n          \"patchMode\": \"ImageDefault\",\r\n
-        \         \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n        \"enableVMAgentPlatformUpdates\":
-        false\r\n      },\r\n      \"secrets\": [],\r\n      \"allowExtensionOperations\":
-        true,\r\n      \"requireGuestProvisionSignal\": true\r\n    },\r\n    \"networkProfile\":
-        {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
-        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
-        false\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"timeCreated\": \"2022-12-13T22:51:52.3460253+00:00\"\r\n  }\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '3291'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 13 Dec 2022 22:55:43 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/LowCostGet3Min;3983,Microsoft.Compute/LowCostGet30Min;31976
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vm boot-diagnostics disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n
-      User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?$expand=instanceView&api-version=2022-08-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"cli000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003\",\r\n
-        \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westus2\",\r\n
-        \ \"tags\": {\r\n    \"azsecpack\": \"nonprod\",\r\n    \"platformsettings.host_environment.service.platform_optedin_for_rootcerts\":
-        \"true\"\r\n  },\r\n  \"identity\": {\r\n    \"type\": \"UserAssigned\",\r\n
-        \   \"userAssignedIdentities\": {\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/AzSecPackAutoConfigUA-westus2\":
-        {\r\n        \"principalId\": \"684d55e2-8922-4966-a660-2d38ca4a1711\",\r\n
-        \       \"clientId\": \"6d45cf55-f311-4228-97b0-c22ae418aad6\"\r\n      }\r\n
-        \   }\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"d54f150a-5634-4201-b5af-271e2cd52432\",\r\n
-        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
-        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
-        \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
-        \"18.04-LTS\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
-        \"18.04.202212090\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\",\r\n
-        \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
-        \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_SERIALCONSOLELMXZIWWK5PS5Z6A7GSGJPKCGAUTWUFSF6S5STLYYHQ6COP3BWYY27/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\"\r\n
-        \       },\r\n        \"deleteOption\": \"Detach\",\r\n        \"diskSizeGB\":
-        30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
-        {\r\n      \"computerName\": \"cli000003\",\r\n      \"adminUsername\": \"rhl\",\r\n
-        \     \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
-        true,\r\n        \"ssh\": {\r\n          \"publicKeys\": [\r\n            {\r\n
-        \             \"path\": \"/home/rhl/.ssh/authorized_keys\",\r\n              \"keyData\":
-        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h\"\r\n
-        \           }\r\n          ]\r\n        },\r\n        \"provisionVMAgent\":
-        true,\r\n        \"patchSettings\": {\r\n          \"patchMode\": \"ImageDefault\",\r\n
-        \         \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n        \"enableVMAgentPlatformUpdates\":
-        false\r\n      },\r\n      \"secrets\": [],\r\n      \"allowExtensionOperations\":
-        true,\r\n      \"requireGuestProvisionSignal\": true\r\n    },\r\n    \"networkProfile\":
-        {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
-        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
-        false\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"instanceView\": {\r\n      \"computerName\": \"cli000003\",\r\n      \"osName\":
-        \"ubuntu\",\r\n      \"osVersion\": \"18.04\",\r\n      \"vmAgent\": {\r\n
-        \       \"vmAgentVersion\": \"2.9.0.4\",\r\n        \"statuses\": [\r\n          {\r\n
-        \           \"code\": \"ProvisioningState/succeeded\",\r\n            \"level\":
-        \"Info\",\r\n            \"displayStatus\": \"Ready\",\r\n            \"message\":
-        \"Guest Agent is running\",\r\n            \"time\": \"2022-12-13T22:54:35+00:00\"\r\n
-        \         }\r\n        ],\r\n        \"extensionHandlers\": []\r\n      },\r\n
-        \     \"disks\": [\r\n        {\r\n          \"name\": \"cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\",\r\n
-        \         \"statuses\": [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n
-        \             \"level\": \"Info\",\r\n              \"displayStatus\": \"Provisioning
-        succeeded\",\r\n              \"time\": \"2022-12-13T22:55:14.423288+00:00\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      ],\r\n      \"hyperVGeneration\":
-        \"V1\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
-        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2022-12-13T22:55:15.970136+00:00\"\r\n
-        \       },\r\n        {\r\n          \"code\": \"PowerState/stopped\",\r\n
-        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"VM stopped\"\r\n
-        \       }\r\n      ]\r\n    },\r\n    \"timeCreated\": \"2022-12-13T22:51:52.3460253+00:00\"\r\n
-        \ }\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '4594'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 13 Dec 2022 22:55:44 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/LowCostGet3Min;3982,Microsoft.Compute/LowCostGet30Min;31975
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vm start
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      ParameterSetName:
-      - -g -n
-      User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003/start?api-version=2022-08-01
-  response:
-    body:
-      string: ''
-    headers:
-      azure-asyncnotification:
-      - Enabled
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/e4bef235-dbcb-49db-8f8d-be4b11dd19a7?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Tue, 13 Dec 2022 22:55:45 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/e4bef235-dbcb-49db-8f8d-be4b11dd19a7?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/1d2958fc-ef91-4d87-92dd-93d69bcbda2f?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-11-01
       pragma:
       - no-cache
       server:
@@ -3236,7 +2084,7 @@ interactions:
       x-ms-ratelimit-remaining-resource:
       - Microsoft.Compute/UpdateVM3Min;235,Microsoft.Compute/UpdateVM30Min;1195
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
     status:
       code: 202
       message: Accepted
@@ -3254,13 +2102,13 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/e4bef235-dbcb-49db-8f8d-be4b11dd19a7?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/1d2958fc-ef91-4d87-92dd-93d69bcbda2f?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T22:55:45.7980954+00:00\",\r\n  \"status\":
-        \"InProgress\",\r\n  \"name\": \"e4bef235-dbcb-49db-8f8d-be4b11dd19a7\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T14:57:09.6911417+00:00\",\r\n  \"status\":
+        \"InProgress\",\r\n  \"name\": \"1d2958fc-ef91-4d87-92dd-93d69bcbda2f\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -3269,7 +2117,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:55:45 GMT
+      - Mon, 06 Mar 2023 14:57:19 GMT
       expires:
       - '-1'
       pragma:
@@ -3286,7 +2134,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14976,Microsoft.Compute/GetOperation30Min;29974
+      - Microsoft.Compute/GetOperation3Min;14979,Microsoft.Compute/GetOperation30Min;29915
     status:
       code: 200
       message: OK
@@ -3304,14 +2152,14 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/e4bef235-dbcb-49db-8f8d-be4b11dd19a7?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/1d2958fc-ef91-4d87-92dd-93d69bcbda2f?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T22:55:45.7980954+00:00\",\r\n  \"endTime\":
-        \"2022-12-13T22:55:51.6261805+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"name\": \"e4bef235-dbcb-49db-8f8d-be4b11dd19a7\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T14:57:09.6911417+00:00\",\r\n  \"endTime\":
+        \"2023-03-06T14:57:21.0503975+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"name\": \"1d2958fc-ef91-4d87-92dd-93d69bcbda2f\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -3320,7 +2168,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:55:54 GMT
+      - Mon, 06 Mar 2023 14:57:29 GMT
       expires:
       - '-1'
       pragma:
@@ -3337,7 +2185,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14974,Microsoft.Compute/GetOperation30Min;29972
+      - Microsoft.Compute/GetOperation3Min;14974,Microsoft.Compute/GetOperation30Min;29910
     status:
       code: 200
       message: OK
@@ -3355,9 +2203,9 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/e4bef235-dbcb-49db-8f8d-be4b11dd19a7?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/1d2958fc-ef91-4d87-92dd-93d69bcbda2f?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-11-01
   response:
     body:
       string: ''
@@ -3367,7 +2215,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 13 Dec 2022 22:55:55 GMT
+      - Mon, 06 Mar 2023 14:57:29 GMT
       expires:
       - '-1'
       pragma:
@@ -3380,7 +2228,865 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14973,Microsoft.Compute/GetOperation30Min;29971
+      - Microsoft.Compute/GetOperation3Min;14973,Microsoft.Compute/GetOperation30Min;29909
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm stop
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003/powerOff?skipShutdown=false&api-version=2022-11-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncnotification:
+      - Enabled
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/f42bfb17-72c5-4351-973e-100910e7b7bb?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Mon, 06 Mar 2023 14:57:30 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/f42bfb17-72c5-4351-973e-100910e7b7bb?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-11-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/UpdateVM3Min;234,Microsoft.Compute/UpdateVM30Min;1194
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm stop
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/f42bfb17-72c5-4351-973e-100910e7b7bb?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
+  response:
+    body:
+      string: "{\r\n  \"startTime\": \"2023-03-06T14:57:31.0816733+00:00\",\r\n  \"endTime\":
+        \"2023-03-06T14:57:34.2691356+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"name\": \"f42bfb17-72c5-4351-973e-100910e7b7bb\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '184'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 06 Mar 2023 14:58:00 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/GetOperation3Min;14967,Microsoft.Compute/GetOperation30Min;29901
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm stop
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/f42bfb17-72c5-4351-973e-100910e7b7bb?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-11-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Mon, 06 Mar 2023 14:58:00 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/GetOperation3Min;14966,Microsoft.Compute/GetOperation30Min;29900
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm stop
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?$expand=instanceView&api-version=2022-11-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"cli000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003\",\r\n
+        \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westus2\",\r\n
+        \ \"tags\": {\r\n    \"azsecpack\": \"nonprod\",\r\n    \"platformsettings.host_environment.service.platform_optedin_for_rootcerts\":
+        \"true\"\r\n  },\r\n  \"identity\": {\r\n    \"type\": \"UserAssigned\",\r\n
+        \   \"userAssignedIdentities\": {\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/AzSecPackAutoConfigUA-westus2\":
+        {\r\n        \"principalId\": \"684d55e2-8922-4966-a660-2d38ca4a1711\",\r\n
+        \       \"clientId\": \"6d45cf55-f311-4228-97b0-c22ae418aad6\"\r\n      }\r\n
+        \   }\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"94bb0e59-1bcd-493b-aa53-580e2ad730d7\",\r\n
+        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
+        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
+        \"18.04-LTS\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
+        \"18.04.202302100\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\",\r\n
+        \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
+        \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_SERIALCONSOLE46W4L74TUUPDKTQIUNEVCDRGNWE77YHJM4DVRHN3I4J7UGNGQPGEM/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\"\r\n
+        \       },\r\n        \"deleteOption\": \"Detach\",\r\n        \"diskSizeGB\":
+        30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
+        {\r\n      \"computerName\": \"cli000003\",\r\n      \"adminUsername\": \"rhoover\",\r\n
+        \     \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
+        true,\r\n        \"ssh\": {\r\n          \"publicKeys\": [\r\n            {\r\n
+        \             \"path\": \"/home/rhoover/.ssh/authorized_keys\",\r\n              \"keyData\":
+        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+        REDMOND+rhoover@DESKTOP-XVFR7ID\\n\"\r\n            }\r\n          ]\r\n        },\r\n
+        \       \"provisionVMAgent\": true,\r\n        \"patchSettings\": {\r\n          \"patchMode\":
+        \"ImageDefault\",\r\n          \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n
+        \       \"enableVMAgentPlatformUpdates\": false\r\n      },\r\n      \"secrets\":
+        [],\r\n      \"allowExtensionOperations\": true,\r\n      \"requireGuestProvisionSignal\":
+        true\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
+        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
+        true\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"instanceView\": {\r\n      \"vmAgent\": {\r\n        \"vmAgentVersion\":
+        \"Unknown\",\r\n        \"statuses\": [\r\n          {\r\n            \"code\":
+        \"ProvisioningState/Unavailable\",\r\n            \"level\": \"Warning\",\r\n
+        \           \"displayStatus\": \"Not Ready\",\r\n            \"message\":
+        \"VM status blob is found but not yet populated.\",\r\n            \"time\":
+        \"2023-03-06T14:58:02+00:00\"\r\n          }\r\n        ]\r\n      },\r\n
+        \     \"disks\": [\r\n        {\r\n          \"name\": \"cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\",\r\n
+        \         \"statuses\": [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n
+        \             \"level\": \"Info\",\r\n              \"displayStatus\": \"Provisioning
+        succeeded\",\r\n              \"time\": \"2023-03-06T14:57:37.691+00:00\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      ],\r\n      \"bootDiagnostics\":
+        {},\r\n      \"hyperVGeneration\": \"V1\",\r\n      \"statuses\": [\r\n        {\r\n
+        \         \"code\": \"ProvisioningState/succeeded\",\r\n          \"level\":
+        \"Info\",\r\n          \"displayStatus\": \"Provisioning succeeded\",\r\n
+        \         \"time\": \"2023-03-06T14:57:38.9878913+00:00\"\r\n        },\r\n
+        \       {\r\n          \"code\": \"PowerState/stopped\",\r\n          \"level\":
+        \"Info\",\r\n          \"displayStatus\": \"VM stopped\"\r\n        }\r\n
+        \     ]\r\n    },\r\n    \"timeCreated\": \"2023-03-06T14:55:01.5508486+00:00\"\r\n
+        \ }\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '4742'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 06 Mar 2023 14:58:01 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/LowCostGet3Min;3961,Microsoft.Compute/LowCostGet30Min;31953
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm stop
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.SerialConsole/consoleServices/default?api-version=2018-05-01
+  response:
+    body:
+      string: "{\n \"properties\": {\n  \"disabled\": false\n }\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '43'
+      content-type:
+      - application/json; charset=UTF-8
+      date:
+      - Mon, 06 Mar 2023 14:58:02 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm boot-diagnostics disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?api-version=2022-11-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"cli000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003\",\r\n
+        \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westus2\",\r\n
+        \ \"tags\": {\r\n    \"azsecpack\": \"nonprod\",\r\n    \"platformsettings.host_environment.service.platform_optedin_for_rootcerts\":
+        \"true\"\r\n  },\r\n  \"identity\": {\r\n    \"type\": \"UserAssigned\",\r\n
+        \   \"userAssignedIdentities\": {\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/AzSecPackAutoConfigUA-westus2\":
+        {\r\n        \"principalId\": \"684d55e2-8922-4966-a660-2d38ca4a1711\",\r\n
+        \       \"clientId\": \"6d45cf55-f311-4228-97b0-c22ae418aad6\"\r\n      }\r\n
+        \   }\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"94bb0e59-1bcd-493b-aa53-580e2ad730d7\",\r\n
+        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
+        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
+        \"18.04-LTS\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
+        \"18.04.202302100\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\",\r\n
+        \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
+        \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_SERIALCONSOLE46W4L74TUUPDKTQIUNEVCDRGNWE77YHJM4DVRHN3I4J7UGNGQPGEM/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\"\r\n
+        \       },\r\n        \"deleteOption\": \"Detach\",\r\n        \"diskSizeGB\":
+        30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
+        {\r\n      \"computerName\": \"cli000003\",\r\n      \"adminUsername\": \"rhoover\",\r\n
+        \     \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
+        true,\r\n        \"ssh\": {\r\n          \"publicKeys\": [\r\n            {\r\n
+        \             \"path\": \"/home/rhoover/.ssh/authorized_keys\",\r\n              \"keyData\":
+        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+        REDMOND+rhoover@DESKTOP-XVFR7ID\\n\"\r\n            }\r\n          ]\r\n        },\r\n
+        \       \"provisionVMAgent\": true,\r\n        \"patchSettings\": {\r\n          \"patchMode\":
+        \"ImageDefault\",\r\n          \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n
+        \       \"enableVMAgentPlatformUpdates\": false\r\n      },\r\n      \"secrets\":
+        [],\r\n      \"allowExtensionOperations\": true,\r\n      \"requireGuestProvisionSignal\":
+        true\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
+        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
+        true\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"timeCreated\": \"2023-03-06T14:55:01.5508486+00:00\"\r\n  }\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '3504'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 06 Mar 2023 14:58:02 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/LowCostGet3Min;3960,Microsoft.Compute/LowCostGet30Min;31952
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "westus2", "tags": {"azsecpack": "nonprod", "platformsettings.host_environment.service.platform_optedin_for_rootcerts":
+      "true"}, "identity": {"type": "UserAssigned", "userAssignedIdentities": {"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/AzSecPackAutoConfigUA-westus2":
+      {}}}, "properties": {"hardwareProfile": {"vmSize": "Standard_DS1_v2"}, "storageProfile":
+      {"osDisk": {"osType": "Linux", "name": "cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f",
+      "caching": "ReadWrite", "createOption": "FromImage", "diskSizeGB": 30, "managedDisk":
+      {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_SERIALCONSOLE46W4L74TUUPDKTQIUNEVCDRGNWE77YHJM4DVRHN3I4J7UGNGQPGEM/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f",
+      "storageAccountType": "Premium_LRS"}, "deleteOption": "Detach"}, "dataDisks":
+      []}, "osProfile": {"computerName": "cli000003", "adminUsername": "rhoover",
+      "linuxConfiguration": {"disablePasswordAuthentication": true, "ssh": {"publicKeys":
+      [{"path": "/home/rhoover/.ssh/authorized_keys", "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+      REDMOND+rhoover@DESKTOP-XVFR7ID\n"}]}, "provisionVMAgent": true, "patchSettings":
+      {"patchMode": "ImageDefault", "assessmentMode": "ImageDefault"}, "enableVMAgentPlatformUpdates":
+      false}, "secrets": [], "allowExtensionOperations": true, "requireGuestProvisionSignal":
+      true}, "networkProfile": {"networkInterfaces": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic"}]},
+      "diagnosticsProfile": {"bootDiagnostics": {"enabled": false}}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm boot-diagnostics disable
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2294'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?api-version=2022-11-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"cli000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003\",\r\n
+        \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westus2\",\r\n
+        \ \"tags\": {\r\n    \"azsecpack\": \"nonprod\",\r\n    \"platformsettings.host_environment.service.platform_optedin_for_rootcerts\":
+        \"true\"\r\n  },\r\n  \"identity\": {\r\n    \"type\": \"UserAssigned\",\r\n
+        \   \"userAssignedIdentities\": {\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/AzSecPackAutoConfigUA-westus2\":
+        {\r\n        \"principalId\": \"684d55e2-8922-4966-a660-2d38ca4a1711\",\r\n
+        \       \"clientId\": \"6d45cf55-f311-4228-97b0-c22ae418aad6\"\r\n      }\r\n
+        \   }\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"94bb0e59-1bcd-493b-aa53-580e2ad730d7\",\r\n
+        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
+        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
+        \"18.04-LTS\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
+        \"18.04.202302100\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\",\r\n
+        \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
+        \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_SERIALCONSOLE46W4L74TUUPDKTQIUNEVCDRGNWE77YHJM4DVRHN3I4J7UGNGQPGEM/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\"\r\n
+        \       },\r\n        \"deleteOption\": \"Detach\",\r\n        \"diskSizeGB\":
+        30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
+        {\r\n      \"computerName\": \"cli000003\",\r\n      \"adminUsername\": \"rhoover\",\r\n
+        \     \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
+        true,\r\n        \"ssh\": {\r\n          \"publicKeys\": [\r\n            {\r\n
+        \             \"path\": \"/home/rhoover/.ssh/authorized_keys\",\r\n              \"keyData\":
+        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+        REDMOND+rhoover@DESKTOP-XVFR7ID\\n\"\r\n            }\r\n          ]\r\n        },\r\n
+        \       \"provisionVMAgent\": true,\r\n        \"patchSettings\": {\r\n          \"patchMode\":
+        \"ImageDefault\",\r\n          \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n
+        \       \"enableVMAgentPlatformUpdates\": false\r\n      },\r\n      \"secrets\":
+        [],\r\n      \"allowExtensionOperations\": true,\r\n      \"requireGuestProvisionSignal\":
+        true\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
+        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
+        false\r\n      }\r\n    },\r\n    \"provisioningState\": \"Updating\",\r\n
+        \   \"timeCreated\": \"2023-03-06T14:55:01.5508486+00:00\"\r\n  }\r\n}"
+    headers:
+      azure-asyncnotification:
+      - Enabled
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/a39dca88-c0a8-4b7c-ad73-a16d0ba3adad?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '3504'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 06 Mar 2023 14:58:04 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/PutVM3Min;614,Microsoft.Compute/PutVM30Min;3088
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm boot-diagnostics disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/a39dca88-c0a8-4b7c-ad73-a16d0ba3adad?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
+  response:
+    body:
+      string: "{\r\n  \"startTime\": \"2023-03-06T14:58:03.9722088+00:00\",\r\n  \"endTime\":
+        \"2023-03-06T14:58:05.8315532+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"name\": \"a39dca88-c0a8-4b7c-ad73-a16d0ba3adad\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '184'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 06 Mar 2023 14:58:34 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/GetOperation3Min;14960,Microsoft.Compute/GetOperation30Min;29893
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm boot-diagnostics disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?api-version=2022-11-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"cli000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003\",\r\n
+        \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westus2\",\r\n
+        \ \"tags\": {\r\n    \"azsecpack\": \"nonprod\",\r\n    \"platformsettings.host_environment.service.platform_optedin_for_rootcerts\":
+        \"true\"\r\n  },\r\n  \"identity\": {\r\n    \"type\": \"UserAssigned\",\r\n
+        \   \"userAssignedIdentities\": {\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/AzSecPackAutoConfigUA-westus2\":
+        {\r\n        \"principalId\": \"684d55e2-8922-4966-a660-2d38ca4a1711\",\r\n
+        \       \"clientId\": \"6d45cf55-f311-4228-97b0-c22ae418aad6\"\r\n      }\r\n
+        \   }\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"94bb0e59-1bcd-493b-aa53-580e2ad730d7\",\r\n
+        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
+        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
+        \"18.04-LTS\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
+        \"18.04.202302100\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\",\r\n
+        \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
+        \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_SERIALCONSOLE46W4L74TUUPDKTQIUNEVCDRGNWE77YHJM4DVRHN3I4J7UGNGQPGEM/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\"\r\n
+        \       },\r\n        \"deleteOption\": \"Detach\",\r\n        \"diskSizeGB\":
+        30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
+        {\r\n      \"computerName\": \"cli000003\",\r\n      \"adminUsername\": \"rhoover\",\r\n
+        \     \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
+        true,\r\n        \"ssh\": {\r\n          \"publicKeys\": [\r\n            {\r\n
+        \             \"path\": \"/home/rhoover/.ssh/authorized_keys\",\r\n              \"keyData\":
+        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+        REDMOND+rhoover@DESKTOP-XVFR7ID\\n\"\r\n            }\r\n          ]\r\n        },\r\n
+        \       \"provisionVMAgent\": true,\r\n        \"patchSettings\": {\r\n          \"patchMode\":
+        \"ImageDefault\",\r\n          \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n
+        \       \"enableVMAgentPlatformUpdates\": false\r\n      },\r\n      \"secrets\":
+        [],\r\n      \"allowExtensionOperations\": true,\r\n      \"requireGuestProvisionSignal\":
+        true\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
+        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
+        false\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"timeCreated\": \"2023-03-06T14:55:01.5508486+00:00\"\r\n  }\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '3505'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 06 Mar 2023 14:58:34 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/LowCostGet3Min;3960,Microsoft.Compute/LowCostGet30Min;31944
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm boot-diagnostics disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?$expand=instanceView&api-version=2022-11-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"cli000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003\",\r\n
+        \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westus2\",\r\n
+        \ \"tags\": {\r\n    \"azsecpack\": \"nonprod\",\r\n    \"platformsettings.host_environment.service.platform_optedin_for_rootcerts\":
+        \"true\"\r\n  },\r\n  \"identity\": {\r\n    \"type\": \"UserAssigned\",\r\n
+        \   \"userAssignedIdentities\": {\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/AzSecPackAutoConfigUA-westus2\":
+        {\r\n        \"principalId\": \"684d55e2-8922-4966-a660-2d38ca4a1711\",\r\n
+        \       \"clientId\": \"6d45cf55-f311-4228-97b0-c22ae418aad6\"\r\n      }\r\n
+        \   }\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"94bb0e59-1bcd-493b-aa53-580e2ad730d7\",\r\n
+        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
+        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
+        \"18.04-LTS\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
+        \"18.04.202302100\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\",\r\n
+        \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
+        \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_SERIALCONSOLE46W4L74TUUPDKTQIUNEVCDRGNWE77YHJM4DVRHN3I4J7UGNGQPGEM/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\"\r\n
+        \       },\r\n        \"deleteOption\": \"Detach\",\r\n        \"diskSizeGB\":
+        30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
+        {\r\n      \"computerName\": \"cli000003\",\r\n      \"adminUsername\": \"rhoover\",\r\n
+        \     \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
+        true,\r\n        \"ssh\": {\r\n          \"publicKeys\": [\r\n            {\r\n
+        \             \"path\": \"/home/rhoover/.ssh/authorized_keys\",\r\n              \"keyData\":
+        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+        REDMOND+rhoover@DESKTOP-XVFR7ID\\n\"\r\n            }\r\n          ]\r\n        },\r\n
+        \       \"provisionVMAgent\": true,\r\n        \"patchSettings\": {\r\n          \"patchMode\":
+        \"ImageDefault\",\r\n          \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n
+        \       \"enableVMAgentPlatformUpdates\": false\r\n      },\r\n      \"secrets\":
+        [],\r\n      \"allowExtensionOperations\": true,\r\n      \"requireGuestProvisionSignal\":
+        true\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
+        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
+        false\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"instanceView\": {\r\n      \"vmAgent\": {\r\n        \"vmAgentVersion\":
+        \"Unknown\",\r\n        \"statuses\": [\r\n          {\r\n            \"code\":
+        \"ProvisioningState/Unavailable\",\r\n            \"level\": \"Warning\",\r\n
+        \           \"displayStatus\": \"Not Ready\",\r\n            \"message\":
+        \"VM status blob is found but not yet populated.\",\r\n            \"time\":
+        \"2023-03-06T14:58:35+00:00\"\r\n          }\r\n        ]\r\n      },\r\n
+        \     \"disks\": [\r\n        {\r\n          \"name\": \"cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\",\r\n
+        \         \"statuses\": [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n
+        \             \"level\": \"Info\",\r\n              \"displayStatus\": \"Provisioning
+        succeeded\",\r\n              \"time\": \"2023-03-06T14:58:04.5346581+00:00\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      ],\r\n      \"hyperVGeneration\":
+        \"V1\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2023-03-06T14:58:05.8159459+00:00\"\r\n
+        \       },\r\n        {\r\n          \"code\": \"PowerState/stopped\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"VM stopped\"\r\n
+        \       }\r\n      ]\r\n    },\r\n    \"timeCreated\": \"2023-03-06T14:55:01.5508486+00:00\"\r\n
+        \ }\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '4717'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 06 Mar 2023 14:58:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/LowCostGet3Min;3959,Microsoft.Compute/LowCostGet30Min;31943
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm start
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003/start?api-version=2022-11-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncnotification:
+      - Enabled
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/01616e2d-afd1-487a-a825-7076d729e3e6?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Mon, 06 Mar 2023 14:58:36 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/01616e2d-afd1-487a-a825-7076d729e3e6?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-11-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/UpdateVM3Min;233,Microsoft.Compute/UpdateVM30Min;1193
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/01616e2d-afd1-487a-a825-7076d729e3e6?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
+  response:
+    body:
+      string: "{\r\n  \"startTime\": \"2023-03-06T14:58:36.3939834+00:00\",\r\n  \"endTime\":
+        \"2023-03-06T14:58:39.378375+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"name\": \"01616e2d-afd1-487a-a825-7076d729e3e6\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '183'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 06 Mar 2023 14:58:46 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/GetOperation3Min;14957,Microsoft.Compute/GetOperation30Min;29890
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm start
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/01616e2d-afd1-487a-a825-7076d729e3e6?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-11-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Mon, 06 Mar 2023 14:58:46 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/GetOperation3Min;14956,Microsoft.Compute/GetOperation30Min;29889
     status:
       code: 200
       message: OK
@@ -3398,9 +3104,9 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?$expand=instanceView&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?$expand=instanceView&api-version=2022-11-01
   response:
     body:
       string: "{\r\n  \"name\": \"cli000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003\",\r\n
@@ -3410,59 +3116,58 @@ interactions:
         \   \"userAssignedIdentities\": {\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/AzSecPackAutoConfigUA-westus2\":
         {\r\n        \"principalId\": \"684d55e2-8922-4966-a660-2d38ca4a1711\",\r\n
         \       \"clientId\": \"6d45cf55-f311-4228-97b0-c22ae418aad6\"\r\n      }\r\n
-        \   }\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"d54f150a-5634-4201-b5af-271e2cd52432\",\r\n
+        \   }\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"94bb0e59-1bcd-493b-aa53-580e2ad730d7\",\r\n
         \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
         \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
         \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
         \"18.04-LTS\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
-        \"18.04.202212090\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\",\r\n
+        \"18.04.202302100\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\",\r\n
         \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
         \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_SERIALCONSOLELMXZIWWK5PS5Z6A7GSGJPKCGAUTWUFSF6S5STLYYHQ6COP3BWYY27/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\"\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_SERIALCONSOLE46W4L74TUUPDKTQIUNEVCDRGNWE77YHJM4DVRHN3I4J7UGNGQPGEM/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\"\r\n
         \       },\r\n        \"deleteOption\": \"Detach\",\r\n        \"diskSizeGB\":
         30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
-        {\r\n      \"computerName\": \"cli000003\",\r\n      \"adminUsername\": \"rhl\",\r\n
+        {\r\n      \"computerName\": \"cli000003\",\r\n      \"adminUsername\": \"rhoover\",\r\n
         \     \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
         true,\r\n        \"ssh\": {\r\n          \"publicKeys\": [\r\n            {\r\n
-        \             \"path\": \"/home/rhl/.ssh/authorized_keys\",\r\n              \"keyData\":
-        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h\"\r\n
-        \           }\r\n          ]\r\n        },\r\n        \"provisionVMAgent\":
-        true,\r\n        \"patchSettings\": {\r\n          \"patchMode\": \"ImageDefault\",\r\n
-        \         \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n        \"enableVMAgentPlatformUpdates\":
-        false\r\n      },\r\n      \"secrets\": [],\r\n      \"allowExtensionOperations\":
-        true,\r\n      \"requireGuestProvisionSignal\": true\r\n    },\r\n    \"networkProfile\":
-        {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
+        \             \"path\": \"/home/rhoover/.ssh/authorized_keys\",\r\n              \"keyData\":
+        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+        REDMOND+rhoover@DESKTOP-XVFR7ID\\n\"\r\n            }\r\n          ]\r\n        },\r\n
+        \       \"provisionVMAgent\": true,\r\n        \"patchSettings\": {\r\n          \"patchMode\":
+        \"ImageDefault\",\r\n          \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n
+        \       \"enableVMAgentPlatformUpdates\": false\r\n      },\r\n      \"secrets\":
+        [],\r\n      \"allowExtensionOperations\": true,\r\n      \"requireGuestProvisionSignal\":
+        true\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
         \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
         false\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"instanceView\": {\r\n      \"computerName\": \"cli000003\",\r\n      \"osName\":
-        \"ubuntu\",\r\n      \"osVersion\": \"18.04\",\r\n      \"vmAgent\": {\r\n
-        \       \"vmAgentVersion\": \"2.9.0.4\",\r\n        \"statuses\": [\r\n          {\r\n
-        \           \"code\": \"ProvisioningState/succeeded\",\r\n            \"level\":
-        \"Info\",\r\n            \"displayStatus\": \"Ready\",\r\n            \"message\":
-        \"Guest Agent is running\",\r\n            \"time\": \"2022-12-13T22:54:35+00:00\"\r\n
-        \         }\r\n        ],\r\n        \"extensionHandlers\": []\r\n      },\r\n
-        \     \"disks\": [\r\n        {\r\n          \"name\": \"cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\",\r\n
+        \   \"instanceView\": {\r\n      \"vmAgent\": {\r\n        \"vmAgentVersion\":
+        \"Unknown\",\r\n        \"statuses\": [\r\n          {\r\n            \"code\":
+        \"ProvisioningState/Unavailable\",\r\n            \"level\": \"Warning\",\r\n
+        \           \"displayStatus\": \"Not Ready\",\r\n            \"message\":
+        \"VM status blob is found but not yet populated.\",\r\n            \"time\":
+        \"2023-03-06T14:58:47+00:00\"\r\n          }\r\n        ]\r\n      },\r\n
+        \     \"disks\": [\r\n        {\r\n          \"name\": \"cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\",\r\n
         \         \"statuses\": [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n
         \             \"level\": \"Info\",\r\n              \"displayStatus\": \"Provisioning
-        succeeded\",\r\n              \"time\": \"2022-12-13T22:55:14.423288+00:00\"\r\n
+        succeeded\",\r\n              \"time\": \"2023-03-06T14:58:04.5346581+00:00\"\r\n
         \           }\r\n          ]\r\n        }\r\n      ],\r\n      \"hyperVGeneration\":
         \"V1\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2022-12-13T22:55:51.6261805+00:00\"\r\n
+        succeeded\",\r\n          \"time\": \"2023-03-06T14:58:39.3626933+00:00\"\r\n
         \       },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\n
-        \       }\r\n      ]\r\n    },\r\n    \"timeCreated\": \"2022-12-13T22:51:52.3460253+00:00\"\r\n
+        \       }\r\n      ]\r\n    },\r\n    \"timeCreated\": \"2023-03-06T14:55:01.5508486+00:00\"\r\n
         \ }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '4595'
+      - '4717'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:55:54 GMT
+      - Mon, 06 Mar 2023 14:58:47 GMT
       expires:
       - '-1'
       pragma:
@@ -3479,7 +3184,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/LowCostGet3Min;3980,Microsoft.Compute/LowCostGet30Min;31973
+      - Microsoft.Compute/LowCostGet3Min;3957,Microsoft.Compute/LowCostGet30Min;31941
     status:
       code: 200
       message: OK
@@ -3497,9 +3202,9 @@ interactions:
       ParameterSetName:
       - -g -n --storage
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?api-version=2022-11-01
   response:
     body:
       string: "{\r\n  \"name\": \"cli000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003\",\r\n
@@ -3509,41 +3214,41 @@ interactions:
         \   \"userAssignedIdentities\": {\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/AzSecPackAutoConfigUA-westus2\":
         {\r\n        \"principalId\": \"684d55e2-8922-4966-a660-2d38ca4a1711\",\r\n
         \       \"clientId\": \"6d45cf55-f311-4228-97b0-c22ae418aad6\"\r\n      }\r\n
-        \   }\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"d54f150a-5634-4201-b5af-271e2cd52432\",\r\n
+        \   }\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"94bb0e59-1bcd-493b-aa53-580e2ad730d7\",\r\n
         \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
         \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
         \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
         \"18.04-LTS\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
-        \"18.04.202212090\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\",\r\n
+        \"18.04.202302100\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\",\r\n
         \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
         \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_SERIALCONSOLELMXZIWWK5PS5Z6A7GSGJPKCGAUTWUFSF6S5STLYYHQ6COP3BWYY27/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\"\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_SERIALCONSOLE46W4L74TUUPDKTQIUNEVCDRGNWE77YHJM4DVRHN3I4J7UGNGQPGEM/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\"\r\n
         \       },\r\n        \"deleteOption\": \"Detach\",\r\n        \"diskSizeGB\":
         30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
-        {\r\n      \"computerName\": \"cli000003\",\r\n      \"adminUsername\": \"rhl\",\r\n
+        {\r\n      \"computerName\": \"cli000003\",\r\n      \"adminUsername\": \"rhoover\",\r\n
         \     \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
         true,\r\n        \"ssh\": {\r\n          \"publicKeys\": [\r\n            {\r\n
-        \             \"path\": \"/home/rhl/.ssh/authorized_keys\",\r\n              \"keyData\":
-        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h\"\r\n
-        \           }\r\n          ]\r\n        },\r\n        \"provisionVMAgent\":
-        true,\r\n        \"patchSettings\": {\r\n          \"patchMode\": \"ImageDefault\",\r\n
-        \         \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n        \"enableVMAgentPlatformUpdates\":
-        false\r\n      },\r\n      \"secrets\": [],\r\n      \"allowExtensionOperations\":
-        true,\r\n      \"requireGuestProvisionSignal\": true\r\n    },\r\n    \"networkProfile\":
-        {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
+        \             \"path\": \"/home/rhoover/.ssh/authorized_keys\",\r\n              \"keyData\":
+        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+        REDMOND+rhoover@DESKTOP-XVFR7ID\\n\"\r\n            }\r\n          ]\r\n        },\r\n
+        \       \"provisionVMAgent\": true,\r\n        \"patchSettings\": {\r\n          \"patchMode\":
+        \"ImageDefault\",\r\n          \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n
+        \       \"enableVMAgentPlatformUpdates\": false\r\n      },\r\n      \"secrets\":
+        [],\r\n      \"allowExtensionOperations\": true,\r\n      \"requireGuestProvisionSignal\":
+        true\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
         \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
         false\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"timeCreated\": \"2022-12-13T22:51:52.3460253+00:00\"\r\n  }\r\n}"
+        \   \"timeCreated\": \"2023-03-06T14:55:01.5508486+00:00\"\r\n  }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3291'
+      - '3505'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:55:56 GMT
+      - Mon, 06 Mar 2023 14:58:46 GMT
       expires:
       - '-1'
       pragma:
@@ -3560,7 +3265,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/LowCostGet3Min;3979,Microsoft.Compute/LowCostGet30Min;31972
+      - Microsoft.Compute/LowCostGet3Min;3956,Microsoft.Compute/LowCostGet30Min;31940
     status:
       code: 200
       message: OK
@@ -3578,21 +3283,21 @@ interactions:
       ParameterSetName:
       - -g -n --storage
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/storageAccounts?api-version=2022-09-01
   response:
     body:
-      string: '{"value":[{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloud-shell-storage-eastus/providers/Microsoft.Storage/storageAccounts/cs210032001f4814ba9","name":"cs210032001f4814ba9","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"ms-resource-usage":"azure-cloud-shell"},"properties":{"keyCreationTime":{"key1":"2022-05-16T14:16:22.3477819Z","key2":"2022-05-16T14:16:22.3477819Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-16T14:16:22.3477819Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-16T14:16:22.3477819Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-05-16T14:16:22.2227752Z","primaryEndpoints":{"dfs":"https://cs210032001f4814ba9.dfs.core.windows.net/","web":"https://cs210032001f4814ba9.z13.web.core.windows.net/","blob":"https://cs210032001f4814ba9.blob.core.windows.net/","queue":"https://cs210032001f4814ba9.queue.core.windows.net/","table":"https://cs210032001f4814ba9.table.core.windows.net/","file":"https://cs210032001f4814ba9.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/kustoflow/providers/Microsoft.Storage/storageAccounts/csslinuxkustoflow","name":"csslinuxkustoflow","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"CreatedBy":"craigw"},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-02-01T20:08:38.6849654Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-02-01T20:08:38.6849654Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2019-02-01T20:08:38.5912170Z","primaryEndpoints":{"dfs":"https://csslinuxkustoflow.dfs.core.windows.net/","web":"https://csslinuxkustoflow.z13.web.core.windows.net/","blob":"https://csslinuxkustoflow.blob.core.windows.net/","queue":"https://csslinuxkustoflow.queue.core.windows.net/","table":"https://csslinuxkustoflow.table.core.windows.net/","file":"https://csslinuxkustoflow.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://csslinuxkustoflow-secondary.dfs.core.windows.net/","web":"https://csslinuxkustoflow-secondary.z13.web.core.windows.net/","blob":"https://csslinuxkustoflow-secondary.blob.core.windows.net/","queue":"https://csslinuxkustoflow-secondary.queue.core.windows.net/","table":"https://csslinuxkustoflow-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guidomtesttrafficmanagerrg/providers/Microsoft.Storage/storageAccounts/guidomteststoraccfortm","name":"guidomteststoraccfortm","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-10-18T18:01:13.5231266Z","key2":"2022-10-18T18:01:13.5231266Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-10-18T18:01:13.5387607Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-10-18T18:01:13.5387607Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-10-18T18:01:13.3825002Z","primaryEndpoints":{"dfs":"https://guidomteststoraccfortm.dfs.core.windows.net/","web":"https://guidomteststoraccfortm.z13.web.core.windows.net/","blob":"https://guidomteststoraccfortm.blob.core.windows.net/","queue":"https://guidomteststoraccfortm.queue.core.windows.net/","table":"https://guidomteststoraccfortm.table.core.windows.net/","file":"https://guidomteststoraccfortm.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://guidomteststoraccfortm-secondary.dfs.core.windows.net/","web":"https://guidomteststoraccfortm-secondary.z13.web.core.windows.net/","blob":"https://guidomteststoraccfortm-secondary.blob.core.windows.net/","queue":"https://guidomteststoraccfortm-secondary.queue.core.windows.net/","table":"https://guidomteststoraccfortm-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnertestvmrg-eastus/providers/Microsoft.Storage/storageAccounts/scrunnercrkwpdn5nhtgg","name":"scrunnercrkwpdn5nhtgg","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-05-12T20:03:57.6389684Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-05-12T20:03:57.6389684Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-05-12T20:03:57.5451905Z","primaryEndpoints":{"blob":"https://scrunnercrkwpdn5nhtgg.blob.core.windows.net/","queue":"https://scrunnercrkwpdn5nhtgg.queue.core.windows.net/","table":"https://scrunnercrkwpdn5nhtgg.table.core.windows.net/","file":"https://scrunnercrkwpdn5nhtgg.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/storage-RG/providers/Microsoft.Storage/storageAccounts/serialconsolepreview","name":"serialconsolepreview","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2021-05-07T21:41:56.3607334Z","key2":"2021-05-07T21:41:56.3607334Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2021-05-07T21:41:56.3607334Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2021-05-07T21:41:56.3607334Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2021-05-07T21:41:56.2513536Z","primaryEndpoints":{"dfs":"https://serialconsolepreview.dfs.core.windows.net/","web":"https://serialconsolepreview.z13.web.core.windows.net/","blob":"https://serialconsolepreview.blob.core.windows.net/","queue":"https://serialconsolepreview.queue.core.windows.net/","table":"https://serialconsolepreview.table.core.windows.net/","file":"https://serialconsolepreview.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://serialconsolepreview-secondary.dfs.core.windows.net/","web":"https://serialconsolepreview-secondary.z13.web.core.windows.net/","blob":"https://serialconsolepreview-secondary.blob.core.windows.net/","queue":"https://serialconsolepreview-secondary.queue.core.windows.net/","table":"https://serialconsolepreview-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/serialconsole-test/providers/Microsoft.Storage/storageAccounts/serialconsoletestdiag","name":"serialconsoletestdiag","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"resourceAccessRules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Deny"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-02-06T20:21:39.7019315Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-02-06T20:21:39.7019315Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2019-02-06T20:21:39.5925779Z","primaryEndpoints":{"blob":"https://serialconsoletestdiag.blob.core.windows.net/","queue":"https://serialconsoletestdiag.queue.core.windows.net/","table":"https://serialconsoletestdiag.table.core.windows.net/","file":"https://serialconsoletestdiag.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/serialTest-EastUS/providers/Microsoft.Storage/storageAccounts/serialtesta8d7fdee41","name":"serialtesta8d7fdee41","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-07-11T00:38:13.5389932Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-07-11T00:38:13.5389932Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2019-07-11T00:38:13.4452119Z","primaryEndpoints":{"blob":"https://serialtesta8d7fdee41.blob.core.windows.net/","queue":"https://serialtesta8d7fdee41.queue.core.windows.net/","table":"https://serialtesta8d7fdee41.table.core.windows.net/","file":"https://serialtesta8d7fdee41.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/storage-RG/providers/Microsoft.Storage/storageAccounts/serialtestbootdiag123","name":"serialtestbootdiag123","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-01-23T04:03:01.3263151Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-01-23T04:03:01.3263151Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2018-01-23T04:03:01.2951106Z","primaryEndpoints":{"blob":"https://serialtestbootdiag123.blob.core.windows.net/","queue":"https://serialtestbootdiag123.queue.core.windows.net/","table":"https://serialtestbootdiag123.table.core.windows.net/","file":"https://serialtestbootdiag123.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yuas-rg/providers/Microsoft.Storage/storageAccounts/yuasstorageacct","name":"yuasstorageacct","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-08-02T12:18:18.8547131Z","key2":"2022-08-02T12:18:18.8547131Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-08-02T12:18:18.8547131Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-08-02T12:18:18.8547131Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-08-02T12:18:18.7140969Z","primaryEndpoints":{"dfs":"https://yuasstorageacct.dfs.core.windows.net/","web":"https://yuasstorageacct.z13.web.core.windows.net/","blob":"https://yuasstorageacct.blob.core.windows.net/","queue":"https://yuasstorageacct.queue.core.windows.net/","table":"https://yuasstorageacct.table.core.windows.net/","file":"https://yuasstorageacct.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://yuasstorageacct-secondary.dfs.core.windows.net/","web":"https://yuasstorageacct-secondary.z13.web.core.windows.net/","blob":"https://yuasstorageacct-secondary.blob.core.windows.net/","queue":"https://yuasstorageacct-secondary.queue.core.windows.net/","table":"https://yuasstorageacct-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/bkerrigan-dev-rg/providers/Microsoft.Storage/storageAccounts/bkerriganbootdiag","name":"bkerriganbootdiag","type":"Microsoft.Storage/storageAccounts","location":"eastus2","tags":{},"properties":{"defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-09-06T13:46:17.8293781Z","key2":"2022-09-06T13:46:17.8293781Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"resourceAccessRules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-09-06T13:46:18.0015953Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-09-06T13:46:18.0015953Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Cool","provisioningState":"Succeeded","creationTime":"2022-09-06T13:46:17.7200090Z","primaryEndpoints":{"dfs":"https://bkerriganbootdiag.dfs.core.windows.net/","web":"https://bkerriganbootdiag.z20.web.core.windows.net/","blob":"https://bkerriganbootdiag.blob.core.windows.net/","queue":"https://bkerriganbootdiag.queue.core.windows.net/","table":"https://bkerriganbootdiag.table.core.windows.net/","file":"https://bkerriganbootdiag.file.core.windows.net/"},"primaryLocation":"eastus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/bkerrigan-dev-rg/providers/Microsoft.Storage/storageAccounts/bktest1234","name":"bktest1234","type":"Microsoft.Storage/storageAccounts","location":"eastus2","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-10-17T15:08:35.0957752Z","key2":"2022-10-17T15:08:35.0957752Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-10-17T15:08:35.3457658Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-10-17T15:08:35.3457658Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-10-17T15:08:34.9707244Z","primaryEndpoints":{"dfs":"https://bktest1234.dfs.core.windows.net/","web":"https://bktest1234.z20.web.core.windows.net/","blob":"https://bktest1234.blob.core.windows.net/","queue":"https://bktest1234.queue.core.windows.net/","table":"https://bktest1234.table.core.windows.net/","file":"https://bktest1234.file.core.windows.net/"},"primaryLocation":"eastus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/bkerrigan-dev-rg/providers/Microsoft.Storage/storageAccounts/bktestsa2","name":"bktestsa2","type":"Microsoft.Storage/storageAccounts","location":"eastus2","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","immutableStorageWithVersioning":{"enabled":true},"keyCreationTime":{"key1":"2022-09-27T23:58:45.6496284Z","key2":"2022-09-27T23:58:45.6496284Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-09-27T23:58:46.2902461Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-09-27T23:58:46.2902461Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Cool","provisioningState":"Succeeded","creationTime":"2022-09-27T23:58:45.5558609Z","primaryEndpoints":{"dfs":"https://bktestsa2.dfs.core.windows.net/","web":"https://bktestsa2.z20.web.core.windows.net/","blob":"https://bktestsa2.blob.core.windows.net/","queue":"https://bktestsa2.queue.core.windows.net/","table":"https://bktestsa2.table.core.windows.net/","file":"https://bktestsa2.file.core.windows.net/"},"primaryLocation":"eastus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guptar2/providers/Microsoft.Storage/storageAccounts/guptar2eastus2storage","name":"guptar2eastus2storage","type":"Microsoft.Storage/storageAccounts","location":"eastus2","tags":{"ms-resource-usage":"azure-cloud-shell"},"properties":{"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-07-28T23:08:00.6935848Z","key2":"2022-07-28T23:08:00.6935848Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"resourceAccessRules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[{"value":"20.98.146.84","action":"Allow"},{"value":"20.83.222.102","action":"Allow"},{"value":"20.69.5.162","action":"Allow"},{"value":"20.98.194.64","action":"Allow"}],"defaultAction":"Deny"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-07-28T23:08:00.6935848Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-07-28T23:08:00.6935848Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-07-28T23:08:00.5840608Z","primaryEndpoints":{"dfs":"https://guptar2eastus2storage.dfs.core.windows.net/","web":"https://guptar2eastus2storage.z20.web.core.windows.net/","blob":"https://guptar2eastus2storage.blob.core.windows.net/","queue":"https://guptar2eastus2storage.queue.core.windows.net/","table":"https://guptar2eastus2storage.table.core.windows.net/","file":"https://guptar2eastus2storage.file.core.windows.net/"},"primaryLocation":"eastus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rhel-test/providers/Microsoft.Storage/storageAccounts/rhel77acct","name":"rhel77acct","type":"Microsoft.Storage/storageAccounts","location":"eastus2","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-08-13T20:31:30.8995173Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-08-13T20:31:30.8995173Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-08-13T20:31:30.8215811Z","primaryEndpoints":{"blob":"https://rhel77acct.blob.core.windows.net/","queue":"https://rhel77acct.queue.core.windows.net/","table":"https://rhel77acct.table.core.windows.net/","file":"https://rhel77acct.file.core.windows.net/"},"primaryLocation":"eastus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloud-shell-storage-westus/providers/Microsoft.Storage/storageAccounts/cs4100320010c152e3d","name":"cs4100320010c152e3d","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{"ms-resource-usage":"azure-cloud-shell"},"properties":{"keyCreationTime":{"key1":"2022-02-07T20:19:42.9636823Z","key2":"2022-02-07T20:19:42.9636823Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-02-07T20:19:42.9636823Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-02-07T20:19:42.9636823Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-02-07T20:19:42.8699133Z","primaryEndpoints":{"dfs":"https://cs4100320010c152e3d.dfs.core.windows.net/","web":"https://cs4100320010c152e3d.z22.web.core.windows.net/","blob":"https://cs4100320010c152e3d.blob.core.windows.net/","queue":"https://cs4100320010c152e3d.queue.core.windows.net/","table":"https://cs4100320010c152e3d.table.core.windows.net/","file":"https://cs4100320010c152e3d.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloud-shell-storage-westus/providers/Microsoft.Storage/storageAccounts/cs410037ffea943c134","name":"cs410037ffea943c134","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{"ms-resource-usage":"azure-cloud-shell"},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-03-23T23:07:16.0114253Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-03-23T23:07:16.0114253Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2020-03-23T23:07:15.9333036Z","primaryEndpoints":{"dfs":"https://cs410037ffea943c134.dfs.core.windows.net/","web":"https://cs410037ffea943c134.z22.web.core.windows.net/","blob":"https://cs410037ffea943c134.blob.core.windows.net/","queue":"https://cs410037ffea943c134.queue.core.windows.net/","table":"https://cs410037ffea943c134.table.core.windows.net/","file":"https://cs410037ffea943c134.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloud-shell-storage-westus/providers/Microsoft.Storage/storageAccounts/cs41003bffd81f3ab32","name":"cs41003bffd81f3ab32","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{"ms-resource-usage":"azure-cloud-shell"},"properties":{"keyCreationTime":{"key1":"2022-07-29T00:18:56.4686445Z","key2":"2022-07-29T00:18:56.4686445Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-07-29T00:18:56.4842807Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-07-29T00:18:56.4842807Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-07-29T00:18:56.3748663Z","primaryEndpoints":{"dfs":"https://cs41003bffd81f3ab32.dfs.core.windows.net/","web":"https://cs41003bffd81f3ab32.z22.web.core.windows.net/","blob":"https://cs41003bffd81f3ab32.blob.core.windows.net/","queue":"https://cs41003bffd81f3ab32.queue.core.windows.net/","table":"https://cs41003bffd81f3ab32.table.core.windows.net/","file":"https://cs41003bffd81f3ab32.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloud-shell-storage-westus/providers/Microsoft.Storage/storageAccounts/cs4aa22d82de270x4becxb48","name":"cs4aa22d82de270x4becxb48","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{"ms-resource-usage":"azure-cloud-shell"},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-11-29T23:39:30.3657182Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-11-29T23:39:30.3657182Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2018-11-29T23:39:30.2563159Z","primaryEndpoints":{"blob":"https://cs4aa22d82de270x4becxb48.blob.core.windows.net/","queue":"https://cs4aa22d82de270x4becxb48.queue.core.windows.net/","table":"https://cs4aa22d82de270x4becxb48.table.core.windows.net/","file":"https://cs4aa22d82de270x4becxb48.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guptar2/providers/Microsoft.Storage/storageAccounts/guptar2storagecloudshell","name":"guptar2storagecloudshell","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{"ms-resource-usage":"azure-cloud-shell"},"properties":{"keyCreationTime":{"key1":"2022-09-13T23:27:57.8525804Z","key2":"2022-09-13T23:27:57.8525804Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-09-13T23:27:57.8525804Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-09-13T23:27:57.8525804Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-09-13T23:27:57.7431842Z","primaryEndpoints":{"dfs":"https://guptar2storagecloudshell.dfs.core.windows.net/","web":"https://guptar2storagecloudshell.z22.web.core.windows.net/","blob":"https://guptar2storagecloudshell.blob.core.windows.net/","queue":"https://guptar2storagecloudshell.queue.core.windows.net/","table":"https://guptar2storagecloudshell.table.core.windows.net/","file":"https://guptar2storagecloudshell.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guptar/providers/Microsoft.Storage/storageAccounts/guptardevstorage","name":"guptardevstorage","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{"ms-resource-usage":"azure-cloud-shell"},"properties":{"keyCreationTime":{"key1":"2022-02-15T16:49:43.1435156Z","key2":"2022-02-15T16:49:43.1435156Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-02-15T16:49:43.1591440Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-02-15T16:49:43.1591440Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-02-15T16:49:43.0341047Z","primaryEndpoints":{"dfs":"https://guptardevstorage.dfs.core.windows.net/","web":"https://guptardevstorage.z22.web.core.windows.net/","blob":"https://guptardevstorage.blob.core.windows.net/","queue":"https://guptardevstorage.queue.core.windows.net/","table":"https://guptardevstorage.table.core.windows.net/","file":"https://guptardevstorage.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SCRunner/providers/Microsoft.Storage/storageAccounts/scrunnerstorage","name":"scrunnerstorage","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-03-06T00:42:11.7016543Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-03-06T00:42:11.7016543Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2018-03-06T00:42:11.6234985Z","primaryEndpoints":{"blob":"https://scrunnerstorage.blob.core.windows.net/","queue":"https://scrunnerstorage.queue.core.windows.net/","table":"https://scrunnerstorage.table.core.windows.net/","file":"https://scrunnerstorage.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloud-shell-storage-southcentralus/providers/Microsoft.Storage/storageAccounts/cs710032001417ec1a8","name":"cs710032001417ec1a8","type":"Microsoft.Storage/storageAccounts","location":"southcentralus","tags":{"ms-resource-usage":"azure-cloud-shell"},"properties":{"keyCreationTime":{"key1":"2021-05-18T22:07:33.4170256Z","key2":"2021-05-18T22:07:33.4170256Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2021-05-18T22:07:33.4170256Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2021-05-18T22:07:33.4170256Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2021-05-18T22:07:33.3389725Z","primaryEndpoints":{"dfs":"https://cs710032001417ec1a8.dfs.core.windows.net/","web":"https://cs710032001417ec1a8.z21.web.core.windows.net/","blob":"https://cs710032001417ec1a8.blob.core.windows.net/","queue":"https://cs710032001417ec1a8.queue.core.windows.net/","table":"https://cs710032001417ec1a8.table.core.windows.net/","file":"https://cs710032001417ec1a8.file.core.windows.net/"},"primaryLocation":"southcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rhoover/providers/Microsoft.Storage/storageAccounts/rhooverstorage","name":"rhooverstorage","type":"Microsoft.Storage/storageAccounts","location":"southcentralus","tags":{"ms-resource-usage":"azure-cloud-shell"},"properties":{"keyCreationTime":{"key1":"2022-05-26T17:14:23.5085026Z","key2":"2022-05-26T17:14:23.5085026Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-26T17:14:23.5241285Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-26T17:14:23.5241285Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-05-26T17:14:23.4147520Z","primaryEndpoints":{"dfs":"https://rhooverstorage.dfs.core.windows.net/","web":"https://rhooverstorage.z21.web.core.windows.net/","blob":"https://rhooverstorage.blob.core.windows.net/","queue":"https://rhooverstorage.queue.core.windows.net/","table":"https://rhooverstorage.table.core.windows.net/","file":"https://rhooverstorage.file.core.windows.net/"},"primaryLocation":"southcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/harish-storage/providers/Microsoft.Storage/storageAccounts/aueastsarestricted","name":"aueastsarestricted","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-07-17T04:32:04.7486474Z","key2":"2022-07-17T04:32:04.7486474Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/harish-networking/providers/Microsoft.Network/virtualNetworks/aueast-vnet/subnets/testing","action":"Allow","state":"Succeeded"}],"ipRules":[],"defaultAction":"Deny"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-07-17T04:32:04.7486474Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-07-17T04:32:04.7486474Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-07-17T04:32:04.6861236Z","primaryEndpoints":{"dfs":"https://aueastsarestricted.dfs.core.windows.net/","web":"https://aueastsarestricted.z8.web.core.windows.net/","blob":"https://aueastsarestricted.blob.core.windows.net/","queue":"https://aueastsarestricted.queue.core.windows.net/","table":"https://aueastsarestricted.table.core.windows.net/","file":"https://aueastsarestricted.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/harish-storage/providers/Microsoft.Storage/storageAccounts/aueastsastd","name":"aueastsastd","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-07-17T04:28:55.7260171Z","key2":"2022-07-17T04:28:55.7260171Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-07-17T04:28:55.7416401Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-07-17T04:28:55.7416401Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-07-17T04:28:55.6634675Z","primaryEndpoints":{"dfs":"https://aueastsastd.dfs.core.windows.net/","web":"https://aueastsastd.z8.web.core.windows.net/","blob":"https://aueastsastd.blob.core.windows.net/","queue":"https://aueastsastd.queue.core.windows.net/","table":"https://aueastsastd.table.core.windows.net/","file":"https://aueastsastd.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SCRunnertestvmrg-AustraliaEast/providers/Microsoft.Storage/storageAccounts/scrunner4p3t72mzheluc","name":"scrunner4p3t72mzheluc","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{},"properties":{"keyCreationTime":{"key1":"2021-04-13T22:35:36.6210942Z","key2":"2021-04-13T22:35:36.6210942Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2021-04-13T22:35:36.6210942Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2021-04-13T22:35:36.6210942Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2021-04-13T22:35:36.5429508Z","primaryEndpoints":{"blob":"https://scrunner4p3t72mzheluc.blob.core.windows.net/","queue":"https://scrunner4p3t72mzheluc.queue.core.windows.net/","table":"https://scrunner4p3t72mzheluc.table.core.windows.net/","file":"https://scrunner4p3t72mzheluc.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002","name":"cli000002","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2022-12-13T22:51:17.0682893Z","key2":"2022-12-13T22:51:17.0682893Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-12-13T22:51:17.6307939Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-12-13T22:51:17.6307939Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-12-13T22:51:16.9745683Z","primaryEndpoints":{"blob":"https://cli000002.blob.core.windows.net/","queue":"https://cli000002.queue.core.windows.net/","table":"https://cli000002.table.core.windows.net/","file":"https://cli000002.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsoleimai244luxkv4qi3pzelwnexgjxzvq5n6g6erlqn6mucntnjyn2lt/providers/Microsoft.Storage/storageAccounts/cliaa3vl7jr6zshgrsmarb6m","name":"cliaa3vl7jr6zshgrsmarb6m","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2022-10-12T19:18:45.9704319Z","key2":"2022-10-12T19:18:45.9704319Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-10-12T19:18:46.6892063Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-10-12T19:18:46.6892063Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-10-12T19:18:45.8923129Z","primaryEndpoints":{"blob":"https://cliaa3vl7jr6zshgrsmarb6m.blob.core.windows.net/","queue":"https://cliaa3vl7jr6zshgrsmarb6m.queue.core.windows.net/","table":"https://cliaa3vl7jr6zshgrsmarb6m.table.core.windows.net/","file":"https://cliaa3vl7jr6zshgrsmarb6m.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsoleuprs6wnhhkthfvk3g347c54erbdpkxj7og4vdd5jrhlsj2i6a4y7z/providers/Microsoft.Storage/storageAccounts/cliit6yvjuhqdolxqkfrxi5p","name":"cliit6yvjuhqdolxqkfrxi5p","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2022-09-28T02:55:03.4203450Z","key2":"2022-09-28T02:55:03.4203450Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-09-28T02:55:03.8890983Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-09-28T02:55:03.8890983Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-09-28T02:55:03.3421930Z","primaryEndpoints":{"blob":"https://cliit6yvjuhqdolxqkfrxi5p.blob.core.windows.net/","queue":"https://cliit6yvjuhqdolxqkfrxi5p.queue.core.windows.net/","table":"https://cliit6yvjuhqdolxqkfrxi5p.table.core.windows.net/","file":"https://cliit6yvjuhqdolxqkfrxi5p.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsolefxqkhafj52ep4gg474dntlscgprhtrbvwhs2ff4fvipbw5tg2cexz/providers/Microsoft.Storage/storageAccounts/clipfdv4l2hramy2ysuln7bs","name":"clipfdv4l2hramy2ysuln7bs","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2022-10-12T19:55:35.0170190Z","key2":"2022-10-12T19:55:35.0170190Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-10-12T19:55:35.4701769Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-10-12T19:55:35.4701769Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-10-12T19:55:34.9076957Z","primaryEndpoints":{"blob":"https://clipfdv4l2hramy2ysuln7bs.blob.core.windows.net/","queue":"https://clipfdv4l2hramy2ysuln7bs.queue.core.windows.net/","table":"https://clipfdv4l2hramy2ysuln7bs.table.core.windows.net/","file":"https://clipfdv4l2hramy2ysuln7bs.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guptar2/providers/Microsoft.Storage/storageAccounts/guptar2diagnosticsv1","name":"guptar2diagnosticsv1","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2022-04-05T17:21:41.8250582Z","key2":"2022-04-05T17:21:41.8250582Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:21:41.8250582Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:21:41.8250582Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-04-05T17:21:41.7313240Z","primaryEndpoints":{"blob":"https://guptar2diagnosticsv1.blob.core.windows.net/","queue":"https://guptar2diagnosticsv1.queue.core.windows.net/","table":"https://guptar2diagnosticsv1.table.core.windows.net/","file":"https://guptar2diagnosticsv1.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guptar2/providers/Microsoft.Storage/storageAccounts/guptar2diagnosticsv2","name":"guptar2diagnosticsv2","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-04-05T17:22:55.8411567Z","key2":"2022-04-05T17:22:55.8411567Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"resourceAccessRules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[{"value":"20.98.146.84","action":"Allow"},{"value":"20.83.222.102","action":"Allow"},{"value":"20.98.194.64","action":"Allow"},{"value":"20.69.5.162","action":"Allow"}],"defaultAction":"Deny"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:22:55.8411567Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:22:55.8411567Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-04-05T17:22:55.7318000Z","primaryEndpoints":{"dfs":"https://guptar2diagnosticsv2.dfs.core.windows.net/","web":"https://guptar2diagnosticsv2.z5.web.core.windows.net/","blob":"https://guptar2diagnosticsv2.blob.core.windows.net/","queue":"https://guptar2diagnosticsv2.queue.core.windows.net/","table":"https://guptar2diagnosticsv2.table.core.windows.net/","file":"https://guptar2diagnosticsv2.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sericonrp-trafficmanager/providers/Microsoft.Storage/storageAccounts/sericonrpdevtmstorage","name":"sericonrpdevtmstorage","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-11-30T19:15:41.5013570Z","key2":"2022-11-30T19:15:41.5013570Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-11-30T19:15:42.0638737Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-11-30T19:15:42.0638737Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-11-30T19:15:41.4075777Z","primaryEndpoints":{"dfs":"https://sericonrpdevtmstorage.dfs.core.windows.net/","web":"https://sericonrpdevtmstorage.z5.web.core.windows.net/","blob":"https://sericonrpdevtmstorage.blob.core.windows.net/","queue":"https://sericonrpdevtmstorage.queue.core.windows.net/","table":"https://sericonrpdevtmstorage.table.core.windows.net/","file":"https://sericonrpdevtmstorage.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available","secondaryLocation":"westcentralus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://sericonrpdevtmstorage-secondary.dfs.core.windows.net/","web":"https://sericonrpdevtmstorage-secondary.z5.web.core.windows.net/","blob":"https://sericonrpdevtmstorage-secondary.blob.core.windows.net/","queue":"https://sericonrpdevtmstorage-secondary.queue.core.windows.net/","table":"https://sericonrpdevtmstorage-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guptar2/providers/Microsoft.Storage/storageAccounts/guptar3storage","name":"guptar3storage","type":"Microsoft.Storage/storageAccounts","location":"westcentralus","tags":{},"properties":{"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-09-20T21:34:53.7867708Z","key2":"2022-09-20T21:34:53.7867708Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"resourceAccessRules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[{"value":"20.98.146.84","action":"Allow"},{"value":"20.98.194.64","action":"Allow"},{"value":"20.69.5.162","action":"Allow"},{"value":"20.83.222.102","action":"Allow"}],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-09-20T21:34:53.8024125Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-09-20T21:34:53.8024125Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-09-20T21:34:53.7086332Z","primaryEndpoints":{"blob":"https://guptar3storage.blob.core.windows.net/","queue":"https://guptar3storage.queue.core.windows.net/","table":"https://guptar3storage.table.core.windows.net/","file":"https://guptar3storage.file.core.windows.net/"},"primaryLocation":"westcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rhoover-dev-rg/providers/Microsoft.Storage/storageAccounts/rhooverdevrgdiag","name":"rhooverdevrgdiag","type":"Microsoft.Storage/storageAccounts","location":"westcentralus","tags":{},"properties":{"defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-06-20T19:39:24.4605968Z","key2":"2022-06-20T19:39:24.4605968Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":false,"networkAcls":{"resourceAccessRules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[{"value":"20.98.146.84","action":"Allow"},{"value":"20.98.194.64","action":"Allow"},{"value":"20.69.5.162","action":"Allow"},{"value":"20.83.222.102","action":"Allow"}],"defaultAction":"Deny"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-06-20T19:39:24.4762287Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-06-20T19:39:24.4762287Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-06-20T19:39:24.4137057Z","primaryEndpoints":{"blob":"https://rhooverdevrgdiag.blob.core.windows.net/","queue":"https://rhooverdevrgdiag.queue.core.windows.net/","table":"https://rhooverdevrgdiag.table.core.windows.net/","file":"https://rhooverdevrgdiag.file.core.windows.net/"},"primaryLocation":"westcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnertestvmrg-westcentralus/providers/Microsoft.Storage/storageAccounts/scrunnerrfscmqxeni3uq","name":"scrunnerrfscmqxeni3uq","type":"Microsoft.Storage/storageAccounts","location":"westcentralus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-04-10T22:28:55.2104910Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-04-10T22:28:55.2104910Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-04-10T22:28:55.1479670Z","primaryEndpoints":{"blob":"https://scrunnerrfscmqxeni3uq.blob.core.windows.net/","queue":"https://scrunnerrfscmqxeni3uq.queue.core.windows.net/","table":"https://scrunnerrfscmqxeni3uq.table.core.windows.net/","file":"https://scrunnerrfscmqxeni3uq.file.core.windows.net/"},"primaryLocation":"westcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ubuntu-westus3_group/providers/Microsoft.Storage/storageAccounts/ubuntuwestus3groupdiag","name":"ubuntuwestus3groupdiag","type":"Microsoft.Storage/storageAccounts","location":"westus3","tags":{},"properties":{"keyCreationTime":{"key1":"2022-04-18T19:48:38.9882588Z","key2":"2022-04-18T19:48:38.9882588Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-18T19:48:38.9882588Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-18T19:48:38.9882588Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-04-18T19:48:38.9258191Z","primaryEndpoints":{"blob":"https://ubuntuwestus3groupdiag.blob.core.windows.net/","queue":"https://ubuntuwestus3groupdiag.queue.core.windows.net/","table":"https://ubuntuwestus3groupdiag.table.core.windows.net/","file":"https://ubuntuwestus3groupdiag.file.core.windows.net/"},"primaryLocation":"westus3","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guptar2/providers/Microsoft.Storage/storageAccounts/cloudshellcanarystorage","name":"cloudshellcanarystorage","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"keyCreationTime":{"key1":"2022-08-01T21:16:45.8824319Z","key2":"2022-08-01T21:16:45.8824319Z"},"allowCrossTenantReplication":false,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-08-01T21:16:46.0855567Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-08-01T21:16:46.0855567Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-08-01T21:16:45.8043474Z","primaryEndpoints":{"dfs":"https://cloudshellcanarystorage.dfs.core.windows.net/","web":"https://cloudshellcanarystorage.z3.web.core.windows.net/","blob":"https://cloudshellcanarystorage.blob.core.windows.net/","queue":"https://cloudshellcanarystorage.queue.core.windows.net/","table":"https://cloudshellcanarystorage.table.core.windows.net/","file":"https://cloudshellcanarystorage.file.core.windows.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}}]}'
+      string: '{"value":[{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloud-shell-storage-eastus/providers/Microsoft.Storage/storageAccounts/cs210032001f4814ba9","name":"cs210032001f4814ba9","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"ms-resource-usage":"azure-cloud-shell"},"properties":{"keyCreationTime":{"key1":"2022-05-16T14:16:22.3477819Z","key2":"2022-05-16T14:16:22.3477819Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-16T14:16:22.3477819Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-16T14:16:22.3477819Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-05-16T14:16:22.2227752Z","primaryEndpoints":{"dfs":"https://cs210032001f4814ba9.dfs.core.windows.net/","web":"https://cs210032001f4814ba9.z13.web.core.windows.net/","blob":"https://cs210032001f4814ba9.blob.core.windows.net/","queue":"https://cs210032001f4814ba9.queue.core.windows.net/","table":"https://cs210032001f4814ba9.table.core.windows.net/","file":"https://cs210032001f4814ba9.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/kustoflow/providers/Microsoft.Storage/storageAccounts/csslinuxkustoflow","name":"csslinuxkustoflow","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"CreatedBy":"craigw"},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-02-01T20:08:38.6849654Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-02-01T20:08:38.6849654Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2019-02-01T20:08:38.5912170Z","primaryEndpoints":{"dfs":"https://csslinuxkustoflow.dfs.core.windows.net/","web":"https://csslinuxkustoflow.z13.web.core.windows.net/","blob":"https://csslinuxkustoflow.blob.core.windows.net/","queue":"https://csslinuxkustoflow.queue.core.windows.net/","table":"https://csslinuxkustoflow.table.core.windows.net/","file":"https://csslinuxkustoflow.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://csslinuxkustoflow-secondary.dfs.core.windows.net/","web":"https://csslinuxkustoflow-secondary.z13.web.core.windows.net/","blob":"https://csslinuxkustoflow-secondary.blob.core.windows.net/","queue":"https://csslinuxkustoflow-secondary.queue.core.windows.net/","table":"https://csslinuxkustoflow-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guidomassonitest-rg/providers/Microsoft.Storage/storageAccounts/guidomassonitestrg88ad","name":"guidomassonitestrg88ad","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-01-23T18:52:02.5484088Z","key2":"2023-01-23T18:52:02.5484088Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-01-23T18:52:02.5484088Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-01-23T18:52:02.5484088Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-01-23T18:52:02.4077698Z","primaryEndpoints":{"blob":"https://guidomassonitestrg88ad.blob.core.windows.net/","queue":"https://guidomassonitestrg88ad.queue.core.windows.net/","table":"https://guidomassonitestrg88ad.table.core.windows.net/","file":"https://guidomassonitestrg88ad.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guidomtesttrafficmanagerrg/providers/Microsoft.Storage/storageAccounts/guidomteststoraccfortm","name":"guidomteststoraccfortm","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-10-18T18:01:13.5231266Z","key2":"2022-10-18T18:01:13.5231266Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-10-18T18:01:13.5387607Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-10-18T18:01:13.5387607Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-10-18T18:01:13.3825002Z","primaryEndpoints":{"dfs":"https://guidomteststoraccfortm.dfs.core.windows.net/","web":"https://guidomteststoraccfortm.z13.web.core.windows.net/","blob":"https://guidomteststoraccfortm.blob.core.windows.net/","queue":"https://guidomteststoraccfortm.queue.core.windows.net/","table":"https://guidomteststoraccfortm.table.core.windows.net/","file":"https://guidomteststoraccfortm.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://guidomteststoraccfortm-secondary.dfs.core.windows.net/","web":"https://guidomteststoraccfortm-secondary.z13.web.core.windows.net/","blob":"https://guidomteststoraccfortm-secondary.blob.core.windows.net/","queue":"https://guidomteststoraccfortm-secondary.queue.core.windows.net/","table":"https://guidomteststoraccfortm-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnertestvmrg-eastus/providers/Microsoft.Storage/storageAccounts/scrunnercrkwpdn5nhtgg","name":"scrunnercrkwpdn5nhtgg","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-05-12T20:03:57.6389684Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-05-12T20:03:57.6389684Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-05-12T20:03:57.5451905Z","primaryEndpoints":{"blob":"https://scrunnercrkwpdn5nhtgg.blob.core.windows.net/","queue":"https://scrunnercrkwpdn5nhtgg.queue.core.windows.net/","table":"https://scrunnercrkwpdn5nhtgg.table.core.windows.net/","file":"https://scrunnercrkwpdn5nhtgg.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnervmrg-eastus/providers/Microsoft.Storage/storageAccounts/scrunneri2ezqh4xu2wqq","name":"scrunneri2ezqh4xu2wqq","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-02-11T08:01:12.9383535Z","key2":"2023-02-11T08:01:12.9383535Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:01:12.9383535Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:01:12.9383535Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-02-11T08:01:12.6883669Z","primaryEndpoints":{"blob":"https://scrunneri2ezqh4xu2wqq.blob.core.windows.net/","queue":"https://scrunneri2ezqh4xu2wqq.queue.core.windows.net/","table":"https://scrunneri2ezqh4xu2wqq.table.core.windows.net/","file":"https://scrunneri2ezqh4xu2wqq.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/serialTest-EastUS/providers/Microsoft.Storage/storageAccounts/serialtesta8d7fdee41","name":"serialtesta8d7fdee41","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-07-11T00:38:13.5389932Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-07-11T00:38:13.5389932Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2019-07-11T00:38:13.4452119Z","primaryEndpoints":{"blob":"https://serialtesta8d7fdee41.blob.core.windows.net/","queue":"https://serialtesta8d7fdee41.queue.core.windows.net/","table":"https://serialtesta8d7fdee41.table.core.windows.net/","file":"https://serialtesta8d7fdee41.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/storage-RG/providers/Microsoft.Storage/storageAccounts/serialtestbootdiag123","name":"serialtestbootdiag123","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-01-23T04:03:01.3263151Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-01-23T04:03:01.3263151Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2018-01-23T04:03:01.2951106Z","primaryEndpoints":{"blob":"https://serialtestbootdiag123.blob.core.windows.net/","queue":"https://serialtestbootdiag123.queue.core.windows.net/","table":"https://serialtestbootdiag123.table.core.windows.net/","file":"https://serialtestbootdiag123.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yuas-rg/providers/Microsoft.Storage/storageAccounts/yuasstorageacct","name":"yuasstorageacct","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-08-02T12:18:18.8547131Z","key2":"2022-08-02T12:18:18.8547131Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-08-02T12:18:18.8547131Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-08-02T12:18:18.8547131Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-08-02T12:18:18.7140969Z","primaryEndpoints":{"dfs":"https://yuasstorageacct.dfs.core.windows.net/","web":"https://yuasstorageacct.z13.web.core.windows.net/","blob":"https://yuasstorageacct.blob.core.windows.net/","queue":"https://yuasstorageacct.queue.core.windows.net/","table":"https://yuasstorageacct.table.core.windows.net/","file":"https://yuasstorageacct.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://yuasstorageacct-secondary.dfs.core.windows.net/","web":"https://yuasstorageacct-secondary.z13.web.core.windows.net/","blob":"https://yuasstorageacct-secondary.blob.core.windows.net/","queue":"https://yuasstorageacct-secondary.queue.core.windows.net/","table":"https://yuasstorageacct-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/bkerrigan-dev-rg/providers/Microsoft.Storage/storageAccounts/bktestsa2","name":"bktestsa2","type":"Microsoft.Storage/storageAccounts","location":"eastus2","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","immutableStorageWithVersioning":{"enabled":true},"keyCreationTime":{"key1":"2022-09-27T23:58:45.6496284Z","key2":"2022-09-27T23:58:45.6496284Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-09-27T23:58:46.2902461Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-09-27T23:58:46.2902461Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Cool","provisioningState":"Succeeded","creationTime":"2022-09-27T23:58:45.5558609Z","primaryEndpoints":{"dfs":"https://bktestsa2.dfs.core.windows.net/","web":"https://bktestsa2.z20.web.core.windows.net/","blob":"https://bktestsa2.blob.core.windows.net/","queue":"https://bktestsa2.queue.core.windows.net/","table":"https://bktestsa2.table.core.windows.net/","file":"https://bktestsa2.file.core.windows.net/"},"primaryLocation":"eastus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rhel-test/providers/Microsoft.Storage/storageAccounts/rhel77acct","name":"rhel77acct","type":"Microsoft.Storage/storageAccounts","location":"eastus2","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-08-13T20:31:30.8995173Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-08-13T20:31:30.8995173Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-08-13T20:31:30.8215811Z","primaryEndpoints":{"blob":"https://rhel77acct.blob.core.windows.net/","queue":"https://rhel77acct.queue.core.windows.net/","table":"https://rhel77acct.table.core.windows.net/","file":"https://rhel77acct.file.core.windows.net/"},"primaryLocation":"eastus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SCRunner/providers/Microsoft.Storage/storageAccounts/scrunnerstorage","name":"scrunnerstorage","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-03-06T00:42:11.7016543Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-03-06T00:42:11.7016543Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2018-03-06T00:42:11.6234985Z","primaryEndpoints":{"blob":"https://scrunnerstorage.blob.core.windows.net/","queue":"https://scrunnerstorage.queue.core.windows.net/","table":"https://scrunnerstorage.table.core.windows.net/","file":"https://scrunnerstorage.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rhoover/providers/Microsoft.Storage/storageAccounts/rhooverstorage","name":"rhooverstorage","type":"Microsoft.Storage/storageAccounts","location":"southcentralus","tags":{"ms-resource-usage":"azure-cloud-shell"},"properties":{"keyCreationTime":{"key1":"2022-05-26T17:14:23.5085026Z","key2":"2022-05-26T17:14:23.5085026Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-26T17:14:23.5241285Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-26T17:14:23.5241285Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-05-26T17:14:23.4147520Z","primaryEndpoints":{"dfs":"https://rhooverstorage.dfs.core.windows.net/","web":"https://rhooverstorage.z21.web.core.windows.net/","blob":"https://rhooverstorage.blob.core.windows.net/","queue":"https://rhooverstorage.queue.core.windows.net/","table":"https://rhooverstorage.table.core.windows.net/","file":"https://rhooverstorage.file.core.windows.net/"},"primaryLocation":"southcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SCRunnertestvmrg-AustraliaEast/providers/Microsoft.Storage/storageAccounts/scrunner4p3t72mzheluc","name":"scrunner4p3t72mzheluc","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{},"properties":{"keyCreationTime":{"key1":"2021-04-13T22:35:36.6210942Z","key2":"2021-04-13T22:35:36.6210942Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2021-04-13T22:35:36.6210942Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2021-04-13T22:35:36.6210942Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2021-04-13T22:35:36.5429508Z","primaryEndpoints":{"blob":"https://scrunner4p3t72mzheluc.blob.core.windows.net/","queue":"https://scrunner4p3t72mzheluc.queue.core.windows.net/","table":"https://scrunner4p3t72mzheluc.table.core.windows.net/","file":"https://scrunner4p3t72mzheluc.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnervmrg-australiaeast/providers/Microsoft.Storage/storageAccounts/scrunner56hymyctm4kw2","name":"scrunner56hymyctm4kw2","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{},"properties":{"keyCreationTime":{"key1":"2023-02-11T08:42:58.2414102Z","key2":"2023-02-11T08:42:58.2414102Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:42:59.3196006Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:42:59.3196006Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-02-11T08:42:58.1476588Z","primaryEndpoints":{"blob":"https://scrunner56hymyctm4kw2.blob.core.windows.net/","queue":"https://scrunner56hymyctm4kw2.queue.core.windows.net/","table":"https://scrunner56hymyctm4kw2.table.core.windows.net/","file":"https://scrunner56hymyctm4kw2.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsolestuzi7ftnukpi2fyagwys225gbsh73m2h2z7zwjnemrgl5jrfrevg/providers/Microsoft.Storage/storageAccounts/clij3widgfvooidlncm4zwgr","name":"clij3widgfvooidlncm4zwgr","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T14:54:24.1363998Z","key2":"2023-03-06T14:54:24.1363998Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.6364190Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.6364190Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T14:54:24.0114062Z","primaryEndpoints":{"blob":"https://clij3widgfvooidlncm4zwgr.blob.core.windows.net/","queue":"https://clij3widgfvooidlncm4zwgr.queue.core.windows.net/","table":"https://clij3widgfvooidlncm4zwgr.table.core.windows.net/","file":"https://clij3widgfvooidlncm4zwgr.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole5tcj2ew64bk7ldvza4svhihc3neijmp2pf772b3gbkcg66mpvtqch/providers/Microsoft.Storage/storageAccounts/clinweeode546qd5ftxj3u56","name":"clinweeode546qd5ftxj3u56","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T14:54:25.0895677Z","key2":"2023-03-06T14:54:25.0895677Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:25.7770917Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:25.7770917Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T14:54:24.9801941Z","primaryEndpoints":{"blob":"https://clinweeode546qd5ftxj3u56.blob.core.windows.net/","queue":"https://clinweeode546qd5ftxj3u56.queue.core.windows.net/","table":"https://clinweeode546qd5ftxj3u56.table.core.windows.net/","file":"https://clinweeode546qd5ftxj3u56.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsolex4geueyy52iloaspyxz3rrqwxv2syvnkjiljxbv522buwxqpiljme/providers/Microsoft.Storage/storageAccounts/clipf6qz5nxegbgku5yqzkd2","name":"clipf6qz5nxegbgku5yqzkd2","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T07:45:44.7937561Z","key2":"2023-03-06T07:45:44.7937561Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:45:45.1687946Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:45:45.1687946Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T07:45:44.7000168Z","primaryEndpoints":{"blob":"https://clipf6qz5nxegbgku5yqzkd2.blob.core.windows.net/","queue":"https://clipf6qz5nxegbgku5yqzkd2.queue.core.windows.net/","table":"https://clipf6qz5nxegbgku5yqzkd2.table.core.windows.net/","file":"https://clipf6qz5nxegbgku5yqzkd2.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsolep35rualbmodx4sho6gltgwspkbsxnsj34im3hqgkvnopy3hqugcaw/providers/Microsoft.Storage/storageAccounts/clite7vcjveueljfi27rolvu","name":"clite7vcjveueljfi27rolvu","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T14:54:23.8082415Z","key2":"2023-03-06T14:54:23.8082415Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.5270280Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.5270280Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T14:54:23.6989027Z","primaryEndpoints":{"blob":"https://clite7vcjveueljfi27rolvu.blob.core.windows.net/","queue":"https://clite7vcjveueljfi27rolvu.queue.core.windows.net/","table":"https://clite7vcjveueljfi27rolvu.table.core.windows.net/","file":"https://clite7vcjveueljfi27rolvu.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsoledcvrpndxic4emeqq5apwkns4qa5owpy4jn3b536ks35zdrmn7bl5k/providers/Microsoft.Storage/storageAccounts/cliwqnm2fo7pftnxlk7c734i","name":"cliwqnm2fo7pftnxlk7c734i","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T07:34:57.7461613Z","key2":"2023-03-06T07:34:57.7461613Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:34:57.9961851Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:34:57.9961851Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T07:34:57.6368148Z","primaryEndpoints":{"blob":"https://cliwqnm2fo7pftnxlk7c734i.blob.core.windows.net/","queue":"https://cliwqnm2fo7pftnxlk7c734i.queue.core.windows.net/","table":"https://cliwqnm2fo7pftnxlk7c734i.table.core.windows.net/","file":"https://cliwqnm2fo7pftnxlk7c734i.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002","name":"cli000002","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T14:54:24.1208364Z","key2":"2023-03-06T14:54:24.1208364Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.6676739Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.6676739Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T14:54:24.0114062Z","primaryEndpoints":{"blob":"https://cli000002.blob.core.windows.net/","queue":"https://cli000002.queue.core.windows.net/","table":"https://cli000002.table.core.windows.net/","file":"https://cli000002.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guptar2/providers/Microsoft.Storage/storageAccounts/guptar2diagnosticsv1","name":"guptar2diagnosticsv1","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2022-04-05T17:21:41.8250582Z","key2":"2022-04-05T17:21:41.8250582Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:21:41.8250582Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:21:41.8250582Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-04-05T17:21:41.7313240Z","primaryEndpoints":{"blob":"https://guptar2diagnosticsv1.blob.core.windows.net/","queue":"https://guptar2diagnosticsv1.queue.core.windows.net/","table":"https://guptar2diagnosticsv1.table.core.windows.net/","file":"https://guptar2diagnosticsv1.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guptar2/providers/Microsoft.Storage/storageAccounts/guptar2diagnosticsv2","name":"guptar2diagnosticsv2","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-04-05T17:22:55.8411567Z","key2":"2022-04-05T17:22:55.8411567Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"resourceAccessRules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[{"value":"20.98.146.84","action":"Allow"},{"value":"20.83.222.102","action":"Allow"},{"value":"20.98.194.64","action":"Allow"},{"value":"20.69.5.162","action":"Allow"}],"defaultAction":"Deny"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:22:55.8411567Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:22:55.8411567Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-04-05T17:22:55.7318000Z","primaryEndpoints":{"dfs":"https://guptar2diagnosticsv2.dfs.core.windows.net/","web":"https://guptar2diagnosticsv2.z5.web.core.windows.net/","blob":"https://guptar2diagnosticsv2.blob.core.windows.net/","queue":"https://guptar2diagnosticsv2.queue.core.windows.net/","table":"https://guptar2diagnosticsv2.table.core.windows.net/","file":"https://guptar2diagnosticsv2.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sericonrp-trafficmanager/providers/Microsoft.Storage/storageAccounts/sericonrpdevtmstorage","name":"sericonrpdevtmstorage","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-11-30T19:15:41.5013570Z","key2":"2022-11-30T19:15:41.5013570Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-11-30T19:15:42.0638737Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-11-30T19:15:42.0638737Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-11-30T19:15:41.4075777Z","primaryEndpoints":{"dfs":"https://sericonrpdevtmstorage.dfs.core.windows.net/","web":"https://sericonrpdevtmstorage.z5.web.core.windows.net/","blob":"https://sericonrpdevtmstorage.blob.core.windows.net/","queue":"https://sericonrpdevtmstorage.queue.core.windows.net/","table":"https://sericonrpdevtmstorage.table.core.windows.net/","file":"https://sericonrpdevtmstorage.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available","secondaryLocation":"westcentralus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://sericonrpdevtmstorage-secondary.dfs.core.windows.net/","web":"https://sericonrpdevtmstorage-secondary.z5.web.core.windows.net/","blob":"https://sericonrpdevtmstorage-secondary.blob.core.windows.net/","queue":"https://sericonrpdevtmstorage-secondary.queue.core.windows.net/","table":"https://sericonrpdevtmstorage-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ops/providers/Microsoft.Storage/storageAccounts/sericonstorage","name":"sericonstorage","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2023-03-05T19:58:00.4355863Z","key2":"2023-03-05T19:58:00.4355863Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-05T19:58:00.9824831Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-05T19:58:00.9824831Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2023-03-05T19:58:00.3262342Z","primaryEndpoints":{"dfs":"https://sericonstorage.dfs.core.windows.net/","web":"https://sericonstorage.z5.web.core.windows.net/","blob":"https://sericonstorage.blob.core.windows.net/","queue":"https://sericonstorage.queue.core.windows.net/","table":"https://sericonstorage.table.core.windows.net/","file":"https://sericonstorage.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rhoover-dev-rg/providers/Microsoft.Storage/storageAccounts/rhooverdevrgdiag","name":"rhooverdevrgdiag","type":"Microsoft.Storage/storageAccounts","location":"westcentralus","tags":{},"properties":{"defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-06-20T19:39:24.4605968Z","key2":"2022-06-20T19:39:24.4605968Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":false,"networkAcls":{"resourceAccessRules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[{"value":"20.98.146.84","action":"Allow"},{"value":"20.98.194.64","action":"Allow"},{"value":"20.69.5.162","action":"Allow"},{"value":"20.83.222.102","action":"Allow"},{"value":"76.197.206.105","action":"Allow"}],"defaultAction":"Deny"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-06-20T19:39:24.4762287Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-06-20T19:39:24.4762287Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-06-20T19:39:24.4137057Z","primaryEndpoints":{"blob":"https://rhooverdevrgdiag.blob.core.windows.net/","queue":"https://rhooverdevrgdiag.queue.core.windows.net/","table":"https://rhooverdevrgdiag.table.core.windows.net/","file":"https://rhooverdevrgdiag.file.core.windows.net/"},"primaryLocation":"westcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnervmrg-westcentralus/providers/Microsoft.Storage/storageAccounts/scrunneraoptpjec4skce","name":"scrunneraoptpjec4skce","type":"Microsoft.Storage/storageAccounts","location":"westcentralus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-02-11T08:40:40.0686467Z","key2":"2023-02-11T08:40:40.0686467Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:40:40.5842822Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:40:40.5842822Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-02-11T08:40:40.0061730Z","primaryEndpoints":{"blob":"https://scrunneraoptpjec4skce.blob.core.windows.net/","queue":"https://scrunneraoptpjec4skce.queue.core.windows.net/","table":"https://scrunneraoptpjec4skce.table.core.windows.net/","file":"https://scrunneraoptpjec4skce.file.core.windows.net/"},"primaryLocation":"westcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnertestvmrg-westcentralus/providers/Microsoft.Storage/storageAccounts/scrunnerrfscmqxeni3uq","name":"scrunnerrfscmqxeni3uq","type":"Microsoft.Storage/storageAccounts","location":"westcentralus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-04-10T22:28:55.2104910Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-04-10T22:28:55.2104910Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-04-10T22:28:55.1479670Z","primaryEndpoints":{"blob":"https://scrunnerrfscmqxeni3uq.blob.core.windows.net/","queue":"https://scrunnerrfscmqxeni3uq.queue.core.windows.net/","table":"https://scrunnerrfscmqxeni3uq.table.core.windows.net/","file":"https://scrunnerrfscmqxeni3uq.file.core.windows.net/"},"primaryLocation":"westcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ubuntu-westus3_group/providers/Microsoft.Storage/storageAccounts/ubuntuwestus3groupdiag","name":"ubuntuwestus3groupdiag","type":"Microsoft.Storage/storageAccounts","location":"westus3","tags":{},"properties":{"keyCreationTime":{"key1":"2022-04-18T19:48:38.9882588Z","key2":"2022-04-18T19:48:38.9882588Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-18T19:48:38.9882588Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-18T19:48:38.9882588Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-04-18T19:48:38.9258191Z","primaryEndpoints":{"blob":"https://ubuntuwestus3groupdiag.blob.core.windows.net/","queue":"https://ubuntuwestus3groupdiag.queue.core.windows.net/","table":"https://ubuntuwestus3groupdiag.table.core.windows.net/","file":"https://ubuntuwestus3groupdiag.file.core.windows.net/"},"primaryLocation":"westus3","statusOfPrimary":"available"}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '57696'
+      - '42669'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:55:57 GMT
+      - Mon, 06 Mar 2023 14:58:48 GMT
       expires:
       - '-1'
       pragma:
@@ -3604,15 +3309,14 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-original-request-ids:
-      - c6a2aad5-b8ae-4330-8e31-f73862e25a44
-      - d128d52c-2696-4d7a-a9b3-bcbbe5d36150
-      - 330fb37a-a3c3-41ad-8158-93362b17055b
-      - 304ceedb-8767-4a9d-9df8-a2bd52ec639b
-      - 2f5d3e20-c78d-4911-99bd-42e4ec7b6b3c
-      - 10ff9220-483f-43b6-8e84-e9337fa1de10
-      - 1eab786a-a160-4cdb-ab28-4ee96e8c03b0
-      - 3df87300-6453-414c-84c8-af3dda57f7fd
-      - d04a793a-cf18-49d2-b22b-943a0f43ed80
+      - f22a4907-0ed5-4031-9953-7640a80e96ae
+      - 9bdfa2df-19c9-4bc9-98d7-afed8d0f47df
+      - a08c4aa5-1ff6-483a-aff3-9ab90849453d
+      - 8c6dd981-6538-4344-a916-7efb95e87374
+      - a8475e8d-447f-497d-bb2c-511e604ea4dd
+      - 223ba1a7-0064-401c-9e1d-4b7a7073cad8
+      - 606e0be5-d46a-41c6-931d-f5c7d6ee23da
+      - fb0acab2-0e75-4989-99da-fdbc87387f02
     status:
       code: 200
       message: OK
@@ -3620,17 +3324,17 @@ interactions:
     body: '{"location": "westus2", "tags": {"azsecpack": "nonprod", "platformsettings.host_environment.service.platform_optedin_for_rootcerts":
       "true"}, "identity": {"type": "UserAssigned", "userAssignedIdentities": {"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/AzSecPackAutoConfigUA-westus2":
       {}}}, "properties": {"hardwareProfile": {"vmSize": "Standard_DS1_v2"}, "storageProfile":
-      {"osDisk": {"osType": "Linux", "name": "cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e",
+      {"osDisk": {"osType": "Linux", "name": "cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f",
       "caching": "ReadWrite", "createOption": "FromImage", "diskSizeGB": 30, "managedDisk":
-      {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_SERIALCONSOLELMXZIWWK5PS5Z6A7GSGJPKCGAUTWUFSF6S5STLYYHQ6COP3BWYY27/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e",
+      {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_SERIALCONSOLE46W4L74TUUPDKTQIUNEVCDRGNWE77YHJM4DVRHN3I4J7UGNGQPGEM/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f",
       "storageAccountType": "Premium_LRS"}, "deleteOption": "Detach"}, "dataDisks":
-      []}, "osProfile": {"computerName": "cli000003", "adminUsername": "rhl", "linuxConfiguration":
-      {"disablePasswordAuthentication": true, "ssh": {"publicKeys": [{"path": "/home/rhl/.ssh/authorized_keys",
-      "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h"}]},
-      "provisionVMAgent": true, "patchSettings": {"patchMode": "ImageDefault", "assessmentMode":
-      "ImageDefault"}, "enableVMAgentPlatformUpdates": false}, "secrets": [], "allowExtensionOperations":
-      true, "requireGuestProvisionSignal": true}, "networkProfile": {"networkInterfaces":
-      [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic"}]},
+      []}, "osProfile": {"computerName": "cli000003", "adminUsername": "rhoover",
+      "linuxConfiguration": {"disablePasswordAuthentication": true, "ssh": {"publicKeys":
+      [{"path": "/home/rhoover/.ssh/authorized_keys", "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+      REDMOND+rhoover@DESKTOP-XVFR7ID\n"}]}, "provisionVMAgent": true, "patchSettings":
+      {"patchMode": "ImageDefault", "assessmentMode": "ImageDefault"}, "enableVMAgentPlatformUpdates":
+      false}, "secrets": [], "allowExtensionOperations": true, "requireGuestProvisionSignal":
+      true}, "networkProfile": {"networkInterfaces": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic"}]},
       "diagnosticsProfile": {"bootDiagnostics": {"enabled": true, "storageUri": "https://cli000002.blob.core.windows.net/"}}}}'
     headers:
       Accept:
@@ -3642,15 +3346,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '2137'
+      - '2351'
       Content-Type:
       - application/json
       ParameterSetName:
       - -g -n --storage
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?api-version=2022-11-01
   response:
     body:
       string: "{\r\n  \"name\": \"cli000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003\",\r\n
@@ -3660,46 +3364,46 @@ interactions:
         \   \"userAssignedIdentities\": {\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/AzSecPackAutoConfigUA-westus2\":
         {\r\n        \"principalId\": \"684d55e2-8922-4966-a660-2d38ca4a1711\",\r\n
         \       \"clientId\": \"6d45cf55-f311-4228-97b0-c22ae418aad6\"\r\n      }\r\n
-        \   }\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"d54f150a-5634-4201-b5af-271e2cd52432\",\r\n
+        \   }\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"94bb0e59-1bcd-493b-aa53-580e2ad730d7\",\r\n
         \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
         \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
         \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
         \"18.04-LTS\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
-        \"18.04.202212090\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\",\r\n
+        \"18.04.202302100\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\",\r\n
         \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
         \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_SERIALCONSOLELMXZIWWK5PS5Z6A7GSGJPKCGAUTWUFSF6S5STLYYHQ6COP3BWYY27/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\"\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_SERIALCONSOLE46W4L74TUUPDKTQIUNEVCDRGNWE77YHJM4DVRHN3I4J7UGNGQPGEM/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\"\r\n
         \       },\r\n        \"deleteOption\": \"Detach\",\r\n        \"diskSizeGB\":
         30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
-        {\r\n      \"computerName\": \"cli000003\",\r\n      \"adminUsername\": \"rhl\",\r\n
+        {\r\n      \"computerName\": \"cli000003\",\r\n      \"adminUsername\": \"rhoover\",\r\n
         \     \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
         true,\r\n        \"ssh\": {\r\n          \"publicKeys\": [\r\n            {\r\n
-        \             \"path\": \"/home/rhl/.ssh/authorized_keys\",\r\n              \"keyData\":
-        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h\"\r\n
-        \           }\r\n          ]\r\n        },\r\n        \"provisionVMAgent\":
-        true,\r\n        \"patchSettings\": {\r\n          \"patchMode\": \"ImageDefault\",\r\n
-        \         \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n        \"enableVMAgentPlatformUpdates\":
-        false\r\n      },\r\n      \"secrets\": [],\r\n      \"allowExtensionOperations\":
-        true,\r\n      \"requireGuestProvisionSignal\": true\r\n    },\r\n    \"networkProfile\":
-        {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
+        \             \"path\": \"/home/rhoover/.ssh/authorized_keys\",\r\n              \"keyData\":
+        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+        REDMOND+rhoover@DESKTOP-XVFR7ID\\n\"\r\n            }\r\n          ]\r\n        },\r\n
+        \       \"provisionVMAgent\": true,\r\n        \"patchSettings\": {\r\n          \"patchMode\":
+        \"ImageDefault\",\r\n          \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n
+        \       \"enableVMAgentPlatformUpdates\": false\r\n      },\r\n      \"secrets\":
+        [],\r\n      \"allowExtensionOperations\": true,\r\n      \"requireGuestProvisionSignal\":
+        true\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
         \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
         true,\r\n        \"storageUri\": \"https://cli000002.blob.core.windows.net/\"\r\n
         \     }\r\n    },\r\n    \"provisioningState\": \"Updating\",\r\n    \"timeCreated\":
-        \"2022-12-13T22:51:52.3460253+00:00\"\r\n  }\r\n}"
+        \"2023-03-06T14:55:01.5508486+00:00\"\r\n  }\r\n}"
     headers:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/a1c9d71d-9be6-4547-880b-406531e2ecd8?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/a48d89a0-9760-43b5-97a0-9206e2aade23?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
       cache-control:
       - no-cache
       content-length:
-      - '3356'
+      - '3570'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:55:59 GMT
+      - Mon, 06 Mar 2023 14:58:49 GMT
       expires:
       - '-1'
       pragma:
@@ -3716,7 +3420,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/PutVM3Min;599,Microsoft.Compute/PutVM30Min;3006
+      - Microsoft.Compute/PutVM3Min;614,Microsoft.Compute/PutVM30Min;3087
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
     status:
@@ -3736,64 +3440,14 @@ interactions:
       ParameterSetName:
       - -g -n --storage
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/a1c9d71d-9be6-4547-880b-406531e2ecd8?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/a48d89a0-9760-43b5-97a0-9206e2aade23?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T22:55:58.8918036+00:00\",\r\n  \"status\":
-        \"InProgress\",\r\n  \"name\": \"a1c9d71d-9be6-4547-880b-406531e2ecd8\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '134'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 13 Dec 2022 22:55:59 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14972,Microsoft.Compute/GetOperation30Min;29970
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vm boot-diagnostics enable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --storage
-      User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/a1c9d71d-9be6-4547-880b-406531e2ecd8?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
-  response:
-    body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T22:55:58.8918036+00:00\",\r\n  \"endTime\":
-        \"2022-12-13T22:56:03.7355455+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"name\": \"a1c9d71d-9be6-4547-880b-406531e2ecd8\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T14:58:49.1751579+00:00\",\r\n  \"endTime\":
+        \"2023-03-06T14:58:57.5345488+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"name\": \"a48d89a0-9760-43b5-97a0-9206e2aade23\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -3802,7 +3456,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:56:28 GMT
+      - Mon, 06 Mar 2023 14:59:19 GMT
       expires:
       - '-1'
       pragma:
@@ -3819,7 +3473,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14973,Microsoft.Compute/GetOperation30Min;29969
+      - Microsoft.Compute/GetOperation3Min;14950,Microsoft.Compute/GetOperation30Min;29879
     status:
       code: 200
       message: OK
@@ -3837,9 +3491,9 @@ interactions:
       ParameterSetName:
       - -g -n --storage
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?api-version=2022-11-01
   response:
     body:
       string: "{\r\n  \"name\": \"cli000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003\",\r\n
@@ -3849,42 +3503,42 @@ interactions:
         \   \"userAssignedIdentities\": {\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/AzSecPackAutoConfigUA-westus2\":
         {\r\n        \"principalId\": \"684d55e2-8922-4966-a660-2d38ca4a1711\",\r\n
         \       \"clientId\": \"6d45cf55-f311-4228-97b0-c22ae418aad6\"\r\n      }\r\n
-        \   }\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"d54f150a-5634-4201-b5af-271e2cd52432\",\r\n
+        \   }\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"94bb0e59-1bcd-493b-aa53-580e2ad730d7\",\r\n
         \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
         \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
         \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
         \"18.04-LTS\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
-        \"18.04.202212090\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\",\r\n
+        \"18.04.202302100\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\",\r\n
         \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
         \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_SERIALCONSOLELMXZIWWK5PS5Z6A7GSGJPKCGAUTWUFSF6S5STLYYHQ6COP3BWYY27/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\"\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_SERIALCONSOLE46W4L74TUUPDKTQIUNEVCDRGNWE77YHJM4DVRHN3I4J7UGNGQPGEM/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\"\r\n
         \       },\r\n        \"deleteOption\": \"Detach\",\r\n        \"diskSizeGB\":
         30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
-        {\r\n      \"computerName\": \"cli000003\",\r\n      \"adminUsername\": \"rhl\",\r\n
+        {\r\n      \"computerName\": \"cli000003\",\r\n      \"adminUsername\": \"rhoover\",\r\n
         \     \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
         true,\r\n        \"ssh\": {\r\n          \"publicKeys\": [\r\n            {\r\n
-        \             \"path\": \"/home/rhl/.ssh/authorized_keys\",\r\n              \"keyData\":
-        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h\"\r\n
-        \           }\r\n          ]\r\n        },\r\n        \"provisionVMAgent\":
-        true,\r\n        \"patchSettings\": {\r\n          \"patchMode\": \"ImageDefault\",\r\n
-        \         \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n        \"enableVMAgentPlatformUpdates\":
-        false\r\n      },\r\n      \"secrets\": [],\r\n      \"allowExtensionOperations\":
-        true,\r\n      \"requireGuestProvisionSignal\": true\r\n    },\r\n    \"networkProfile\":
-        {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
+        \             \"path\": \"/home/rhoover/.ssh/authorized_keys\",\r\n              \"keyData\":
+        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+        REDMOND+rhoover@DESKTOP-XVFR7ID\\n\"\r\n            }\r\n          ]\r\n        },\r\n
+        \       \"provisionVMAgent\": true,\r\n        \"patchSettings\": {\r\n          \"patchMode\":
+        \"ImageDefault\",\r\n          \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n
+        \       \"enableVMAgentPlatformUpdates\": false\r\n      },\r\n      \"secrets\":
+        [],\r\n      \"allowExtensionOperations\": true,\r\n      \"requireGuestProvisionSignal\":
+        true\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
         \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
         true,\r\n        \"storageUri\": \"https://cli000002.blob.core.windows.net/\"\r\n
         \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"timeCreated\":
-        \"2022-12-13T22:51:52.3460253+00:00\"\r\n  }\r\n}"
+        \"2023-03-06T14:55:01.5508486+00:00\"\r\n  }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3357'
+      - '3571'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:56:29 GMT
+      - Mon, 06 Mar 2023 14:59:20 GMT
       expires:
       - '-1'
       pragma:
@@ -3901,7 +3555,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/LowCostGet3Min;3978,Microsoft.Compute/LowCostGet30Min;31969
+      - Microsoft.Compute/LowCostGet3Min;3954,Microsoft.Compute/LowCostGet30Min;31934
     status:
       code: 200
       message: OK
@@ -3919,9 +3573,9 @@ interactions:
       ParameterSetName:
       - -g -n --storage
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?$expand=instanceView&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?$expand=instanceView&api-version=2022-11-01
   response:
     body:
       string: "{\r\n  \"name\": \"cli000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003\",\r\n
@@ -3931,62 +3585,62 @@ interactions:
         \   \"userAssignedIdentities\": {\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/AzSecPackAutoConfigUA-westus2\":
         {\r\n        \"principalId\": \"684d55e2-8922-4966-a660-2d38ca4a1711\",\r\n
         \       \"clientId\": \"6d45cf55-f311-4228-97b0-c22ae418aad6\"\r\n      }\r\n
-        \   }\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"d54f150a-5634-4201-b5af-271e2cd52432\",\r\n
+        \   }\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"94bb0e59-1bcd-493b-aa53-580e2ad730d7\",\r\n
         \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
         \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
         \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
         \"18.04-LTS\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
-        \"18.04.202212090\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\",\r\n
+        \"18.04.202302100\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\",\r\n
         \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
         \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_SERIALCONSOLELMXZIWWK5PS5Z6A7GSGJPKCGAUTWUFSF6S5STLYYHQ6COP3BWYY27/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\"\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_SERIALCONSOLE46W4L74TUUPDKTQIUNEVCDRGNWE77YHJM4DVRHN3I4J7UGNGQPGEM/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\"\r\n
         \       },\r\n        \"deleteOption\": \"Detach\",\r\n        \"diskSizeGB\":
         30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
-        {\r\n      \"computerName\": \"cli000003\",\r\n      \"adminUsername\": \"rhl\",\r\n
+        {\r\n      \"computerName\": \"cli000003\",\r\n      \"adminUsername\": \"rhoover\",\r\n
         \     \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
         true,\r\n        \"ssh\": {\r\n          \"publicKeys\": [\r\n            {\r\n
-        \             \"path\": \"/home/rhl/.ssh/authorized_keys\",\r\n              \"keyData\":
-        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h\"\r\n
-        \           }\r\n          ]\r\n        },\r\n        \"provisionVMAgent\":
-        true,\r\n        \"patchSettings\": {\r\n          \"patchMode\": \"ImageDefault\",\r\n
-        \         \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n        \"enableVMAgentPlatformUpdates\":
-        false\r\n      },\r\n      \"secrets\": [],\r\n      \"allowExtensionOperations\":
-        true,\r\n      \"requireGuestProvisionSignal\": true\r\n    },\r\n    \"networkProfile\":
-        {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
+        \             \"path\": \"/home/rhoover/.ssh/authorized_keys\",\r\n              \"keyData\":
+        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+        REDMOND+rhoover@DESKTOP-XVFR7ID\\n\"\r\n            }\r\n          ]\r\n        },\r\n
+        \       \"provisionVMAgent\": true,\r\n        \"patchSettings\": {\r\n          \"patchMode\":
+        \"ImageDefault\",\r\n          \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n
+        \       \"enableVMAgentPlatformUpdates\": false\r\n      },\r\n      \"secrets\":
+        [],\r\n      \"allowExtensionOperations\": true,\r\n      \"requireGuestProvisionSignal\":
+        true\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
         \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
         true,\r\n        \"storageUri\": \"https://cli000002.blob.core.windows.net/\"\r\n
         \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\":
-        {\r\n      \"computerName\": \"cli000003\",\r\n      \"osName\": \"ubuntu\",\r\n
-        \     \"osVersion\": \"18.04\",\r\n      \"vmAgent\": {\r\n        \"vmAgentVersion\":
-        \"2.9.0.4\",\r\n        \"statuses\": [\r\n          {\r\n            \"code\":
-        \"ProvisioningState/succeeded\",\r\n            \"level\": \"Info\",\r\n            \"displayStatus\":
-        \"Ready\",\r\n            \"message\": \"Guest Agent is running\",\r\n            \"time\":
-        \"2022-12-13T22:56:08+00:00\"\r\n          }\r\n        ],\r\n        \"extensionHandlers\":
-        []\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\",\r\n
-        \         \"statuses\": [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n
+        {\r\n      \"vmAgent\": {\r\n        \"vmAgentVersion\": \"Unknown\",\r\n
+        \       \"statuses\": [\r\n          {\r\n            \"code\": \"ProvisioningState/Unavailable\",\r\n
+        \           \"level\": \"Warning\",\r\n            \"displayStatus\": \"Not
+        Ready\",\r\n            \"message\": \"VM status blob is found but not yet
+        populated.\",\r\n            \"time\": \"2023-03-06T14:59:21+00:00\"\r\n          }\r\n
+        \       ]\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\":
+        \"cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\",\r\n          \"statuses\":
+        [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n
         \             \"level\": \"Info\",\r\n              \"displayStatus\": \"Provisioning
-        succeeded\",\r\n              \"time\": \"2022-12-13T22:55:14.423288+00:00\"\r\n
+        succeeded\",\r\n              \"time\": \"2023-03-06T14:58:04.5346581+00:00\"\r\n
         \           }\r\n          ]\r\n        }\r\n      ],\r\n      \"bootDiagnostics\":
-        {\r\n        \"consoleScreenshotBlobUri\": \"https://cli000002.blob.core.windows.net/bootdiagnostics-clik3qxir-d54f150a-5634-4201-b5af-271e2cd52432/cli000003.d54f150a-5634-4201-b5af-271e2cd52432.screenshot.bmp\",\r\n
-        \       \"serialConsoleLogBlobUri\": \"https://cli000002.blob.core.windows.net/bootdiagnostics-clik3qxir-d54f150a-5634-4201-b5af-271e2cd52432/cli000003.d54f150a-5634-4201-b5af-271e2cd52432.serialconsole.log\"\r\n
+        {\r\n        \"consoleScreenshotBlobUri\": \"https://cli000002.blob.core.windows.net/bootdiagnostics-cli7hpi2h-94bb0e59-1bcd-493b-aa53-580e2ad730d7/cli000003.94bb0e59-1bcd-493b-aa53-580e2ad730d7.screenshot.bmp\",\r\n
+        \       \"serialConsoleLogBlobUri\": \"https://cli000002.blob.core.windows.net/bootdiagnostics-cli7hpi2h-94bb0e59-1bcd-493b-aa53-580e2ad730d7/cli000003.94bb0e59-1bcd-493b-aa53-580e2ad730d7.serialconsole.log\"\r\n
         \     },\r\n      \"hyperVGeneration\": \"V1\",\r\n      \"statuses\": [\r\n
         \       {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n          \"level\":
         \"Info\",\r\n          \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \         \"time\": \"2022-12-13T22:56:03.7199254+00:00\"\r\n        },\r\n
+        \         \"time\": \"2023-03-06T14:58:57.5189131+00:00\"\r\n        },\r\n
         \       {\r\n          \"code\": \"PowerState/running\",\r\n          \"level\":
         \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\n        }\r\n
-        \     ]\r\n    },\r\n    \"timeCreated\": \"2022-12-13T22:51:52.3460253+00:00\"\r\n
+        \     ]\r\n    },\r\n    \"timeCreated\": \"2023-03-06T14:55:01.5508486+00:00\"\r\n
         \ }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '5110'
+      - '5232'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:56:29 GMT
+      - Mon, 06 Mar 2023 14:59:21 GMT
       expires:
       - '-1'
       pragma:
@@ -4003,7 +3657,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/LowCostGet3Min;3982,Microsoft.Compute/LowCostGet30Min;31968
+      - Microsoft.Compute/LowCostGet3Min;3953,Microsoft.Compute/LowCostGet30Min;31933
     status:
       code: 200
       message: OK
@@ -4021,12 +3675,63 @@ interactions:
       ParameterSetName:
       - -g -n --storage
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/storageAccounts?api-version=2022-09-01
+  response:
+    body:
+      string: '{"value":[{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloud-shell-storage-eastus/providers/Microsoft.Storage/storageAccounts/cs210032001f4814ba9","name":"cs210032001f4814ba9","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"ms-resource-usage":"azure-cloud-shell"},"properties":{"keyCreationTime":{"key1":"2022-05-16T14:16:22.3477819Z","key2":"2022-05-16T14:16:22.3477819Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-16T14:16:22.3477819Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-16T14:16:22.3477819Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-05-16T14:16:22.2227752Z","primaryEndpoints":{"dfs":"https://cs210032001f4814ba9.dfs.core.windows.net/","web":"https://cs210032001f4814ba9.z13.web.core.windows.net/","blob":"https://cs210032001f4814ba9.blob.core.windows.net/","queue":"https://cs210032001f4814ba9.queue.core.windows.net/","table":"https://cs210032001f4814ba9.table.core.windows.net/","file":"https://cs210032001f4814ba9.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/kustoflow/providers/Microsoft.Storage/storageAccounts/csslinuxkustoflow","name":"csslinuxkustoflow","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"CreatedBy":"craigw"},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-02-01T20:08:38.6849654Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-02-01T20:08:38.6849654Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2019-02-01T20:08:38.5912170Z","primaryEndpoints":{"dfs":"https://csslinuxkustoflow.dfs.core.windows.net/","web":"https://csslinuxkustoflow.z13.web.core.windows.net/","blob":"https://csslinuxkustoflow.blob.core.windows.net/","queue":"https://csslinuxkustoflow.queue.core.windows.net/","table":"https://csslinuxkustoflow.table.core.windows.net/","file":"https://csslinuxkustoflow.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://csslinuxkustoflow-secondary.dfs.core.windows.net/","web":"https://csslinuxkustoflow-secondary.z13.web.core.windows.net/","blob":"https://csslinuxkustoflow-secondary.blob.core.windows.net/","queue":"https://csslinuxkustoflow-secondary.queue.core.windows.net/","table":"https://csslinuxkustoflow-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guidomassonitest-rg/providers/Microsoft.Storage/storageAccounts/guidomassonitestrg88ad","name":"guidomassonitestrg88ad","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-01-23T18:52:02.5484088Z","key2":"2023-01-23T18:52:02.5484088Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-01-23T18:52:02.5484088Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-01-23T18:52:02.5484088Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-01-23T18:52:02.4077698Z","primaryEndpoints":{"blob":"https://guidomassonitestrg88ad.blob.core.windows.net/","queue":"https://guidomassonitestrg88ad.queue.core.windows.net/","table":"https://guidomassonitestrg88ad.table.core.windows.net/","file":"https://guidomassonitestrg88ad.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guidomtesttrafficmanagerrg/providers/Microsoft.Storage/storageAccounts/guidomteststoraccfortm","name":"guidomteststoraccfortm","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-10-18T18:01:13.5231266Z","key2":"2022-10-18T18:01:13.5231266Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-10-18T18:01:13.5387607Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-10-18T18:01:13.5387607Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-10-18T18:01:13.3825002Z","primaryEndpoints":{"dfs":"https://guidomteststoraccfortm.dfs.core.windows.net/","web":"https://guidomteststoraccfortm.z13.web.core.windows.net/","blob":"https://guidomteststoraccfortm.blob.core.windows.net/","queue":"https://guidomteststoraccfortm.queue.core.windows.net/","table":"https://guidomteststoraccfortm.table.core.windows.net/","file":"https://guidomteststoraccfortm.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://guidomteststoraccfortm-secondary.dfs.core.windows.net/","web":"https://guidomteststoraccfortm-secondary.z13.web.core.windows.net/","blob":"https://guidomteststoraccfortm-secondary.blob.core.windows.net/","queue":"https://guidomteststoraccfortm-secondary.queue.core.windows.net/","table":"https://guidomteststoraccfortm-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnertestvmrg-eastus/providers/Microsoft.Storage/storageAccounts/scrunnercrkwpdn5nhtgg","name":"scrunnercrkwpdn5nhtgg","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-05-12T20:03:57.6389684Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-05-12T20:03:57.6389684Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-05-12T20:03:57.5451905Z","primaryEndpoints":{"blob":"https://scrunnercrkwpdn5nhtgg.blob.core.windows.net/","queue":"https://scrunnercrkwpdn5nhtgg.queue.core.windows.net/","table":"https://scrunnercrkwpdn5nhtgg.table.core.windows.net/","file":"https://scrunnercrkwpdn5nhtgg.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnervmrg-eastus/providers/Microsoft.Storage/storageAccounts/scrunneri2ezqh4xu2wqq","name":"scrunneri2ezqh4xu2wqq","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-02-11T08:01:12.9383535Z","key2":"2023-02-11T08:01:12.9383535Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:01:12.9383535Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:01:12.9383535Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-02-11T08:01:12.6883669Z","primaryEndpoints":{"blob":"https://scrunneri2ezqh4xu2wqq.blob.core.windows.net/","queue":"https://scrunneri2ezqh4xu2wqq.queue.core.windows.net/","table":"https://scrunneri2ezqh4xu2wqq.table.core.windows.net/","file":"https://scrunneri2ezqh4xu2wqq.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/serialTest-EastUS/providers/Microsoft.Storage/storageAccounts/serialtesta8d7fdee41","name":"serialtesta8d7fdee41","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-07-11T00:38:13.5389932Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-07-11T00:38:13.5389932Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2019-07-11T00:38:13.4452119Z","primaryEndpoints":{"blob":"https://serialtesta8d7fdee41.blob.core.windows.net/","queue":"https://serialtesta8d7fdee41.queue.core.windows.net/","table":"https://serialtesta8d7fdee41.table.core.windows.net/","file":"https://serialtesta8d7fdee41.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/storage-RG/providers/Microsoft.Storage/storageAccounts/serialtestbootdiag123","name":"serialtestbootdiag123","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-01-23T04:03:01.3263151Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-01-23T04:03:01.3263151Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2018-01-23T04:03:01.2951106Z","primaryEndpoints":{"blob":"https://serialtestbootdiag123.blob.core.windows.net/","queue":"https://serialtestbootdiag123.queue.core.windows.net/","table":"https://serialtestbootdiag123.table.core.windows.net/","file":"https://serialtestbootdiag123.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yuas-rg/providers/Microsoft.Storage/storageAccounts/yuasstorageacct","name":"yuasstorageacct","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-08-02T12:18:18.8547131Z","key2":"2022-08-02T12:18:18.8547131Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-08-02T12:18:18.8547131Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-08-02T12:18:18.8547131Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-08-02T12:18:18.7140969Z","primaryEndpoints":{"dfs":"https://yuasstorageacct.dfs.core.windows.net/","web":"https://yuasstorageacct.z13.web.core.windows.net/","blob":"https://yuasstorageacct.blob.core.windows.net/","queue":"https://yuasstorageacct.queue.core.windows.net/","table":"https://yuasstorageacct.table.core.windows.net/","file":"https://yuasstorageacct.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://yuasstorageacct-secondary.dfs.core.windows.net/","web":"https://yuasstorageacct-secondary.z13.web.core.windows.net/","blob":"https://yuasstorageacct-secondary.blob.core.windows.net/","queue":"https://yuasstorageacct-secondary.queue.core.windows.net/","table":"https://yuasstorageacct-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/bkerrigan-dev-rg/providers/Microsoft.Storage/storageAccounts/bktestsa2","name":"bktestsa2","type":"Microsoft.Storage/storageAccounts","location":"eastus2","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","immutableStorageWithVersioning":{"enabled":true},"keyCreationTime":{"key1":"2022-09-27T23:58:45.6496284Z","key2":"2022-09-27T23:58:45.6496284Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-09-27T23:58:46.2902461Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-09-27T23:58:46.2902461Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Cool","provisioningState":"Succeeded","creationTime":"2022-09-27T23:58:45.5558609Z","primaryEndpoints":{"dfs":"https://bktestsa2.dfs.core.windows.net/","web":"https://bktestsa2.z20.web.core.windows.net/","blob":"https://bktestsa2.blob.core.windows.net/","queue":"https://bktestsa2.queue.core.windows.net/","table":"https://bktestsa2.table.core.windows.net/","file":"https://bktestsa2.file.core.windows.net/"},"primaryLocation":"eastus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rhel-test/providers/Microsoft.Storage/storageAccounts/rhel77acct","name":"rhel77acct","type":"Microsoft.Storage/storageAccounts","location":"eastus2","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-08-13T20:31:30.8995173Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-08-13T20:31:30.8995173Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-08-13T20:31:30.8215811Z","primaryEndpoints":{"blob":"https://rhel77acct.blob.core.windows.net/","queue":"https://rhel77acct.queue.core.windows.net/","table":"https://rhel77acct.table.core.windows.net/","file":"https://rhel77acct.file.core.windows.net/"},"primaryLocation":"eastus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SCRunner/providers/Microsoft.Storage/storageAccounts/scrunnerstorage","name":"scrunnerstorage","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-03-06T00:42:11.7016543Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-03-06T00:42:11.7016543Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2018-03-06T00:42:11.6234985Z","primaryEndpoints":{"blob":"https://scrunnerstorage.blob.core.windows.net/","queue":"https://scrunnerstorage.queue.core.windows.net/","table":"https://scrunnerstorage.table.core.windows.net/","file":"https://scrunnerstorage.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rhoover/providers/Microsoft.Storage/storageAccounts/rhooverstorage","name":"rhooverstorage","type":"Microsoft.Storage/storageAccounts","location":"southcentralus","tags":{"ms-resource-usage":"azure-cloud-shell"},"properties":{"keyCreationTime":{"key1":"2022-05-26T17:14:23.5085026Z","key2":"2022-05-26T17:14:23.5085026Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-26T17:14:23.5241285Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-26T17:14:23.5241285Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-05-26T17:14:23.4147520Z","primaryEndpoints":{"dfs":"https://rhooverstorage.dfs.core.windows.net/","web":"https://rhooverstorage.z21.web.core.windows.net/","blob":"https://rhooverstorage.blob.core.windows.net/","queue":"https://rhooverstorage.queue.core.windows.net/","table":"https://rhooverstorage.table.core.windows.net/","file":"https://rhooverstorage.file.core.windows.net/"},"primaryLocation":"southcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SCRunnertestvmrg-AustraliaEast/providers/Microsoft.Storage/storageAccounts/scrunner4p3t72mzheluc","name":"scrunner4p3t72mzheluc","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{},"properties":{"keyCreationTime":{"key1":"2021-04-13T22:35:36.6210942Z","key2":"2021-04-13T22:35:36.6210942Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2021-04-13T22:35:36.6210942Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2021-04-13T22:35:36.6210942Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2021-04-13T22:35:36.5429508Z","primaryEndpoints":{"blob":"https://scrunner4p3t72mzheluc.blob.core.windows.net/","queue":"https://scrunner4p3t72mzheluc.queue.core.windows.net/","table":"https://scrunner4p3t72mzheluc.table.core.windows.net/","file":"https://scrunner4p3t72mzheluc.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnervmrg-australiaeast/providers/Microsoft.Storage/storageAccounts/scrunner56hymyctm4kw2","name":"scrunner56hymyctm4kw2","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{},"properties":{"keyCreationTime":{"key1":"2023-02-11T08:42:58.2414102Z","key2":"2023-02-11T08:42:58.2414102Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:42:59.3196006Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:42:59.3196006Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-02-11T08:42:58.1476588Z","primaryEndpoints":{"blob":"https://scrunner56hymyctm4kw2.blob.core.windows.net/","queue":"https://scrunner56hymyctm4kw2.queue.core.windows.net/","table":"https://scrunner56hymyctm4kw2.table.core.windows.net/","file":"https://scrunner56hymyctm4kw2.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsolestuzi7ftnukpi2fyagwys225gbsh73m2h2z7zwjnemrgl5jrfrevg/providers/Microsoft.Storage/storageAccounts/clij3widgfvooidlncm4zwgr","name":"clij3widgfvooidlncm4zwgr","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T14:54:24.1363998Z","key2":"2023-03-06T14:54:24.1363998Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.6364190Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.6364190Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T14:54:24.0114062Z","primaryEndpoints":{"blob":"https://clij3widgfvooidlncm4zwgr.blob.core.windows.net/","queue":"https://clij3widgfvooidlncm4zwgr.queue.core.windows.net/","table":"https://clij3widgfvooidlncm4zwgr.table.core.windows.net/","file":"https://clij3widgfvooidlncm4zwgr.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsolek4hibhcaoukjiclxhnksydes553f4t7r3glwjvxloifh37s6yqdk5/providers/Microsoft.Storage/storageAccounts/cliln4rgfngepmlxlmpwv5wk","name":"cliln4rgfngepmlxlmpwv5wk","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T14:58:59.2000914Z","key2":"2023-03-06T14:58:59.2000914Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:58:59.8876132Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:58:59.8876132Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T14:58:59.1063047Z","primaryEndpoints":{"blob":"https://cliln4rgfngepmlxlmpwv5wk.blob.core.windows.net/","queue":"https://cliln4rgfngepmlxlmpwv5wk.queue.core.windows.net/","table":"https://cliln4rgfngepmlxlmpwv5wk.table.core.windows.net/","file":"https://cliln4rgfngepmlxlmpwv5wk.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsolex4geueyy52iloaspyxz3rrqwxv2syvnkjiljxbv522buwxqpiljme/providers/Microsoft.Storage/storageAccounts/clipf6qz5nxegbgku5yqzkd2","name":"clipf6qz5nxegbgku5yqzkd2","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T07:45:44.7937561Z","key2":"2023-03-06T07:45:44.7937561Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:45:45.1687946Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:45:45.1687946Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T07:45:44.7000168Z","primaryEndpoints":{"blob":"https://clipf6qz5nxegbgku5yqzkd2.blob.core.windows.net/","queue":"https://clipf6qz5nxegbgku5yqzkd2.queue.core.windows.net/","table":"https://clipf6qz5nxegbgku5yqzkd2.table.core.windows.net/","file":"https://clipf6qz5nxegbgku5yqzkd2.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsolep35rualbmodx4sho6gltgwspkbsxnsj34im3hqgkvnopy3hqugcaw/providers/Microsoft.Storage/storageAccounts/clite7vcjveueljfi27rolvu","name":"clite7vcjveueljfi27rolvu","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T14:54:23.8082415Z","key2":"2023-03-06T14:54:23.8082415Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.5270280Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.5270280Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T14:54:23.6989027Z","primaryEndpoints":{"blob":"https://clite7vcjveueljfi27rolvu.blob.core.windows.net/","queue":"https://clite7vcjveueljfi27rolvu.queue.core.windows.net/","table":"https://clite7vcjveueljfi27rolvu.table.core.windows.net/","file":"https://clite7vcjveueljfi27rolvu.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsoledcvrpndxic4emeqq5apwkns4qa5owpy4jn3b536ks35zdrmn7bl5k/providers/Microsoft.Storage/storageAccounts/cliwqnm2fo7pftnxlk7c734i","name":"cliwqnm2fo7pftnxlk7c734i","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T07:34:57.7461613Z","key2":"2023-03-06T07:34:57.7461613Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:34:57.9961851Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:34:57.9961851Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T07:34:57.6368148Z","primaryEndpoints":{"blob":"https://cliwqnm2fo7pftnxlk7c734i.blob.core.windows.net/","queue":"https://cliwqnm2fo7pftnxlk7c734i.queue.core.windows.net/","table":"https://cliwqnm2fo7pftnxlk7c734i.table.core.windows.net/","file":"https://cliwqnm2fo7pftnxlk7c734i.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002","name":"cli000002","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T14:54:24.1208364Z","key2":"2023-03-06T14:54:24.1208364Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.6676739Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.6676739Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T14:54:24.0114062Z","primaryEndpoints":{"blob":"https://cli000002.blob.core.windows.net/","queue":"https://cli000002.queue.core.windows.net/","table":"https://cli000002.table.core.windows.net/","file":"https://cli000002.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guptar2/providers/Microsoft.Storage/storageAccounts/guptar2diagnosticsv1","name":"guptar2diagnosticsv1","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2022-04-05T17:21:41.8250582Z","key2":"2022-04-05T17:21:41.8250582Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:21:41.8250582Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:21:41.8250582Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-04-05T17:21:41.7313240Z","primaryEndpoints":{"blob":"https://guptar2diagnosticsv1.blob.core.windows.net/","queue":"https://guptar2diagnosticsv1.queue.core.windows.net/","table":"https://guptar2diagnosticsv1.table.core.windows.net/","file":"https://guptar2diagnosticsv1.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guptar2/providers/Microsoft.Storage/storageAccounts/guptar2diagnosticsv2","name":"guptar2diagnosticsv2","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-04-05T17:22:55.8411567Z","key2":"2022-04-05T17:22:55.8411567Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"resourceAccessRules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[{"value":"20.98.146.84","action":"Allow"},{"value":"20.83.222.102","action":"Allow"},{"value":"20.98.194.64","action":"Allow"},{"value":"20.69.5.162","action":"Allow"}],"defaultAction":"Deny"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:22:55.8411567Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:22:55.8411567Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-04-05T17:22:55.7318000Z","primaryEndpoints":{"dfs":"https://guptar2diagnosticsv2.dfs.core.windows.net/","web":"https://guptar2diagnosticsv2.z5.web.core.windows.net/","blob":"https://guptar2diagnosticsv2.blob.core.windows.net/","queue":"https://guptar2diagnosticsv2.queue.core.windows.net/","table":"https://guptar2diagnosticsv2.table.core.windows.net/","file":"https://guptar2diagnosticsv2.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sericonrp-trafficmanager/providers/Microsoft.Storage/storageAccounts/sericonrpdevtmstorage","name":"sericonrpdevtmstorage","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-11-30T19:15:41.5013570Z","key2":"2022-11-30T19:15:41.5013570Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-11-30T19:15:42.0638737Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-11-30T19:15:42.0638737Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-11-30T19:15:41.4075777Z","primaryEndpoints":{"dfs":"https://sericonrpdevtmstorage.dfs.core.windows.net/","web":"https://sericonrpdevtmstorage.z5.web.core.windows.net/","blob":"https://sericonrpdevtmstorage.blob.core.windows.net/","queue":"https://sericonrpdevtmstorage.queue.core.windows.net/","table":"https://sericonrpdevtmstorage.table.core.windows.net/","file":"https://sericonrpdevtmstorage.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available","secondaryLocation":"westcentralus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://sericonrpdevtmstorage-secondary.dfs.core.windows.net/","web":"https://sericonrpdevtmstorage-secondary.z5.web.core.windows.net/","blob":"https://sericonrpdevtmstorage-secondary.blob.core.windows.net/","queue":"https://sericonrpdevtmstorage-secondary.queue.core.windows.net/","table":"https://sericonrpdevtmstorage-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ops/providers/Microsoft.Storage/storageAccounts/sericonstorage","name":"sericonstorage","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2023-03-05T19:58:00.4355863Z","key2":"2023-03-05T19:58:00.4355863Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-05T19:58:00.9824831Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-05T19:58:00.9824831Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2023-03-05T19:58:00.3262342Z","primaryEndpoints":{"dfs":"https://sericonstorage.dfs.core.windows.net/","web":"https://sericonstorage.z5.web.core.windows.net/","blob":"https://sericonstorage.blob.core.windows.net/","queue":"https://sericonstorage.queue.core.windows.net/","table":"https://sericonstorage.table.core.windows.net/","file":"https://sericonstorage.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rhoover-dev-rg/providers/Microsoft.Storage/storageAccounts/rhooverdevrgdiag","name":"rhooverdevrgdiag","type":"Microsoft.Storage/storageAccounts","location":"westcentralus","tags":{},"properties":{"defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-06-20T19:39:24.4605968Z","key2":"2022-06-20T19:39:24.4605968Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":false,"networkAcls":{"resourceAccessRules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[{"value":"20.98.146.84","action":"Allow"},{"value":"20.98.194.64","action":"Allow"},{"value":"20.69.5.162","action":"Allow"},{"value":"20.83.222.102","action":"Allow"},{"value":"76.197.206.105","action":"Allow"}],"defaultAction":"Deny"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-06-20T19:39:24.4762287Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-06-20T19:39:24.4762287Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-06-20T19:39:24.4137057Z","primaryEndpoints":{"blob":"https://rhooverdevrgdiag.blob.core.windows.net/","queue":"https://rhooverdevrgdiag.queue.core.windows.net/","table":"https://rhooverdevrgdiag.table.core.windows.net/","file":"https://rhooverdevrgdiag.file.core.windows.net/"},"primaryLocation":"westcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnervmrg-westcentralus/providers/Microsoft.Storage/storageAccounts/scrunneraoptpjec4skce","name":"scrunneraoptpjec4skce","type":"Microsoft.Storage/storageAccounts","location":"westcentralus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-02-11T08:40:40.0686467Z","key2":"2023-02-11T08:40:40.0686467Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:40:40.5842822Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:40:40.5842822Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-02-11T08:40:40.0061730Z","primaryEndpoints":{"blob":"https://scrunneraoptpjec4skce.blob.core.windows.net/","queue":"https://scrunneraoptpjec4skce.queue.core.windows.net/","table":"https://scrunneraoptpjec4skce.table.core.windows.net/","file":"https://scrunneraoptpjec4skce.file.core.windows.net/"},"primaryLocation":"westcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnertestvmrg-westcentralus/providers/Microsoft.Storage/storageAccounts/scrunnerrfscmqxeni3uq","name":"scrunnerrfscmqxeni3uq","type":"Microsoft.Storage/storageAccounts","location":"westcentralus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-04-10T22:28:55.2104910Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-04-10T22:28:55.2104910Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-04-10T22:28:55.1479670Z","primaryEndpoints":{"blob":"https://scrunnerrfscmqxeni3uq.blob.core.windows.net/","queue":"https://scrunnerrfscmqxeni3uq.queue.core.windows.net/","table":"https://scrunnerrfscmqxeni3uq.table.core.windows.net/","file":"https://scrunnerrfscmqxeni3uq.file.core.windows.net/"},"primaryLocation":"westcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ubuntu-westus3_group/providers/Microsoft.Storage/storageAccounts/ubuntuwestus3groupdiag","name":"ubuntuwestus3groupdiag","type":"Microsoft.Storage/storageAccounts","location":"westus3","tags":{},"properties":{"keyCreationTime":{"key1":"2022-04-18T19:48:38.9882588Z","key2":"2022-04-18T19:48:38.9882588Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-18T19:48:38.9882588Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-18T19:48:38.9882588Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-04-18T19:48:38.9258191Z","primaryEndpoints":{"blob":"https://ubuntuwestus3groupdiag.blob.core.windows.net/","queue":"https://ubuntuwestus3groupdiag.queue.core.windows.net/","table":"https://ubuntuwestus3groupdiag.table.core.windows.net/","file":"https://ubuntuwestus3groupdiag.file.core.windows.net/"},"primaryLocation":"westus3","statusOfPrimary":"available"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '42669'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 06 Mar 2023 14:59:21 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-original-request-ids:
+      - 384a3336-91ff-47c5-b2cd-9eb2643ac0f1
+      - 2db5ff68-f930-4a5f-9566-debd26355b8f
+      - c29a55c6-c2f1-4b8e-bba3-e8aee04b168f
+      - ebd5009d-3c51-40b8-9420-3c22a5c4efe8
+      - 7ee5282e-267f-468f-99f6-713440d79b4b
+      - 4ba10947-5a8e-491a-998e-d940aedda342
+      - 941f40d3-4749-4ea6-a86a-d44c41c6bb5f
+      - 0bdead64-0c99-4f1e-9a9f-8ef3200039c4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm boot-diagnostics enable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --storage
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002","name":"cli000002","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2022-12-13T22:51:17.0682893Z","key2":"2022-12-13T22:51:17.0682893Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-12-13T22:51:17.6307939Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-12-13T22:51:17.6307939Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-12-13T22:51:16.9745683Z","primaryEndpoints":{"blob":"https://cli000002.blob.core.windows.net/","queue":"https://cli000002.queue.core.windows.net/","table":"https://cli000002.table.core.windows.net/","file":"https://cli000002.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002","name":"cli000002","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T14:54:24.1208364Z","key2":"2023-03-06T14:54:24.1208364Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.6676739Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.6676739Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T14:54:24.0114062Z","primaryEndpoints":{"blob":"https://cli000002.blob.core.windows.net/","queue":"https://cli000002.queue.core.windows.net/","table":"https://cli000002.table.core.windows.net/","file":"https://cli000002.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -4035,7 +3740,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 13 Dec 2022 22:56:30 GMT
+      - Mon, 06 Mar 2023 14:59:21 GMT
       expires:
       - '-1'
       pragma:
@@ -4067,8 +3772,8 @@ interactions:
       ParameterSetName:
       - -g -n --storage
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
-        (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.SerialConsole/consoleServices/default?api-version=2018-05-01
   response:
@@ -4082,7 +3787,7 @@ interactions:
       content-type:
       - application/json; charset=UTF-8
       date:
-      - Tue, 13 Dec 2022 22:56:30 GMT
+      - Mon, 06 Mar 2023 14:59:21 GMT
       expires:
       - '-1'
       pragma:
@@ -4118,8 +3823,8 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
-        (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
+        (Windows-10-10.0.22621-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.SerialConsole/consoleServices/default/disableConsole?api-version=2018-05-01
   response:
@@ -4133,7 +3838,7 @@ interactions:
       content-type:
       - application/json; charset=UTF-8
       date:
-      - Tue, 13 Dec 2022 22:56:32 GMT
+      - Mon, 06 Mar 2023 14:59:22 GMT
       expires:
       - '-1'
       pragma:
@@ -4167,9 +3872,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?$expand=instanceView&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?$expand=instanceView&api-version=2022-11-01
   response:
     body:
       string: "{\r\n  \"name\": \"cli000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003\",\r\n
@@ -4179,29 +3884,29 @@ interactions:
         \   \"userAssignedIdentities\": {\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/AzSecPackAutoConfigUA-westus2\":
         {\r\n        \"principalId\": \"684d55e2-8922-4966-a660-2d38ca4a1711\",\r\n
         \       \"clientId\": \"6d45cf55-f311-4228-97b0-c22ae418aad6\"\r\n      }\r\n
-        \   }\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"d54f150a-5634-4201-b5af-271e2cd52432\",\r\n
+        \   }\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"94bb0e59-1bcd-493b-aa53-580e2ad730d7\",\r\n
         \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
         \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
         \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
         \"18.04-LTS\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
-        \"18.04.202212090\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\",\r\n
+        \"18.04.202302100\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\",\r\n
         \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
         \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_SERIALCONSOLELMXZIWWK5PS5Z6A7GSGJPKCGAUTWUFSF6S5STLYYHQ6COP3BWYY27/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\"\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_SERIALCONSOLE46W4L74TUUPDKTQIUNEVCDRGNWE77YHJM4DVRHN3I4J7UGNGQPGEM/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\"\r\n
         \       },\r\n        \"deleteOption\": \"Detach\",\r\n        \"diskSizeGB\":
         30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
-        {\r\n      \"computerName\": \"cli000003\",\r\n      \"adminUsername\": \"rhl\",\r\n
+        {\r\n      \"computerName\": \"cli000003\",\r\n      \"adminUsername\": \"rhoover\",\r\n
         \     \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
         true,\r\n        \"ssh\": {\r\n          \"publicKeys\": [\r\n            {\r\n
-        \             \"path\": \"/home/rhl/.ssh/authorized_keys\",\r\n              \"keyData\":
-        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h\"\r\n
-        \           }\r\n          ]\r\n        },\r\n        \"provisionVMAgent\":
-        true,\r\n        \"patchSettings\": {\r\n          \"patchMode\": \"ImageDefault\",\r\n
-        \         \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n        \"enableVMAgentPlatformUpdates\":
-        false\r\n      },\r\n      \"secrets\": [],\r\n      \"allowExtensionOperations\":
-        true,\r\n      \"requireGuestProvisionSignal\": true\r\n    },\r\n    \"networkProfile\":
-        {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
+        \             \"path\": \"/home/rhoover/.ssh/authorized_keys\",\r\n              \"keyData\":
+        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+        REDMOND+rhoover@DESKTOP-XVFR7ID\\n\"\r\n            }\r\n          ]\r\n        },\r\n
+        \       \"provisionVMAgent\": true,\r\n        \"patchSettings\": {\r\n          \"patchMode\":
+        \"ImageDefault\",\r\n          \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n
+        \       \"enableVMAgentPlatformUpdates\": false\r\n      },\r\n      \"secrets\":
+        [],\r\n      \"allowExtensionOperations\": true,\r\n      \"requireGuestProvisionSignal\":
+        true\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
         \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
         true,\r\n        \"storageUri\": \"https://cli000002.blob.core.windows.net/\"\r\n
         \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\":
@@ -4210,31 +3915,31 @@ interactions:
         \"2.9.0.4\",\r\n        \"statuses\": [\r\n          {\r\n            \"code\":
         \"ProvisioningState/succeeded\",\r\n            \"level\": \"Info\",\r\n            \"displayStatus\":
         \"Ready\",\r\n            \"message\": \"Guest Agent is running\",\r\n            \"time\":
-        \"2022-12-13T22:56:08+00:00\"\r\n          }\r\n        ],\r\n        \"extensionHandlers\":
-        []\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\",\r\n
+        \"2023-03-06T14:59:22+00:00\"\r\n          }\r\n        ],\r\n        \"extensionHandlers\":
+        []\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\",\r\n
         \         \"statuses\": [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n
         \             \"level\": \"Info\",\r\n              \"displayStatus\": \"Provisioning
-        succeeded\",\r\n              \"time\": \"2022-12-13T22:55:14.423288+00:00\"\r\n
+        succeeded\",\r\n              \"time\": \"2023-03-06T14:58:04.5346581+00:00\"\r\n
         \           }\r\n          ]\r\n        }\r\n      ],\r\n      \"bootDiagnostics\":
-        {\r\n        \"consoleScreenshotBlobUri\": \"https://cli000002.blob.core.windows.net/bootdiagnostics-clik3qxir-d54f150a-5634-4201-b5af-271e2cd52432/cli000003.d54f150a-5634-4201-b5af-271e2cd52432.screenshot.bmp\",\r\n
-        \       \"serialConsoleLogBlobUri\": \"https://cli000002.blob.core.windows.net/bootdiagnostics-clik3qxir-d54f150a-5634-4201-b5af-271e2cd52432/cli000003.d54f150a-5634-4201-b5af-271e2cd52432.serialconsole.log\"\r\n
+        {\r\n        \"consoleScreenshotBlobUri\": \"https://cli000002.blob.core.windows.net/bootdiagnostics-cli7hpi2h-94bb0e59-1bcd-493b-aa53-580e2ad730d7/cli000003.94bb0e59-1bcd-493b-aa53-580e2ad730d7.screenshot.bmp\",\r\n
+        \       \"serialConsoleLogBlobUri\": \"https://cli000002.blob.core.windows.net/bootdiagnostics-cli7hpi2h-94bb0e59-1bcd-493b-aa53-580e2ad730d7/cli000003.94bb0e59-1bcd-493b-aa53-580e2ad730d7.serialconsole.log\"\r\n
         \     },\r\n      \"hyperVGeneration\": \"V1\",\r\n      \"statuses\": [\r\n
         \       {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n          \"level\":
         \"Info\",\r\n          \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \         \"time\": \"2022-12-13T22:56:03.7199254+00:00\"\r\n        },\r\n
+        \         \"time\": \"2023-03-06T14:58:57.5189131+00:00\"\r\n        },\r\n
         \       {\r\n          \"code\": \"PowerState/running\",\r\n          \"level\":
         \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\n        }\r\n
-        \     ]\r\n    },\r\n    \"timeCreated\": \"2022-12-13T22:51:52.3460253+00:00\"\r\n
+        \     ]\r\n    },\r\n    \"timeCreated\": \"2023-03-06T14:55:01.5508486+00:00\"\r\n
         \ }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '5110'
+      - '5325'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:56:31 GMT
+      - Mon, 06 Mar 2023 14:59:22 GMT
       expires:
       - '-1'
       pragma:
@@ -4251,7 +3956,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/LowCostGet3Min;3980,Microsoft.Compute/LowCostGet30Min;31966
+      - Microsoft.Compute/LowCostGet3Min;3952,Microsoft.Compute/LowCostGet30Min;31932
     status:
       code: 200
       message: OK
@@ -4267,12 +3972,61 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/storageAccounts?api-version=2022-09-01
+  response:
+    body:
+      string: '{"value":[{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloud-shell-storage-eastus/providers/Microsoft.Storage/storageAccounts/cs210032001f4814ba9","name":"cs210032001f4814ba9","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"ms-resource-usage":"azure-cloud-shell"},"properties":{"keyCreationTime":{"key1":"2022-05-16T14:16:22.3477819Z","key2":"2022-05-16T14:16:22.3477819Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-16T14:16:22.3477819Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-16T14:16:22.3477819Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-05-16T14:16:22.2227752Z","primaryEndpoints":{"dfs":"https://cs210032001f4814ba9.dfs.core.windows.net/","web":"https://cs210032001f4814ba9.z13.web.core.windows.net/","blob":"https://cs210032001f4814ba9.blob.core.windows.net/","queue":"https://cs210032001f4814ba9.queue.core.windows.net/","table":"https://cs210032001f4814ba9.table.core.windows.net/","file":"https://cs210032001f4814ba9.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/kustoflow/providers/Microsoft.Storage/storageAccounts/csslinuxkustoflow","name":"csslinuxkustoflow","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"CreatedBy":"craigw"},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-02-01T20:08:38.6849654Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-02-01T20:08:38.6849654Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2019-02-01T20:08:38.5912170Z","primaryEndpoints":{"dfs":"https://csslinuxkustoflow.dfs.core.windows.net/","web":"https://csslinuxkustoflow.z13.web.core.windows.net/","blob":"https://csslinuxkustoflow.blob.core.windows.net/","queue":"https://csslinuxkustoflow.queue.core.windows.net/","table":"https://csslinuxkustoflow.table.core.windows.net/","file":"https://csslinuxkustoflow.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://csslinuxkustoflow-secondary.dfs.core.windows.net/","web":"https://csslinuxkustoflow-secondary.z13.web.core.windows.net/","blob":"https://csslinuxkustoflow-secondary.blob.core.windows.net/","queue":"https://csslinuxkustoflow-secondary.queue.core.windows.net/","table":"https://csslinuxkustoflow-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guidomassonitest-rg/providers/Microsoft.Storage/storageAccounts/guidomassonitestrg88ad","name":"guidomassonitestrg88ad","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-01-23T18:52:02.5484088Z","key2":"2023-01-23T18:52:02.5484088Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-01-23T18:52:02.5484088Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-01-23T18:52:02.5484088Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-01-23T18:52:02.4077698Z","primaryEndpoints":{"blob":"https://guidomassonitestrg88ad.blob.core.windows.net/","queue":"https://guidomassonitestrg88ad.queue.core.windows.net/","table":"https://guidomassonitestrg88ad.table.core.windows.net/","file":"https://guidomassonitestrg88ad.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guidomtesttrafficmanagerrg/providers/Microsoft.Storage/storageAccounts/guidomteststoraccfortm","name":"guidomteststoraccfortm","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-10-18T18:01:13.5231266Z","key2":"2022-10-18T18:01:13.5231266Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-10-18T18:01:13.5387607Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-10-18T18:01:13.5387607Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-10-18T18:01:13.3825002Z","primaryEndpoints":{"dfs":"https://guidomteststoraccfortm.dfs.core.windows.net/","web":"https://guidomteststoraccfortm.z13.web.core.windows.net/","blob":"https://guidomteststoraccfortm.blob.core.windows.net/","queue":"https://guidomteststoraccfortm.queue.core.windows.net/","table":"https://guidomteststoraccfortm.table.core.windows.net/","file":"https://guidomteststoraccfortm.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://guidomteststoraccfortm-secondary.dfs.core.windows.net/","web":"https://guidomteststoraccfortm-secondary.z13.web.core.windows.net/","blob":"https://guidomteststoraccfortm-secondary.blob.core.windows.net/","queue":"https://guidomteststoraccfortm-secondary.queue.core.windows.net/","table":"https://guidomteststoraccfortm-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnertestvmrg-eastus/providers/Microsoft.Storage/storageAccounts/scrunnercrkwpdn5nhtgg","name":"scrunnercrkwpdn5nhtgg","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-05-12T20:03:57.6389684Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-05-12T20:03:57.6389684Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-05-12T20:03:57.5451905Z","primaryEndpoints":{"blob":"https://scrunnercrkwpdn5nhtgg.blob.core.windows.net/","queue":"https://scrunnercrkwpdn5nhtgg.queue.core.windows.net/","table":"https://scrunnercrkwpdn5nhtgg.table.core.windows.net/","file":"https://scrunnercrkwpdn5nhtgg.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnervmrg-eastus/providers/Microsoft.Storage/storageAccounts/scrunneri2ezqh4xu2wqq","name":"scrunneri2ezqh4xu2wqq","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-02-11T08:01:12.9383535Z","key2":"2023-02-11T08:01:12.9383535Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:01:12.9383535Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:01:12.9383535Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-02-11T08:01:12.6883669Z","primaryEndpoints":{"blob":"https://scrunneri2ezqh4xu2wqq.blob.core.windows.net/","queue":"https://scrunneri2ezqh4xu2wqq.queue.core.windows.net/","table":"https://scrunneri2ezqh4xu2wqq.table.core.windows.net/","file":"https://scrunneri2ezqh4xu2wqq.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/serialTest-EastUS/providers/Microsoft.Storage/storageAccounts/serialtesta8d7fdee41","name":"serialtesta8d7fdee41","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-07-11T00:38:13.5389932Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-07-11T00:38:13.5389932Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2019-07-11T00:38:13.4452119Z","primaryEndpoints":{"blob":"https://serialtesta8d7fdee41.blob.core.windows.net/","queue":"https://serialtesta8d7fdee41.queue.core.windows.net/","table":"https://serialtesta8d7fdee41.table.core.windows.net/","file":"https://serialtesta8d7fdee41.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/storage-RG/providers/Microsoft.Storage/storageAccounts/serialtestbootdiag123","name":"serialtestbootdiag123","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-01-23T04:03:01.3263151Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-01-23T04:03:01.3263151Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2018-01-23T04:03:01.2951106Z","primaryEndpoints":{"blob":"https://serialtestbootdiag123.blob.core.windows.net/","queue":"https://serialtestbootdiag123.queue.core.windows.net/","table":"https://serialtestbootdiag123.table.core.windows.net/","file":"https://serialtestbootdiag123.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yuas-rg/providers/Microsoft.Storage/storageAccounts/yuasstorageacct","name":"yuasstorageacct","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-08-02T12:18:18.8547131Z","key2":"2022-08-02T12:18:18.8547131Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-08-02T12:18:18.8547131Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-08-02T12:18:18.8547131Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-08-02T12:18:18.7140969Z","primaryEndpoints":{"dfs":"https://yuasstorageacct.dfs.core.windows.net/","web":"https://yuasstorageacct.z13.web.core.windows.net/","blob":"https://yuasstorageacct.blob.core.windows.net/","queue":"https://yuasstorageacct.queue.core.windows.net/","table":"https://yuasstorageacct.table.core.windows.net/","file":"https://yuasstorageacct.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://yuasstorageacct-secondary.dfs.core.windows.net/","web":"https://yuasstorageacct-secondary.z13.web.core.windows.net/","blob":"https://yuasstorageacct-secondary.blob.core.windows.net/","queue":"https://yuasstorageacct-secondary.queue.core.windows.net/","table":"https://yuasstorageacct-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/bkerrigan-dev-rg/providers/Microsoft.Storage/storageAccounts/bktestsa2","name":"bktestsa2","type":"Microsoft.Storage/storageAccounts","location":"eastus2","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","immutableStorageWithVersioning":{"enabled":true},"keyCreationTime":{"key1":"2022-09-27T23:58:45.6496284Z","key2":"2022-09-27T23:58:45.6496284Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-09-27T23:58:46.2902461Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-09-27T23:58:46.2902461Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Cool","provisioningState":"Succeeded","creationTime":"2022-09-27T23:58:45.5558609Z","primaryEndpoints":{"dfs":"https://bktestsa2.dfs.core.windows.net/","web":"https://bktestsa2.z20.web.core.windows.net/","blob":"https://bktestsa2.blob.core.windows.net/","queue":"https://bktestsa2.queue.core.windows.net/","table":"https://bktestsa2.table.core.windows.net/","file":"https://bktestsa2.file.core.windows.net/"},"primaryLocation":"eastus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rhel-test/providers/Microsoft.Storage/storageAccounts/rhel77acct","name":"rhel77acct","type":"Microsoft.Storage/storageAccounts","location":"eastus2","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-08-13T20:31:30.8995173Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-08-13T20:31:30.8995173Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-08-13T20:31:30.8215811Z","primaryEndpoints":{"blob":"https://rhel77acct.blob.core.windows.net/","queue":"https://rhel77acct.queue.core.windows.net/","table":"https://rhel77acct.table.core.windows.net/","file":"https://rhel77acct.file.core.windows.net/"},"primaryLocation":"eastus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SCRunner/providers/Microsoft.Storage/storageAccounts/scrunnerstorage","name":"scrunnerstorage","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-03-06T00:42:11.7016543Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-03-06T00:42:11.7016543Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2018-03-06T00:42:11.6234985Z","primaryEndpoints":{"blob":"https://scrunnerstorage.blob.core.windows.net/","queue":"https://scrunnerstorage.queue.core.windows.net/","table":"https://scrunnerstorage.table.core.windows.net/","file":"https://scrunnerstorage.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rhoover/providers/Microsoft.Storage/storageAccounts/rhooverstorage","name":"rhooverstorage","type":"Microsoft.Storage/storageAccounts","location":"southcentralus","tags":{"ms-resource-usage":"azure-cloud-shell"},"properties":{"keyCreationTime":{"key1":"2022-05-26T17:14:23.5085026Z","key2":"2022-05-26T17:14:23.5085026Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-26T17:14:23.5241285Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-26T17:14:23.5241285Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-05-26T17:14:23.4147520Z","primaryEndpoints":{"dfs":"https://rhooverstorage.dfs.core.windows.net/","web":"https://rhooverstorage.z21.web.core.windows.net/","blob":"https://rhooverstorage.blob.core.windows.net/","queue":"https://rhooverstorage.queue.core.windows.net/","table":"https://rhooverstorage.table.core.windows.net/","file":"https://rhooverstorage.file.core.windows.net/"},"primaryLocation":"southcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SCRunnertestvmrg-AustraliaEast/providers/Microsoft.Storage/storageAccounts/scrunner4p3t72mzheluc","name":"scrunner4p3t72mzheluc","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{},"properties":{"keyCreationTime":{"key1":"2021-04-13T22:35:36.6210942Z","key2":"2021-04-13T22:35:36.6210942Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2021-04-13T22:35:36.6210942Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2021-04-13T22:35:36.6210942Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2021-04-13T22:35:36.5429508Z","primaryEndpoints":{"blob":"https://scrunner4p3t72mzheluc.blob.core.windows.net/","queue":"https://scrunner4p3t72mzheluc.queue.core.windows.net/","table":"https://scrunner4p3t72mzheluc.table.core.windows.net/","file":"https://scrunner4p3t72mzheluc.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnervmrg-australiaeast/providers/Microsoft.Storage/storageAccounts/scrunner56hymyctm4kw2","name":"scrunner56hymyctm4kw2","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{},"properties":{"keyCreationTime":{"key1":"2023-02-11T08:42:58.2414102Z","key2":"2023-02-11T08:42:58.2414102Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:42:59.3196006Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:42:59.3196006Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-02-11T08:42:58.1476588Z","primaryEndpoints":{"blob":"https://scrunner56hymyctm4kw2.blob.core.windows.net/","queue":"https://scrunner56hymyctm4kw2.queue.core.windows.net/","table":"https://scrunner56hymyctm4kw2.table.core.windows.net/","file":"https://scrunner56hymyctm4kw2.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsolestuzi7ftnukpi2fyagwys225gbsh73m2h2z7zwjnemrgl5jrfrevg/providers/Microsoft.Storage/storageAccounts/clij3widgfvooidlncm4zwgr","name":"clij3widgfvooidlncm4zwgr","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T14:54:24.1363998Z","key2":"2023-03-06T14:54:24.1363998Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.6364190Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.6364190Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T14:54:24.0114062Z","primaryEndpoints":{"blob":"https://clij3widgfvooidlncm4zwgr.blob.core.windows.net/","queue":"https://clij3widgfvooidlncm4zwgr.queue.core.windows.net/","table":"https://clij3widgfvooidlncm4zwgr.table.core.windows.net/","file":"https://clij3widgfvooidlncm4zwgr.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsolek4hibhcaoukjiclxhnksydes553f4t7r3glwjvxloifh37s6yqdk5/providers/Microsoft.Storage/storageAccounts/cliln4rgfngepmlxlmpwv5wk","name":"cliln4rgfngepmlxlmpwv5wk","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T14:58:59.2000914Z","key2":"2023-03-06T14:58:59.2000914Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:58:59.8876132Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:58:59.8876132Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T14:58:59.1063047Z","primaryEndpoints":{"blob":"https://cliln4rgfngepmlxlmpwv5wk.blob.core.windows.net/","queue":"https://cliln4rgfngepmlxlmpwv5wk.queue.core.windows.net/","table":"https://cliln4rgfngepmlxlmpwv5wk.table.core.windows.net/","file":"https://cliln4rgfngepmlxlmpwv5wk.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsolex4geueyy52iloaspyxz3rrqwxv2syvnkjiljxbv522buwxqpiljme/providers/Microsoft.Storage/storageAccounts/clipf6qz5nxegbgku5yqzkd2","name":"clipf6qz5nxegbgku5yqzkd2","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T07:45:44.7937561Z","key2":"2023-03-06T07:45:44.7937561Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:45:45.1687946Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:45:45.1687946Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T07:45:44.7000168Z","primaryEndpoints":{"blob":"https://clipf6qz5nxegbgku5yqzkd2.blob.core.windows.net/","queue":"https://clipf6qz5nxegbgku5yqzkd2.queue.core.windows.net/","table":"https://clipf6qz5nxegbgku5yqzkd2.table.core.windows.net/","file":"https://clipf6qz5nxegbgku5yqzkd2.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsolep35rualbmodx4sho6gltgwspkbsxnsj34im3hqgkvnopy3hqugcaw/providers/Microsoft.Storage/storageAccounts/clite7vcjveueljfi27rolvu","name":"clite7vcjveueljfi27rolvu","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T14:54:23.8082415Z","key2":"2023-03-06T14:54:23.8082415Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.5270280Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.5270280Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T14:54:23.6989027Z","primaryEndpoints":{"blob":"https://clite7vcjveueljfi27rolvu.blob.core.windows.net/","queue":"https://clite7vcjveueljfi27rolvu.queue.core.windows.net/","table":"https://clite7vcjveueljfi27rolvu.table.core.windows.net/","file":"https://clite7vcjveueljfi27rolvu.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsoledcvrpndxic4emeqq5apwkns4qa5owpy4jn3b536ks35zdrmn7bl5k/providers/Microsoft.Storage/storageAccounts/cliwqnm2fo7pftnxlk7c734i","name":"cliwqnm2fo7pftnxlk7c734i","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T07:34:57.7461613Z","key2":"2023-03-06T07:34:57.7461613Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:34:57.9961851Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:34:57.9961851Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T07:34:57.6368148Z","primaryEndpoints":{"blob":"https://cliwqnm2fo7pftnxlk7c734i.blob.core.windows.net/","queue":"https://cliwqnm2fo7pftnxlk7c734i.queue.core.windows.net/","table":"https://cliwqnm2fo7pftnxlk7c734i.table.core.windows.net/","file":"https://cliwqnm2fo7pftnxlk7c734i.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002","name":"cli000002","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T14:54:24.1208364Z","key2":"2023-03-06T14:54:24.1208364Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.6676739Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.6676739Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T14:54:24.0114062Z","primaryEndpoints":{"blob":"https://cli000002.blob.core.windows.net/","queue":"https://cli000002.queue.core.windows.net/","table":"https://cli000002.table.core.windows.net/","file":"https://cli000002.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guptar2/providers/Microsoft.Storage/storageAccounts/guptar2diagnosticsv1","name":"guptar2diagnosticsv1","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2022-04-05T17:21:41.8250582Z","key2":"2022-04-05T17:21:41.8250582Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:21:41.8250582Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:21:41.8250582Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-04-05T17:21:41.7313240Z","primaryEndpoints":{"blob":"https://guptar2diagnosticsv1.blob.core.windows.net/","queue":"https://guptar2diagnosticsv1.queue.core.windows.net/","table":"https://guptar2diagnosticsv1.table.core.windows.net/","file":"https://guptar2diagnosticsv1.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guptar2/providers/Microsoft.Storage/storageAccounts/guptar2diagnosticsv2","name":"guptar2diagnosticsv2","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-04-05T17:22:55.8411567Z","key2":"2022-04-05T17:22:55.8411567Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"resourceAccessRules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[{"value":"20.98.146.84","action":"Allow"},{"value":"20.83.222.102","action":"Allow"},{"value":"20.98.194.64","action":"Allow"},{"value":"20.69.5.162","action":"Allow"}],"defaultAction":"Deny"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:22:55.8411567Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:22:55.8411567Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-04-05T17:22:55.7318000Z","primaryEndpoints":{"dfs":"https://guptar2diagnosticsv2.dfs.core.windows.net/","web":"https://guptar2diagnosticsv2.z5.web.core.windows.net/","blob":"https://guptar2diagnosticsv2.blob.core.windows.net/","queue":"https://guptar2diagnosticsv2.queue.core.windows.net/","table":"https://guptar2diagnosticsv2.table.core.windows.net/","file":"https://guptar2diagnosticsv2.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sericonrp-trafficmanager/providers/Microsoft.Storage/storageAccounts/sericonrpdevtmstorage","name":"sericonrpdevtmstorage","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-11-30T19:15:41.5013570Z","key2":"2022-11-30T19:15:41.5013570Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-11-30T19:15:42.0638737Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-11-30T19:15:42.0638737Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-11-30T19:15:41.4075777Z","primaryEndpoints":{"dfs":"https://sericonrpdevtmstorage.dfs.core.windows.net/","web":"https://sericonrpdevtmstorage.z5.web.core.windows.net/","blob":"https://sericonrpdevtmstorage.blob.core.windows.net/","queue":"https://sericonrpdevtmstorage.queue.core.windows.net/","table":"https://sericonrpdevtmstorage.table.core.windows.net/","file":"https://sericonrpdevtmstorage.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available","secondaryLocation":"westcentralus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://sericonrpdevtmstorage-secondary.dfs.core.windows.net/","web":"https://sericonrpdevtmstorage-secondary.z5.web.core.windows.net/","blob":"https://sericonrpdevtmstorage-secondary.blob.core.windows.net/","queue":"https://sericonrpdevtmstorage-secondary.queue.core.windows.net/","table":"https://sericonrpdevtmstorage-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ops/providers/Microsoft.Storage/storageAccounts/sericonstorage","name":"sericonstorage","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2023-03-05T19:58:00.4355863Z","key2":"2023-03-05T19:58:00.4355863Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-05T19:58:00.9824831Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-05T19:58:00.9824831Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2023-03-05T19:58:00.3262342Z","primaryEndpoints":{"dfs":"https://sericonstorage.dfs.core.windows.net/","web":"https://sericonstorage.z5.web.core.windows.net/","blob":"https://sericonstorage.blob.core.windows.net/","queue":"https://sericonstorage.queue.core.windows.net/","table":"https://sericonstorage.table.core.windows.net/","file":"https://sericonstorage.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rhoover-dev-rg/providers/Microsoft.Storage/storageAccounts/rhooverdevrgdiag","name":"rhooverdevrgdiag","type":"Microsoft.Storage/storageAccounts","location":"westcentralus","tags":{},"properties":{"defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-06-20T19:39:24.4605968Z","key2":"2022-06-20T19:39:24.4605968Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":false,"networkAcls":{"resourceAccessRules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[{"value":"20.98.146.84","action":"Allow"},{"value":"20.98.194.64","action":"Allow"},{"value":"20.69.5.162","action":"Allow"},{"value":"20.83.222.102","action":"Allow"},{"value":"76.197.206.105","action":"Allow"}],"defaultAction":"Deny"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-06-20T19:39:24.4762287Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-06-20T19:39:24.4762287Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-06-20T19:39:24.4137057Z","primaryEndpoints":{"blob":"https://rhooverdevrgdiag.blob.core.windows.net/","queue":"https://rhooverdevrgdiag.queue.core.windows.net/","table":"https://rhooverdevrgdiag.table.core.windows.net/","file":"https://rhooverdevrgdiag.file.core.windows.net/"},"primaryLocation":"westcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnervmrg-westcentralus/providers/Microsoft.Storage/storageAccounts/scrunneraoptpjec4skce","name":"scrunneraoptpjec4skce","type":"Microsoft.Storage/storageAccounts","location":"westcentralus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-02-11T08:40:40.0686467Z","key2":"2023-02-11T08:40:40.0686467Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:40:40.5842822Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:40:40.5842822Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-02-11T08:40:40.0061730Z","primaryEndpoints":{"blob":"https://scrunneraoptpjec4skce.blob.core.windows.net/","queue":"https://scrunneraoptpjec4skce.queue.core.windows.net/","table":"https://scrunneraoptpjec4skce.table.core.windows.net/","file":"https://scrunneraoptpjec4skce.file.core.windows.net/"},"primaryLocation":"westcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnertestvmrg-westcentralus/providers/Microsoft.Storage/storageAccounts/scrunnerrfscmqxeni3uq","name":"scrunnerrfscmqxeni3uq","type":"Microsoft.Storage/storageAccounts","location":"westcentralus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-04-10T22:28:55.2104910Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-04-10T22:28:55.2104910Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-04-10T22:28:55.1479670Z","primaryEndpoints":{"blob":"https://scrunnerrfscmqxeni3uq.blob.core.windows.net/","queue":"https://scrunnerrfscmqxeni3uq.queue.core.windows.net/","table":"https://scrunnerrfscmqxeni3uq.table.core.windows.net/","file":"https://scrunnerrfscmqxeni3uq.file.core.windows.net/"},"primaryLocation":"westcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ubuntu-westus3_group/providers/Microsoft.Storage/storageAccounts/ubuntuwestus3groupdiag","name":"ubuntuwestus3groupdiag","type":"Microsoft.Storage/storageAccounts","location":"westus3","tags":{},"properties":{"keyCreationTime":{"key1":"2022-04-18T19:48:38.9882588Z","key2":"2022-04-18T19:48:38.9882588Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-18T19:48:38.9882588Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-18T19:48:38.9882588Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-04-18T19:48:38.9258191Z","primaryEndpoints":{"blob":"https://ubuntuwestus3groupdiag.blob.core.windows.net/","queue":"https://ubuntuwestus3groupdiag.queue.core.windows.net/","table":"https://ubuntuwestus3groupdiag.table.core.windows.net/","file":"https://ubuntuwestus3groupdiag.file.core.windows.net/"},"primaryLocation":"westus3","statusOfPrimary":"available"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '42669'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 06 Mar 2023 14:59:23 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-original-request-ids:
+      - 7d88dd73-d50b-4809-aab8-6dae9409258f
+      - 772b8a67-f005-4473-b508-1f3362975f90
+      - 8465d3bb-e524-4497-9e8d-a814b758a5cd
+      - b8802316-0a04-4b59-b74b-d04c6878767f
+      - 0bc1b431-65e5-4408-ab6f-6ee59f7dbb87
+      - fa174405-060e-4048-9c96-17aca723f277
+      - 9feb96e5-f4fe-4f51-9587-d85b975c1906
+      - a6b6e4dd-5f85-499d-90c0-dedd3b570d64
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - serial-console disable
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002","name":"cli000002","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2022-12-13T22:51:17.0682893Z","key2":"2022-12-13T22:51:17.0682893Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-12-13T22:51:17.6307939Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-12-13T22:51:17.6307939Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-12-13T22:51:16.9745683Z","primaryEndpoints":{"blob":"https://cli000002.blob.core.windows.net/","queue":"https://cli000002.queue.core.windows.net/","table":"https://cli000002.table.core.windows.net/","file":"https://cli000002.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002","name":"cli000002","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T14:54:24.1208364Z","key2":"2023-03-06T14:54:24.1208364Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.6676739Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.6676739Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T14:54:24.0114062Z","primaryEndpoints":{"blob":"https://cli000002.blob.core.windows.net/","queue":"https://cli000002.queue.core.windows.net/","table":"https://cli000002.table.core.windows.net/","file":"https://cli000002.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -4281,7 +4035,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 13 Dec 2022 22:56:32 GMT
+      - Mon, 06 Mar 2023 14:59:23 GMT
       expires:
       - '-1'
       pragma:
@@ -4311,8 +4065,8 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
-        (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.SerialConsole/consoleServices/default?api-version=2018-05-01
   response:
@@ -4326,7 +4080,7 @@ interactions:
       content-type:
       - application/json; charset=UTF-8
       date:
-      - Tue, 13 Dec 2022 22:56:32 GMT
+      - Mon, 06 Mar 2023 14:59:23 GMT
       expires:
       - '-1'
       pragma:
@@ -4362,8 +4116,8 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
-        (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
+        (Windows-10-10.0.22621-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.SerialConsole/consoleServices/default/enableConsole?api-version=2018-05-01
   response:
@@ -4377,7 +4131,7 @@ interactions:
       content-type:
       - application/json; charset=UTF-8
       date:
-      - Tue, 13 Dec 2022 22:56:33 GMT
+      - Mon, 06 Mar 2023 14:59:24 GMT
       expires:
       - '-1'
       pragma:
@@ -4411,9 +4165,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?$expand=instanceView&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?$expand=instanceView&api-version=2022-11-01
   response:
     body:
       string: "{\r\n  \"name\": \"cli000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003\",\r\n
@@ -4423,29 +4177,29 @@ interactions:
         \   \"userAssignedIdentities\": {\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/AzSecPackAutoConfigUA-westus2\":
         {\r\n        \"principalId\": \"684d55e2-8922-4966-a660-2d38ca4a1711\",\r\n
         \       \"clientId\": \"6d45cf55-f311-4228-97b0-c22ae418aad6\"\r\n      }\r\n
-        \   }\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"d54f150a-5634-4201-b5af-271e2cd52432\",\r\n
+        \   }\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"94bb0e59-1bcd-493b-aa53-580e2ad730d7\",\r\n
         \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
         \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
         \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
         \"18.04-LTS\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
-        \"18.04.202212090\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\",\r\n
+        \"18.04.202302100\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\",\r\n
         \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
         \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_SERIALCONSOLELMXZIWWK5PS5Z6A7GSGJPKCGAUTWUFSF6S5STLYYHQ6COP3BWYY27/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\"\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_SERIALCONSOLE46W4L74TUUPDKTQIUNEVCDRGNWE77YHJM4DVRHN3I4J7UGNGQPGEM/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\"\r\n
         \       },\r\n        \"deleteOption\": \"Detach\",\r\n        \"diskSizeGB\":
         30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
-        {\r\n      \"computerName\": \"cli000003\",\r\n      \"adminUsername\": \"rhl\",\r\n
+        {\r\n      \"computerName\": \"cli000003\",\r\n      \"adminUsername\": \"rhoover\",\r\n
         \     \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
         true,\r\n        \"ssh\": {\r\n          \"publicKeys\": [\r\n            {\r\n
-        \             \"path\": \"/home/rhl/.ssh/authorized_keys\",\r\n              \"keyData\":
-        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h\"\r\n
-        \           }\r\n          ]\r\n        },\r\n        \"provisionVMAgent\":
-        true,\r\n        \"patchSettings\": {\r\n          \"patchMode\": \"ImageDefault\",\r\n
-        \         \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n        \"enableVMAgentPlatformUpdates\":
-        false\r\n      },\r\n      \"secrets\": [],\r\n      \"allowExtensionOperations\":
-        true,\r\n      \"requireGuestProvisionSignal\": true\r\n    },\r\n    \"networkProfile\":
-        {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
+        \             \"path\": \"/home/rhoover/.ssh/authorized_keys\",\r\n              \"keyData\":
+        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+        REDMOND+rhoover@DESKTOP-XVFR7ID\\n\"\r\n            }\r\n          ]\r\n        },\r\n
+        \       \"provisionVMAgent\": true,\r\n        \"patchSettings\": {\r\n          \"patchMode\":
+        \"ImageDefault\",\r\n          \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n
+        \       \"enableVMAgentPlatformUpdates\": false\r\n      },\r\n      \"secrets\":
+        [],\r\n      \"allowExtensionOperations\": true,\r\n      \"requireGuestProvisionSignal\":
+        true\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
         \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
         true,\r\n        \"storageUri\": \"https://cli000002.blob.core.windows.net/\"\r\n
         \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\":
@@ -4454,31 +4208,31 @@ interactions:
         \"2.9.0.4\",\r\n        \"statuses\": [\r\n          {\r\n            \"code\":
         \"ProvisioningState/succeeded\",\r\n            \"level\": \"Info\",\r\n            \"displayStatus\":
         \"Ready\",\r\n            \"message\": \"Guest Agent is running\",\r\n            \"time\":
-        \"2022-12-13T22:56:08+00:00\"\r\n          }\r\n        ],\r\n        \"extensionHandlers\":
-        []\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\",\r\n
+        \"2023-03-06T14:59:22+00:00\"\r\n          }\r\n        ],\r\n        \"extensionHandlers\":
+        []\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\",\r\n
         \         \"statuses\": [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n
         \             \"level\": \"Info\",\r\n              \"displayStatus\": \"Provisioning
-        succeeded\",\r\n              \"time\": \"2022-12-13T22:55:14.423288+00:00\"\r\n
+        succeeded\",\r\n              \"time\": \"2023-03-06T14:58:04.5346581+00:00\"\r\n
         \           }\r\n          ]\r\n        }\r\n      ],\r\n      \"bootDiagnostics\":
-        {\r\n        \"consoleScreenshotBlobUri\": \"https://cli000002.blob.core.windows.net/bootdiagnostics-clik3qxir-d54f150a-5634-4201-b5af-271e2cd52432/cli000003.d54f150a-5634-4201-b5af-271e2cd52432.screenshot.bmp\",\r\n
-        \       \"serialConsoleLogBlobUri\": \"https://cli000002.blob.core.windows.net/bootdiagnostics-clik3qxir-d54f150a-5634-4201-b5af-271e2cd52432/cli000003.d54f150a-5634-4201-b5af-271e2cd52432.serialconsole.log\"\r\n
+        {\r\n        \"consoleScreenshotBlobUri\": \"https://cli000002.blob.core.windows.net/bootdiagnostics-cli7hpi2h-94bb0e59-1bcd-493b-aa53-580e2ad730d7/cli000003.94bb0e59-1bcd-493b-aa53-580e2ad730d7.screenshot.bmp\",\r\n
+        \       \"serialConsoleLogBlobUri\": \"https://cli000002.blob.core.windows.net/bootdiagnostics-cli7hpi2h-94bb0e59-1bcd-493b-aa53-580e2ad730d7/cli000003.94bb0e59-1bcd-493b-aa53-580e2ad730d7.serialconsole.log\"\r\n
         \     },\r\n      \"hyperVGeneration\": \"V1\",\r\n      \"statuses\": [\r\n
         \       {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n          \"level\":
         \"Info\",\r\n          \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \         \"time\": \"2022-12-13T22:56:03.7199254+00:00\"\r\n        },\r\n
+        \         \"time\": \"2023-03-06T14:58:57.5189131+00:00\"\r\n        },\r\n
         \       {\r\n          \"code\": \"PowerState/running\",\r\n          \"level\":
         \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\n        }\r\n
-        \     ]\r\n    },\r\n    \"timeCreated\": \"2022-12-13T22:51:52.3460253+00:00\"\r\n
+        \     ]\r\n    },\r\n    \"timeCreated\": \"2023-03-06T14:55:01.5508486+00:00\"\r\n
         \ }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '5110'
+      - '5325'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:56:33 GMT
+      - Mon, 06 Mar 2023 14:59:24 GMT
       expires:
       - '-1'
       pragma:
@@ -4495,7 +4249,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/LowCostGet3Min;3979,Microsoft.Compute/LowCostGet30Min;31965
+      - Microsoft.Compute/LowCostGet3Min;3951,Microsoft.Compute/LowCostGet30Min;31931
     status:
       code: 200
       message: OK
@@ -4511,12 +4265,61 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/storageAccounts?api-version=2022-09-01
+  response:
+    body:
+      string: '{"value":[{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloud-shell-storage-eastus/providers/Microsoft.Storage/storageAccounts/cs210032001f4814ba9","name":"cs210032001f4814ba9","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"ms-resource-usage":"azure-cloud-shell"},"properties":{"keyCreationTime":{"key1":"2022-05-16T14:16:22.3477819Z","key2":"2022-05-16T14:16:22.3477819Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-16T14:16:22.3477819Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-16T14:16:22.3477819Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-05-16T14:16:22.2227752Z","primaryEndpoints":{"dfs":"https://cs210032001f4814ba9.dfs.core.windows.net/","web":"https://cs210032001f4814ba9.z13.web.core.windows.net/","blob":"https://cs210032001f4814ba9.blob.core.windows.net/","queue":"https://cs210032001f4814ba9.queue.core.windows.net/","table":"https://cs210032001f4814ba9.table.core.windows.net/","file":"https://cs210032001f4814ba9.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/kustoflow/providers/Microsoft.Storage/storageAccounts/csslinuxkustoflow","name":"csslinuxkustoflow","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"CreatedBy":"craigw"},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-02-01T20:08:38.6849654Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-02-01T20:08:38.6849654Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2019-02-01T20:08:38.5912170Z","primaryEndpoints":{"dfs":"https://csslinuxkustoflow.dfs.core.windows.net/","web":"https://csslinuxkustoflow.z13.web.core.windows.net/","blob":"https://csslinuxkustoflow.blob.core.windows.net/","queue":"https://csslinuxkustoflow.queue.core.windows.net/","table":"https://csslinuxkustoflow.table.core.windows.net/","file":"https://csslinuxkustoflow.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://csslinuxkustoflow-secondary.dfs.core.windows.net/","web":"https://csslinuxkustoflow-secondary.z13.web.core.windows.net/","blob":"https://csslinuxkustoflow-secondary.blob.core.windows.net/","queue":"https://csslinuxkustoflow-secondary.queue.core.windows.net/","table":"https://csslinuxkustoflow-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guidomassonitest-rg/providers/Microsoft.Storage/storageAccounts/guidomassonitestrg88ad","name":"guidomassonitestrg88ad","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-01-23T18:52:02.5484088Z","key2":"2023-01-23T18:52:02.5484088Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-01-23T18:52:02.5484088Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-01-23T18:52:02.5484088Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-01-23T18:52:02.4077698Z","primaryEndpoints":{"blob":"https://guidomassonitestrg88ad.blob.core.windows.net/","queue":"https://guidomassonitestrg88ad.queue.core.windows.net/","table":"https://guidomassonitestrg88ad.table.core.windows.net/","file":"https://guidomassonitestrg88ad.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guidomtesttrafficmanagerrg/providers/Microsoft.Storage/storageAccounts/guidomteststoraccfortm","name":"guidomteststoraccfortm","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-10-18T18:01:13.5231266Z","key2":"2022-10-18T18:01:13.5231266Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-10-18T18:01:13.5387607Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-10-18T18:01:13.5387607Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-10-18T18:01:13.3825002Z","primaryEndpoints":{"dfs":"https://guidomteststoraccfortm.dfs.core.windows.net/","web":"https://guidomteststoraccfortm.z13.web.core.windows.net/","blob":"https://guidomteststoraccfortm.blob.core.windows.net/","queue":"https://guidomteststoraccfortm.queue.core.windows.net/","table":"https://guidomteststoraccfortm.table.core.windows.net/","file":"https://guidomteststoraccfortm.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://guidomteststoraccfortm-secondary.dfs.core.windows.net/","web":"https://guidomteststoraccfortm-secondary.z13.web.core.windows.net/","blob":"https://guidomteststoraccfortm-secondary.blob.core.windows.net/","queue":"https://guidomteststoraccfortm-secondary.queue.core.windows.net/","table":"https://guidomteststoraccfortm-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnertestvmrg-eastus/providers/Microsoft.Storage/storageAccounts/scrunnercrkwpdn5nhtgg","name":"scrunnercrkwpdn5nhtgg","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-05-12T20:03:57.6389684Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-05-12T20:03:57.6389684Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-05-12T20:03:57.5451905Z","primaryEndpoints":{"blob":"https://scrunnercrkwpdn5nhtgg.blob.core.windows.net/","queue":"https://scrunnercrkwpdn5nhtgg.queue.core.windows.net/","table":"https://scrunnercrkwpdn5nhtgg.table.core.windows.net/","file":"https://scrunnercrkwpdn5nhtgg.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnervmrg-eastus/providers/Microsoft.Storage/storageAccounts/scrunneri2ezqh4xu2wqq","name":"scrunneri2ezqh4xu2wqq","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-02-11T08:01:12.9383535Z","key2":"2023-02-11T08:01:12.9383535Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:01:12.9383535Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:01:12.9383535Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-02-11T08:01:12.6883669Z","primaryEndpoints":{"blob":"https://scrunneri2ezqh4xu2wqq.blob.core.windows.net/","queue":"https://scrunneri2ezqh4xu2wqq.queue.core.windows.net/","table":"https://scrunneri2ezqh4xu2wqq.table.core.windows.net/","file":"https://scrunneri2ezqh4xu2wqq.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/serialTest-EastUS/providers/Microsoft.Storage/storageAccounts/serialtesta8d7fdee41","name":"serialtesta8d7fdee41","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-07-11T00:38:13.5389932Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-07-11T00:38:13.5389932Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2019-07-11T00:38:13.4452119Z","primaryEndpoints":{"blob":"https://serialtesta8d7fdee41.blob.core.windows.net/","queue":"https://serialtesta8d7fdee41.queue.core.windows.net/","table":"https://serialtesta8d7fdee41.table.core.windows.net/","file":"https://serialtesta8d7fdee41.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/storage-RG/providers/Microsoft.Storage/storageAccounts/serialtestbootdiag123","name":"serialtestbootdiag123","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-01-23T04:03:01.3263151Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-01-23T04:03:01.3263151Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2018-01-23T04:03:01.2951106Z","primaryEndpoints":{"blob":"https://serialtestbootdiag123.blob.core.windows.net/","queue":"https://serialtestbootdiag123.queue.core.windows.net/","table":"https://serialtestbootdiag123.table.core.windows.net/","file":"https://serialtestbootdiag123.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yuas-rg/providers/Microsoft.Storage/storageAccounts/yuasstorageacct","name":"yuasstorageacct","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-08-02T12:18:18.8547131Z","key2":"2022-08-02T12:18:18.8547131Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-08-02T12:18:18.8547131Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-08-02T12:18:18.8547131Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-08-02T12:18:18.7140969Z","primaryEndpoints":{"dfs":"https://yuasstorageacct.dfs.core.windows.net/","web":"https://yuasstorageacct.z13.web.core.windows.net/","blob":"https://yuasstorageacct.blob.core.windows.net/","queue":"https://yuasstorageacct.queue.core.windows.net/","table":"https://yuasstorageacct.table.core.windows.net/","file":"https://yuasstorageacct.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://yuasstorageacct-secondary.dfs.core.windows.net/","web":"https://yuasstorageacct-secondary.z13.web.core.windows.net/","blob":"https://yuasstorageacct-secondary.blob.core.windows.net/","queue":"https://yuasstorageacct-secondary.queue.core.windows.net/","table":"https://yuasstorageacct-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/bkerrigan-dev-rg/providers/Microsoft.Storage/storageAccounts/bktestsa2","name":"bktestsa2","type":"Microsoft.Storage/storageAccounts","location":"eastus2","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","immutableStorageWithVersioning":{"enabled":true},"keyCreationTime":{"key1":"2022-09-27T23:58:45.6496284Z","key2":"2022-09-27T23:58:45.6496284Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-09-27T23:58:46.2902461Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-09-27T23:58:46.2902461Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Cool","provisioningState":"Succeeded","creationTime":"2022-09-27T23:58:45.5558609Z","primaryEndpoints":{"dfs":"https://bktestsa2.dfs.core.windows.net/","web":"https://bktestsa2.z20.web.core.windows.net/","blob":"https://bktestsa2.blob.core.windows.net/","queue":"https://bktestsa2.queue.core.windows.net/","table":"https://bktestsa2.table.core.windows.net/","file":"https://bktestsa2.file.core.windows.net/"},"primaryLocation":"eastus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rhel-test/providers/Microsoft.Storage/storageAccounts/rhel77acct","name":"rhel77acct","type":"Microsoft.Storage/storageAccounts","location":"eastus2","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-08-13T20:31:30.8995173Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-08-13T20:31:30.8995173Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-08-13T20:31:30.8215811Z","primaryEndpoints":{"blob":"https://rhel77acct.blob.core.windows.net/","queue":"https://rhel77acct.queue.core.windows.net/","table":"https://rhel77acct.table.core.windows.net/","file":"https://rhel77acct.file.core.windows.net/"},"primaryLocation":"eastus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SCRunner/providers/Microsoft.Storage/storageAccounts/scrunnerstorage","name":"scrunnerstorage","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-03-06T00:42:11.7016543Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-03-06T00:42:11.7016543Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2018-03-06T00:42:11.6234985Z","primaryEndpoints":{"blob":"https://scrunnerstorage.blob.core.windows.net/","queue":"https://scrunnerstorage.queue.core.windows.net/","table":"https://scrunnerstorage.table.core.windows.net/","file":"https://scrunnerstorage.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rhoover/providers/Microsoft.Storage/storageAccounts/rhooverstorage","name":"rhooverstorage","type":"Microsoft.Storage/storageAccounts","location":"southcentralus","tags":{"ms-resource-usage":"azure-cloud-shell"},"properties":{"keyCreationTime":{"key1":"2022-05-26T17:14:23.5085026Z","key2":"2022-05-26T17:14:23.5085026Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-26T17:14:23.5241285Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-26T17:14:23.5241285Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-05-26T17:14:23.4147520Z","primaryEndpoints":{"dfs":"https://rhooverstorage.dfs.core.windows.net/","web":"https://rhooverstorage.z21.web.core.windows.net/","blob":"https://rhooverstorage.blob.core.windows.net/","queue":"https://rhooverstorage.queue.core.windows.net/","table":"https://rhooverstorage.table.core.windows.net/","file":"https://rhooverstorage.file.core.windows.net/"},"primaryLocation":"southcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SCRunnertestvmrg-AustraliaEast/providers/Microsoft.Storage/storageAccounts/scrunner4p3t72mzheluc","name":"scrunner4p3t72mzheluc","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{},"properties":{"keyCreationTime":{"key1":"2021-04-13T22:35:36.6210942Z","key2":"2021-04-13T22:35:36.6210942Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2021-04-13T22:35:36.6210942Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2021-04-13T22:35:36.6210942Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2021-04-13T22:35:36.5429508Z","primaryEndpoints":{"blob":"https://scrunner4p3t72mzheluc.blob.core.windows.net/","queue":"https://scrunner4p3t72mzheluc.queue.core.windows.net/","table":"https://scrunner4p3t72mzheluc.table.core.windows.net/","file":"https://scrunner4p3t72mzheluc.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnervmrg-australiaeast/providers/Microsoft.Storage/storageAccounts/scrunner56hymyctm4kw2","name":"scrunner56hymyctm4kw2","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{},"properties":{"keyCreationTime":{"key1":"2023-02-11T08:42:58.2414102Z","key2":"2023-02-11T08:42:58.2414102Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:42:59.3196006Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:42:59.3196006Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-02-11T08:42:58.1476588Z","primaryEndpoints":{"blob":"https://scrunner56hymyctm4kw2.blob.core.windows.net/","queue":"https://scrunner56hymyctm4kw2.queue.core.windows.net/","table":"https://scrunner56hymyctm4kw2.table.core.windows.net/","file":"https://scrunner56hymyctm4kw2.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsolestuzi7ftnukpi2fyagwys225gbsh73m2h2z7zwjnemrgl5jrfrevg/providers/Microsoft.Storage/storageAccounts/clij3widgfvooidlncm4zwgr","name":"clij3widgfvooidlncm4zwgr","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T14:54:24.1363998Z","key2":"2023-03-06T14:54:24.1363998Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.6364190Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.6364190Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T14:54:24.0114062Z","primaryEndpoints":{"blob":"https://clij3widgfvooidlncm4zwgr.blob.core.windows.net/","queue":"https://clij3widgfvooidlncm4zwgr.queue.core.windows.net/","table":"https://clij3widgfvooidlncm4zwgr.table.core.windows.net/","file":"https://clij3widgfvooidlncm4zwgr.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsolek4hibhcaoukjiclxhnksydes553f4t7r3glwjvxloifh37s6yqdk5/providers/Microsoft.Storage/storageAccounts/cliln4rgfngepmlxlmpwv5wk","name":"cliln4rgfngepmlxlmpwv5wk","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T14:58:59.2000914Z","key2":"2023-03-06T14:58:59.2000914Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:58:59.8876132Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:58:59.8876132Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T14:58:59.1063047Z","primaryEndpoints":{"blob":"https://cliln4rgfngepmlxlmpwv5wk.blob.core.windows.net/","queue":"https://cliln4rgfngepmlxlmpwv5wk.queue.core.windows.net/","table":"https://cliln4rgfngepmlxlmpwv5wk.table.core.windows.net/","file":"https://cliln4rgfngepmlxlmpwv5wk.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsolex4geueyy52iloaspyxz3rrqwxv2syvnkjiljxbv522buwxqpiljme/providers/Microsoft.Storage/storageAccounts/clipf6qz5nxegbgku5yqzkd2","name":"clipf6qz5nxegbgku5yqzkd2","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T07:45:44.7937561Z","key2":"2023-03-06T07:45:44.7937561Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:45:45.1687946Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:45:45.1687946Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T07:45:44.7000168Z","primaryEndpoints":{"blob":"https://clipf6qz5nxegbgku5yqzkd2.blob.core.windows.net/","queue":"https://clipf6qz5nxegbgku5yqzkd2.queue.core.windows.net/","table":"https://clipf6qz5nxegbgku5yqzkd2.table.core.windows.net/","file":"https://clipf6qz5nxegbgku5yqzkd2.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsolep35rualbmodx4sho6gltgwspkbsxnsj34im3hqgkvnopy3hqugcaw/providers/Microsoft.Storage/storageAccounts/clite7vcjveueljfi27rolvu","name":"clite7vcjveueljfi27rolvu","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T14:54:23.8082415Z","key2":"2023-03-06T14:54:23.8082415Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.5270280Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.5270280Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T14:54:23.6989027Z","primaryEndpoints":{"blob":"https://clite7vcjveueljfi27rolvu.blob.core.windows.net/","queue":"https://clite7vcjveueljfi27rolvu.queue.core.windows.net/","table":"https://clite7vcjveueljfi27rolvu.table.core.windows.net/","file":"https://clite7vcjveueljfi27rolvu.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsoledcvrpndxic4emeqq5apwkns4qa5owpy4jn3b536ks35zdrmn7bl5k/providers/Microsoft.Storage/storageAccounts/cliwqnm2fo7pftnxlk7c734i","name":"cliwqnm2fo7pftnxlk7c734i","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T07:34:57.7461613Z","key2":"2023-03-06T07:34:57.7461613Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:34:57.9961851Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:34:57.9961851Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T07:34:57.6368148Z","primaryEndpoints":{"blob":"https://cliwqnm2fo7pftnxlk7c734i.blob.core.windows.net/","queue":"https://cliwqnm2fo7pftnxlk7c734i.queue.core.windows.net/","table":"https://cliwqnm2fo7pftnxlk7c734i.table.core.windows.net/","file":"https://cliwqnm2fo7pftnxlk7c734i.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002","name":"cli000002","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T14:54:24.1208364Z","key2":"2023-03-06T14:54:24.1208364Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.6676739Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.6676739Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T14:54:24.0114062Z","primaryEndpoints":{"blob":"https://cli000002.blob.core.windows.net/","queue":"https://cli000002.queue.core.windows.net/","table":"https://cli000002.table.core.windows.net/","file":"https://cli000002.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guptar2/providers/Microsoft.Storage/storageAccounts/guptar2diagnosticsv1","name":"guptar2diagnosticsv1","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2022-04-05T17:21:41.8250582Z","key2":"2022-04-05T17:21:41.8250582Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:21:41.8250582Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:21:41.8250582Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-04-05T17:21:41.7313240Z","primaryEndpoints":{"blob":"https://guptar2diagnosticsv1.blob.core.windows.net/","queue":"https://guptar2diagnosticsv1.queue.core.windows.net/","table":"https://guptar2diagnosticsv1.table.core.windows.net/","file":"https://guptar2diagnosticsv1.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guptar2/providers/Microsoft.Storage/storageAccounts/guptar2diagnosticsv2","name":"guptar2diagnosticsv2","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-04-05T17:22:55.8411567Z","key2":"2022-04-05T17:22:55.8411567Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"resourceAccessRules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[{"value":"20.98.146.84","action":"Allow"},{"value":"20.83.222.102","action":"Allow"},{"value":"20.98.194.64","action":"Allow"},{"value":"20.69.5.162","action":"Allow"}],"defaultAction":"Deny"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:22:55.8411567Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:22:55.8411567Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-04-05T17:22:55.7318000Z","primaryEndpoints":{"dfs":"https://guptar2diagnosticsv2.dfs.core.windows.net/","web":"https://guptar2diagnosticsv2.z5.web.core.windows.net/","blob":"https://guptar2diagnosticsv2.blob.core.windows.net/","queue":"https://guptar2diagnosticsv2.queue.core.windows.net/","table":"https://guptar2diagnosticsv2.table.core.windows.net/","file":"https://guptar2diagnosticsv2.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sericonrp-trafficmanager/providers/Microsoft.Storage/storageAccounts/sericonrpdevtmstorage","name":"sericonrpdevtmstorage","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-11-30T19:15:41.5013570Z","key2":"2022-11-30T19:15:41.5013570Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-11-30T19:15:42.0638737Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-11-30T19:15:42.0638737Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-11-30T19:15:41.4075777Z","primaryEndpoints":{"dfs":"https://sericonrpdevtmstorage.dfs.core.windows.net/","web":"https://sericonrpdevtmstorage.z5.web.core.windows.net/","blob":"https://sericonrpdevtmstorage.blob.core.windows.net/","queue":"https://sericonrpdevtmstorage.queue.core.windows.net/","table":"https://sericonrpdevtmstorage.table.core.windows.net/","file":"https://sericonrpdevtmstorage.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available","secondaryLocation":"westcentralus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://sericonrpdevtmstorage-secondary.dfs.core.windows.net/","web":"https://sericonrpdevtmstorage-secondary.z5.web.core.windows.net/","blob":"https://sericonrpdevtmstorage-secondary.blob.core.windows.net/","queue":"https://sericonrpdevtmstorage-secondary.queue.core.windows.net/","table":"https://sericonrpdevtmstorage-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ops/providers/Microsoft.Storage/storageAccounts/sericonstorage","name":"sericonstorage","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2023-03-05T19:58:00.4355863Z","key2":"2023-03-05T19:58:00.4355863Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-05T19:58:00.9824831Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-05T19:58:00.9824831Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2023-03-05T19:58:00.3262342Z","primaryEndpoints":{"dfs":"https://sericonstorage.dfs.core.windows.net/","web":"https://sericonstorage.z5.web.core.windows.net/","blob":"https://sericonstorage.blob.core.windows.net/","queue":"https://sericonstorage.queue.core.windows.net/","table":"https://sericonstorage.table.core.windows.net/","file":"https://sericonstorage.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rhoover-dev-rg/providers/Microsoft.Storage/storageAccounts/rhooverdevrgdiag","name":"rhooverdevrgdiag","type":"Microsoft.Storage/storageAccounts","location":"westcentralus","tags":{},"properties":{"defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-06-20T19:39:24.4605968Z","key2":"2022-06-20T19:39:24.4605968Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":false,"networkAcls":{"resourceAccessRules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[{"value":"20.98.146.84","action":"Allow"},{"value":"20.98.194.64","action":"Allow"},{"value":"20.69.5.162","action":"Allow"},{"value":"20.83.222.102","action":"Allow"},{"value":"76.197.206.105","action":"Allow"}],"defaultAction":"Deny"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-06-20T19:39:24.4762287Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-06-20T19:39:24.4762287Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-06-20T19:39:24.4137057Z","primaryEndpoints":{"blob":"https://rhooverdevrgdiag.blob.core.windows.net/","queue":"https://rhooverdevrgdiag.queue.core.windows.net/","table":"https://rhooverdevrgdiag.table.core.windows.net/","file":"https://rhooverdevrgdiag.file.core.windows.net/"},"primaryLocation":"westcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnervmrg-westcentralus/providers/Microsoft.Storage/storageAccounts/scrunneraoptpjec4skce","name":"scrunneraoptpjec4skce","type":"Microsoft.Storage/storageAccounts","location":"westcentralus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-02-11T08:40:40.0686467Z","key2":"2023-02-11T08:40:40.0686467Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:40:40.5842822Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:40:40.5842822Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-02-11T08:40:40.0061730Z","primaryEndpoints":{"blob":"https://scrunneraoptpjec4skce.blob.core.windows.net/","queue":"https://scrunneraoptpjec4skce.queue.core.windows.net/","table":"https://scrunneraoptpjec4skce.table.core.windows.net/","file":"https://scrunneraoptpjec4skce.file.core.windows.net/"},"primaryLocation":"westcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnertestvmrg-westcentralus/providers/Microsoft.Storage/storageAccounts/scrunnerrfscmqxeni3uq","name":"scrunnerrfscmqxeni3uq","type":"Microsoft.Storage/storageAccounts","location":"westcentralus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-04-10T22:28:55.2104910Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-04-10T22:28:55.2104910Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-04-10T22:28:55.1479670Z","primaryEndpoints":{"blob":"https://scrunnerrfscmqxeni3uq.blob.core.windows.net/","queue":"https://scrunnerrfscmqxeni3uq.queue.core.windows.net/","table":"https://scrunnerrfscmqxeni3uq.table.core.windows.net/","file":"https://scrunnerrfscmqxeni3uq.file.core.windows.net/"},"primaryLocation":"westcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ubuntu-westus3_group/providers/Microsoft.Storage/storageAccounts/ubuntuwestus3groupdiag","name":"ubuntuwestus3groupdiag","type":"Microsoft.Storage/storageAccounts","location":"westus3","tags":{},"properties":{"keyCreationTime":{"key1":"2022-04-18T19:48:38.9882588Z","key2":"2022-04-18T19:48:38.9882588Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-18T19:48:38.9882588Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-18T19:48:38.9882588Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-04-18T19:48:38.9258191Z","primaryEndpoints":{"blob":"https://ubuntuwestus3groupdiag.blob.core.windows.net/","queue":"https://ubuntuwestus3groupdiag.queue.core.windows.net/","table":"https://ubuntuwestus3groupdiag.table.core.windows.net/","file":"https://ubuntuwestus3groupdiag.file.core.windows.net/"},"primaryLocation":"westus3","statusOfPrimary":"available"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '42669'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 06 Mar 2023 14:59:25 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-original-request-ids:
+      - 67fd4b3e-6f27-4af7-bf33-cbfef8d6d177
+      - b224fef0-2e5a-4acc-b819-1e76d6b5f4c3
+      - 7d9313c1-370b-41bb-a963-18164d70b8eb
+      - 04ca1b33-0fa9-468e-85cd-e3409760893b
+      - 6d333032-e463-47b7-ab6d-d47b8bc1c47a
+      - b2f219e0-79d8-4d69-9756-1c96ce9fca31
+      - 57077e7f-aa47-4f59-96b6-1d2b93013382
+      - bfac14bc-f3da-4ae5-805c-481c5b99b16a
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - serial-console enable
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002","name":"cli000002","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2022-12-13T22:51:17.0682893Z","key2":"2022-12-13T22:51:17.0682893Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-12-13T22:51:17.6307939Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-12-13T22:51:17.6307939Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-12-13T22:51:16.9745683Z","primaryEndpoints":{"blob":"https://cli000002.blob.core.windows.net/","queue":"https://cli000002.queue.core.windows.net/","table":"https://cli000002.table.core.windows.net/","file":"https://cli000002.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002","name":"cli000002","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T14:54:24.1208364Z","key2":"2023-03-06T14:54:24.1208364Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.6676739Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.6676739Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T14:54:24.0114062Z","primaryEndpoints":{"blob":"https://cli000002.blob.core.windows.net/","queue":"https://cli000002.queue.core.windows.net/","table":"https://cli000002.table.core.windows.net/","file":"https://cli000002.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -4525,7 +4328,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 13 Dec 2022 22:56:34 GMT
+      - Mon, 06 Mar 2023 14:59:26 GMT
       expires:
       - '-1'
       pragma:
@@ -4555,8 +4358,8 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
-        (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.SerialConsole/consoleServices/default?api-version=2018-05-01
   response:
@@ -4570,7 +4373,7 @@ interactions:
       content-type:
       - application/json; charset=UTF-8
       date:
-      - Tue, 13 Dec 2022 22:56:34 GMT
+      - Mon, 06 Mar 2023 14:59:25 GMT
       expires:
       - '-1'
       pragma:
@@ -4606,9 +4409,9 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003/powerOff?skipShutdown=false&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003/powerOff?skipShutdown=false&api-version=2022-11-01
   response:
     body:
       string: ''
@@ -4616,17 +4419,17 @@ interactions:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/40c767a3-0ad3-4542-8bca-479d7c90074c?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/3d8b3ee4-ff96-4500-a90c-d6a08d5d97da?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Tue, 13 Dec 2022 22:56:35 GMT
+      - Mon, 06 Mar 2023 14:59:26 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/40c767a3-0ad3-4542-8bca-479d7c90074c?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/3d8b3ee4-ff96-4500-a90c-d6a08d5d97da?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-11-01
       pragma:
       - no-cache
       server:
@@ -4637,7 +4440,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/UpdateVM3Min;237,Microsoft.Compute/UpdateVM30Min;1194
+      - Microsoft.Compute/UpdateVM3Min;234,Microsoft.Compute/UpdateVM30Min;1192
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
     status:
@@ -4657,64 +4460,14 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/40c767a3-0ad3-4542-8bca-479d7c90074c?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/3d8b3ee4-ff96-4500-a90c-d6a08d5d97da?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T22:56:35.9854402+00:00\",\r\n  \"status\":
-        \"InProgress\",\r\n  \"name\": \"40c767a3-0ad3-4542-8bca-479d7c90074c\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '134'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 13 Dec 2022 22:56:35 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14978,Microsoft.Compute/GetOperation30Min;29967
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vm stop
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n
-      User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/40c767a3-0ad3-4542-8bca-479d7c90074c?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
-  response:
-    body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T22:56:35.9854402+00:00\",\r\n  \"endTime\":
-        \"2022-12-13T22:56:41.0322985+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"name\": \"40c767a3-0ad3-4542-8bca-479d7c90074c\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T14:59:27.5188202+00:00\",\r\n  \"endTime\":
+        \"2023-03-06T14:59:30.1594781+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"name\": \"3d8b3ee4-ff96-4500-a90c-d6a08d5d97da\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -4723,7 +4476,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:57:05 GMT
+      - Mon, 06 Mar 2023 14:59:56 GMT
       expires:
       - '-1'
       pragma:
@@ -4740,7 +4493,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14978,Microsoft.Compute/GetOperation30Min;29964
+      - Microsoft.Compute/GetOperation3Min;14943,Microsoft.Compute/GetOperation30Min;29868
     status:
       code: 200
       message: OK
@@ -4758,9 +4511,9 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/40c767a3-0ad3-4542-8bca-479d7c90074c?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/3d8b3ee4-ff96-4500-a90c-d6a08d5d97da?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-11-01
   response:
     body:
       string: ''
@@ -4770,7 +4523,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 13 Dec 2022 22:57:05 GMT
+      - Mon, 06 Mar 2023 14:59:56 GMT
       expires:
       - '-1'
       pragma:
@@ -4783,7 +4536,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14977,Microsoft.Compute/GetOperation30Min;29963
+      - Microsoft.Compute/GetOperation3Min;14942,Microsoft.Compute/GetOperation30Min;29867
     status:
       code: 200
       message: OK
@@ -4801,9 +4554,9 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?$expand=instanceView&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?$expand=instanceView&api-version=2022-11-01
   response:
     body:
       string: "{\r\n  \"name\": \"cli000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003\",\r\n
@@ -4813,29 +4566,29 @@ interactions:
         \   \"userAssignedIdentities\": {\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/AzSecPackAutoConfigUA-westus2\":
         {\r\n        \"principalId\": \"684d55e2-8922-4966-a660-2d38ca4a1711\",\r\n
         \       \"clientId\": \"6d45cf55-f311-4228-97b0-c22ae418aad6\"\r\n      }\r\n
-        \   }\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"d54f150a-5634-4201-b5af-271e2cd52432\",\r\n
+        \   }\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"94bb0e59-1bcd-493b-aa53-580e2ad730d7\",\r\n
         \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
         \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
         \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
         \"18.04-LTS\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
-        \"18.04.202212090\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\",\r\n
+        \"18.04.202302100\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\",\r\n
         \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
         \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_SERIALCONSOLELMXZIWWK5PS5Z6A7GSGJPKCGAUTWUFSF6S5STLYYHQ6COP3BWYY27/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\"\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_SERIALCONSOLE46W4L74TUUPDKTQIUNEVCDRGNWE77YHJM4DVRHN3I4J7UGNGQPGEM/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\"\r\n
         \       },\r\n        \"deleteOption\": \"Detach\",\r\n        \"diskSizeGB\":
         30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
-        {\r\n      \"computerName\": \"cli000003\",\r\n      \"adminUsername\": \"rhl\",\r\n
+        {\r\n      \"computerName\": \"cli000003\",\r\n      \"adminUsername\": \"rhoover\",\r\n
         \     \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
         true,\r\n        \"ssh\": {\r\n          \"publicKeys\": [\r\n            {\r\n
-        \             \"path\": \"/home/rhl/.ssh/authorized_keys\",\r\n              \"keyData\":
-        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h\"\r\n
-        \           }\r\n          ]\r\n        },\r\n        \"provisionVMAgent\":
-        true,\r\n        \"patchSettings\": {\r\n          \"patchMode\": \"ImageDefault\",\r\n
-        \         \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n        \"enableVMAgentPlatformUpdates\":
-        false\r\n      },\r\n      \"secrets\": [],\r\n      \"allowExtensionOperations\":
-        true,\r\n      \"requireGuestProvisionSignal\": true\r\n    },\r\n    \"networkProfile\":
-        {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
+        \             \"path\": \"/home/rhoover/.ssh/authorized_keys\",\r\n              \"keyData\":
+        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+        REDMOND+rhoover@DESKTOP-XVFR7ID\\n\"\r\n            }\r\n          ]\r\n        },\r\n
+        \       \"provisionVMAgent\": true,\r\n        \"patchSettings\": {\r\n          \"patchMode\":
+        \"ImageDefault\",\r\n          \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n
+        \       \"enableVMAgentPlatformUpdates\": false\r\n      },\r\n      \"secrets\":
+        [],\r\n      \"allowExtensionOperations\": true,\r\n      \"requireGuestProvisionSignal\":
+        true\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
         \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
         true,\r\n        \"storageUri\": \"https://cli000002.blob.core.windows.net/\"\r\n
         \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\":
@@ -4844,31 +4597,31 @@ interactions:
         \"2.9.0.4\",\r\n        \"statuses\": [\r\n          {\r\n            \"code\":
         \"ProvisioningState/succeeded\",\r\n            \"level\": \"Info\",\r\n            \"displayStatus\":
         \"Ready\",\r\n            \"message\": \"Guest Agent is running\",\r\n            \"time\":
-        \"2022-12-13T22:56:08+00:00\"\r\n          }\r\n        ],\r\n        \"extensionHandlers\":
-        []\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\",\r\n
+        \"2023-03-06T14:59:22+00:00\"\r\n          }\r\n        ],\r\n        \"extensionHandlers\":
+        []\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\",\r\n
         \         \"statuses\": [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n
         \             \"level\": \"Info\",\r\n              \"displayStatus\": \"Provisioning
-        succeeded\",\r\n              \"time\": \"2022-12-13T22:55:14.423288+00:00\"\r\n
+        succeeded\",\r\n              \"time\": \"2023-03-06T14:58:04.5346581+00:00\"\r\n
         \           }\r\n          ]\r\n        }\r\n      ],\r\n      \"bootDiagnostics\":
-        {\r\n        \"consoleScreenshotBlobUri\": \"https://cli000002.blob.core.windows.net/bootdiagnostics-clik3qxir-d54f150a-5634-4201-b5af-271e2cd52432/cli000003.d54f150a-5634-4201-b5af-271e2cd52432.screenshot.bmp\",\r\n
-        \       \"serialConsoleLogBlobUri\": \"https://cli000002.blob.core.windows.net/bootdiagnostics-clik3qxir-d54f150a-5634-4201-b5af-271e2cd52432/cli000003.d54f150a-5634-4201-b5af-271e2cd52432.serialconsole.log\"\r\n
+        {\r\n        \"consoleScreenshotBlobUri\": \"https://cli000002.blob.core.windows.net/bootdiagnostics-cli7hpi2h-94bb0e59-1bcd-493b-aa53-580e2ad730d7/cli000003.94bb0e59-1bcd-493b-aa53-580e2ad730d7.screenshot.bmp\",\r\n
+        \       \"serialConsoleLogBlobUri\": \"https://cli000002.blob.core.windows.net/bootdiagnostics-cli7hpi2h-94bb0e59-1bcd-493b-aa53-580e2ad730d7/cli000003.94bb0e59-1bcd-493b-aa53-580e2ad730d7.serialconsole.log\"\r\n
         \     },\r\n      \"hyperVGeneration\": \"V1\",\r\n      \"statuses\": [\r\n
         \       {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n          \"level\":
         \"Info\",\r\n          \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \         \"time\": \"2022-12-13T22:56:41.016659+00:00\"\r\n        },\r\n
+        \         \"time\": \"2023-03-06T14:59:30.1437886+00:00\"\r\n        },\r\n
         \       {\r\n          \"code\": \"PowerState/stopped\",\r\n          \"level\":
         \"Info\",\r\n          \"displayStatus\": \"VM stopped\"\r\n        }\r\n
-        \     ]\r\n    },\r\n    \"timeCreated\": \"2022-12-13T22:51:52.3460253+00:00\"\r\n
+        \     ]\r\n    },\r\n    \"timeCreated\": \"2023-03-06T14:55:01.5508486+00:00\"\r\n
         \ }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '5109'
+      - '5325'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:57:06 GMT
+      - Mon, 06 Mar 2023 14:59:57 GMT
       expires:
       - '-1'
       pragma:
@@ -4885,7 +4638,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/LowCostGet3Min;3980,Microsoft.Compute/LowCostGet30Min;31964
+      - Microsoft.Compute/LowCostGet3Min;3952,Microsoft.Compute/LowCostGet30Min;31929
     status:
       code: 200
       message: OK
@@ -4903,12 +4656,63 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/storageAccounts?api-version=2022-09-01
+  response:
+    body:
+      string: '{"value":[{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloud-shell-storage-eastus/providers/Microsoft.Storage/storageAccounts/cs210032001f4814ba9","name":"cs210032001f4814ba9","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"ms-resource-usage":"azure-cloud-shell"},"properties":{"keyCreationTime":{"key1":"2022-05-16T14:16:22.3477819Z","key2":"2022-05-16T14:16:22.3477819Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-16T14:16:22.3477819Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-16T14:16:22.3477819Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-05-16T14:16:22.2227752Z","primaryEndpoints":{"dfs":"https://cs210032001f4814ba9.dfs.core.windows.net/","web":"https://cs210032001f4814ba9.z13.web.core.windows.net/","blob":"https://cs210032001f4814ba9.blob.core.windows.net/","queue":"https://cs210032001f4814ba9.queue.core.windows.net/","table":"https://cs210032001f4814ba9.table.core.windows.net/","file":"https://cs210032001f4814ba9.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/kustoflow/providers/Microsoft.Storage/storageAccounts/csslinuxkustoflow","name":"csslinuxkustoflow","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"CreatedBy":"craigw"},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-02-01T20:08:38.6849654Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-02-01T20:08:38.6849654Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2019-02-01T20:08:38.5912170Z","primaryEndpoints":{"dfs":"https://csslinuxkustoflow.dfs.core.windows.net/","web":"https://csslinuxkustoflow.z13.web.core.windows.net/","blob":"https://csslinuxkustoflow.blob.core.windows.net/","queue":"https://csslinuxkustoflow.queue.core.windows.net/","table":"https://csslinuxkustoflow.table.core.windows.net/","file":"https://csslinuxkustoflow.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://csslinuxkustoflow-secondary.dfs.core.windows.net/","web":"https://csslinuxkustoflow-secondary.z13.web.core.windows.net/","blob":"https://csslinuxkustoflow-secondary.blob.core.windows.net/","queue":"https://csslinuxkustoflow-secondary.queue.core.windows.net/","table":"https://csslinuxkustoflow-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guidomassonitest-rg/providers/Microsoft.Storage/storageAccounts/guidomassonitestrg88ad","name":"guidomassonitestrg88ad","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-01-23T18:52:02.5484088Z","key2":"2023-01-23T18:52:02.5484088Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-01-23T18:52:02.5484088Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-01-23T18:52:02.5484088Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-01-23T18:52:02.4077698Z","primaryEndpoints":{"blob":"https://guidomassonitestrg88ad.blob.core.windows.net/","queue":"https://guidomassonitestrg88ad.queue.core.windows.net/","table":"https://guidomassonitestrg88ad.table.core.windows.net/","file":"https://guidomassonitestrg88ad.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guidomtesttrafficmanagerrg/providers/Microsoft.Storage/storageAccounts/guidomteststoraccfortm","name":"guidomteststoraccfortm","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-10-18T18:01:13.5231266Z","key2":"2022-10-18T18:01:13.5231266Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-10-18T18:01:13.5387607Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-10-18T18:01:13.5387607Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-10-18T18:01:13.3825002Z","primaryEndpoints":{"dfs":"https://guidomteststoraccfortm.dfs.core.windows.net/","web":"https://guidomteststoraccfortm.z13.web.core.windows.net/","blob":"https://guidomteststoraccfortm.blob.core.windows.net/","queue":"https://guidomteststoraccfortm.queue.core.windows.net/","table":"https://guidomteststoraccfortm.table.core.windows.net/","file":"https://guidomteststoraccfortm.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://guidomteststoraccfortm-secondary.dfs.core.windows.net/","web":"https://guidomteststoraccfortm-secondary.z13.web.core.windows.net/","blob":"https://guidomteststoraccfortm-secondary.blob.core.windows.net/","queue":"https://guidomteststoraccfortm-secondary.queue.core.windows.net/","table":"https://guidomteststoraccfortm-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnertestvmrg-eastus/providers/Microsoft.Storage/storageAccounts/scrunnercrkwpdn5nhtgg","name":"scrunnercrkwpdn5nhtgg","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-05-12T20:03:57.6389684Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-05-12T20:03:57.6389684Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-05-12T20:03:57.5451905Z","primaryEndpoints":{"blob":"https://scrunnercrkwpdn5nhtgg.blob.core.windows.net/","queue":"https://scrunnercrkwpdn5nhtgg.queue.core.windows.net/","table":"https://scrunnercrkwpdn5nhtgg.table.core.windows.net/","file":"https://scrunnercrkwpdn5nhtgg.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnervmrg-eastus/providers/Microsoft.Storage/storageAccounts/scrunneri2ezqh4xu2wqq","name":"scrunneri2ezqh4xu2wqq","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-02-11T08:01:12.9383535Z","key2":"2023-02-11T08:01:12.9383535Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:01:12.9383535Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:01:12.9383535Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-02-11T08:01:12.6883669Z","primaryEndpoints":{"blob":"https://scrunneri2ezqh4xu2wqq.blob.core.windows.net/","queue":"https://scrunneri2ezqh4xu2wqq.queue.core.windows.net/","table":"https://scrunneri2ezqh4xu2wqq.table.core.windows.net/","file":"https://scrunneri2ezqh4xu2wqq.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/serialTest-EastUS/providers/Microsoft.Storage/storageAccounts/serialtesta8d7fdee41","name":"serialtesta8d7fdee41","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-07-11T00:38:13.5389932Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-07-11T00:38:13.5389932Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2019-07-11T00:38:13.4452119Z","primaryEndpoints":{"blob":"https://serialtesta8d7fdee41.blob.core.windows.net/","queue":"https://serialtesta8d7fdee41.queue.core.windows.net/","table":"https://serialtesta8d7fdee41.table.core.windows.net/","file":"https://serialtesta8d7fdee41.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/storage-RG/providers/Microsoft.Storage/storageAccounts/serialtestbootdiag123","name":"serialtestbootdiag123","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-01-23T04:03:01.3263151Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-01-23T04:03:01.3263151Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2018-01-23T04:03:01.2951106Z","primaryEndpoints":{"blob":"https://serialtestbootdiag123.blob.core.windows.net/","queue":"https://serialtestbootdiag123.queue.core.windows.net/","table":"https://serialtestbootdiag123.table.core.windows.net/","file":"https://serialtestbootdiag123.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yuas-rg/providers/Microsoft.Storage/storageAccounts/yuasstorageacct","name":"yuasstorageacct","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-08-02T12:18:18.8547131Z","key2":"2022-08-02T12:18:18.8547131Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-08-02T12:18:18.8547131Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-08-02T12:18:18.8547131Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-08-02T12:18:18.7140969Z","primaryEndpoints":{"dfs":"https://yuasstorageacct.dfs.core.windows.net/","web":"https://yuasstorageacct.z13.web.core.windows.net/","blob":"https://yuasstorageacct.blob.core.windows.net/","queue":"https://yuasstorageacct.queue.core.windows.net/","table":"https://yuasstorageacct.table.core.windows.net/","file":"https://yuasstorageacct.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://yuasstorageacct-secondary.dfs.core.windows.net/","web":"https://yuasstorageacct-secondary.z13.web.core.windows.net/","blob":"https://yuasstorageacct-secondary.blob.core.windows.net/","queue":"https://yuasstorageacct-secondary.queue.core.windows.net/","table":"https://yuasstorageacct-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/bkerrigan-dev-rg/providers/Microsoft.Storage/storageAccounts/bktestsa2","name":"bktestsa2","type":"Microsoft.Storage/storageAccounts","location":"eastus2","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","immutableStorageWithVersioning":{"enabled":true},"keyCreationTime":{"key1":"2022-09-27T23:58:45.6496284Z","key2":"2022-09-27T23:58:45.6496284Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-09-27T23:58:46.2902461Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-09-27T23:58:46.2902461Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Cool","provisioningState":"Succeeded","creationTime":"2022-09-27T23:58:45.5558609Z","primaryEndpoints":{"dfs":"https://bktestsa2.dfs.core.windows.net/","web":"https://bktestsa2.z20.web.core.windows.net/","blob":"https://bktestsa2.blob.core.windows.net/","queue":"https://bktestsa2.queue.core.windows.net/","table":"https://bktestsa2.table.core.windows.net/","file":"https://bktestsa2.file.core.windows.net/"},"primaryLocation":"eastus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rhel-test/providers/Microsoft.Storage/storageAccounts/rhel77acct","name":"rhel77acct","type":"Microsoft.Storage/storageAccounts","location":"eastus2","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-08-13T20:31:30.8995173Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-08-13T20:31:30.8995173Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-08-13T20:31:30.8215811Z","primaryEndpoints":{"blob":"https://rhel77acct.blob.core.windows.net/","queue":"https://rhel77acct.queue.core.windows.net/","table":"https://rhel77acct.table.core.windows.net/","file":"https://rhel77acct.file.core.windows.net/"},"primaryLocation":"eastus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SCRunner/providers/Microsoft.Storage/storageAccounts/scrunnerstorage","name":"scrunnerstorage","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-03-06T00:42:11.7016543Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-03-06T00:42:11.7016543Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2018-03-06T00:42:11.6234985Z","primaryEndpoints":{"blob":"https://scrunnerstorage.blob.core.windows.net/","queue":"https://scrunnerstorage.queue.core.windows.net/","table":"https://scrunnerstorage.table.core.windows.net/","file":"https://scrunnerstorage.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rhoover/providers/Microsoft.Storage/storageAccounts/rhooverstorage","name":"rhooverstorage","type":"Microsoft.Storage/storageAccounts","location":"southcentralus","tags":{"ms-resource-usage":"azure-cloud-shell"},"properties":{"keyCreationTime":{"key1":"2022-05-26T17:14:23.5085026Z","key2":"2022-05-26T17:14:23.5085026Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-26T17:14:23.5241285Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-26T17:14:23.5241285Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-05-26T17:14:23.4147520Z","primaryEndpoints":{"dfs":"https://rhooverstorage.dfs.core.windows.net/","web":"https://rhooverstorage.z21.web.core.windows.net/","blob":"https://rhooverstorage.blob.core.windows.net/","queue":"https://rhooverstorage.queue.core.windows.net/","table":"https://rhooverstorage.table.core.windows.net/","file":"https://rhooverstorage.file.core.windows.net/"},"primaryLocation":"southcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SCRunnertestvmrg-AustraliaEast/providers/Microsoft.Storage/storageAccounts/scrunner4p3t72mzheluc","name":"scrunner4p3t72mzheluc","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{},"properties":{"keyCreationTime":{"key1":"2021-04-13T22:35:36.6210942Z","key2":"2021-04-13T22:35:36.6210942Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2021-04-13T22:35:36.6210942Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2021-04-13T22:35:36.6210942Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2021-04-13T22:35:36.5429508Z","primaryEndpoints":{"blob":"https://scrunner4p3t72mzheluc.blob.core.windows.net/","queue":"https://scrunner4p3t72mzheluc.queue.core.windows.net/","table":"https://scrunner4p3t72mzheluc.table.core.windows.net/","file":"https://scrunner4p3t72mzheluc.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnervmrg-australiaeast/providers/Microsoft.Storage/storageAccounts/scrunner56hymyctm4kw2","name":"scrunner56hymyctm4kw2","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{},"properties":{"keyCreationTime":{"key1":"2023-02-11T08:42:58.2414102Z","key2":"2023-02-11T08:42:58.2414102Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:42:59.3196006Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:42:59.3196006Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-02-11T08:42:58.1476588Z","primaryEndpoints":{"blob":"https://scrunner56hymyctm4kw2.blob.core.windows.net/","queue":"https://scrunner56hymyctm4kw2.queue.core.windows.net/","table":"https://scrunner56hymyctm4kw2.table.core.windows.net/","file":"https://scrunner56hymyctm4kw2.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsolestuzi7ftnukpi2fyagwys225gbsh73m2h2z7zwjnemrgl5jrfrevg/providers/Microsoft.Storage/storageAccounts/clij3widgfvooidlncm4zwgr","name":"clij3widgfvooidlncm4zwgr","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T14:54:24.1363998Z","key2":"2023-03-06T14:54:24.1363998Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.6364190Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.6364190Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T14:54:24.0114062Z","primaryEndpoints":{"blob":"https://clij3widgfvooidlncm4zwgr.blob.core.windows.net/","queue":"https://clij3widgfvooidlncm4zwgr.queue.core.windows.net/","table":"https://clij3widgfvooidlncm4zwgr.table.core.windows.net/","file":"https://clij3widgfvooidlncm4zwgr.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsolek4hibhcaoukjiclxhnksydes553f4t7r3glwjvxloifh37s6yqdk5/providers/Microsoft.Storage/storageAccounts/cliln4rgfngepmlxlmpwv5wk","name":"cliln4rgfngepmlxlmpwv5wk","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T14:58:59.2000914Z","key2":"2023-03-06T14:58:59.2000914Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:58:59.8876132Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:58:59.8876132Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T14:58:59.1063047Z","primaryEndpoints":{"blob":"https://cliln4rgfngepmlxlmpwv5wk.blob.core.windows.net/","queue":"https://cliln4rgfngepmlxlmpwv5wk.queue.core.windows.net/","table":"https://cliln4rgfngepmlxlmpwv5wk.table.core.windows.net/","file":"https://cliln4rgfngepmlxlmpwv5wk.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsolex4geueyy52iloaspyxz3rrqwxv2syvnkjiljxbv522buwxqpiljme/providers/Microsoft.Storage/storageAccounts/clipf6qz5nxegbgku5yqzkd2","name":"clipf6qz5nxegbgku5yqzkd2","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T07:45:44.7937561Z","key2":"2023-03-06T07:45:44.7937561Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:45:45.1687946Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:45:45.1687946Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T07:45:44.7000168Z","primaryEndpoints":{"blob":"https://clipf6qz5nxegbgku5yqzkd2.blob.core.windows.net/","queue":"https://clipf6qz5nxegbgku5yqzkd2.queue.core.windows.net/","table":"https://clipf6qz5nxegbgku5yqzkd2.table.core.windows.net/","file":"https://clipf6qz5nxegbgku5yqzkd2.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsolep35rualbmodx4sho6gltgwspkbsxnsj34im3hqgkvnopy3hqugcaw/providers/Microsoft.Storage/storageAccounts/clite7vcjveueljfi27rolvu","name":"clite7vcjveueljfi27rolvu","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T14:54:23.8082415Z","key2":"2023-03-06T14:54:23.8082415Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.5270280Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.5270280Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T14:54:23.6989027Z","primaryEndpoints":{"blob":"https://clite7vcjveueljfi27rolvu.blob.core.windows.net/","queue":"https://clite7vcjveueljfi27rolvu.queue.core.windows.net/","table":"https://clite7vcjveueljfi27rolvu.table.core.windows.net/","file":"https://clite7vcjveueljfi27rolvu.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsoledcvrpndxic4emeqq5apwkns4qa5owpy4jn3b536ks35zdrmn7bl5k/providers/Microsoft.Storage/storageAccounts/cliwqnm2fo7pftnxlk7c734i","name":"cliwqnm2fo7pftnxlk7c734i","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T07:34:57.7461613Z","key2":"2023-03-06T07:34:57.7461613Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:34:57.9961851Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:34:57.9961851Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T07:34:57.6368148Z","primaryEndpoints":{"blob":"https://cliwqnm2fo7pftnxlk7c734i.blob.core.windows.net/","queue":"https://cliwqnm2fo7pftnxlk7c734i.queue.core.windows.net/","table":"https://cliwqnm2fo7pftnxlk7c734i.table.core.windows.net/","file":"https://cliwqnm2fo7pftnxlk7c734i.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002","name":"cli000002","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T14:54:24.1208364Z","key2":"2023-03-06T14:54:24.1208364Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.6676739Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.6676739Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T14:54:24.0114062Z","primaryEndpoints":{"blob":"https://cli000002.blob.core.windows.net/","queue":"https://cli000002.queue.core.windows.net/","table":"https://cli000002.table.core.windows.net/","file":"https://cli000002.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guptar2/providers/Microsoft.Storage/storageAccounts/guptar2diagnosticsv1","name":"guptar2diagnosticsv1","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2022-04-05T17:21:41.8250582Z","key2":"2022-04-05T17:21:41.8250582Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:21:41.8250582Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:21:41.8250582Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-04-05T17:21:41.7313240Z","primaryEndpoints":{"blob":"https://guptar2diagnosticsv1.blob.core.windows.net/","queue":"https://guptar2diagnosticsv1.queue.core.windows.net/","table":"https://guptar2diagnosticsv1.table.core.windows.net/","file":"https://guptar2diagnosticsv1.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guptar2/providers/Microsoft.Storage/storageAccounts/guptar2diagnosticsv2","name":"guptar2diagnosticsv2","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-04-05T17:22:55.8411567Z","key2":"2022-04-05T17:22:55.8411567Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"resourceAccessRules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[{"value":"20.98.146.84","action":"Allow"},{"value":"20.83.222.102","action":"Allow"},{"value":"20.98.194.64","action":"Allow"},{"value":"20.69.5.162","action":"Allow"}],"defaultAction":"Deny"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:22:55.8411567Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:22:55.8411567Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-04-05T17:22:55.7318000Z","primaryEndpoints":{"dfs":"https://guptar2diagnosticsv2.dfs.core.windows.net/","web":"https://guptar2diagnosticsv2.z5.web.core.windows.net/","blob":"https://guptar2diagnosticsv2.blob.core.windows.net/","queue":"https://guptar2diagnosticsv2.queue.core.windows.net/","table":"https://guptar2diagnosticsv2.table.core.windows.net/","file":"https://guptar2diagnosticsv2.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sericonrp-trafficmanager/providers/Microsoft.Storage/storageAccounts/sericonrpdevtmstorage","name":"sericonrpdevtmstorage","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-11-30T19:15:41.5013570Z","key2":"2022-11-30T19:15:41.5013570Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-11-30T19:15:42.0638737Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-11-30T19:15:42.0638737Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-11-30T19:15:41.4075777Z","primaryEndpoints":{"dfs":"https://sericonrpdevtmstorage.dfs.core.windows.net/","web":"https://sericonrpdevtmstorage.z5.web.core.windows.net/","blob":"https://sericonrpdevtmstorage.blob.core.windows.net/","queue":"https://sericonrpdevtmstorage.queue.core.windows.net/","table":"https://sericonrpdevtmstorage.table.core.windows.net/","file":"https://sericonrpdevtmstorage.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available","secondaryLocation":"westcentralus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://sericonrpdevtmstorage-secondary.dfs.core.windows.net/","web":"https://sericonrpdevtmstorage-secondary.z5.web.core.windows.net/","blob":"https://sericonrpdevtmstorage-secondary.blob.core.windows.net/","queue":"https://sericonrpdevtmstorage-secondary.queue.core.windows.net/","table":"https://sericonrpdevtmstorage-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ops/providers/Microsoft.Storage/storageAccounts/sericonstorage","name":"sericonstorage","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2023-03-05T19:58:00.4355863Z","key2":"2023-03-05T19:58:00.4355863Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-05T19:58:00.9824831Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-05T19:58:00.9824831Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2023-03-05T19:58:00.3262342Z","primaryEndpoints":{"dfs":"https://sericonstorage.dfs.core.windows.net/","web":"https://sericonstorage.z5.web.core.windows.net/","blob":"https://sericonstorage.blob.core.windows.net/","queue":"https://sericonstorage.queue.core.windows.net/","table":"https://sericonstorage.table.core.windows.net/","file":"https://sericonstorage.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rhoover-dev-rg/providers/Microsoft.Storage/storageAccounts/rhooverdevrgdiag","name":"rhooverdevrgdiag","type":"Microsoft.Storage/storageAccounts","location":"westcentralus","tags":{},"properties":{"defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-06-20T19:39:24.4605968Z","key2":"2022-06-20T19:39:24.4605968Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":false,"networkAcls":{"resourceAccessRules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[{"value":"20.98.146.84","action":"Allow"},{"value":"20.98.194.64","action":"Allow"},{"value":"20.69.5.162","action":"Allow"},{"value":"20.83.222.102","action":"Allow"},{"value":"76.197.206.105","action":"Allow"}],"defaultAction":"Deny"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-06-20T19:39:24.4762287Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-06-20T19:39:24.4762287Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-06-20T19:39:24.4137057Z","primaryEndpoints":{"blob":"https://rhooverdevrgdiag.blob.core.windows.net/","queue":"https://rhooverdevrgdiag.queue.core.windows.net/","table":"https://rhooverdevrgdiag.table.core.windows.net/","file":"https://rhooverdevrgdiag.file.core.windows.net/"},"primaryLocation":"westcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnervmrg-westcentralus/providers/Microsoft.Storage/storageAccounts/scrunneraoptpjec4skce","name":"scrunneraoptpjec4skce","type":"Microsoft.Storage/storageAccounts","location":"westcentralus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-02-11T08:40:40.0686467Z","key2":"2023-02-11T08:40:40.0686467Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:40:40.5842822Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:40:40.5842822Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-02-11T08:40:40.0061730Z","primaryEndpoints":{"blob":"https://scrunneraoptpjec4skce.blob.core.windows.net/","queue":"https://scrunneraoptpjec4skce.queue.core.windows.net/","table":"https://scrunneraoptpjec4skce.table.core.windows.net/","file":"https://scrunneraoptpjec4skce.file.core.windows.net/"},"primaryLocation":"westcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnertestvmrg-westcentralus/providers/Microsoft.Storage/storageAccounts/scrunnerrfscmqxeni3uq","name":"scrunnerrfscmqxeni3uq","type":"Microsoft.Storage/storageAccounts","location":"westcentralus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-04-10T22:28:55.2104910Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-04-10T22:28:55.2104910Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-04-10T22:28:55.1479670Z","primaryEndpoints":{"blob":"https://scrunnerrfscmqxeni3uq.blob.core.windows.net/","queue":"https://scrunnerrfscmqxeni3uq.queue.core.windows.net/","table":"https://scrunnerrfscmqxeni3uq.table.core.windows.net/","file":"https://scrunnerrfscmqxeni3uq.file.core.windows.net/"},"primaryLocation":"westcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ubuntu-westus3_group/providers/Microsoft.Storage/storageAccounts/ubuntuwestus3groupdiag","name":"ubuntuwestus3groupdiag","type":"Microsoft.Storage/storageAccounts","location":"westus3","tags":{},"properties":{"keyCreationTime":{"key1":"2022-04-18T19:48:38.9882588Z","key2":"2022-04-18T19:48:38.9882588Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-18T19:48:38.9882588Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-18T19:48:38.9882588Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-04-18T19:48:38.9258191Z","primaryEndpoints":{"blob":"https://ubuntuwestus3groupdiag.blob.core.windows.net/","queue":"https://ubuntuwestus3groupdiag.queue.core.windows.net/","table":"https://ubuntuwestus3groupdiag.table.core.windows.net/","file":"https://ubuntuwestus3groupdiag.file.core.windows.net/"},"primaryLocation":"westus3","statusOfPrimary":"available"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '42669'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 06 Mar 2023 14:59:58 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-original-request-ids:
+      - 5375bdd4-c7aa-4005-b42e-78570fc44837
+      - ad9241fa-2c26-491c-8f74-cf54599b4f08
+      - 241574f9-a8ad-4a45-93b3-9140e8803d62
+      - 3477030e-0793-42d7-8aa5-6cc26430962e
+      - 9eade093-18a0-458c-97c7-23955679b934
+      - cf798aef-4eef-4bbc-8082-d9fb901a9d22
+      - 89851354-778d-49a5-b68f-297baa75e7df
+      - da0df989-c03b-418f-a217-a4719f48cd07
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm stop
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002","name":"cli000002","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2022-12-13T22:51:17.0682893Z","key2":"2022-12-13T22:51:17.0682893Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-12-13T22:51:17.6307939Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-12-13T22:51:17.6307939Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-12-13T22:51:16.9745683Z","primaryEndpoints":{"blob":"https://cli000002.blob.core.windows.net/","queue":"https://cli000002.queue.core.windows.net/","table":"https://cli000002.table.core.windows.net/","file":"https://cli000002.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002","name":"cli000002","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T14:54:24.1208364Z","key2":"2023-03-06T14:54:24.1208364Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.6676739Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.6676739Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T14:54:24.0114062Z","primaryEndpoints":{"blob":"https://cli000002.blob.core.windows.net/","queue":"https://cli000002.queue.core.windows.net/","table":"https://cli000002.table.core.windows.net/","file":"https://cli000002.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -4917,7 +4721,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 13 Dec 2022 22:57:06 GMT
+      - Mon, 06 Mar 2023 14:59:58 GMT
       expires:
       - '-1'
       pragma:
@@ -4949,8 +4753,8 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
-        (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.SerialConsole/consoleServices/default?api-version=2018-05-01
   response:
@@ -4964,7 +4768,7 @@ interactions:
       content-type:
       - application/json; charset=UTF-8
       date:
-      - Tue, 13 Dec 2022 22:57:06 GMT
+      - Mon, 06 Mar 2023 14:59:58 GMT
       expires:
       - '-1'
       pragma:
@@ -5000,9 +4804,9 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003/deallocate?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003/deallocate?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -5010,17 +4814,17 @@ interactions:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/1c7b6b49-ea4e-493d-8b6d-01ecb22f99bf?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/f929ba6c-263c-4d4e-92f4-2a97a76f13df?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Tue, 13 Dec 2022 22:57:08 GMT
+      - Mon, 06 Mar 2023 14:59:58 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/1c7b6b49-ea4e-493d-8b6d-01ecb22f99bf?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/f929ba6c-263c-4d4e-92f4-2a97a76f13df?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-11-01
       pragma:
       - no-cache
       server:
@@ -5031,7 +4835,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/DeleteVM3Min;239,Microsoft.Compute/DeleteVM30Min;1198
+      - Microsoft.Compute/DeleteVM3Min;238,Microsoft.Compute/DeleteVM30Min;1197
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
     status:
@@ -5051,13 +4855,13 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/1c7b6b49-ea4e-493d-8b6d-01ecb22f99bf?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/f929ba6c-263c-4d4e-92f4-2a97a76f13df?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T22:57:08.6258805+00:00\",\r\n  \"status\":
-        \"InProgress\",\r\n  \"name\": \"1c7b6b49-ea4e-493d-8b6d-01ecb22f99bf\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T14:59:59.5811914+00:00\",\r\n  \"status\":
+        \"InProgress\",\r\n  \"name\": \"f929ba6c-263c-4d4e-92f4-2a97a76f13df\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -5066,7 +4870,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:57:08 GMT
+      - Mon, 06 Mar 2023 15:00:08 GMT
       expires:
       - '-1'
       pragma:
@@ -5083,7 +4887,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14976,Microsoft.Compute/GetOperation30Min;29962
+      - Microsoft.Compute/GetOperation3Min;14952,Microsoft.Compute/GetOperation30Min;29863
     status:
       code: 200
       message: OK
@@ -5101,14 +4905,14 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/1c7b6b49-ea4e-493d-8b6d-01ecb22f99bf?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/f929ba6c-263c-4d4e-92f4-2a97a76f13df?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T22:57:08.6258805+00:00\",\r\n  \"endTime\":
-        \"2022-12-13T22:57:31.6258127+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"name\": \"1c7b6b49-ea4e-493d-8b6d-01ecb22f99bf\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T14:59:59.5811914+00:00\",\r\n  \"endTime\":
+        \"2023-03-06T15:00:19.2842984+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"name\": \"f929ba6c-263c-4d4e-92f4-2a97a76f13df\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -5117,7 +4921,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:57:44 GMT
+      - Mon, 06 Mar 2023 15:00:39 GMT
       expires:
       - '-1'
       pragma:
@@ -5134,7 +4938,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14978,Microsoft.Compute/GetOperation30Min;29958
+      - Microsoft.Compute/GetOperation3Min;14957,Microsoft.Compute/GetOperation30Min;29859
     status:
       code: 200
       message: OK
@@ -5152,9 +4956,9 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/1c7b6b49-ea4e-493d-8b6d-01ecb22f99bf?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/f929ba6c-263c-4d4e-92f4-2a97a76f13df?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-11-01
   response:
     body:
       string: ''
@@ -5164,7 +4968,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 13 Dec 2022 22:57:44 GMT
+      - Mon, 06 Mar 2023 15:00:39 GMT
       expires:
       - '-1'
       pragma:
@@ -5177,7 +4981,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14977,Microsoft.Compute/GetOperation30Min;29957
+      - Microsoft.Compute/GetOperation3Min;14956,Microsoft.Compute/GetOperation30Min;29858
     status:
       code: 200
       message: OK
@@ -5195,9 +4999,9 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?$expand=instanceView&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?$expand=instanceView&api-version=2022-11-01
   response:
     body:
       string: "{\r\n  \"name\": \"cli000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003\",\r\n
@@ -5207,54 +5011,54 @@ interactions:
         \   \"userAssignedIdentities\": {\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/AzSecPackAutoConfigUA-westus2\":
         {\r\n        \"principalId\": \"684d55e2-8922-4966-a660-2d38ca4a1711\",\r\n
         \       \"clientId\": \"6d45cf55-f311-4228-97b0-c22ae418aad6\"\r\n      }\r\n
-        \   }\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"d54f150a-5634-4201-b5af-271e2cd52432\",\r\n
+        \   }\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"94bb0e59-1bcd-493b-aa53-580e2ad730d7\",\r\n
         \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
         \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
         \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
         \"18.04-LTS\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
-        \"18.04.202212090\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\",\r\n
+        \"18.04.202302100\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\",\r\n
         \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
-        \       \"managedDisk\": {\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_SERIALCONSOLELMXZIWWK5PS5Z6A7GSGJPKCGAUTWUFSF6S5STLYYHQ6COP3BWYY27/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\"\r\n
+        \       \"managedDisk\": {\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_SERIALCONSOLE46W4L74TUUPDKTQIUNEVCDRGNWE77YHJM4DVRHN3I4J7UGNGQPGEM/providers/Microsoft.Compute/disks/cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\"\r\n
         \       },\r\n        \"deleteOption\": \"Detach\"\r\n      },\r\n      \"dataDisks\":
         []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"cli000003\",\r\n
-        \     \"adminUsername\": \"rhl\",\r\n      \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
-        true,\r\n        \"ssh\": {\r\n          \"publicKeys\": [\r\n            {\r\n
-        \             \"path\": \"/home/rhl/.ssh/authorized_keys\",\r\n              \"keyData\":
-        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h\"\r\n
-        \           }\r\n          ]\r\n        },\r\n        \"provisionVMAgent\":
-        true,\r\n        \"patchSettings\": {\r\n          \"patchMode\": \"ImageDefault\",\r\n
-        \         \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n        \"enableVMAgentPlatformUpdates\":
-        false\r\n      },\r\n      \"secrets\": [],\r\n      \"allowExtensionOperations\":
-        true,\r\n      \"requireGuestProvisionSignal\": true\r\n    },\r\n    \"networkProfile\":
-        {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
+        \     \"adminUsername\": \"rhoover\",\r\n      \"linuxConfiguration\": {\r\n
+        \       \"disablePasswordAuthentication\": true,\r\n        \"ssh\": {\r\n
+        \         \"publicKeys\": [\r\n            {\r\n              \"path\": \"/home/rhoover/.ssh/authorized_keys\",\r\n
+        \             \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+        REDMOND+rhoover@DESKTOP-XVFR7ID\\n\"\r\n            }\r\n          ]\r\n        },\r\n
+        \       \"provisionVMAgent\": true,\r\n        \"patchSettings\": {\r\n          \"patchMode\":
+        \"ImageDefault\",\r\n          \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n
+        \       \"enableVMAgentPlatformUpdates\": false\r\n      },\r\n      \"secrets\":
+        [],\r\n      \"allowExtensionOperations\": true,\r\n      \"requireGuestProvisionSignal\":
+        true\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/networkInterfaces/cli000003VMNic\"}]},\r\n
         \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
         true,\r\n        \"storageUri\": \"https://cli000002.blob.core.windows.net/\"\r\n
         \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\":
-        {\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"cli000003_OsDisk_1_1aa760ca1ece4f4991c1911423b0900e\",\r\n
+        {\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"cli000003_OsDisk_1_8ff35aca4d9a4f66a19ffce403aeb77f\",\r\n
         \         \"statuses\": [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n
         \             \"level\": \"Info\",\r\n              \"displayStatus\": \"Provisioning
-        succeeded\",\r\n              \"time\": \"2022-12-13T22:57:31.4226869+00:00\"\r\n
+        succeeded\",\r\n              \"time\": \"2023-03-06T15:00:19.0967364+00:00\"\r\n
         \           }\r\n          ]\r\n        }\r\n      ],\r\n      \"bootDiagnostics\":
-        {\r\n        \"consoleScreenshotBlobUri\": \"https://cli000002.blob.core.windows.net/bootdiagnostics-clik3qxir-d54f150a-5634-4201-b5af-271e2cd52432/cli000003.d54f150a-5634-4201-b5af-271e2cd52432.screenshot.bmp\",\r\n
-        \       \"serialConsoleLogBlobUri\": \"https://cli000002.blob.core.windows.net/bootdiagnostics-clik3qxir-d54f150a-5634-4201-b5af-271e2cd52432/cli000003.d54f150a-5634-4201-b5af-271e2cd52432.serialconsole.log\"\r\n
+        {\r\n        \"consoleScreenshotBlobUri\": \"https://cli000002.blob.core.windows.net/bootdiagnostics-cli7hpi2h-94bb0e59-1bcd-493b-aa53-580e2ad730d7/cli000003.94bb0e59-1bcd-493b-aa53-580e2ad730d7.screenshot.bmp\",\r\n
+        \       \"serialConsoleLogBlobUri\": \"https://cli000002.blob.core.windows.net/bootdiagnostics-cli7hpi2h-94bb0e59-1bcd-493b-aa53-580e2ad730d7/cli000003.94bb0e59-1bcd-493b-aa53-580e2ad730d7.serialconsole.log\"\r\n
         \     },\r\n      \"hyperVGeneration\": \"V1\",\r\n      \"statuses\": [\r\n
         \       {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n          \"level\":
         \"Info\",\r\n          \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \         \"time\": \"2022-12-13T22:57:31.4382991+00:00\"\r\n        },\r\n
+        \         \"time\": \"2023-03-06T15:00:19.1124111+00:00\"\r\n        },\r\n
         \       {\r\n          \"code\": \"PowerState/deallocated\",\r\n          \"level\":
         \"Info\",\r\n          \"displayStatus\": \"VM deallocated\"\r\n        }\r\n
-        \     ]\r\n    },\r\n    \"timeCreated\": \"2022-12-13T22:51:52.3460253+00:00\"\r\n
+        \     ]\r\n    },\r\n    \"timeCreated\": \"2023-03-06T14:55:01.5508486+00:00\"\r\n
         \ }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '4570'
+      - '4784'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:57:45 GMT
+      - Mon, 06 Mar 2023 15:00:39 GMT
       expires:
       - '-1'
       pragma:
@@ -5271,7 +5075,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/LowCostGet3Min;3981,Microsoft.Compute/LowCostGet30Min;31962
+      - Microsoft.Compute/LowCostGet3Min;3971,Microsoft.Compute/LowCostGet30Min;31925
     status:
       code: 200
       message: OK
@@ -5289,12 +5093,63 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/storageAccounts?api-version=2022-09-01
+  response:
+    body:
+      string: '{"value":[{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloud-shell-storage-eastus/providers/Microsoft.Storage/storageAccounts/cs210032001f4814ba9","name":"cs210032001f4814ba9","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"ms-resource-usage":"azure-cloud-shell"},"properties":{"keyCreationTime":{"key1":"2022-05-16T14:16:22.3477819Z","key2":"2022-05-16T14:16:22.3477819Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-16T14:16:22.3477819Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-16T14:16:22.3477819Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-05-16T14:16:22.2227752Z","primaryEndpoints":{"dfs":"https://cs210032001f4814ba9.dfs.core.windows.net/","web":"https://cs210032001f4814ba9.z13.web.core.windows.net/","blob":"https://cs210032001f4814ba9.blob.core.windows.net/","queue":"https://cs210032001f4814ba9.queue.core.windows.net/","table":"https://cs210032001f4814ba9.table.core.windows.net/","file":"https://cs210032001f4814ba9.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/kustoflow/providers/Microsoft.Storage/storageAccounts/csslinuxkustoflow","name":"csslinuxkustoflow","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"CreatedBy":"craigw"},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-02-01T20:08:38.6849654Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-02-01T20:08:38.6849654Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2019-02-01T20:08:38.5912170Z","primaryEndpoints":{"dfs":"https://csslinuxkustoflow.dfs.core.windows.net/","web":"https://csslinuxkustoflow.z13.web.core.windows.net/","blob":"https://csslinuxkustoflow.blob.core.windows.net/","queue":"https://csslinuxkustoflow.queue.core.windows.net/","table":"https://csslinuxkustoflow.table.core.windows.net/","file":"https://csslinuxkustoflow.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://csslinuxkustoflow-secondary.dfs.core.windows.net/","web":"https://csslinuxkustoflow-secondary.z13.web.core.windows.net/","blob":"https://csslinuxkustoflow-secondary.blob.core.windows.net/","queue":"https://csslinuxkustoflow-secondary.queue.core.windows.net/","table":"https://csslinuxkustoflow-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guidomassonitest-rg/providers/Microsoft.Storage/storageAccounts/guidomassonitestrg88ad","name":"guidomassonitestrg88ad","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-01-23T18:52:02.5484088Z","key2":"2023-01-23T18:52:02.5484088Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-01-23T18:52:02.5484088Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-01-23T18:52:02.5484088Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-01-23T18:52:02.4077698Z","primaryEndpoints":{"blob":"https://guidomassonitestrg88ad.blob.core.windows.net/","queue":"https://guidomassonitestrg88ad.queue.core.windows.net/","table":"https://guidomassonitestrg88ad.table.core.windows.net/","file":"https://guidomassonitestrg88ad.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guidomtesttrafficmanagerrg/providers/Microsoft.Storage/storageAccounts/guidomteststoraccfortm","name":"guidomteststoraccfortm","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-10-18T18:01:13.5231266Z","key2":"2022-10-18T18:01:13.5231266Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-10-18T18:01:13.5387607Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-10-18T18:01:13.5387607Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-10-18T18:01:13.3825002Z","primaryEndpoints":{"dfs":"https://guidomteststoraccfortm.dfs.core.windows.net/","web":"https://guidomteststoraccfortm.z13.web.core.windows.net/","blob":"https://guidomteststoraccfortm.blob.core.windows.net/","queue":"https://guidomteststoraccfortm.queue.core.windows.net/","table":"https://guidomteststoraccfortm.table.core.windows.net/","file":"https://guidomteststoraccfortm.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://guidomteststoraccfortm-secondary.dfs.core.windows.net/","web":"https://guidomteststoraccfortm-secondary.z13.web.core.windows.net/","blob":"https://guidomteststoraccfortm-secondary.blob.core.windows.net/","queue":"https://guidomteststoraccfortm-secondary.queue.core.windows.net/","table":"https://guidomteststoraccfortm-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnertestvmrg-eastus/providers/Microsoft.Storage/storageAccounts/scrunnercrkwpdn5nhtgg","name":"scrunnercrkwpdn5nhtgg","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-05-12T20:03:57.6389684Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-05-12T20:03:57.6389684Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-05-12T20:03:57.5451905Z","primaryEndpoints":{"blob":"https://scrunnercrkwpdn5nhtgg.blob.core.windows.net/","queue":"https://scrunnercrkwpdn5nhtgg.queue.core.windows.net/","table":"https://scrunnercrkwpdn5nhtgg.table.core.windows.net/","file":"https://scrunnercrkwpdn5nhtgg.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnervmrg-eastus/providers/Microsoft.Storage/storageAccounts/scrunneri2ezqh4xu2wqq","name":"scrunneri2ezqh4xu2wqq","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-02-11T08:01:12.9383535Z","key2":"2023-02-11T08:01:12.9383535Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:01:12.9383535Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:01:12.9383535Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-02-11T08:01:12.6883669Z","primaryEndpoints":{"blob":"https://scrunneri2ezqh4xu2wqq.blob.core.windows.net/","queue":"https://scrunneri2ezqh4xu2wqq.queue.core.windows.net/","table":"https://scrunneri2ezqh4xu2wqq.table.core.windows.net/","file":"https://scrunneri2ezqh4xu2wqq.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/serialTest-EastUS/providers/Microsoft.Storage/storageAccounts/serialtesta8d7fdee41","name":"serialtesta8d7fdee41","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-07-11T00:38:13.5389932Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-07-11T00:38:13.5389932Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2019-07-11T00:38:13.4452119Z","primaryEndpoints":{"blob":"https://serialtesta8d7fdee41.blob.core.windows.net/","queue":"https://serialtesta8d7fdee41.queue.core.windows.net/","table":"https://serialtesta8d7fdee41.table.core.windows.net/","file":"https://serialtesta8d7fdee41.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/storage-RG/providers/Microsoft.Storage/storageAccounts/serialtestbootdiag123","name":"serialtestbootdiag123","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-01-23T04:03:01.3263151Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-01-23T04:03:01.3263151Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2018-01-23T04:03:01.2951106Z","primaryEndpoints":{"blob":"https://serialtestbootdiag123.blob.core.windows.net/","queue":"https://serialtestbootdiag123.queue.core.windows.net/","table":"https://serialtestbootdiag123.table.core.windows.net/","file":"https://serialtestbootdiag123.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yuas-rg/providers/Microsoft.Storage/storageAccounts/yuasstorageacct","name":"yuasstorageacct","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-08-02T12:18:18.8547131Z","key2":"2022-08-02T12:18:18.8547131Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-08-02T12:18:18.8547131Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-08-02T12:18:18.8547131Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-08-02T12:18:18.7140969Z","primaryEndpoints":{"dfs":"https://yuasstorageacct.dfs.core.windows.net/","web":"https://yuasstorageacct.z13.web.core.windows.net/","blob":"https://yuasstorageacct.blob.core.windows.net/","queue":"https://yuasstorageacct.queue.core.windows.net/","table":"https://yuasstorageacct.table.core.windows.net/","file":"https://yuasstorageacct.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://yuasstorageacct-secondary.dfs.core.windows.net/","web":"https://yuasstorageacct-secondary.z13.web.core.windows.net/","blob":"https://yuasstorageacct-secondary.blob.core.windows.net/","queue":"https://yuasstorageacct-secondary.queue.core.windows.net/","table":"https://yuasstorageacct-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/bkerrigan-dev-rg/providers/Microsoft.Storage/storageAccounts/bktestsa2","name":"bktestsa2","type":"Microsoft.Storage/storageAccounts","location":"eastus2","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","immutableStorageWithVersioning":{"enabled":true},"keyCreationTime":{"key1":"2022-09-27T23:58:45.6496284Z","key2":"2022-09-27T23:58:45.6496284Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-09-27T23:58:46.2902461Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-09-27T23:58:46.2902461Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Cool","provisioningState":"Succeeded","creationTime":"2022-09-27T23:58:45.5558609Z","primaryEndpoints":{"dfs":"https://bktestsa2.dfs.core.windows.net/","web":"https://bktestsa2.z20.web.core.windows.net/","blob":"https://bktestsa2.blob.core.windows.net/","queue":"https://bktestsa2.queue.core.windows.net/","table":"https://bktestsa2.table.core.windows.net/","file":"https://bktestsa2.file.core.windows.net/"},"primaryLocation":"eastus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rhel-test/providers/Microsoft.Storage/storageAccounts/rhel77acct","name":"rhel77acct","type":"Microsoft.Storage/storageAccounts","location":"eastus2","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-08-13T20:31:30.8995173Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-08-13T20:31:30.8995173Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-08-13T20:31:30.8215811Z","primaryEndpoints":{"blob":"https://rhel77acct.blob.core.windows.net/","queue":"https://rhel77acct.queue.core.windows.net/","table":"https://rhel77acct.table.core.windows.net/","file":"https://rhel77acct.file.core.windows.net/"},"primaryLocation":"eastus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SCRunner/providers/Microsoft.Storage/storageAccounts/scrunnerstorage","name":"scrunnerstorage","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-03-06T00:42:11.7016543Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-03-06T00:42:11.7016543Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2018-03-06T00:42:11.6234985Z","primaryEndpoints":{"blob":"https://scrunnerstorage.blob.core.windows.net/","queue":"https://scrunnerstorage.queue.core.windows.net/","table":"https://scrunnerstorage.table.core.windows.net/","file":"https://scrunnerstorage.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rhoover/providers/Microsoft.Storage/storageAccounts/rhooverstorage","name":"rhooverstorage","type":"Microsoft.Storage/storageAccounts","location":"southcentralus","tags":{"ms-resource-usage":"azure-cloud-shell"},"properties":{"keyCreationTime":{"key1":"2022-05-26T17:14:23.5085026Z","key2":"2022-05-26T17:14:23.5085026Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-26T17:14:23.5241285Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-26T17:14:23.5241285Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-05-26T17:14:23.4147520Z","primaryEndpoints":{"dfs":"https://rhooverstorage.dfs.core.windows.net/","web":"https://rhooverstorage.z21.web.core.windows.net/","blob":"https://rhooverstorage.blob.core.windows.net/","queue":"https://rhooverstorage.queue.core.windows.net/","table":"https://rhooverstorage.table.core.windows.net/","file":"https://rhooverstorage.file.core.windows.net/"},"primaryLocation":"southcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SCRunnertestvmrg-AustraliaEast/providers/Microsoft.Storage/storageAccounts/scrunner4p3t72mzheluc","name":"scrunner4p3t72mzheluc","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{},"properties":{"keyCreationTime":{"key1":"2021-04-13T22:35:36.6210942Z","key2":"2021-04-13T22:35:36.6210942Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2021-04-13T22:35:36.6210942Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2021-04-13T22:35:36.6210942Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2021-04-13T22:35:36.5429508Z","primaryEndpoints":{"blob":"https://scrunner4p3t72mzheluc.blob.core.windows.net/","queue":"https://scrunner4p3t72mzheluc.queue.core.windows.net/","table":"https://scrunner4p3t72mzheluc.table.core.windows.net/","file":"https://scrunner4p3t72mzheluc.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnervmrg-australiaeast/providers/Microsoft.Storage/storageAccounts/scrunner56hymyctm4kw2","name":"scrunner56hymyctm4kw2","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{},"properties":{"keyCreationTime":{"key1":"2023-02-11T08:42:58.2414102Z","key2":"2023-02-11T08:42:58.2414102Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:42:59.3196006Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:42:59.3196006Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-02-11T08:42:58.1476588Z","primaryEndpoints":{"blob":"https://scrunner56hymyctm4kw2.blob.core.windows.net/","queue":"https://scrunner56hymyctm4kw2.queue.core.windows.net/","table":"https://scrunner56hymyctm4kw2.table.core.windows.net/","file":"https://scrunner56hymyctm4kw2.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsolestuzi7ftnukpi2fyagwys225gbsh73m2h2z7zwjnemrgl5jrfrevg/providers/Microsoft.Storage/storageAccounts/clij3widgfvooidlncm4zwgr","name":"clij3widgfvooidlncm4zwgr","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T14:54:24.1363998Z","key2":"2023-03-06T14:54:24.1363998Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.6364190Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.6364190Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T14:54:24.0114062Z","primaryEndpoints":{"blob":"https://clij3widgfvooidlncm4zwgr.blob.core.windows.net/","queue":"https://clij3widgfvooidlncm4zwgr.queue.core.windows.net/","table":"https://clij3widgfvooidlncm4zwgr.table.core.windows.net/","file":"https://clij3widgfvooidlncm4zwgr.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsolek4hibhcaoukjiclxhnksydes553f4t7r3glwjvxloifh37s6yqdk5/providers/Microsoft.Storage/storageAccounts/cliln4rgfngepmlxlmpwv5wk","name":"cliln4rgfngepmlxlmpwv5wk","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T14:58:59.2000914Z","key2":"2023-03-06T14:58:59.2000914Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:58:59.8876132Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:58:59.8876132Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T14:58:59.1063047Z","primaryEndpoints":{"blob":"https://cliln4rgfngepmlxlmpwv5wk.blob.core.windows.net/","queue":"https://cliln4rgfngepmlxlmpwv5wk.queue.core.windows.net/","table":"https://cliln4rgfngepmlxlmpwv5wk.table.core.windows.net/","file":"https://cliln4rgfngepmlxlmpwv5wk.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsolex4geueyy52iloaspyxz3rrqwxv2syvnkjiljxbv522buwxqpiljme/providers/Microsoft.Storage/storageAccounts/clipf6qz5nxegbgku5yqzkd2","name":"clipf6qz5nxegbgku5yqzkd2","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T07:45:44.7937561Z","key2":"2023-03-06T07:45:44.7937561Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:45:45.1687946Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:45:45.1687946Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T07:45:44.7000168Z","primaryEndpoints":{"blob":"https://clipf6qz5nxegbgku5yqzkd2.blob.core.windows.net/","queue":"https://clipf6qz5nxegbgku5yqzkd2.queue.core.windows.net/","table":"https://clipf6qz5nxegbgku5yqzkd2.table.core.windows.net/","file":"https://clipf6qz5nxegbgku5yqzkd2.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsolep35rualbmodx4sho6gltgwspkbsxnsj34im3hqgkvnopy3hqugcaw/providers/Microsoft.Storage/storageAccounts/clite7vcjveueljfi27rolvu","name":"clite7vcjveueljfi27rolvu","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T14:54:23.8082415Z","key2":"2023-03-06T14:54:23.8082415Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.5270280Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.5270280Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T14:54:23.6989027Z","primaryEndpoints":{"blob":"https://clite7vcjveueljfi27rolvu.blob.core.windows.net/","queue":"https://clite7vcjveueljfi27rolvu.queue.core.windows.net/","table":"https://clite7vcjveueljfi27rolvu.table.core.windows.net/","file":"https://clite7vcjveueljfi27rolvu.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsoledcvrpndxic4emeqq5apwkns4qa5owpy4jn3b536ks35zdrmn7bl5k/providers/Microsoft.Storage/storageAccounts/cliwqnm2fo7pftnxlk7c734i","name":"cliwqnm2fo7pftnxlk7c734i","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T07:34:57.7461613Z","key2":"2023-03-06T07:34:57.7461613Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:34:57.9961851Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:34:57.9961851Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T07:34:57.6368148Z","primaryEndpoints":{"blob":"https://cliwqnm2fo7pftnxlk7c734i.blob.core.windows.net/","queue":"https://cliwqnm2fo7pftnxlk7c734i.queue.core.windows.net/","table":"https://cliwqnm2fo7pftnxlk7c734i.table.core.windows.net/","file":"https://cliwqnm2fo7pftnxlk7c734i.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002","name":"cli000002","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T14:54:24.1208364Z","key2":"2023-03-06T14:54:24.1208364Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.6676739Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.6676739Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T14:54:24.0114062Z","primaryEndpoints":{"blob":"https://cli000002.blob.core.windows.net/","queue":"https://cli000002.queue.core.windows.net/","table":"https://cli000002.table.core.windows.net/","file":"https://cli000002.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guptar2/providers/Microsoft.Storage/storageAccounts/guptar2diagnosticsv1","name":"guptar2diagnosticsv1","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2022-04-05T17:21:41.8250582Z","key2":"2022-04-05T17:21:41.8250582Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:21:41.8250582Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:21:41.8250582Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-04-05T17:21:41.7313240Z","primaryEndpoints":{"blob":"https://guptar2diagnosticsv1.blob.core.windows.net/","queue":"https://guptar2diagnosticsv1.queue.core.windows.net/","table":"https://guptar2diagnosticsv1.table.core.windows.net/","file":"https://guptar2diagnosticsv1.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guptar2/providers/Microsoft.Storage/storageAccounts/guptar2diagnosticsv2","name":"guptar2diagnosticsv2","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-04-05T17:22:55.8411567Z","key2":"2022-04-05T17:22:55.8411567Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"resourceAccessRules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[{"value":"20.98.146.84","action":"Allow"},{"value":"20.83.222.102","action":"Allow"},{"value":"20.98.194.64","action":"Allow"},{"value":"20.69.5.162","action":"Allow"}],"defaultAction":"Deny"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:22:55.8411567Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:22:55.8411567Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-04-05T17:22:55.7318000Z","primaryEndpoints":{"dfs":"https://guptar2diagnosticsv2.dfs.core.windows.net/","web":"https://guptar2diagnosticsv2.z5.web.core.windows.net/","blob":"https://guptar2diagnosticsv2.blob.core.windows.net/","queue":"https://guptar2diagnosticsv2.queue.core.windows.net/","table":"https://guptar2diagnosticsv2.table.core.windows.net/","file":"https://guptar2diagnosticsv2.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sericonrp-trafficmanager/providers/Microsoft.Storage/storageAccounts/sericonrpdevtmstorage","name":"sericonrpdevtmstorage","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-11-30T19:15:41.5013570Z","key2":"2022-11-30T19:15:41.5013570Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-11-30T19:15:42.0638737Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-11-30T19:15:42.0638737Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-11-30T19:15:41.4075777Z","primaryEndpoints":{"dfs":"https://sericonrpdevtmstorage.dfs.core.windows.net/","web":"https://sericonrpdevtmstorage.z5.web.core.windows.net/","blob":"https://sericonrpdevtmstorage.blob.core.windows.net/","queue":"https://sericonrpdevtmstorage.queue.core.windows.net/","table":"https://sericonrpdevtmstorage.table.core.windows.net/","file":"https://sericonrpdevtmstorage.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available","secondaryLocation":"westcentralus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://sericonrpdevtmstorage-secondary.dfs.core.windows.net/","web":"https://sericonrpdevtmstorage-secondary.z5.web.core.windows.net/","blob":"https://sericonrpdevtmstorage-secondary.blob.core.windows.net/","queue":"https://sericonrpdevtmstorage-secondary.queue.core.windows.net/","table":"https://sericonrpdevtmstorage-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ops/providers/Microsoft.Storage/storageAccounts/sericonstorage","name":"sericonstorage","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2023-03-05T19:58:00.4355863Z","key2":"2023-03-05T19:58:00.4355863Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-05T19:58:00.9824831Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-05T19:58:00.9824831Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2023-03-05T19:58:00.3262342Z","primaryEndpoints":{"dfs":"https://sericonstorage.dfs.core.windows.net/","web":"https://sericonstorage.z5.web.core.windows.net/","blob":"https://sericonstorage.blob.core.windows.net/","queue":"https://sericonstorage.queue.core.windows.net/","table":"https://sericonstorage.table.core.windows.net/","file":"https://sericonstorage.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rhoover-dev-rg/providers/Microsoft.Storage/storageAccounts/rhooverdevrgdiag","name":"rhooverdevrgdiag","type":"Microsoft.Storage/storageAccounts","location":"westcentralus","tags":{},"properties":{"defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-06-20T19:39:24.4605968Z","key2":"2022-06-20T19:39:24.4605968Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":false,"networkAcls":{"resourceAccessRules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[{"value":"20.98.146.84","action":"Allow"},{"value":"20.98.194.64","action":"Allow"},{"value":"20.69.5.162","action":"Allow"},{"value":"20.83.222.102","action":"Allow"},{"value":"76.197.206.105","action":"Allow"}],"defaultAction":"Deny"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-06-20T19:39:24.4762287Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-06-20T19:39:24.4762287Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-06-20T19:39:24.4137057Z","primaryEndpoints":{"blob":"https://rhooverdevrgdiag.blob.core.windows.net/","queue":"https://rhooverdevrgdiag.queue.core.windows.net/","table":"https://rhooverdevrgdiag.table.core.windows.net/","file":"https://rhooverdevrgdiag.file.core.windows.net/"},"primaryLocation":"westcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnervmrg-westcentralus/providers/Microsoft.Storage/storageAccounts/scrunneraoptpjec4skce","name":"scrunneraoptpjec4skce","type":"Microsoft.Storage/storageAccounts","location":"westcentralus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-02-11T08:40:40.0686467Z","key2":"2023-02-11T08:40:40.0686467Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:40:40.5842822Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:40:40.5842822Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-02-11T08:40:40.0061730Z","primaryEndpoints":{"blob":"https://scrunneraoptpjec4skce.blob.core.windows.net/","queue":"https://scrunneraoptpjec4skce.queue.core.windows.net/","table":"https://scrunneraoptpjec4skce.table.core.windows.net/","file":"https://scrunneraoptpjec4skce.file.core.windows.net/"},"primaryLocation":"westcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnertestvmrg-westcentralus/providers/Microsoft.Storage/storageAccounts/scrunnerrfscmqxeni3uq","name":"scrunnerrfscmqxeni3uq","type":"Microsoft.Storage/storageAccounts","location":"westcentralus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-04-10T22:28:55.2104910Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-04-10T22:28:55.2104910Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-04-10T22:28:55.1479670Z","primaryEndpoints":{"blob":"https://scrunnerrfscmqxeni3uq.blob.core.windows.net/","queue":"https://scrunnerrfscmqxeni3uq.queue.core.windows.net/","table":"https://scrunnerrfscmqxeni3uq.table.core.windows.net/","file":"https://scrunnerrfscmqxeni3uq.file.core.windows.net/"},"primaryLocation":"westcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ubuntu-westus3_group/providers/Microsoft.Storage/storageAccounts/ubuntuwestus3groupdiag","name":"ubuntuwestus3groupdiag","type":"Microsoft.Storage/storageAccounts","location":"westus3","tags":{},"properties":{"keyCreationTime":{"key1":"2022-04-18T19:48:38.9882588Z","key2":"2022-04-18T19:48:38.9882588Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-18T19:48:38.9882588Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-18T19:48:38.9882588Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-04-18T19:48:38.9258191Z","primaryEndpoints":{"blob":"https://ubuntuwestus3groupdiag.blob.core.windows.net/","queue":"https://ubuntuwestus3groupdiag.queue.core.windows.net/","table":"https://ubuntuwestus3groupdiag.table.core.windows.net/","file":"https://ubuntuwestus3groupdiag.file.core.windows.net/"},"primaryLocation":"westus3","statusOfPrimary":"available"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '42669'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 06 Mar 2023 15:00:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-original-request-ids:
+      - 00a5bc0c-ebb0-452f-8735-dcd234c8fd96
+      - 3b3e32c6-3dbc-4b34-bbc3-ba224f8925bd
+      - 7ebeda38-bc15-4b35-a615-4d9290ada013
+      - ccba6528-7ad4-4c85-9ffc-85ccde4f3559
+      - 176ba88e-a1e5-4275-aeaa-fba585782375
+      - 55483e18-d3e0-44da-a94f-e82ba8a5f53c
+      - e3c1dfc0-eb7b-46bc-a545-b8282d3be3cf
+      - f1c78dfe-0168-4dad-9c12-b0e7544c2ad6
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm deallocate
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002","name":"cli000002","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2022-12-13T22:51:17.0682893Z","key2":"2022-12-13T22:51:17.0682893Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-12-13T22:51:17.6307939Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-12-13T22:51:17.6307939Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-12-13T22:51:16.9745683Z","primaryEndpoints":{"blob":"https://cli000002.blob.core.windows.net/","queue":"https://cli000002.queue.core.windows.net/","table":"https://cli000002.table.core.windows.net/","file":"https://cli000002.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002","name":"cli000002","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T14:54:24.1208364Z","key2":"2023-03-06T14:54:24.1208364Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.6676739Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T14:54:24.6676739Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T14:54:24.0114062Z","primaryEndpoints":{"blob":"https://cli000002.blob.core.windows.net/","queue":"https://cli000002.queue.core.windows.net/","table":"https://cli000002.table.core.windows.net/","file":"https://cli000002.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -5303,7 +5158,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 13 Dec 2022 22:57:45 GMT
+      - Mon, 06 Mar 2023 15:00:40 GMT
       expires:
       - '-1'
       pragma:
@@ -5335,8 +5190,8 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
-        (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.SerialConsole/consoleServices/default?api-version=2018-05-01
   response:
@@ -5350,7 +5205,7 @@ interactions:
       content-type:
       - application/json; charset=UTF-8
       date:
-      - Tue, 13 Dec 2022 22:57:46 GMT
+      - Mon, 06 Mar 2023 15:00:40 GMT
       expires:
       - '-1'
       pragma:

--- a/src/serial-console/azext_serialconsole/tests/latest/recordings/test_check_resource_VMSS.yaml
+++ b/src/serial-console/azext_serialconsole/tests/latest/recordings/test_check_resource_VMSS.yaml
@@ -11,9 +11,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?$expand=instanceView&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?$expand=instanceView&api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Compute/virtualMachines/cli000003''
@@ -27,7 +27,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:58:13 GMT
+      - Mon, 06 Mar 2023 15:01:06 GMT
       expires:
       - '-1'
       pragma:
@@ -53,9 +53,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Compute/virtualMachineScaleSets/cli000003''
@@ -69,7 +69,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:58:14 GMT
+      - Mon, 06 Mar 2023 15:01:06 GMT
       expires:
       - '-1'
       pragma:
@@ -95,9 +95,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/0/instanceView?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/0/instanceView?api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"ParentResourceNotFound","message":"Can not perform
@@ -111,7 +111,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:58:13 GMT
+      - Mon, 06 Mar 2023 15:01:06 GMT
       expires:
       - '-1'
       pragma:
@@ -135,7 +135,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.28.1
+      - python-requests/2.26.0
     method: GET
     uri: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/arm-compute/quickstart-templates/aliases.json
   response:
@@ -202,11 +202,11 @@ interactions:
       content-type:
       - text/plain; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:58:16 GMT
+      - Mon, 06 Mar 2023 15:01:07 GMT
       etag:
       - W/"41b202f4dc5098d126019dc00721a4c5e30df0c5196794514fadc3710ee2a5cb"
       expires:
-      - Tue, 13 Dec 2022 23:03:16 GMT
+      - Mon, 06 Mar 2023 15:06:07 GMT
       source-age:
       - '0'
       strict-transport-security:
@@ -222,15 +222,15 @@ interactions:
       x-content-type-options:
       - nosniff
       x-fastly-request-id:
-      - 9543def0c4cd47c27893b6c209d6012f277fb222
+      - fc166179d425df7b01a9cb56c01fb81d3cb4473c
       x-frame-options:
       - deny
       x-github-request-id:
-      - 42FE:0D55:4E604:6620A:639901FC
+      - 2404:0661:52C8DE:6E0168:6405FB51
       x-served-by:
-      - cache-pao17425-PAO
+      - cache-dal2120143-DAL
       x-timer:
-      - S1670972296.880040,VS0,VE153
+      - S1678114868.556267,VS0,VE196
       x-xss-protection:
       - 1; mode=block
     status:
@@ -250,13 +250,13 @@ interactions:
       ParameterSetName:
       - -g -n --image --instance-count -l
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/publishers/Canonical/artifacttypes/vmimage/offers/UbuntuServer/skus/18.04-LTS/versions?$top=1&$orderby=name%20desc&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/publishers/Canonical/artifacttypes/vmimage/offers/UbuntuServer/skus/18.04-LTS/versions?$top=1&$orderby=name%20desc&api-version=2022-11-01
   response:
     body:
-      string: "[\r\n  {\r\n    \"location\": \"westus2\",\r\n    \"name\": \"18.04.202212090\",\r\n
-        \   \"id\": \"/Subscriptions/00000000-0000-0000-0000-000000000000/Providers/Microsoft.Compute/Locations/westus2/Publishers/Canonical/ArtifactTypes/VMImage/Offers/UbuntuServer/Skus/18.04-LTS/Versions/18.04.202212090\"\r\n
+      string: "[\r\n  {\r\n    \"location\": \"westus2\",\r\n    \"name\": \"18.04.202302100\",\r\n
+        \   \"id\": \"/Subscriptions/00000000-0000-0000-0000-000000000000/Providers/Microsoft.Compute/Locations/westus2/Publishers/Canonical/ArtifactTypes/VMImage/Offers/UbuntuServer/Skus/18.04-LTS/Versions/18.04.202302100\"\r\n
         \ }\r\n]"
     headers:
       cache-control:
@@ -266,7 +266,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:58:16 GMT
+      - Mon, 06 Mar 2023 15:01:07 GMT
       expires:
       - '-1'
       pragma:
@@ -283,7 +283,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/ListVMImagesVersionsFromLocation3Min;15999,Microsoft.Compute/ListVMImagesVersionsFromLocation30Min;43994
+      - Microsoft.Compute/ListVMImagesVersionsFromLocation3Min;15991,Microsoft.Compute/ListVMImagesVersionsFromLocation30Min;43966
     status:
       code: 200
       message: OK
@@ -301,9 +301,9 @@ interactions:
       ParameterSetName:
       - -g -n --image --instance-count -l
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/publishers/Canonical/artifacttypes/vmimage/offers/UbuntuServer/skus/18.04-LTS/versions/18.04.202212090?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/publishers/Canonical/artifacttypes/vmimage/offers/UbuntuServer/skus/18.04-LTS/versions/18.04.202302100?api-version=2022-11-01
   response:
     body:
       string: "{\r\n  \"properties\": {\r\n    \"hyperVGeneration\": \"V1\",\r\n    \"architecture\":
@@ -317,8 +317,8 @@ interactions:
         \"IsHibernateSupported\",\r\n        \"value\": \"True\"\r\n      }\r\n    ],\r\n
         \   \"osDiskImage\": {\r\n      \"operatingSystem\": \"Linux\",\r\n      \"sizeInGb\":
         31,\r\n      \"sizeInBytes\": 32213303808\r\n    },\r\n    \"dataDiskImages\":
-        []\r\n  },\r\n  \"location\": \"westus2\",\r\n  \"name\": \"18.04.202212090\",\r\n
-        \ \"id\": \"/Subscriptions/00000000-0000-0000-0000-000000000000/Providers/Microsoft.Compute/Locations/westus2/Publishers/Canonical/ArtifactTypes/VMImage/Offers/UbuntuServer/Skus/18.04-LTS/Versions/18.04.202212090\"\r\n}"
+        []\r\n  },\r\n  \"location\": \"westus2\",\r\n  \"name\": \"18.04.202302100\",\r\n
+        \ \"id\": \"/Subscriptions/00000000-0000-0000-0000-000000000000/Providers/Microsoft.Compute/Locations/westus2/Publishers/Canonical/ArtifactTypes/VMImage/Offers/UbuntuServer/Skus/18.04-LTS/Versions/18.04.202302100\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -327,7 +327,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:58:15 GMT
+      - Mon, 06 Mar 2023 15:01:08 GMT
       expires:
       - '-1'
       pragma:
@@ -344,7 +344,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetVMImageFromLocation3Min;12999,Microsoft.Compute/GetVMImageFromLocation30Min;73995
+      - Microsoft.Compute/GetVMImageFromLocation3Min;12995,Microsoft.Compute/GetVMImageFromLocation30Min;73978
     status:
       code: 200
       message: OK
@@ -362,7 +362,7 @@ interactions:
       ParameterSetName:
       - -g -n --image --instance-count -l
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-network/21.0.1 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-network/21.0.1 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks?api-version=2022-01-01
   response:
@@ -376,7 +376,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:58:16 GMT
+      - Mon, 06 Mar 2023 15:01:08 GMT
       expires:
       - '-1'
       pragma:
@@ -400,7 +400,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.28.1
+      - python-requests/2.26.0
     method: GET
     uri: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/arm-compute/quickstart-templates/aliases.json
   response:
@@ -467,11 +467,11 @@ interactions:
       content-type:
       - text/plain; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:58:17 GMT
+      - Mon, 06 Mar 2023 15:01:09 GMT
       etag:
       - W/"41b202f4dc5098d126019dc00721a4c5e30df0c5196794514fadc3710ee2a5cb"
       expires:
-      - Tue, 13 Dec 2022 23:03:17 GMT
+      - Mon, 06 Mar 2023 15:06:09 GMT
       source-age:
       - '1'
       strict-transport-security:
@@ -487,15 +487,15 @@ interactions:
       x-content-type-options:
       - nosniff
       x-fastly-request-id:
-      - 96cd955f0d105a66843a8b306498560bc3af5515
+      - acc85ebe5fd51d4c569dffdf10ad7db2a714f55d
       x-frame-options:
       - deny
       x-github-request-id:
-      - 42FE:0D55:4E604:6620A:639901FC
+      - 2404:0661:52C8DE:6E0168:6405FB51
       x-served-by:
-      - cache-pao17433-PAO
+      - cache-dal21258-DAL
       x-timer:
-      - S1670972297.120532,VS0,VE3
+      - S1678114869.241703,VS0,VE1
       x-xss-protection:
       - 1; mode=block
     status:
@@ -515,13 +515,13 @@ interactions:
       ParameterSetName:
       - -g -n --image --instance-count -l
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/publishers/Canonical/artifacttypes/vmimage/offers/UbuntuServer/skus/18.04-LTS/versions?$top=1&$orderby=name%20desc&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/publishers/Canonical/artifacttypes/vmimage/offers/UbuntuServer/skus/18.04-LTS/versions?$top=1&$orderby=name%20desc&api-version=2022-11-01
   response:
     body:
-      string: "[\r\n  {\r\n    \"location\": \"westus2\",\r\n    \"name\": \"18.04.202212090\",\r\n
-        \   \"id\": \"/Subscriptions/00000000-0000-0000-0000-000000000000/Providers/Microsoft.Compute/Locations/westus2/Publishers/Canonical/ArtifactTypes/VMImage/Offers/UbuntuServer/Skus/18.04-LTS/Versions/18.04.202212090\"\r\n
+      string: "[\r\n  {\r\n    \"location\": \"westus2\",\r\n    \"name\": \"18.04.202302100\",\r\n
+        \   \"id\": \"/Subscriptions/00000000-0000-0000-0000-000000000000/Providers/Microsoft.Compute/Locations/westus2/Publishers/Canonical/ArtifactTypes/VMImage/Offers/UbuntuServer/Skus/18.04-LTS/Versions/18.04.202302100\"\r\n
         \ }\r\n]"
     headers:
       cache-control:
@@ -531,7 +531,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:58:16 GMT
+      - Mon, 06 Mar 2023 15:01:08 GMT
       expires:
       - '-1'
       pragma:
@@ -548,7 +548,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/ListVMImagesVersionsFromLocation3Min;15998,Microsoft.Compute/ListVMImagesVersionsFromLocation30Min;43993
+      - Microsoft.Compute/ListVMImagesVersionsFromLocation3Min;15990,Microsoft.Compute/ListVMImagesVersionsFromLocation30Min;43965
     status:
       code: 200
       message: OK
@@ -566,9 +566,9 @@ interactions:
       ParameterSetName:
       - -g -n --image --instance-count -l
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/publishers/Canonical/artifacttypes/vmimage/offers/UbuntuServer/skus/18.04-LTS/versions/18.04.202212090?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/publishers/Canonical/artifacttypes/vmimage/offers/UbuntuServer/skus/18.04-LTS/versions/18.04.202302100?api-version=2022-11-01
   response:
     body:
       string: "{\r\n  \"properties\": {\r\n    \"hyperVGeneration\": \"V1\",\r\n    \"architecture\":
@@ -582,8 +582,8 @@ interactions:
         \"IsHibernateSupported\",\r\n        \"value\": \"True\"\r\n      }\r\n    ],\r\n
         \   \"osDiskImage\": {\r\n      \"operatingSystem\": \"Linux\",\r\n      \"sizeInGb\":
         31,\r\n      \"sizeInBytes\": 32213303808\r\n    },\r\n    \"dataDiskImages\":
-        []\r\n  },\r\n  \"location\": \"westus2\",\r\n  \"name\": \"18.04.202212090\",\r\n
-        \ \"id\": \"/Subscriptions/00000000-0000-0000-0000-000000000000/Providers/Microsoft.Compute/Locations/westus2/Publishers/Canonical/ArtifactTypes/VMImage/Offers/UbuntuServer/Skus/18.04-LTS/Versions/18.04.202212090\"\r\n}"
+        []\r\n  },\r\n  \"location\": \"westus2\",\r\n  \"name\": \"18.04.202302100\",\r\n
+        \ \"id\": \"/Subscriptions/00000000-0000-0000-0000-000000000000/Providers/Microsoft.Compute/Locations/westus2/Publishers/Canonical/ArtifactTypes/VMImage/Offers/UbuntuServer/Skus/18.04-LTS/Versions/18.04.202302100\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -592,7 +592,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:58:17 GMT
+      - Mon, 06 Mar 2023 15:01:10 GMT
       expires:
       - '-1'
       pragma:
@@ -609,7 +609,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetVMImageFromLocation3Min;12998,Microsoft.Compute/GetVMImageFromLocation30Min;73994
+      - Microsoft.Compute/GetVMImageFromLocation3Min;12994,Microsoft.Compute/GetVMImageFromLocation30Min;73977
     status:
       code: 200
       message: OK
@@ -627,13 +627,13 @@ interactions:
       ParameterSetName:
       - -g -n --image --instance-count -l
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/publishers/Canonical/artifacttypes/vmimage/offers/UbuntuServer/skus/18.04-LTS/versions?$top=1&$orderby=name%20desc&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/publishers/Canonical/artifacttypes/vmimage/offers/UbuntuServer/skus/18.04-LTS/versions?$top=1&$orderby=name%20desc&api-version=2022-11-01
   response:
     body:
-      string: "[\r\n  {\r\n    \"location\": \"westus2\",\r\n    \"name\": \"18.04.202212090\",\r\n
-        \   \"id\": \"/Subscriptions/00000000-0000-0000-0000-000000000000/Providers/Microsoft.Compute/Locations/westus2/Publishers/Canonical/ArtifactTypes/VMImage/Offers/UbuntuServer/Skus/18.04-LTS/Versions/18.04.202212090\"\r\n
+      string: "[\r\n  {\r\n    \"location\": \"westus2\",\r\n    \"name\": \"18.04.202302100\",\r\n
+        \   \"id\": \"/Subscriptions/00000000-0000-0000-0000-000000000000/Providers/Microsoft.Compute/Locations/westus2/Publishers/Canonical/ArtifactTypes/VMImage/Offers/UbuntuServer/Skus/18.04-LTS/Versions/18.04.202302100\"\r\n
         \ }\r\n]"
     headers:
       cache-control:
@@ -643,7 +643,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:58:17 GMT
+      - Mon, 06 Mar 2023 15:01:10 GMT
       expires:
       - '-1'
       pragma:
@@ -660,7 +660,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/ListVMImagesVersionsFromLocation3Min;15997,Microsoft.Compute/ListVMImagesVersionsFromLocation30Min;43992
+      - Microsoft.Compute/ListVMImagesVersionsFromLocation3Min;15989,Microsoft.Compute/ListVMImagesVersionsFromLocation30Min;43964
     status:
       code: 200
       message: OK
@@ -678,9 +678,9 @@ interactions:
       ParameterSetName:
       - -g -n --image --instance-count -l
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/publishers/Canonical/artifacttypes/vmimage/offers/UbuntuServer/skus/18.04-LTS/versions/18.04.202212090?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/publishers/Canonical/artifacttypes/vmimage/offers/UbuntuServer/skus/18.04-LTS/versions/18.04.202302100?api-version=2022-11-01
   response:
     body:
       string: "{\r\n  \"properties\": {\r\n    \"hyperVGeneration\": \"V1\",\r\n    \"architecture\":
@@ -694,8 +694,8 @@ interactions:
         \"IsHibernateSupported\",\r\n        \"value\": \"True\"\r\n      }\r\n    ],\r\n
         \   \"osDiskImage\": {\r\n      \"operatingSystem\": \"Linux\",\r\n      \"sizeInGb\":
         31,\r\n      \"sizeInBytes\": 32213303808\r\n    },\r\n    \"dataDiskImages\":
-        []\r\n  },\r\n  \"location\": \"westus2\",\r\n  \"name\": \"18.04.202212090\",\r\n
-        \ \"id\": \"/Subscriptions/00000000-0000-0000-0000-000000000000/Providers/Microsoft.Compute/Locations/westus2/Publishers/Canonical/ArtifactTypes/VMImage/Offers/UbuntuServer/Skus/18.04-LTS/Versions/18.04.202212090\"\r\n}"
+        []\r\n  },\r\n  \"location\": \"westus2\",\r\n  \"name\": \"18.04.202302100\",\r\n
+        \ \"id\": \"/Subscriptions/00000000-0000-0000-0000-000000000000/Providers/Microsoft.Compute/Locations/westus2/Publishers/Canonical/ArtifactTypes/VMImage/Offers/UbuntuServer/Skus/18.04-LTS/Versions/18.04.202302100\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -704,7 +704,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:58:17 GMT
+      - Mon, 06 Mar 2023 15:01:10 GMT
       expires:
       - '-1'
       pragma:
@@ -721,7 +721,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetVMImageFromLocation3Min;12997,Microsoft.Compute/GetVMImageFromLocation30Min;73993
+      - Microsoft.Compute/GetVMImageFromLocation3Min;12993,Microsoft.Compute/GetVMImageFromLocation30Min;73976
     status:
       code: 200
       message: OK
@@ -744,19 +744,19 @@ interactions:
       ''/frontendIPConfigurations/'', ''loadBalancerFrontEnd'')]"}, "protocol": "tcp",
       "frontendPortRangeStart": "50000", "frontendPortRangeEnd": "50119", "backendPort":
       22}}]}}, {"type": "Microsoft.Compute/virtualMachineScaleSets", "name": "cli000003",
-      "location": "westus2", "tags": {}, "apiVersion": "2022-08-01", "dependsOn":
+      "location": "westus2", "tags": {}, "apiVersion": "2022-11-01", "dependsOn":
       ["Microsoft.Network/virtualNetworks/cli000003VNET", "Microsoft.Network/loadBalancers/cli000003LB"],
       "properties": {"overprovision": true, "upgradePolicy": {"mode": "manual", "rollingUpgradePolicy":
       {}}, "singlePlacementGroup": null, "virtualMachineProfile": {"storageProfile":
       {"osDisk": {"createOption": "FromImage", "caching": "ReadWrite", "managedDisk":
       {"storageAccountType": null}}, "imageReference": {"publisher": "Canonical",
       "offer": "UbuntuServer", "sku": "18.04-LTS", "version": "latest"}}, "osProfile":
-      {"computerNamePrefix": "cli5o787e", "adminUsername": "rhl", "linuxConfiguration":
-      {"disablePasswordAuthentication": true, "ssh": {"publicKeys": [{"path": "/home/rhl/.ssh/authorized_keys",
-      "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h"}]}}},
-      "networkProfile": {"networkInterfaceConfigurations": [{"name": "cli5o787eNic",
-      "properties": {"ipConfigurations": [{"name": "cli5o787eIPConfig", "properties":
-      {"subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET/subnets/cli000003Subnet"},
+      {"computerNamePrefix": "cliuz26de", "adminUsername": "rhoover", "linuxConfiguration":
+      {"disablePasswordAuthentication": true, "ssh": {"publicKeys": [{"path": "/home/rhoover/.ssh/authorized_keys",
+      "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+      REDMOND+rhoover@DESKTOP-XVFR7ID\n"}]}}}, "networkProfile": {"networkInterfaceConfigurations":
+      [{"name": "cliuz26deNic", "properties": {"ipConfigurations": [{"name": "cliuz26deIPConfig",
+      "properties": {"subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET/subnets/cli000003Subnet"},
       "loadBalancerBackendAddressPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/backendAddressPools/cli000003LBBEPool"}],
       "loadBalancerInboundNatPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/inboundNatPools/cli000003LBNatPool"}]}}],
       "primary": "true"}}]}}, "orchestrationMode": "Uniform"}, "sku": {"name": "Standard_DS1_v2",
@@ -773,21 +773,21 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '4106'
+      - '4320'
       Content-Type:
       - application/json
       ParameterSetName:
       - -g -n --image --instance-count -l
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_serialconsole000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2021-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Resources/deployments/vmss_deploy_otMFVcYECTQp8FMR1EQFyziOZguKFTy3","name":"vmss_deploy_otMFVcYECTQp8FMR1EQFyziOZguKFTy3","type":"Microsoft.Resources/deployments","properties":{"templateHash":"12738683678369510000","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2022-12-13T22:58:22.5140752Z","duration":"PT0.0006407S","correlationId":"169540b4-4a53-4d3c-a86f-f9d67835ada5","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus2"]},{"resourceType":"publicIPAddresses","locations":["westus2"]},{"resourceType":"loadBalancers","locations":["westus2"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus2"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"cli000003VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/publicIPAddresses/cli000003LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"cli000003LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"cli000003LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"cli000003VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"cli000003LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"cli000003"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Resources/deployments/vmss_deploy_tFvIP2liVXj0GEb0kMl3PnTp555oT72U","name":"vmss_deploy_tFvIP2liVXj0GEb0kMl3PnTp555oT72U","type":"Microsoft.Resources/deployments","properties":{"templateHash":"12330572724569140869","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2023-03-06T15:01:16.4743047Z","duration":"PT0.0005579S","correlationId":"446d8059-3690-4f4d-82eb-9d5eee26d92f","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus2"]},{"resourceType":"publicIPAddresses","locations":["westus2"]},{"resourceType":"loadBalancers","locations":["westus2"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus2"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"cli000003VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/publicIPAddresses/cli000003LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"cli000003LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"cli000003LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"cli000003VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"cli000003LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"cli000003"}]}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_serialconsole000001/providers/Microsoft.Resources/deployments/vmss_deploy_otMFVcYECTQp8FMR1EQFyziOZguKFTy3/operationStatuses/08585306345841544282?api-version=2021-04-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_serialconsole000001/providers/Microsoft.Resources/deployments/vmss_deploy_tFvIP2liVXj0GEb0kMl3PnTp555oT72U/operationStatuses/08585234920103861021?api-version=2021-04-01
       cache-control:
       - no-cache
       content-length:
@@ -795,7 +795,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:58:22 GMT
+      - Mon, 06 Mar 2023 15:01:17 GMT
       expires:
       - '-1'
       pragma:
@@ -823,51 +823,9 @@ interactions:
       ParameterSetName:
       - -g -n --image --instance-count -l
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_serialconsole000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585306345841544282?api-version=2021-04-01
-  response:
-    body:
-      string: '{"status":"Accepted"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 13 Dec 2022 22:58:22 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vmss create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --image --instance-count -l
-      User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_serialconsole000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585306345841544282?api-version=2021-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_serialconsole000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585234920103861021?api-version=2021-04-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -879,7 +837,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:58:52 GMT
+      - Mon, 06 Mar 2023 15:01:47 GMT
       expires:
       - '-1'
       pragma:
@@ -907,9 +865,9 @@ interactions:
       ParameterSetName:
       - -g -n --image --instance-count -l
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_serialconsole000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585306345841544282?api-version=2021-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_serialconsole000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585234920103861021?api-version=2021-04-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -921,7 +879,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:59:22 GMT
+      - Mon, 06 Mar 2023 15:02:16 GMT
       expires:
       - '-1'
       pragma:
@@ -949,9 +907,9 @@ interactions:
       ParameterSetName:
       - -g -n --image --instance-count -l
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_serialconsole000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585306345841544282?api-version=2021-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_serialconsole000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585234920103861021?api-version=2021-04-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -963,7 +921,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 22:59:53 GMT
+      - Mon, 06 Mar 2023 15:02:47 GMT
       expires:
       - '-1'
       pragma:
@@ -991,9 +949,9 @@ interactions:
       ParameterSetName:
       - -g -n --image --instance-count -l
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_serialconsole000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585306345841544282?api-version=2021-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_serialconsole000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585234920103861021?api-version=2021-04-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -1005,7 +963,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:00:23 GMT
+      - Mon, 06 Mar 2023 15:03:17 GMT
       expires:
       - '-1'
       pragma:
@@ -1033,51 +991,9 @@ interactions:
       ParameterSetName:
       - -g -n --image --instance-count -l
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_serialconsole000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585306345841544282?api-version=2021-04-01
-  response:
-    body:
-      string: '{"status":"Running"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '20'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 13 Dec 2022 23:00:52 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vmss create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --image --instance-count -l
-      User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_serialconsole000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585306345841544282?api-version=2021-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_serialconsole000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585234920103861021?api-version=2021-04-01
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -1089,7 +1005,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:01:22 GMT
+      - Mon, 06 Mar 2023 15:03:47 GMT
       expires:
       - '-1'
       pragma:
@@ -1117,22 +1033,23 @@ interactions:
       ParameterSetName:
       - -g -n --image --instance-count -l
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_serialconsole000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2021-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Resources/deployments/vmss_deploy_otMFVcYECTQp8FMR1EQFyziOZguKFTy3","name":"vmss_deploy_otMFVcYECTQp8FMR1EQFyziOZguKFTy3","type":"Microsoft.Resources/deployments","properties":{"templateHash":"12738683678369510000","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2022-12-13T23:00:58.750847Z","duration":"PT2M36.2374125S","correlationId":"169540b4-4a53-4d3c-a86f-f9d67835ada5","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus2"]},{"resourceType":"publicIPAddresses","locations":["westus2"]},{"resourceType":"loadBalancers","locations":["westus2"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus2"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"cli000003VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/publicIPAddresses/cli000003LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"cli000003LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"cli000003LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"cli000003VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"cli000003LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"cli000003"}],"outputs":{"vmss":{"type":"Object","value":{"singlePlacementGroup":true,"orchestrationMode":"Uniform","upgradePolicy":{"mode":"Manual","rollingUpgradePolicy":{"maxBatchInstancePercent":20,"maxUnhealthyInstancePercent":20,"maxUnhealthyUpgradedInstancePercent":20,"pauseTimeBetweenBatches":"PT0S"}},"virtualMachineProfile":{"osProfile":{"computerNamePrefix":"cli5o787e","adminUsername":"rhl","linuxConfiguration":{"disablePasswordAuthentication":true,"ssh":{"publicKeys":[{"path":"/home/rhl/.ssh/authorized_keys","keyData":"ssh-rsa
-        AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h"}]},"provisionVMAgent":true,"enableVMAgentPlatformUpdates":false},"secrets":[],"allowExtensionOperations":true,"requireGuestProvisionSignal":true},"storageProfile":{"osDisk":{"osType":"Linux","createOption":"FromImage","caching":"ReadWrite","managedDisk":{"storageAccountType":"Premium_LRS"},"diskSizeGB":30},"imageReference":{"publisher":"Canonical","offer":"UbuntuServer","sku":"18.04-LTS","version":"latest"}},"networkProfile":{"networkInterfaceConfigurations":[{"name":"cli5o787eNic","properties":{"primary":true,"enableAcceleratedNetworking":false,"disableTcpStateTracking":false,"dnsSettings":{"dnsServers":[]},"enableIPForwarding":false,"ipConfigurations":[{"name":"cli5o787eIPConfig","properties":{"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET/subnets/cli000003Subnet"},"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/backendAddressPools/cli000003LBBEPool"}],"loadBalancerInboundNatPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/inboundNatPools/cli000003LBNatPool"}]}}]}}]},"extensionProfile":{"extensions":[{"name":"Microsoft.Azure.Monitor.AzureMonitorLinuxAgent","properties":{"autoUpgradeMinorVersion":true,"enableAutomaticUpgrade":true,"publisher":"Microsoft.Azure.Monitor","type":"AzureMonitorLinuxAgent","typeHandlerVersion":"1.0","settings":{"GCS_AUTO_CONFIG":true}}},{"name":"Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent","properties":{"autoUpgradeMinorVersion":true,"enableAutomaticUpgrade":true,"publisher":"Microsoft.Azure.Security.Monitoring","type":"AzureSecurityLinuxAgent","typeHandlerVersion":"2.0","settings":{"enableGenevaUpload":true,"enableAutoConfig":true,"reportSuccessOnUnsupportedDistro":true}}}]}},"provisioningState":"Succeeded","overprovision":true,"doNotRunExtensionsOnOverprovisionedVMs":false,"uniqueId":"c72549ea-142c-4eb1-8178-a7442e2bc6db","timeCreated":"2022-12-13T22:58:32.1880141+00:00"}}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/publicIPAddresses/cli000003LBPublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Resources/deployments/vmss_deploy_tFvIP2liVXj0GEb0kMl3PnTp555oT72U","name":"vmss_deploy_tFvIP2liVXj0GEb0kMl3PnTp555oT72U","type":"Microsoft.Resources/deployments","properties":{"templateHash":"12330572724569140869","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2023-03-06T15:03:34.8013748Z","duration":"PT2M18.327628S","correlationId":"446d8059-3690-4f4d-82eb-9d5eee26d92f","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus2"]},{"resourceType":"publicIPAddresses","locations":["westus2"]},{"resourceType":"loadBalancers","locations":["westus2"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus2"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"cli000003VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/publicIPAddresses/cli000003LBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"cli000003LBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"cli000003LB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"cli000003VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"cli000003LB"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"cli000003"}],"outputs":{"vmss":{"type":"Object","value":{"singlePlacementGroup":true,"orchestrationMode":"Uniform","upgradePolicy":{"mode":"Manual","rollingUpgradePolicy":{"maxBatchInstancePercent":20,"maxUnhealthyInstancePercent":20,"maxUnhealthyUpgradedInstancePercent":20,"pauseTimeBetweenBatches":"PT0S","maxSurge":false,"rollbackFailedInstancesOnPolicyBreach":false}},"virtualMachineProfile":{"osProfile":{"computerNamePrefix":"cliuz26de","adminUsername":"rhoover","linuxConfiguration":{"disablePasswordAuthentication":true,"ssh":{"publicKeys":[{"path":"/home/rhoover/.ssh/authorized_keys","keyData":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+        REDMOND+rhoover@DESKTOP-XVFR7ID\n"}]},"provisionVMAgent":true,"enableVMAgentPlatformUpdates":false},"secrets":[],"allowExtensionOperations":true,"requireGuestProvisionSignal":true},"storageProfile":{"osDisk":{"osType":"Linux","createOption":"FromImage","caching":"ReadWrite","managedDisk":{"storageAccountType":"Premium_LRS"},"diskSizeGB":30},"imageReference":{"publisher":"Canonical","offer":"UbuntuServer","sku":"18.04-LTS","version":"latest"}},"networkProfile":{"networkInterfaceConfigurations":[{"name":"cliuz26deNic","properties":{"primary":true,"enableAcceleratedNetworking":false,"disableTcpStateTracking":false,"dnsSettings":{"dnsServers":[]},"enableIPForwarding":false,"ipConfigurations":[{"name":"cliuz26deIPConfig","properties":{"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET/subnets/cli000003Subnet"},"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/backendAddressPools/cli000003LBBEPool"}],"loadBalancerInboundNatPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/inboundNatPools/cli000003LBNatPool"}]}}]}}]},"extensionProfile":{"extensions":[{"name":"Microsoft.Azure.Monitor.AzureMonitorLinuxAgent","properties":{"autoUpgradeMinorVersion":true,"enableAutomaticUpgrade":true,"publisher":"Microsoft.Azure.Monitor","type":"AzureMonitorLinuxAgent","typeHandlerVersion":"1.0","settings":{"GCS_AUTO_CONFIG":true}}},{"name":"Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent","properties":{"autoUpgradeMinorVersion":true,"enableAutomaticUpgrade":true,"publisher":"Microsoft.Azure.Security.Monitoring","type":"AzureSecurityLinuxAgent","typeHandlerVersion":"2.0","settings":{"enableGenevaUpload":true,"enableAutoConfig":true,"reportSuccessOnUnsupportedDistro":true}}}]}},"provisioningState":"Succeeded","overprovision":true,"doNotRunExtensionsOnOverprovisionedVMs":false,"uniqueId":"6aa1f17d-1da0-4dfe-b11e-b77e59e02135","timeCreated":"2023-03-06T15:01:24.7059254+00:00"}}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/publicIPAddresses/cli000003LBPublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET"}]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '6270'
+      - '6547'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:01:22 GMT
+      - Mon, 06 Mar 2023 15:03:48 GMT
       expires:
       - '-1'
       pragma:
@@ -1160,9 +1077,9 @@ interactions:
       ParameterSetName:
       - -g -n --image --instance-count -l
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?$expand=instanceView&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003?$expand=instanceView&api-version=2022-11-01
   response:
     body:
       string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Compute/virtualMachines/cli000003''
@@ -1176,7 +1093,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:01:24 GMT
+      - Mon, 06 Mar 2023 15:03:48 GMT
       expires:
       - '-1'
       pragma:
@@ -1204,9 +1121,9 @@ interactions:
       ParameterSetName:
       - -g -n --image --instance-count -l
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003?api-version=2022-11-01
   response:
     body:
       string: "{\r\n  \"name\": \"cli000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003\",\r\n
@@ -1218,23 +1135,24 @@ interactions:
         \   \"upgradePolicy\": {\r\n      \"mode\": \"Manual\",\r\n      \"rollingUpgradePolicy\":
         {\r\n        \"maxBatchInstancePercent\": 20,\r\n        \"maxUnhealthyInstancePercent\":
         20,\r\n        \"maxUnhealthyUpgradedInstancePercent\": 20,\r\n        \"pauseTimeBetweenBatches\":
-        \"PT0S\"\r\n      }\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\":
-        {\r\n        \"computerNamePrefix\": \"cli5o787e\",\r\n        \"adminUsername\":
-        \"rhl\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\":
+        \"PT0S\",\r\n        \"maxSurge\": false,\r\n        \"rollbackFailedInstancesOnPolicyBreach\":
+        false\r\n      }\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\":
+        {\r\n        \"computerNamePrefix\": \"cliuz26de\",\r\n        \"adminUsername\":
+        \"rhoover\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\":
         true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n              {\r\n
-        \               \"path\": \"/home/rhl/.ssh/authorized_keys\",\r\n                \"keyData\":
-        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h\"\r\n
-        \             }\r\n            ]\r\n          },\r\n          \"provisionVMAgent\":
-        true,\r\n          \"enableVMAgentPlatformUpdates\": false\r\n        },\r\n
-        \       \"secrets\": [],\r\n        \"allowExtensionOperations\": true,\r\n
-        \       \"requireGuestProvisionSignal\": true\r\n      },\r\n      \"storageProfile\":
+        \               \"path\": \"/home/rhoover/.ssh/authorized_keys\",\r\n                \"keyData\":
+        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+        REDMOND+rhoover@DESKTOP-XVFR7ID\\n\"\r\n              }\r\n            ]\r\n
+        \         },\r\n          \"provisionVMAgent\": true,\r\n          \"enableVMAgentPlatformUpdates\":
+        false\r\n        },\r\n        \"secrets\": [],\r\n        \"allowExtensionOperations\":
+        true,\r\n        \"requireGuestProvisionSignal\": true\r\n      },\r\n      \"storageProfile\":
         {\r\n        \"osDisk\": {\r\n          \"osType\": \"Linux\",\r\n          \"createOption\":
         \"FromImage\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\":
         {\r\n            \"storageAccountType\": \"Premium_LRS\"\r\n          },\r\n
         \         \"diskSizeGB\": 30\r\n        },\r\n        \"imageReference\":
         {\r\n          \"publisher\": \"Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n
         \         \"sku\": \"18.04-LTS\",\r\n          \"version\": \"latest\"\r\n
-        \       }\r\n      },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"cli5o787eNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"disableTcpStateTracking\":false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\":[{\"name\":\"cli5o787eIPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET/subnets/cli000003Subnet\"},\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/backendAddressPools/cli000003LBBEPool\"}],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/inboundNatPools/cli000003LBNatPool\"}]}}]}}]},\r\n
+        \       }\r\n      },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"cliuz26deNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"disableTcpStateTracking\":false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\":[{\"name\":\"cliuz26deIPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET/subnets/cli000003Subnet\"},\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/backendAddressPools/cli000003LBBEPool\"}],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/inboundNatPools/cli000003LBNatPool\"}]}}]}}]},\r\n
         \     \"extensionProfile\": {\r\n        \"extensions\": [\r\n          {\r\n
         \           \"name\": \"Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n
         \           \"properties\": {\r\n              \"autoUpgradeMinorVersion\":
@@ -1250,17 +1168,17 @@ interactions:
         {\"enableGenevaUpload\":true,\"enableAutoConfig\":true,\"reportSuccessOnUnsupportedDistro\":true}\r\n
         \           }\r\n          }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\":
         \"Succeeded\",\r\n    \"overprovision\": true,\r\n    \"doNotRunExtensionsOnOverprovisionedVMs\":
-        false,\r\n    \"uniqueId\": \"c72549ea-142c-4eb1-8178-a7442e2bc6db\",\r\n
-        \   \"timeCreated\": \"2022-12-13T22:58:32.1880141+00:00\"\r\n  }\r\n}"
+        false,\r\n    \"uniqueId\": \"6aa1f17d-1da0-4dfe-b11e-b77e59e02135\",\r\n
+        \   \"timeCreated\": \"2023-03-06T15:01:24.7059254+00:00\"\r\n  }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '4648'
+      - '4947'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:01:24 GMT
+      - Mon, 06 Mar 2023 15:03:48 GMT
       expires:
       - '-1'
       pragma:
@@ -1277,7 +1195,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetVMScaleSet3Min;396,Microsoft.Compute/GetVMScaleSet30Min;2596
+      - Microsoft.Compute/GetVMScaleSet3Min;378,Microsoft.Compute/GetVMScaleSet30Min;2516
     status:
       code: 200
       message: OK
@@ -1295,9 +1213,9 @@ interactions:
       ParameterSetName:
       - --resource-group --name --query
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines?api-version=2022-11-01
   response:
     body:
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"cli000003_0\",\r\n
@@ -1309,30 +1227,30 @@ interactions:
         \       \"name\": \"Standard_DS1_v2\",\r\n        \"tier\": \"Standard\"\r\n
         \     },\r\n      \"properties\": {\r\n        \"latestModelApplied\": true,\r\n
         \       \"modelDefinitionApplied\": \"VirtualMachineScaleSet\",\r\n        \"networkProfileConfiguration\":
-        {\"networkInterfaceConfigurations\":[{\"name\":\"cli5o787eNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"disableTcpStateTracking\":false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\":[{\"name\":\"cli5o787eIPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET/subnets/cli000003Subnet\"},\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/backendAddressPools/cli000003LBBEPool\"}],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/inboundNatPools/cli000003LBNatPool\"}]}}]}}]},\r\n
-        \       \"vmId\": \"41607d1a-6fda-44cf-a06d-f740a4d6c361\",\r\n        \"hardwareProfile\":
+        {\"networkInterfaceConfigurations\":[{\"name\":\"cliuz26deNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"disableTcpStateTracking\":false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\":[{\"name\":\"cliuz26deIPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET/subnets/cli000003Subnet\"},\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/backendAddressPools/cli000003LBBEPool\"}],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/inboundNatPools/cli000003LBNatPool\"}]}}]}}]},\r\n
+        \       \"vmId\": \"63427c18-2b06-4b69-a3d0-7bf65456e448\",\r\n        \"hardwareProfile\":
         {\r\n          \"vmSize\": \"Standard_DS1_v2\"\r\n        },\r\n        \"storageProfile\":
         {\r\n          \"imageReference\": {\r\n            \"publisher\": \"Canonical\",\r\n
         \           \"offer\": \"UbuntuServer\",\r\n            \"sku\": \"18.04-LTS\",\r\n
-        \           \"version\": \"latest\",\r\n            \"exactVersion\": \"18.04.202212090\"\r\n
+        \           \"version\": \"latest\",\r\n            \"exactVersion\": \"18.04.202302100\"\r\n
         \         },\r\n          \"osDisk\": {\r\n            \"osType\": \"Linux\",\r\n
-        \           \"name\": \"cli5oqyn2zpljvxqcitncli5oqyn2zpljvxqcitnmOS__1_2ea7e97866bb44bda7d057d8d61f14e4\",\r\n
+        \           \"name\": \"cliuztvtdw4jbve2omq7cliuztvtdw4jbve2omq73OS__1_3040b08d49ec44489f9d85f41bdcc8f8\",\r\n
         \           \"createOption\": \"FromImage\",\r\n            \"caching\": \"ReadWrite\",\r\n
         \           \"managedDisk\": {\r\n              \"storageAccountType\": \"Premium_LRS\",\r\n
-        \             \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/disks/cli5oqyn2zpljvxqcitncli5oqyn2zpljvxqcitnmOS__1_2ea7e97866bb44bda7d057d8d61f14e4\"\r\n
+        \             \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/disks/cliuztvtdw4jbve2omq7cliuztvtdw4jbve2omq73OS__1_3040b08d49ec44489f9d85f41bdcc8f8\"\r\n
         \           },\r\n            \"diskSizeGB\": 30\r\n          },\r\n          \"dataDisks\":
         []\r\n        },\r\n        \"osProfile\": {\r\n          \"computerName\":
-        \"cli5o787e000000\",\r\n          \"adminUsername\": \"rhl\",\r\n          \"linuxConfiguration\":
+        \"cliuz26de000000\",\r\n          \"adminUsername\": \"rhoover\",\r\n          \"linuxConfiguration\":
         {\r\n            \"disablePasswordAuthentication\": true,\r\n            \"ssh\":
         {\r\n              \"publicKeys\": [\r\n                {\r\n                  \"path\":
-        \"/home/rhl/.ssh/authorized_keys\",\r\n                  \"keyData\": \"ssh-rsa
-        AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h\"\r\n
-        \               }\r\n              ]\r\n            },\r\n            \"provisionVMAgent\":
-        true,\r\n            \"enableVMAgentPlatformUpdates\": false\r\n          },\r\n
-        \         \"secrets\": [],\r\n          \"allowExtensionOperations\": true,\r\n
-        \         \"requireGuestProvisionSignal\": true\r\n        },\r\n        \"networkProfile\":
-        {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/0/networkInterfaces/cli5o787eNic\"}]},\r\n
-        \       \"provisioningState\": \"Updating\",\r\n        \"timeCreated\": \"2022-12-13T22:58:32.3755398+00:00\"\r\n
+        \"/home/rhoover/.ssh/authorized_keys\",\r\n                  \"keyData\":
+        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+        REDMOND+rhoover@DESKTOP-XVFR7ID\\n\"\r\n                }\r\n              ]\r\n
+        \           },\r\n            \"provisionVMAgent\": true,\r\n            \"enableVMAgentPlatformUpdates\":
+        false\r\n          },\r\n          \"secrets\": [],\r\n          \"allowExtensionOperations\":
+        true,\r\n          \"requireGuestProvisionSignal\": true\r\n        },\r\n
+        \       \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/0/networkInterfaces/cliuz26deNic\"}]},\r\n
+        \       \"provisioningState\": \"Updating\",\r\n        \"timeCreated\": \"2023-03-06T15:01:24.8622061+00:00\"\r\n
         \     },\r\n      \"resources\": [\r\n        {\r\n          \"name\": \"Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n
         \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003_0/extensions/Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n
         \         \"type\": \"Microsoft.Compute/virtualMachines/extensions\",\r\n
@@ -1350,41 +1268,41 @@ interactions:
         \           \"type\": \"AzureSecurityLinuxAgent\",\r\n            \"typeHandlerVersion\":
         \"2.0\",\r\n            \"settings\": {\"enableGenevaUpload\":true,\"enableAutoConfig\":true,\"reportSuccessOnUnsupportedDistro\":true}\r\n
         \         }\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"name\":
-        \"cli000003_2\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/2\",\r\n
+        \"cli000003_3\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/3\",\r\n
         \     \"type\": \"Microsoft.Compute/virtualMachineScaleSets/virtualMachines\",\r\n
         \     \"location\": \"westus2\",\r\n      \"tags\": {\r\n        \"azsecpack\":
         \"nonprod\",\r\n        \"platformsettings.host_environment.service.platform_optedin_for_rootcerts\":
-        \"true\"\r\n      },\r\n      \"instanceId\": \"2\",\r\n      \"sku\": {\r\n
+        \"true\"\r\n      },\r\n      \"instanceId\": \"3\",\r\n      \"sku\": {\r\n
         \       \"name\": \"Standard_DS1_v2\",\r\n        \"tier\": \"Standard\"\r\n
         \     },\r\n      \"properties\": {\r\n        \"latestModelApplied\": true,\r\n
         \       \"modelDefinitionApplied\": \"VirtualMachineScaleSet\",\r\n        \"networkProfileConfiguration\":
-        {\"networkInterfaceConfigurations\":[{\"name\":\"cli5o787eNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"disableTcpStateTracking\":false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\":[{\"name\":\"cli5o787eIPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET/subnets/cli000003Subnet\"},\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/backendAddressPools/cli000003LBBEPool\"}],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/inboundNatPools/cli000003LBNatPool\"}]}}]}}]},\r\n
-        \       \"vmId\": \"a19f6f91-7994-467b-a23e-a6660ca2db24\",\r\n        \"hardwareProfile\":
+        {\"networkInterfaceConfigurations\":[{\"name\":\"cliuz26deNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"disableTcpStateTracking\":false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\":[{\"name\":\"cliuz26deIPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET/subnets/cli000003Subnet\"},\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/backendAddressPools/cli000003LBBEPool\"}],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/inboundNatPools/cli000003LBNatPool\"}]}}]}}]},\r\n
+        \       \"vmId\": \"ffa83b08-9cdf-4ddd-8c22-38ec3747c4fa\",\r\n        \"hardwareProfile\":
         {\r\n          \"vmSize\": \"Standard_DS1_v2\"\r\n        },\r\n        \"storageProfile\":
         {\r\n          \"imageReference\": {\r\n            \"publisher\": \"Canonical\",\r\n
         \           \"offer\": \"UbuntuServer\",\r\n            \"sku\": \"18.04-LTS\",\r\n
-        \           \"version\": \"latest\",\r\n            \"exactVersion\": \"18.04.202212090\"\r\n
+        \           \"version\": \"latest\",\r\n            \"exactVersion\": \"18.04.202302100\"\r\n
         \         },\r\n          \"osDisk\": {\r\n            \"osType\": \"Linux\",\r\n
-        \           \"name\": \"cli5oqyn2zpljvxqcitncli5oqyn2zpljvxqcitnmOS__1_fc2a2b19ddde4a019629d326a068caf5\",\r\n
+        \           \"name\": \"cliuztvtdw4jbve2omq7cliuztvtdw4jbve2omq73OS__1_023d79a2b12548fba5c6e457bd338d14\",\r\n
         \           \"createOption\": \"FromImage\",\r\n            \"caching\": \"ReadWrite\",\r\n
         \           \"managedDisk\": {\r\n              \"storageAccountType\": \"Premium_LRS\",\r\n
-        \             \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/disks/cli5oqyn2zpljvxqcitncli5oqyn2zpljvxqcitnmOS__1_fc2a2b19ddde4a019629d326a068caf5\"\r\n
+        \             \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/disks/cliuztvtdw4jbve2omq7cliuztvtdw4jbve2omq73OS__1_023d79a2b12548fba5c6e457bd338d14\"\r\n
         \           },\r\n            \"diskSizeGB\": 30\r\n          },\r\n          \"dataDisks\":
         []\r\n        },\r\n        \"osProfile\": {\r\n          \"computerName\":
-        \"cli5o787e000002\",\r\n          \"adminUsername\": \"rhl\",\r\n          \"linuxConfiguration\":
+        \"cliuz26de000003\",\r\n          \"adminUsername\": \"rhoover\",\r\n          \"linuxConfiguration\":
         {\r\n            \"disablePasswordAuthentication\": true,\r\n            \"ssh\":
         {\r\n              \"publicKeys\": [\r\n                {\r\n                  \"path\":
-        \"/home/rhl/.ssh/authorized_keys\",\r\n                  \"keyData\": \"ssh-rsa
-        AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h\"\r\n
-        \               }\r\n              ]\r\n            },\r\n            \"provisionVMAgent\":
-        true,\r\n            \"enableVMAgentPlatformUpdates\": false\r\n          },\r\n
-        \         \"secrets\": [],\r\n          \"allowExtensionOperations\": true,\r\n
-        \         \"requireGuestProvisionSignal\": true\r\n        },\r\n        \"networkProfile\":
-        {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/2/networkInterfaces/cli5o787eNic\"}]},\r\n
+        \"/home/rhoover/.ssh/authorized_keys\",\r\n                  \"keyData\":
+        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+        REDMOND+rhoover@DESKTOP-XVFR7ID\\n\"\r\n                }\r\n              ]\r\n
+        \           },\r\n            \"provisionVMAgent\": true,\r\n            \"enableVMAgentPlatformUpdates\":
+        false\r\n          },\r\n          \"secrets\": [],\r\n          \"allowExtensionOperations\":
+        true,\r\n          \"requireGuestProvisionSignal\": true\r\n        },\r\n
+        \       \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/3/networkInterfaces/cliuz26deNic\"}]},\r\n
         \       \"provisioningState\": \"Succeeded\",\r\n        \"timeCreated\":
-        \"2022-12-13T22:58:32.3755398+00:00\"\r\n      },\r\n      \"resources\":
+        \"2023-03-06T15:01:24.8622061+00:00\"\r\n      },\r\n      \"resources\":
         [\r\n        {\r\n          \"name\": \"Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003_2/extensions/Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003_3/extensions/Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n
         \         \"type\": \"Microsoft.Compute/virtualMachines/extensions\",\r\n
         \         \"location\": \"westus2\",\r\n          \"properties\": {\r\n            \"autoUpgradeMinorVersion\":
         true,\r\n            \"provisioningState\": \"Succeeded\",\r\n            \"enableAutomaticUpgrade\":
@@ -1392,7 +1310,7 @@ interactions:
         \"AzureMonitorLinuxAgent\",\r\n            \"typeHandlerVersion\": \"1.0\",\r\n
         \           \"settings\": {\"GCS_AUTO_CONFIG\":true}\r\n          }\r\n        },\r\n
         \       {\r\n          \"name\": \"Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003_2/extensions/Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent\",\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachines/cli000003_3/extensions/Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent\",\r\n
         \         \"type\": \"Microsoft.Compute/virtualMachines/extensions\",\r\n
         \         \"location\": \"westus2\",\r\n          \"properties\": {\r\n            \"autoUpgradeMinorVersion\":
         true,\r\n            \"provisioningState\": \"Succeeded\",\r\n            \"enableAutomaticUpgrade\":
@@ -1404,11 +1322,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '11871'
+      - '12299'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:01:25 GMT
+      - Mon, 06 Mar 2023 15:03:48 GMT
       expires:
       - '-1'
       pragma:
@@ -1425,7 +1343,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/HighCostGetVMScaleSet3Min;179,Microsoft.Compute/HighCostGetVMScaleSet30Min;899,Microsoft.Compute/VMScaleSetVMViews3Min;4996
+      - Microsoft.Compute/HighCostGetVMScaleSet3Min;178,Microsoft.Compute/HighCostGetVMScaleSet30Min;895,Microsoft.Compute/VMScaleSetVMViews3Min;4991
       x-ms-request-charge:
       - '4'
     status:
@@ -1445,9 +1363,9 @@ interactions:
       ParameterSetName:
       - --name --resource-group --set
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003?api-version=2022-11-01
   response:
     body:
       string: "{\r\n  \"name\": \"cli000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003\",\r\n
@@ -1459,23 +1377,24 @@ interactions:
         \   \"upgradePolicy\": {\r\n      \"mode\": \"Manual\",\r\n      \"rollingUpgradePolicy\":
         {\r\n        \"maxBatchInstancePercent\": 20,\r\n        \"maxUnhealthyInstancePercent\":
         20,\r\n        \"maxUnhealthyUpgradedInstancePercent\": 20,\r\n        \"pauseTimeBetweenBatches\":
-        \"PT0S\"\r\n      }\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\":
-        {\r\n        \"computerNamePrefix\": \"cli5o787e\",\r\n        \"adminUsername\":
-        \"rhl\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\":
+        \"PT0S\",\r\n        \"maxSurge\": false,\r\n        \"rollbackFailedInstancesOnPolicyBreach\":
+        false\r\n      }\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\":
+        {\r\n        \"computerNamePrefix\": \"cliuz26de\",\r\n        \"adminUsername\":
+        \"rhoover\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\":
         true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n              {\r\n
-        \               \"path\": \"/home/rhl/.ssh/authorized_keys\",\r\n                \"keyData\":
-        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h\"\r\n
-        \             }\r\n            ]\r\n          },\r\n          \"provisionVMAgent\":
-        true,\r\n          \"enableVMAgentPlatformUpdates\": false\r\n        },\r\n
-        \       \"secrets\": [],\r\n        \"allowExtensionOperations\": true,\r\n
-        \       \"requireGuestProvisionSignal\": true\r\n      },\r\n      \"storageProfile\":
+        \               \"path\": \"/home/rhoover/.ssh/authorized_keys\",\r\n                \"keyData\":
+        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+        REDMOND+rhoover@DESKTOP-XVFR7ID\\n\"\r\n              }\r\n            ]\r\n
+        \         },\r\n          \"provisionVMAgent\": true,\r\n          \"enableVMAgentPlatformUpdates\":
+        false\r\n        },\r\n        \"secrets\": [],\r\n        \"allowExtensionOperations\":
+        true,\r\n        \"requireGuestProvisionSignal\": true\r\n      },\r\n      \"storageProfile\":
         {\r\n        \"osDisk\": {\r\n          \"osType\": \"Linux\",\r\n          \"createOption\":
         \"FromImage\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\":
         {\r\n            \"storageAccountType\": \"Premium_LRS\"\r\n          },\r\n
         \         \"diskSizeGB\": 30\r\n        },\r\n        \"imageReference\":
         {\r\n          \"publisher\": \"Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n
         \         \"sku\": \"18.04-LTS\",\r\n          \"version\": \"latest\"\r\n
-        \       }\r\n      },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"cli5o787eNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"disableTcpStateTracking\":false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\":[{\"name\":\"cli5o787eIPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET/subnets/cli000003Subnet\"},\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/backendAddressPools/cli000003LBBEPool\"}],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/inboundNatPools/cli000003LBNatPool\"}]}}]}}]},\r\n
+        \       }\r\n      },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"cliuz26deNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"disableTcpStateTracking\":false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\":[{\"name\":\"cliuz26deIPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET/subnets/cli000003Subnet\"},\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/backendAddressPools/cli000003LBBEPool\"}],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/inboundNatPools/cli000003LBNatPool\"}]}}]}}]},\r\n
         \     \"extensionProfile\": {\r\n        \"extensions\": [\r\n          {\r\n
         \           \"name\": \"Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n
         \           \"properties\": {\r\n              \"autoUpgradeMinorVersion\":
@@ -1491,17 +1410,17 @@ interactions:
         {\"enableGenevaUpload\":true,\"enableAutoConfig\":true,\"reportSuccessOnUnsupportedDistro\":true}\r\n
         \           }\r\n          }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\":
         \"Succeeded\",\r\n    \"overprovision\": true,\r\n    \"doNotRunExtensionsOnOverprovisionedVMs\":
-        false,\r\n    \"uniqueId\": \"c72549ea-142c-4eb1-8178-a7442e2bc6db\",\r\n
-        \   \"timeCreated\": \"2022-12-13T22:58:32.1880141+00:00\"\r\n  }\r\n}"
+        false,\r\n    \"uniqueId\": \"6aa1f17d-1da0-4dfe-b11e-b77e59e02135\",\r\n
+        \   \"timeCreated\": \"2023-03-06T15:01:24.7059254+00:00\"\r\n  }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '4648'
+      - '4947'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:01:25 GMT
+      - Mon, 06 Mar 2023 15:03:49 GMT
       expires:
       - '-1'
       pragma:
@@ -1518,7 +1437,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetVMScaleSet3Min;395,Microsoft.Compute/GetVMScaleSet30Min;2595
+      - Microsoft.Compute/GetVMScaleSet3Min;377,Microsoft.Compute/GetVMScaleSet30Min;2515
     status:
       code: 200
       message: OK
@@ -1527,17 +1446,19 @@ interactions:
       "true"}, "sku": {"name": "Standard_DS1_v2", "tier": "Standard", "capacity":
       2}, "properties": {"upgradePolicy": {"mode": "Manual", "rollingUpgradePolicy":
       {"maxBatchInstancePercent": 20, "maxUnhealthyInstancePercent": 20, "maxUnhealthyUpgradedInstancePercent":
-      20, "pauseTimeBetweenBatches": "PT0S"}}, "virtualMachineProfile": {"osProfile":
-      {"computerNamePrefix": "cli5o787e", "adminUsername": "rhl", "linuxConfiguration":
-      {"disablePasswordAuthentication": true, "ssh": {"publicKeys": [{"path": "/home/rhl/.ssh/authorized_keys",
-      "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h"}]},
-      "provisionVMAgent": true, "enableVMAgentPlatformUpdates": false}, "secrets":
-      [], "allowExtensionOperations": true}, "storageProfile": {"osDisk": {"caching":
-      "ReadWrite", "createOption": "FromImage", "diskSizeGB": 30, "osType": "Linux",
-      "managedDisk": {"storageAccountType": "Premium_LRS"}}}, "networkProfile": {"networkInterfaceConfigurations":
-      [{"name": "cli5o787eNic", "properties": {"primary": true, "enableAcceleratedNetworking":
+      20, "pauseTimeBetweenBatches": "PT0S", "rollbackFailedInstancesOnPolicyBreach":
+      false, "maxSurge": false}}, "virtualMachineProfile": {"osProfile": {"computerNamePrefix":
+      "cliuz26de", "adminUsername": "rhoover", "linuxConfiguration": {"disablePasswordAuthentication":
+      true, "ssh": {"publicKeys": [{"path": "/home/rhoover/.ssh/authorized_keys",
+      "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+      REDMOND+rhoover@DESKTOP-XVFR7ID\n"}]}, "provisionVMAgent": true, "enableVMAgentPlatformUpdates":
+      false}, "secrets": [], "allowExtensionOperations": true, "requireGuestProvisionSignal":
+      true}, "storageProfile": {"osDisk": {"caching": "ReadWrite", "createOption":
+      "FromImage", "diskSizeGB": 30, "osType": "Linux", "managedDisk": {"storageAccountType":
+      "Premium_LRS"}}}, "networkProfile": {"networkInterfaceConfigurations": [{"name":
+      "cliuz26deNic", "properties": {"primary": true, "enableAcceleratedNetworking":
       false, "disableTcpStateTracking": false, "dnsSettings": {"dnsServers": []},
-      "ipConfigurations": [{"name": "cli5o787eIPConfig", "properties": {"subnet":
+      "ipConfigurations": [{"name": "cliuz26deIPConfig", "properties": {"subnet":
       {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET/subnets/cli000003Subnet"},
       "privateIPAddressVersion": "IPv4", "loadBalancerBackendAddressPools": [{"id":
       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/backendAddressPools/cli000003LBBEPool"}],
@@ -1562,15 +1483,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '3269'
+      - '3587'
       Content-Type:
       - application/json
       ParameterSetName:
       - --name --resource-group --set
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003?api-version=2022-11-01
   response:
     body:
       string: "{\r\n  \"name\": \"cli000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003\",\r\n
@@ -1582,23 +1503,24 @@ interactions:
         \   \"upgradePolicy\": {\r\n      \"mode\": \"Manual\",\r\n      \"rollingUpgradePolicy\":
         {\r\n        \"maxBatchInstancePercent\": 20,\r\n        \"maxUnhealthyInstancePercent\":
         20,\r\n        \"maxUnhealthyUpgradedInstancePercent\": 20,\r\n        \"pauseTimeBetweenBatches\":
-        \"PT0S\"\r\n      }\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\":
-        {\r\n        \"computerNamePrefix\": \"cli5o787e\",\r\n        \"adminUsername\":
-        \"rhl\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\":
+        \"PT0S\",\r\n        \"maxSurge\": false,\r\n        \"rollbackFailedInstancesOnPolicyBreach\":
+        false\r\n      }\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\":
+        {\r\n        \"computerNamePrefix\": \"cliuz26de\",\r\n        \"adminUsername\":
+        \"rhoover\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\":
         true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n              {\r\n
-        \               \"path\": \"/home/rhl/.ssh/authorized_keys\",\r\n                \"keyData\":
-        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h\"\r\n
-        \             }\r\n            ]\r\n          },\r\n          \"provisionVMAgent\":
-        true,\r\n          \"enableVMAgentPlatformUpdates\": false\r\n        },\r\n
-        \       \"secrets\": [],\r\n        \"allowExtensionOperations\": true,\r\n
-        \       \"requireGuestProvisionSignal\": true\r\n      },\r\n      \"storageProfile\":
+        \               \"path\": \"/home/rhoover/.ssh/authorized_keys\",\r\n                \"keyData\":
+        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+        REDMOND+rhoover@DESKTOP-XVFR7ID\\n\"\r\n              }\r\n            ]\r\n
+        \         },\r\n          \"provisionVMAgent\": true,\r\n          \"enableVMAgentPlatformUpdates\":
+        false\r\n        },\r\n        \"secrets\": [],\r\n        \"allowExtensionOperations\":
+        true,\r\n        \"requireGuestProvisionSignal\": true\r\n      },\r\n      \"storageProfile\":
         {\r\n        \"osDisk\": {\r\n          \"osType\": \"Linux\",\r\n          \"createOption\":
         \"FromImage\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\":
         {\r\n            \"storageAccountType\": \"Premium_LRS\"\r\n          },\r\n
         \         \"diskSizeGB\": 30\r\n        },\r\n        \"imageReference\":
         {\r\n          \"publisher\": \"Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n
         \         \"sku\": \"18.04-LTS\",\r\n          \"version\": \"latest\"\r\n
-        \       }\r\n      },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"cli5o787eNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"disableTcpStateTracking\":false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\":[{\"name\":\"cli5o787eIPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET/subnets/cli000003Subnet\"},\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/backendAddressPools/cli000003LBBEPool\"}],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/inboundNatPools/cli000003LBNatPool\"}]}}]}}]},\r\n
+        \       }\r\n      },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"cliuz26deNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"disableTcpStateTracking\":false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\":[{\"name\":\"cliuz26deIPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET/subnets/cli000003Subnet\"},\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/backendAddressPools/cli000003LBBEPool\"}],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/inboundNatPools/cli000003LBNatPool\"}]}}]}}]},\r\n
         \     \"diagnosticsProfile\": {\r\n        \"bootDiagnostics\": {\r\n          \"enabled\":
         true\r\n        }\r\n      },\r\n      \"extensionProfile\": {\r\n        \"extensions\":
         [\r\n          {\r\n            \"name\": \"Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n
@@ -1615,21 +1537,21 @@ interactions:
         {\"enableGenevaUpload\":true,\"enableAutoConfig\":true,\"reportSuccessOnUnsupportedDistro\":true}\r\n
         \           }\r\n          }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\":
         \"Updating\",\r\n    \"overprovision\": true,\r\n    \"doNotRunExtensionsOnOverprovisionedVMs\":
-        false,\r\n    \"uniqueId\": \"c72549ea-142c-4eb1-8178-a7442e2bc6db\",\r\n
-        \   \"timeCreated\": \"2022-12-13T22:58:32.1880141+00:00\"\r\n  }\r\n}"
+        false,\r\n    \"uniqueId\": \"6aa1f17d-1da0-4dfe-b11e-b77e59e02135\",\r\n
+        \   \"timeCreated\": \"2023-03-06T15:01:24.7059254+00:00\"\r\n  }\r\n}"
     headers:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/4c23e694-1258-4568-b3ab-e46adafd7a61?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/ff42cdb6-8bc0-48ce-b81d-6e6817b31954?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
       cache-control:
       - no-cache
       content-length:
-      - '4756'
+      - '5055'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:01:29 GMT
+      - Mon, 06 Mar 2023 15:03:52 GMT
       expires:
       - '-1'
       pragma:
@@ -1646,7 +1568,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/CreateVMScaleSet3Min;149,Microsoft.Compute/CreateVMScaleSet30Min;754,Microsoft.Compute/VmssQueuedVMOperations;0
+      - Microsoft.Compute/CreateVMScaleSet3Min;150,Microsoft.Compute/CreateVMScaleSet30Min;759,Microsoft.Compute/VmssQueuedVMOperations;0
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-ms-request-charge:
@@ -1668,13 +1590,13 @@ interactions:
       ParameterSetName:
       - --name --resource-group --set
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/4c23e694-1258-4568-b3ab-e46adafd7a61?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/ff42cdb6-8bc0-48ce-b81d-6e6817b31954?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:01:28.7185252+00:00\",\r\n  \"status\":
-        \"InProgress\",\r\n  \"name\": \"4c23e694-1258-4568-b3ab-e46adafd7a61\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T15:03:52.5648782+00:00\",\r\n  \"status\":
+        \"InProgress\",\r\n  \"name\": \"ff42cdb6-8bc0-48ce-b81d-6e6817b31954\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -1683,7 +1605,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:01:29 GMT
+      - Mon, 06 Mar 2023 15:04:03 GMT
       expires:
       - '-1'
       pragma:
@@ -1700,7 +1622,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14993,Microsoft.Compute/GetOperation30Min;29949
+      - Microsoft.Compute/GetOperation3Min;14967,Microsoft.Compute/GetOperation30Min;29819
     status:
       code: 200
       message: OK
@@ -1718,14 +1640,164 @@ interactions:
       ParameterSetName:
       - --name --resource-group --set
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/4c23e694-1258-4568-b3ab-e46adafd7a61?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/ff42cdb6-8bc0-48ce-b81d-6e6817b31954?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:01:28.7185252+00:00\",\r\n  \"endTime\":
-        \"2022-12-13T23:01:55.8434574+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"name\": \"4c23e694-1258-4568-b3ab-e46adafd7a61\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T15:03:52.5648782+00:00\",\r\n  \"status\":
+        \"InProgress\",\r\n  \"name\": \"ff42cdb6-8bc0-48ce-b81d-6e6817b31954\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '134'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 06 Mar 2023 15:04:39 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/GetOperation3Min;14970,Microsoft.Compute/GetOperation30Min;29815
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vmss update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --set
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/ff42cdb6-8bc0-48ce-b81d-6e6817b31954?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
+  response:
+    body:
+      string: "{\r\n  \"startTime\": \"2023-03-06T15:03:52.5648782+00:00\",\r\n  \"status\":
+        \"InProgress\",\r\n  \"name\": \"ff42cdb6-8bc0-48ce-b81d-6e6817b31954\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '134'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 06 Mar 2023 15:05:10 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/GetOperation3Min;14967,Microsoft.Compute/GetOperation30Min;29807
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vmss update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --set
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/ff42cdb6-8bc0-48ce-b81d-6e6817b31954?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
+  response:
+    body:
+      string: "{\r\n  \"startTime\": \"2023-03-06T15:03:52.5648782+00:00\",\r\n  \"status\":
+        \"InProgress\",\r\n  \"name\": \"ff42cdb6-8bc0-48ce-b81d-6e6817b31954\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '134'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 06 Mar 2023 15:05:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/GetOperation3Min;14962,Microsoft.Compute/GetOperation30Min;29798
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vmss update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --set
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/ff42cdb6-8bc0-48ce-b81d-6e6817b31954?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
+  response:
+    body:
+      string: "{\r\n  \"startTime\": \"2023-03-06T15:03:52.5648782+00:00\",\r\n  \"endTime\":
+        \"2023-03-06T15:05:46.4863929+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"name\": \"ff42cdb6-8bc0-48ce-b81d-6e6817b31954\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -1734,7 +1806,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:02:06 GMT
+      - Mon, 06 Mar 2023 15:06:10 GMT
       expires:
       - '-1'
       pragma:
@@ -1751,7 +1823,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14993,Microsoft.Compute/GetOperation30Min;29948
+      - Microsoft.Compute/GetOperation3Min;14964,Microsoft.Compute/GetOperation30Min;29794
     status:
       code: 200
       message: OK
@@ -1769,9 +1841,9 @@ interactions:
       ParameterSetName:
       - --name --resource-group --set
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003?api-version=2022-11-01
   response:
     body:
       string: "{\r\n  \"name\": \"cli000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003\",\r\n
@@ -1783,23 +1855,24 @@ interactions:
         \   \"upgradePolicy\": {\r\n      \"mode\": \"Manual\",\r\n      \"rollingUpgradePolicy\":
         {\r\n        \"maxBatchInstancePercent\": 20,\r\n        \"maxUnhealthyInstancePercent\":
         20,\r\n        \"maxUnhealthyUpgradedInstancePercent\": 20,\r\n        \"pauseTimeBetweenBatches\":
-        \"PT0S\"\r\n      }\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\":
-        {\r\n        \"computerNamePrefix\": \"cli5o787e\",\r\n        \"adminUsername\":
-        \"rhl\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\":
+        \"PT0S\",\r\n        \"maxSurge\": false,\r\n        \"rollbackFailedInstancesOnPolicyBreach\":
+        false\r\n      }\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\":
+        {\r\n        \"computerNamePrefix\": \"cliuz26de\",\r\n        \"adminUsername\":
+        \"rhoover\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\":
         true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n              {\r\n
-        \               \"path\": \"/home/rhl/.ssh/authorized_keys\",\r\n                \"keyData\":
-        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h\"\r\n
-        \             }\r\n            ]\r\n          },\r\n          \"provisionVMAgent\":
-        true,\r\n          \"enableVMAgentPlatformUpdates\": false\r\n        },\r\n
-        \       \"secrets\": [],\r\n        \"allowExtensionOperations\": true,\r\n
-        \       \"requireGuestProvisionSignal\": true\r\n      },\r\n      \"storageProfile\":
+        \               \"path\": \"/home/rhoover/.ssh/authorized_keys\",\r\n                \"keyData\":
+        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+        REDMOND+rhoover@DESKTOP-XVFR7ID\\n\"\r\n              }\r\n            ]\r\n
+        \         },\r\n          \"provisionVMAgent\": true,\r\n          \"enableVMAgentPlatformUpdates\":
+        false\r\n        },\r\n        \"secrets\": [],\r\n        \"allowExtensionOperations\":
+        true,\r\n        \"requireGuestProvisionSignal\": true\r\n      },\r\n      \"storageProfile\":
         {\r\n        \"osDisk\": {\r\n          \"osType\": \"Linux\",\r\n          \"createOption\":
         \"FromImage\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\":
         {\r\n            \"storageAccountType\": \"Premium_LRS\"\r\n          },\r\n
         \         \"diskSizeGB\": 30\r\n        },\r\n        \"imageReference\":
         {\r\n          \"publisher\": \"Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n
         \         \"sku\": \"18.04-LTS\",\r\n          \"version\": \"latest\"\r\n
-        \       }\r\n      },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"cli5o787eNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"disableTcpStateTracking\":false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\":[{\"name\":\"cli5o787eIPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET/subnets/cli000003Subnet\"},\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/backendAddressPools/cli000003LBBEPool\"}],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/inboundNatPools/cli000003LBNatPool\"}]}}]}}]},\r\n
+        \       }\r\n      },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"cliuz26deNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"disableTcpStateTracking\":false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\":[{\"name\":\"cliuz26deIPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET/subnets/cli000003Subnet\"},\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/backendAddressPools/cli000003LBBEPool\"}],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/inboundNatPools/cli000003LBNatPool\"}]}}]}}]},\r\n
         \     \"diagnosticsProfile\": {\r\n        \"bootDiagnostics\": {\r\n          \"enabled\":
         true\r\n        }\r\n      },\r\n      \"extensionProfile\": {\r\n        \"extensions\":
         [\r\n          {\r\n            \"name\": \"Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n
@@ -1816,17 +1889,17 @@ interactions:
         {\"enableGenevaUpload\":true,\"enableAutoConfig\":true,\"reportSuccessOnUnsupportedDistro\":true}\r\n
         \           }\r\n          }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\":
         \"Succeeded\",\r\n    \"overprovision\": true,\r\n    \"doNotRunExtensionsOnOverprovisionedVMs\":
-        false,\r\n    \"uniqueId\": \"c72549ea-142c-4eb1-8178-a7442e2bc6db\",\r\n
-        \   \"timeCreated\": \"2022-12-13T22:58:32.1880141+00:00\"\r\n  }\r\n}"
+        false,\r\n    \"uniqueId\": \"6aa1f17d-1da0-4dfe-b11e-b77e59e02135\",\r\n
+        \   \"timeCreated\": \"2023-03-06T15:01:24.7059254+00:00\"\r\n  }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '4757'
+      - '5056'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:02:06 GMT
+      - Mon, 06 Mar 2023 15:06:10 GMT
       expires:
       - '-1'
       pragma:
@@ -1843,12 +1916,12 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetVMScaleSet3Min;391,Microsoft.Compute/GetVMScaleSet30Min;2591
+      - Microsoft.Compute/GetVMScaleSet3Min;375,Microsoft.Compute/GetVMScaleSet30Min;2497
     status:
       code: 200
       message: OK
 - request:
-    body: '{"instanceIds": ["2"]}'
+    body: '{"instanceIds": ["3"]}'
     headers:
       Accept:
       - application/json
@@ -1865,9 +1938,9 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/manualupgrade?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/manualupgrade?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -1875,17 +1948,17 @@ interactions:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/e227f2e6-6ef2-487f-aad7-355f8d7fbd5d?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/4d4e667b-bd1f-4612-b69d-b7a8d1f21ace?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Tue, 13 Dec 2022 23:02:07 GMT
+      - Mon, 06 Mar 2023 15:06:11 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/e227f2e6-6ef2-487f-aad7-355f8d7fbd5d?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/4d4e667b-bd1f-4612-b69d-b7a8d1f21ace?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-11-01
       pragma:
       - no-cache
       server:
@@ -1896,7 +1969,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/VMScaleSetActions3Min;239,Microsoft.Compute/VMScaleSetActions30Min;1199,Microsoft.Compute/VMScaleSetBatchedVMRequests5Min;3021,Microsoft.Compute/VmssQueuedVMOperations;0
+      - Microsoft.Compute/VMScaleSetActions3Min;239,Microsoft.Compute/VMScaleSetActions30Min;1187,Microsoft.Compute/VMScaleSetBatchedVMRequests5Min;3092,Microsoft.Compute/VmssQueuedVMOperations;0
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-ms-request-charge:
@@ -1918,64 +1991,14 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/e227f2e6-6ef2-487f-aad7-355f8d7fbd5d?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/4d4e667b-bd1f-4612-b69d-b7a8d1f21ace?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:02:07.4058214+00:00\",\r\n  \"status\":
-        \"InProgress\",\r\n  \"name\": \"e227f2e6-6ef2-487f-aad7-355f8d7fbd5d\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '134'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 13 Dec 2022 23:02:07 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14992,Microsoft.Compute/GetOperation30Min;29947
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vmss update-instances
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --instance-ids
-      User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/e227f2e6-6ef2-487f-aad7-355f8d7fbd5d?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
-  response:
-    body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:02:07.4058214+00:00\",\r\n  \"endTime\":
-        \"2022-12-13T23:02:12.6870644+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"name\": \"e227f2e6-6ef2-487f-aad7-355f8d7fbd5d\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T15:06:11.6582221+00:00\",\r\n  \"endTime\":
+        \"2023-03-06T15:06:18.2362292+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"name\": \"4d4e667b-bd1f-4612-b69d-b7a8d1f21ace\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -1984,7 +2007,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:02:37 GMT
+      - Mon, 06 Mar 2023 15:06:42 GMT
       expires:
       - '-1'
       pragma:
@@ -2001,7 +2024,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14990,Microsoft.Compute/GetOperation30Min;29943
+      - Microsoft.Compute/GetOperation3Min;14968,Microsoft.Compute/GetOperation30Min;29788
     status:
       code: 200
       message: OK
@@ -2019,9 +2042,9 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/e227f2e6-6ef2-487f-aad7-355f8d7fbd5d?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/4d4e667b-bd1f-4612-b69d-b7a8d1f21ace?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-11-01
   response:
     body:
       string: ''
@@ -2031,7 +2054,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 13 Dec 2022 23:02:37 GMT
+      - Mon, 06 Mar 2023 15:06:42 GMT
       expires:
       - '-1'
       pragma:
@@ -2044,7 +2067,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14989,Microsoft.Compute/GetOperation30Min;29942
+      - Microsoft.Compute/GetOperation3Min;14967,Microsoft.Compute/GetOperation30Min;29787
     status:
       code: 200
       message: OK
@@ -2062,21 +2085,21 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/2/instanceView?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/3/instanceView?api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"placementGroupId\": \"b12ec8ba-0f67-45f7-a5b3-5e94f2268933\",\r\n
-        \ \"platformUpdateDomain\": 2,\r\n  \"platformFaultDomain\": 2,\r\n  \"computerName\":
-        \"cli5o787e000002\",\r\n  \"osName\": \"ubuntu\",\r\n  \"osVersion\": \"18.04\",\r\n
+      string: "{\r\n  \"placementGroupId\": \"fe2728fc-c0cb-4cea-8d91-bb960a1e6c3b\",\r\n
+        \ \"platformUpdateDomain\": 3,\r\n  \"platformFaultDomain\": 3,\r\n  \"computerName\":
+        \"cliuz26de000003\",\r\n  \"osName\": \"ubuntu\",\r\n  \"osVersion\": \"18.04\",\r\n
         \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"2.9.0.4\",\r\n    \"statuses\":
         [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\",\r\n        \"level\":
         \"Info\",\r\n        \"displayStatus\": \"Ready\",\r\n        \"message\":
-        \"Guest Agent is running\",\r\n        \"time\": \"2022-12-13T23:02:23+00:00\"\r\n
+        \"Guest Agent is running\",\r\n        \"time\": \"2023-03-06T15:05:31+00:00\"\r\n
         \     }\r\n    ],\r\n    \"extensionHandlers\": [\r\n      {\r\n        \"type\":
         \"Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n        \"typeHandlerVersion\":
-        \"1.24.2\",\r\n        \"status\": {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \"1.25.1\",\r\n        \"status\": {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Ready\",\r\n
         \         \"message\": \"Plugin enabled\"\r\n        }\r\n      },\r\n      {\r\n
         \       \"type\": \"Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent\",\r\n
@@ -2084,14 +2107,14 @@ interactions:
         \         \"code\": \"ProvisioningState/succeeded\",\r\n          \"level\":
         \"Info\",\r\n          \"displayStatus\": \"Ready\",\r\n          \"message\":
         \"Plugin enabled\"\r\n        }\r\n      }\r\n    ]\r\n  },\r\n  \"disks\":
-        [\r\n    {\r\n      \"name\": \"cli5oqyn2zpljvxqcitncli5oqyn2zpljvxqcitnmOS__1_fc2a2b19ddde4a019629d326a068caf5\",\r\n
+        [\r\n    {\r\n      \"name\": \"cliuztvtdw4jbve2omq7cliuztvtdw4jbve2omq73OS__1_023d79a2b12548fba5c6e457bd338d14\",\r\n
         \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2022-12-13T23:02:08.2652359+00:00\"\r\n
+        succeeded\",\r\n          \"time\": \"2023-03-06T15:06:12.4393943+00:00\"\r\n
         \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {},\r\n  \"extensions\":
         [\r\n    {\r\n      \"name\": \"Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n
         \     \"type\": \"Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n      \"typeHandlerVersion\":
-        \"1.24.2\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \"1.25.1\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
         succeeded\",\r\n          \"message\": \"Enable succeeded\"\r\n        }\r\n
         \     ]\r\n    },\r\n    {\r\n      \"name\": \"Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent\",\r\n
@@ -2103,7 +2126,7 @@ interactions:
         \   }\r\n  ],\r\n  \"hyperVGeneration\": \"V1\",\r\n  \"statuses\": [\r\n
         \   {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n      \"level\":
         \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n      \"time\":
-        \"2022-12-13T23:02:12.6714544+00:00\"\r\n    },\r\n    {\r\n      \"code\":
+        \"2023-03-06T15:06:18.2052137+00:00\"\r\n    },\r\n    {\r\n      \"code\":
         \"PowerState/running\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\":
         \"VM running\"\r\n    }\r\n  ]\r\n}"
     headers:
@@ -2114,7 +2137,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:02:38 GMT
+      - Mon, 06 Mar 2023 15:06:42 GMT
       expires:
       - '-1'
       pragma:
@@ -2131,7 +2154,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetVMScaleSetVM3Min;499,Microsoft.Compute/GetVMScaleSetVM30Min;2499,Microsoft.Compute/VMScaleSetVMViews3Min;4995
+      - Microsoft.Compute/GetVMScaleSetVM3Min;492,Microsoft.Compute/GetVMScaleSetVM30Min;2473,Microsoft.Compute/VMScaleSetVMViews3Min;4992
       x-ms-request-charge:
       - '1'
     status:
@@ -2151,8 +2174,8 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
-        (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.SerialConsole/consoleServices/default?api-version=2018-05-01
   response:
@@ -2166,7 +2189,7 @@ interactions:
       content-type:
       - application/json; charset=UTF-8
       date:
-      - Tue, 13 Dec 2022 23:02:37 GMT
+      - Mon, 06 Mar 2023 15:06:43 GMT
       expires:
       - '-1'
       pragma:
@@ -2202,9 +2225,9 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/2/deallocate?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/3/deallocate?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -2212,17 +2235,17 @@ interactions:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/982ba895-f53c-468f-9968-5d157af4ce86?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/9e4f0edd-af3e-4938-b411-b910560c08eb?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Tue, 13 Dec 2022 23:02:38 GMT
+      - Mon, 06 Mar 2023 15:06:43 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/982ba895-f53c-468f-9968-5d157af4ce86?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/9e4f0edd-af3e-4938-b411-b910560c08eb?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-11-01
       pragma:
       - no-cache
       server:
@@ -2233,7 +2256,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/DeleteVMScaleSetVM3Min;239,Microsoft.Compute/DeleteVMScaleSetVM30Min;1199,Microsoft.Compute/VMScaleSetBatchedVMRequests5Min;3020,Microsoft.Compute/VmssQueuedVMOperations;0
+      - Microsoft.Compute/DeleteVMScaleSetVM3Min;239,Microsoft.Compute/DeleteVMScaleSetVM30Min;1197,Microsoft.Compute/VMScaleSetBatchedVMRequests5Min;3091,Microsoft.Compute/VmssQueuedVMOperations;0
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-ms-request-charge:
@@ -2255,13 +2278,13 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/982ba895-f53c-468f-9968-5d157af4ce86?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/9e4f0edd-af3e-4938-b411-b910560c08eb?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:02:39.6088371+00:00\",\r\n  \"status\":
-        \"InProgress\",\r\n  \"name\": \"982ba895-f53c-468f-9968-5d157af4ce86\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T15:06:43.7830735+00:00\",\r\n  \"status\":
+        \"InProgress\",\r\n  \"name\": \"9e4f0edd-af3e-4938-b411-b910560c08eb\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -2270,7 +2293,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:02:38 GMT
+      - Mon, 06 Mar 2023 15:07:13 GMT
       expires:
       - '-1'
       pragma:
@@ -2287,7 +2310,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14988,Microsoft.Compute/GetOperation30Min;29941
+      - Microsoft.Compute/GetOperation3Min;14964,Microsoft.Compute/GetOperation30Min;29782
     status:
       code: 200
       message: OK
@@ -2305,13 +2328,13 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/982ba895-f53c-468f-9968-5d157af4ce86?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/9e4f0edd-af3e-4938-b411-b910560c08eb?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:02:39.6088371+00:00\",\r\n  \"status\":
-        \"InProgress\",\r\n  \"name\": \"982ba895-f53c-468f-9968-5d157af4ce86\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T15:06:43.7830735+00:00\",\r\n  \"status\":
+        \"InProgress\",\r\n  \"name\": \"9e4f0edd-af3e-4938-b411-b910560c08eb\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -2320,7 +2343,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:03:08 GMT
+      - Mon, 06 Mar 2023 15:07:43 GMT
       expires:
       - '-1'
       pragma:
@@ -2337,7 +2360,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14986,Microsoft.Compute/GetOperation30Min;29939
+      - Microsoft.Compute/GetOperation3Min;14969,Microsoft.Compute/GetOperation30Min;29778
     status:
       code: 200
       message: OK
@@ -2355,23 +2378,23 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/982ba895-f53c-468f-9968-5d157af4ce86?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/9e4f0edd-af3e-4938-b411-b910560c08eb?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:02:39.6088371+00:00\",\r\n  \"endTime\":
-        \"2022-12-13T23:03:36.1867787+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"name\": \"982ba895-f53c-468f-9968-5d157af4ce86\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T15:06:43.7830735+00:00\",\r\n  \"endTime\":
+        \"2023-03-06T15:08:04.032782+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"name\": \"9e4f0edd-af3e-4938-b411-b910560c08eb\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '184'
+      - '183'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:03:39 GMT
+      - Mon, 06 Mar 2023 15:08:13 GMT
       expires:
       - '-1'
       pragma:
@@ -2388,7 +2411,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14985,Microsoft.Compute/GetOperation30Min;29935
+      - Microsoft.Compute/GetOperation3Min;14971,Microsoft.Compute/GetOperation30Min;29773
     status:
       code: 200
       message: OK
@@ -2406,9 +2429,9 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/982ba895-f53c-468f-9968-5d157af4ce86?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/9e4f0edd-af3e-4938-b411-b910560c08eb?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-11-01
   response:
     body:
       string: ''
@@ -2418,7 +2441,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 13 Dec 2022 23:03:39 GMT
+      - Mon, 06 Mar 2023 15:08:13 GMT
       expires:
       - '-1'
       pragma:
@@ -2431,7 +2454,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14984,Microsoft.Compute/GetOperation30Min;29934
+      - Microsoft.Compute/GetOperation3Min;14970,Microsoft.Compute/GetOperation30Min;29772
     status:
       code: 200
       message: OK
@@ -2449,21 +2472,21 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/2/instanceView?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/3/instanceView?api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"placementGroupId\": \"b12ec8ba-0f67-45f7-a5b3-5e94f2268933\",\r\n
-        \ \"platformUpdateDomain\": 2,\r\n  \"platformFaultDomain\": 2,\r\n  \"disks\":
-        [\r\n    {\r\n      \"name\": \"cli5oqyn2zpljvxqcitncli5oqyn2zpljvxqcitnmOS__1_fc2a2b19ddde4a019629d326a068caf5\",\r\n
+      string: "{\r\n  \"placementGroupId\": \"fe2728fc-c0cb-4cea-8d91-bb960a1e6c3b\",\r\n
+        \ \"platformUpdateDomain\": 3,\r\n  \"platformFaultDomain\": 3,\r\n  \"disks\":
+        [\r\n    {\r\n      \"name\": \"cliuztvtdw4jbve2omq7cliuztvtdw4jbve2omq73OS__1_023d79a2b12548fba5c6e457bd338d14\",\r\n
         \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2022-12-13T23:03:34.0773817+00:00\"\r\n
+        succeeded\",\r\n          \"time\": \"2023-03-06T15:08:03.9546513+00:00\"\r\n
         \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {},\r\n  \"hyperVGeneration\":
         \"V1\",\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
         \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \     \"time\": \"2022-12-13T23:03:34.0930533+00:00\"\r\n    },\r\n    {\r\n
+        \     \"time\": \"2023-03-06T15:08:03.9859063+00:00\"\r\n    },\r\n    {\r\n
         \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
         \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
     headers:
@@ -2474,7 +2497,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:03:40 GMT
+      - Mon, 06 Mar 2023 15:08:14 GMT
       expires:
       - '-1'
       pragma:
@@ -2491,7 +2514,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetVMScaleSetVM3Min;498,Microsoft.Compute/GetVMScaleSetVM30Min;2498,Microsoft.Compute/VMScaleSetVMViews3Min;4994
+      - Microsoft.Compute/GetVMScaleSetVM3Min;498,Microsoft.Compute/GetVMScaleSetVM30Min;2472,Microsoft.Compute/VMScaleSetVMViews3Min;4998
       x-ms-request-charge:
       - '1'
     status:
@@ -2511,8 +2534,8 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
-        (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.SerialConsole/consoleServices/default?api-version=2018-05-01
   response:
@@ -2526,7 +2549,7 @@ interactions:
       content-type:
       - application/json; charset=UTF-8
       date:
-      - Tue, 13 Dec 2022 23:03:40 GMT
+      - Mon, 06 Mar 2023 15:08:14 GMT
       expires:
       - '-1'
       pragma:
@@ -2547,7 +2570,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"instanceIds": ["2"]}'
+    body: '{"instanceIds": ["3"]}'
     headers:
       Accept:
       - application/json
@@ -2564,9 +2587,9 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/start?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/start?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -2574,17 +2597,17 @@ interactions:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/bac22f10-51de-46c7-a698-b8ab9ca24a93?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/1943656c-7e3b-43e8-933c-430161c60f3a?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Tue, 13 Dec 2022 23:03:41 GMT
+      - Mon, 06 Mar 2023 15:08:15 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/bac22f10-51de-46c7-a698-b8ab9ca24a93?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/1943656c-7e3b-43e8-933c-430161c60f3a?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-11-01
       pragma:
       - no-cache
       server:
@@ -2595,9 +2618,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/VMScaleSetActions3Min;238,Microsoft.Compute/VMScaleSetActions30Min;1198,Microsoft.Compute/VMScaleSetBatchedVMRequests5Min;3023,Microsoft.Compute/VmssQueuedVMOperations;0
+      - Microsoft.Compute/VMScaleSetActions3Min;238,Microsoft.Compute/VMScaleSetActions30Min;1186,Microsoft.Compute/VMScaleSetBatchedVMRequests5Min;3046,Microsoft.Compute/VmssQueuedVMOperations;0
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
       x-ms-request-charge:
       - '1'
     status:
@@ -2617,264 +2640,13 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/bac22f10-51de-46c7-a698-b8ab9ca24a93?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/1943656c-7e3b-43e8-933c-430161c60f3a?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:03:41.999226+00:00\",\r\n  \"status\":
-        \"InProgress\",\r\n  \"name\": \"bac22f10-51de-46c7-a698-b8ab9ca24a93\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '133'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 13 Dec 2022 23:03:42 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14983,Microsoft.Compute/GetOperation30Min;29933
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vmss start
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --instance-ids
-      User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/bac22f10-51de-46c7-a698-b8ab9ca24a93?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
-  response:
-    body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:03:41.999226+00:00\",\r\n  \"status\":
-        \"InProgress\",\r\n  \"name\": \"bac22f10-51de-46c7-a698-b8ab9ca24a93\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '133'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 13 Dec 2022 23:04:11 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14982,Microsoft.Compute/GetOperation30Min;29931
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vmss start
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --instance-ids
-      User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/bac22f10-51de-46c7-a698-b8ab9ca24a93?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
-  response:
-    body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:03:41.999226+00:00\",\r\n  \"endTime\":
-        \"2022-12-13T23:04:30.1239524+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"name\": \"bac22f10-51de-46c7-a698-b8ab9ca24a93\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '183'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 13 Dec 2022 23:04:41 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14979,Microsoft.Compute/GetOperation30Min;29928
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vmss start
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --instance-ids
-      User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/bac22f10-51de-46c7-a698-b8ab9ca24a93?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-08-01
-  response:
-    body:
-      string: ''
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Tue, 13 Dec 2022 23:04:41 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14978,Microsoft.Compute/GetOperation30Min;29927
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"instanceIds": ["2"]}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vmss stop
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '22'
-      Content-Type:
-      - application/json
-      ParameterSetName:
-      - -g -n --instance-ids
-      User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/poweroff?skipShutdown=false&api-version=2022-08-01
-  response:
-    body:
-      string: ''
-    headers:
-      azure-asyncnotification:
-      - Enabled
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/e221bc5d-f663-4b58-9381-cea75b0b56f1?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Tue, 13 Dec 2022 23:04:42 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/e221bc5d-f663-4b58-9381-cea75b0b56f1?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-08-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/DeleteVMScaleSet3Min;79,Microsoft.Compute/DeleteVMScaleSet30Min;399,Microsoft.Compute/VMScaleSetBatchedVMRequests5Min;3022,Microsoft.Compute/VmssQueuedVMOperations;0
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
-      x-ms-request-charge:
-      - '1'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vmss stop
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --instance-ids
-      User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/e221bc5d-f663-4b58-9381-cea75b0b56f1?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
-  response:
-    body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:04:43.5145827+00:00\",\r\n  \"status\":
-        \"InProgress\",\r\n  \"name\": \"e221bc5d-f663-4b58-9381-cea75b0b56f1\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T15:08:15.9078095+00:00\",\r\n  \"status\":
+        \"InProgress\",\r\n  \"name\": \"1943656c-7e3b-43e8-933c-430161c60f3a\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -2883,7 +2655,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:04:42 GMT
+      - Mon, 06 Mar 2023 15:08:45 GMT
       expires:
       - '-1'
       pragma:
@@ -2900,7 +2672,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14977,Microsoft.Compute/GetOperation30Min;29926
+      - Microsoft.Compute/GetOperation3Min;14974,Microsoft.Compute/GetOperation30Min;29770
     status:
       code: 200
       message: OK
@@ -2912,29 +2684,29 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
-      - vmss stop
+      - vmss start
       Connection:
       - keep-alive
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/e221bc5d-f663-4b58-9381-cea75b0b56f1?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/1943656c-7e3b-43e8-933c-430161c60f3a?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:04:43.5145827+00:00\",\r\n  \"endTime\":
-        \"2022-12-13T23:04:48.858299+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"name\": \"e221bc5d-f663-4b58-9381-cea75b0b56f1\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T15:08:15.9078095+00:00\",\r\n  \"endTime\":
+        \"2023-03-06T15:09:01.3294787+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"name\": \"1943656c-7e3b-43e8-933c-430161c60f3a\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '183'
+      - '184'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:05:12 GMT
+      - Mon, 06 Mar 2023 15:09:15 GMT
       expires:
       - '-1'
       pragma:
@@ -2951,7 +2723,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14978,Microsoft.Compute/GetOperation30Min;29923
+      - Microsoft.Compute/GetOperation3Min;14975,Microsoft.Compute/GetOperation30Min;29767
     status:
       code: 200
       message: OK
@@ -2963,15 +2735,15 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
-      - vmss stop
+      - vmss start
       Connection:
       - keep-alive
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/e221bc5d-f663-4b58-9381-cea75b0b56f1?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/1943656c-7e3b-43e8-933c-430161c60f3a?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-11-01
   response:
     body:
       string: ''
@@ -2981,7 +2753,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 13 Dec 2022 23:05:12 GMT
+      - Mon, 06 Mar 2023 15:09:15 GMT
       expires:
       - '-1'
       pragma:
@@ -2994,7 +2766,158 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14977,Microsoft.Compute/GetOperation30Min;29922
+      - Microsoft.Compute/GetOperation3Min;14974,Microsoft.Compute/GetOperation30Min;29766
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"instanceIds": ["3"]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vmss stop
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '22'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -n --instance-ids
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/poweroff?skipShutdown=false&api-version=2022-11-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncnotification:
+      - Enabled
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/d2e8fc79-f0e2-4942-9ff4-c2900ea90e9e?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Mon, 06 Mar 2023 15:09:16 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/d2e8fc79-f0e2-4942-9ff4-c2900ea90e9e?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-11-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/DeleteVMScaleSet3Min;78,Microsoft.Compute/DeleteVMScaleSet30Min;394,Microsoft.Compute/VMScaleSetBatchedVMRequests5Min;3045,Microsoft.Compute/VmssQueuedVMOperations;0
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+      x-ms-request-charge:
+      - '1'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vmss stop
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --instance-ids
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/d2e8fc79-f0e2-4942-9ff4-c2900ea90e9e?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
+  response:
+    body:
+      string: "{\r\n  \"startTime\": \"2023-03-06T15:09:17.0480688+00:00\",\r\n  \"endTime\":
+        \"2023-03-06T15:09:28.8447476+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"name\": \"d2e8fc79-f0e2-4942-9ff4-c2900ea90e9e\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '184'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 06 Mar 2023 15:09:46 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/GetOperation3Min;14979,Microsoft.Compute/GetOperation30Min;29763
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vmss stop
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --instance-ids
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/d2e8fc79-f0e2-4942-9ff4-c2900ea90e9e?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-11-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Mon, 06 Mar 2023 15:09:46 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/GetOperation3Min;14978,Microsoft.Compute/GetOperation30Min;29762
     status:
       code: 200
       message: OK
@@ -3012,21 +2935,21 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/2/instanceView?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/3/instanceView?api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"placementGroupId\": \"b12ec8ba-0f67-45f7-a5b3-5e94f2268933\",\r\n
+      string: "{\r\n  \"placementGroupId\": \"fe2728fc-c0cb-4cea-8d91-bb960a1e6c3b\",\r\n
         \ \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n  \"computerName\":
-        \"cli5o787e000002\",\r\n  \"osName\": \"ubuntu\",\r\n  \"osVersion\": \"18.04\",\r\n
+        \"cliuz26de000003\",\r\n  \"osName\": \"ubuntu\",\r\n  \"osVersion\": \"18.04\",\r\n
         \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"2.9.0.4\",\r\n    \"statuses\":
         [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\",\r\n        \"level\":
         \"Info\",\r\n        \"displayStatus\": \"Ready\",\r\n        \"message\":
-        \"Guest Agent is running\",\r\n        \"time\": \"2022-12-13T23:04:24+00:00\"\r\n
+        \"Guest Agent is running\",\r\n        \"time\": \"2023-03-06T15:08:52+00:00\"\r\n
         \     }\r\n    ],\r\n    \"extensionHandlers\": [\r\n      {\r\n        \"type\":
         \"Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n        \"typeHandlerVersion\":
-        \"1.24.2\",\r\n        \"status\": {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \"1.25.1\",\r\n        \"status\": {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Ready\",\r\n
         \         \"message\": \"Plugin enabled\"\r\n        }\r\n      },\r\n      {\r\n
         \       \"type\": \"Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent\",\r\n
@@ -3034,14 +2957,14 @@ interactions:
         \         \"code\": \"ProvisioningState/succeeded\",\r\n          \"level\":
         \"Info\",\r\n          \"displayStatus\": \"Ready\",\r\n          \"message\":
         \"Plugin enabled\"\r\n        }\r\n      }\r\n    ]\r\n  },\r\n  \"disks\":
-        [\r\n    {\r\n      \"name\": \"cli5oqyn2zpljvxqcitncli5oqyn2zpljvxqcitnmOS__1_fc2a2b19ddde4a019629d326a068caf5\",\r\n
+        [\r\n    {\r\n      \"name\": \"cliuztvtdw4jbve2omq7cliuztvtdw4jbve2omq73OS__1_023d79a2b12548fba5c6e457bd338d14\",\r\n
         \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2022-12-13T23:03:44.1086035+00:00\"\r\n
+        succeeded\",\r\n          \"time\": \"2023-03-06T15:08:17.8921737+00:00\"\r\n
         \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {},\r\n  \"extensions\":
         [\r\n    {\r\n      \"name\": \"Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n
         \     \"type\": \"Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n      \"typeHandlerVersion\":
-        \"1.24.2\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \"1.25.1\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
         succeeded\",\r\n          \"message\": \"Enable succeeded\"\r\n        }\r\n
         \     ]\r\n    },\r\n    {\r\n      \"name\": \"Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent\",\r\n
@@ -3053,7 +2976,7 @@ interactions:
         \   }\r\n  ],\r\n  \"hyperVGeneration\": \"V1\",\r\n  \"statuses\": [\r\n
         \   {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n      \"level\":
         \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n      \"time\":
-        \"2022-12-13T23:04:48.8270185+00:00\"\r\n    },\r\n    {\r\n      \"code\":
+        \"2023-03-06T15:09:27.5635391+00:00\"\r\n    },\r\n    {\r\n      \"code\":
         \"PowerState/stopped\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\":
         \"VM stopped\"\r\n    }\r\n  ]\r\n}"
     headers:
@@ -3064,7 +2987,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:05:13 GMT
+      - Mon, 06 Mar 2023 15:09:47 GMT
       expires:
       - '-1'
       pragma:
@@ -3081,7 +3004,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetVMScaleSetVM3Min;497,Microsoft.Compute/GetVMScaleSetVM30Min;2497,Microsoft.Compute/VMScaleSetVMViews3Min;4997
+      - Microsoft.Compute/GetVMScaleSetVM3Min;498,Microsoft.Compute/GetVMScaleSetVM30Min;2471,Microsoft.Compute/VMScaleSetVMViews3Min;4998
       x-ms-request-charge:
       - '1'
     status:
@@ -3101,8 +3024,8 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
-        (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.SerialConsole/consoleServices/default?api-version=2018-05-01
   response:
@@ -3116,7 +3039,7 @@ interactions:
       content-type:
       - application/json; charset=UTF-8
       date:
-      - Tue, 13 Dec 2022 23:05:14 GMT
+      - Mon, 06 Mar 2023 15:09:48 GMT
       expires:
       - '-1'
       pragma:
@@ -3137,7 +3060,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"instanceIds": ["2"]}'
+    body: '{"instanceIds": ["3"]}'
     headers:
       Accept:
       - application/json
@@ -3154,9 +3077,9 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/start?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/start?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -3164,17 +3087,17 @@ interactions:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/020b915e-5e23-4e05-9391-3beddf43dd2e?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/299a6561-dea7-4fef-9719-59c4d06c2d64?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Tue, 13 Dec 2022 23:05:16 GMT
+      - Mon, 06 Mar 2023 15:09:48 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/020b915e-5e23-4e05-9391-3beddf43dd2e?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/299a6561-dea7-4fef-9719-59c4d06c2d64?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-11-01
       pragma:
       - no-cache
       server:
@@ -3185,7 +3108,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/VMScaleSetActions3Min;236,Microsoft.Compute/VMScaleSetActions30Min;1195,Microsoft.Compute/VMScaleSetBatchedVMRequests5Min;3021,Microsoft.Compute/VmssQueuedVMOperations;0
+      - Microsoft.Compute/VMScaleSetActions3Min;238,Microsoft.Compute/VMScaleSetActions30Min;1185,Microsoft.Compute/VMScaleSetBatchedVMRequests5Min;3044,Microsoft.Compute/VmssQueuedVMOperations;0
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-ms-request-charge:
@@ -3207,22 +3130,23 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/020b915e-5e23-4e05-9391-3beddf43dd2e?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/299a6561-dea7-4fef-9719-59c4d06c2d64?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:05:16.0613096+00:00\",\r\n  \"status\":
-        \"InProgress\",\r\n  \"name\": \"020b915e-5e23-4e05-9391-3beddf43dd2e\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T15:09:49.2507516+00:00\",\r\n  \"endTime\":
+        \"2023-03-06T15:09:56.2507578+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"name\": \"299a6561-dea7-4fef-9719-59c4d06c2d64\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '134'
+      - '184'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:05:16 GMT
+      - Mon, 06 Mar 2023 15:10:18 GMT
       expires:
       - '-1'
       pragma:
@@ -3239,7 +3163,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14976,Microsoft.Compute/GetOperation30Min;29921
+      - Microsoft.Compute/GetOperation3Min;14979,Microsoft.Compute/GetOperation30Min;29770
     status:
       code: 200
       message: OK
@@ -3257,60 +3181,9 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/020b915e-5e23-4e05-9391-3beddf43dd2e?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
-  response:
-    body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:05:16.0613096+00:00\",\r\n  \"endTime\":
-        \"2022-12-13T23:05:20.358177+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"name\": \"020b915e-5e23-4e05-9391-3beddf43dd2e\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '183'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 13 Dec 2022 23:05:46 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14979,Microsoft.Compute/GetOperation30Min;29919
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vmss start
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --instance-ids
-      User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/020b915e-5e23-4e05-9391-3beddf43dd2e?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/299a6561-dea7-4fef-9719-59c4d06c2d64?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-11-01
   response:
     body:
       string: ''
@@ -3320,7 +3193,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 13 Dec 2022 23:05:46 GMT
+      - Mon, 06 Mar 2023 15:10:18 GMT
       expires:
       - '-1'
       pragma:
@@ -3333,7 +3206,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14978,Microsoft.Compute/GetOperation30Min;29918
+      - Microsoft.Compute/GetOperation3Min;14978,Microsoft.Compute/GetOperation30Min;29769
     status:
       code: 200
       message: OK
@@ -3351,9 +3224,9 @@ interactions:
       ParameterSetName:
       - --name --resource-group --set
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003?api-version=2022-11-01
   response:
     body:
       string: "{\r\n  \"name\": \"cli000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003\",\r\n
@@ -3369,23 +3242,24 @@ interactions:
         {\r\n      \"mode\": \"Manual\",\r\n      \"rollingUpgradePolicy\": {\r\n
         \       \"maxBatchInstancePercent\": 20,\r\n        \"maxUnhealthyInstancePercent\":
         20,\r\n        \"maxUnhealthyUpgradedInstancePercent\": 20,\r\n        \"pauseTimeBetweenBatches\":
-        \"PT0S\"\r\n      }\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\":
-        {\r\n        \"computerNamePrefix\": \"cli5o787e\",\r\n        \"adminUsername\":
-        \"rhl\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\":
+        \"PT0S\",\r\n        \"maxSurge\": false,\r\n        \"rollbackFailedInstancesOnPolicyBreach\":
+        false\r\n      }\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\":
+        {\r\n        \"computerNamePrefix\": \"cliuz26de\",\r\n        \"adminUsername\":
+        \"rhoover\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\":
         true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n              {\r\n
-        \               \"path\": \"/home/rhl/.ssh/authorized_keys\",\r\n                \"keyData\":
-        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h\"\r\n
-        \             }\r\n            ]\r\n          },\r\n          \"provisionVMAgent\":
-        true,\r\n          \"enableVMAgentPlatformUpdates\": false\r\n        },\r\n
-        \       \"secrets\": [],\r\n        \"allowExtensionOperations\": true,\r\n
-        \       \"requireGuestProvisionSignal\": true\r\n      },\r\n      \"storageProfile\":
+        \               \"path\": \"/home/rhoover/.ssh/authorized_keys\",\r\n                \"keyData\":
+        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+        REDMOND+rhoover@DESKTOP-XVFR7ID\\n\"\r\n              }\r\n            ]\r\n
+        \         },\r\n          \"provisionVMAgent\": true,\r\n          \"enableVMAgentPlatformUpdates\":
+        false\r\n        },\r\n        \"secrets\": [],\r\n        \"allowExtensionOperations\":
+        true,\r\n        \"requireGuestProvisionSignal\": true\r\n      },\r\n      \"storageProfile\":
         {\r\n        \"osDisk\": {\r\n          \"osType\": \"Linux\",\r\n          \"createOption\":
         \"FromImage\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\":
         {\r\n            \"storageAccountType\": \"Premium_LRS\"\r\n          },\r\n
         \         \"diskSizeGB\": 30\r\n        },\r\n        \"imageReference\":
         {\r\n          \"publisher\": \"Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n
         \         \"sku\": \"18.04-LTS\",\r\n          \"version\": \"latest\"\r\n
-        \       }\r\n      },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"cli5o787eNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"disableTcpStateTracking\":false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\":[{\"name\":\"cli5o787eIPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET/subnets/cli000003Subnet\"},\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/backendAddressPools/cli000003LBBEPool\"}],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/inboundNatPools/cli000003LBNatPool\"}]}}]}}]},\r\n
+        \       }\r\n      },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"cliuz26deNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"disableTcpStateTracking\":false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\":[{\"name\":\"cliuz26deIPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET/subnets/cli000003Subnet\"},\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/backendAddressPools/cli000003LBBEPool\"}],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/inboundNatPools/cli000003LBNatPool\"}]}}]}}]},\r\n
         \     \"diagnosticsProfile\": {\r\n        \"bootDiagnostics\": {\r\n          \"enabled\":
         true\r\n        }\r\n      },\r\n      \"extensionProfile\": {\r\n        \"extensions\":
         [\r\n          {\r\n            \"name\": \"Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n
@@ -3402,17 +3276,17 @@ interactions:
         {\"enableGenevaUpload\":true,\"enableAutoConfig\":true,\"reportSuccessOnUnsupportedDistro\":true}\r\n
         \           }\r\n          }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\":
         \"Succeeded\",\r\n    \"overprovision\": true,\r\n    \"doNotRunExtensionsOnOverprovisionedVMs\":
-        false,\r\n    \"uniqueId\": \"c72549ea-142c-4eb1-8178-a7442e2bc6db\",\r\n
-        \   \"timeCreated\": \"2022-12-13T22:58:32.1880141+00:00\"\r\n  }\r\n}"
+        false,\r\n    \"uniqueId\": \"6aa1f17d-1da0-4dfe-b11e-b77e59e02135\",\r\n
+        \   \"timeCreated\": \"2023-03-06T15:01:24.7059254+00:00\"\r\n  }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '5172'
+      - '5471'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:05:47 GMT
+      - Mon, 06 Mar 2023 15:10:20 GMT
       expires:
       - '-1'
       pragma:
@@ -3429,7 +3303,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetVMScaleSet3Min;390,Microsoft.Compute/GetVMScaleSet30Min;2578
+      - Microsoft.Compute/GetVMScaleSet3Min;382,Microsoft.Compute/GetVMScaleSet30Min;2485
     status:
       code: 200
       message: OK
@@ -3439,17 +3313,19 @@ interactions:
       2}, "identity": {"type": "UserAssigned", "userAssignedIdentities": {"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/AzSecPackAutoConfigUA-westus2":
       {}}}, "properties": {"upgradePolicy": {"mode": "Manual", "rollingUpgradePolicy":
       {"maxBatchInstancePercent": 20, "maxUnhealthyInstancePercent": 20, "maxUnhealthyUpgradedInstancePercent":
-      20, "pauseTimeBetweenBatches": "PT0S"}}, "virtualMachineProfile": {"osProfile":
-      {"computerNamePrefix": "cli5o787e", "adminUsername": "rhl", "linuxConfiguration":
-      {"disablePasswordAuthentication": true, "ssh": {"publicKeys": [{"path": "/home/rhl/.ssh/authorized_keys",
-      "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h"}]},
-      "provisionVMAgent": true, "enableVMAgentPlatformUpdates": false}, "secrets":
-      [], "allowExtensionOperations": true}, "storageProfile": {"osDisk": {"caching":
-      "ReadWrite", "createOption": "FromImage", "diskSizeGB": 30, "osType": "Linux",
-      "managedDisk": {"storageAccountType": "Premium_LRS"}}}, "networkProfile": {"networkInterfaceConfigurations":
-      [{"name": "cli5o787eNic", "properties": {"primary": true, "enableAcceleratedNetworking":
+      20, "pauseTimeBetweenBatches": "PT0S", "rollbackFailedInstancesOnPolicyBreach":
+      false, "maxSurge": false}}, "virtualMachineProfile": {"osProfile": {"computerNamePrefix":
+      "cliuz26de", "adminUsername": "rhoover", "linuxConfiguration": {"disablePasswordAuthentication":
+      true, "ssh": {"publicKeys": [{"path": "/home/rhoover/.ssh/authorized_keys",
+      "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+      REDMOND+rhoover@DESKTOP-XVFR7ID\n"}]}, "provisionVMAgent": true, "enableVMAgentPlatformUpdates":
+      false}, "secrets": [], "allowExtensionOperations": true, "requireGuestProvisionSignal":
+      true}, "storageProfile": {"osDisk": {"caching": "ReadWrite", "createOption":
+      "FromImage", "diskSizeGB": 30, "osType": "Linux", "managedDisk": {"storageAccountType":
+      "Premium_LRS"}}}, "networkProfile": {"networkInterfaceConfigurations": [{"name":
+      "cliuz26deNic", "properties": {"primary": true, "enableAcceleratedNetworking":
       false, "disableTcpStateTracking": false, "dnsSettings": {"dnsServers": []},
-      "ipConfigurations": [{"name": "cli5o787eIPConfig", "properties": {"subnet":
+      "ipConfigurations": [{"name": "cliuz26deIPConfig", "properties": {"subnet":
       {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET/subnets/cli000003Subnet"},
       "privateIPAddressVersion": "IPv4", "loadBalancerBackendAddressPools": [{"id":
       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/backendAddressPools/cli000003LBBEPool"}],
@@ -3475,15 +3351,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '3578'
+      - '3896'
       Content-Type:
       - application/json
       ParameterSetName:
       - --name --resource-group --set
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003?api-version=2022-11-01
   response:
     body:
       string: "{\r\n  \"name\": \"cli000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003\",\r\n
@@ -3499,23 +3375,24 @@ interactions:
         {\r\n      \"mode\": \"Manual\",\r\n      \"rollingUpgradePolicy\": {\r\n
         \       \"maxBatchInstancePercent\": 20,\r\n        \"maxUnhealthyInstancePercent\":
         20,\r\n        \"maxUnhealthyUpgradedInstancePercent\": 20,\r\n        \"pauseTimeBetweenBatches\":
-        \"PT0S\"\r\n      }\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\":
-        {\r\n        \"computerNamePrefix\": \"cli5o787e\",\r\n        \"adminUsername\":
-        \"rhl\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\":
+        \"PT0S\",\r\n        \"maxSurge\": false,\r\n        \"rollbackFailedInstancesOnPolicyBreach\":
+        false\r\n      }\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\":
+        {\r\n        \"computerNamePrefix\": \"cliuz26de\",\r\n        \"adminUsername\":
+        \"rhoover\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\":
         true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n              {\r\n
-        \               \"path\": \"/home/rhl/.ssh/authorized_keys\",\r\n                \"keyData\":
-        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h\"\r\n
-        \             }\r\n            ]\r\n          },\r\n          \"provisionVMAgent\":
-        true,\r\n          \"enableVMAgentPlatformUpdates\": false\r\n        },\r\n
-        \       \"secrets\": [],\r\n        \"allowExtensionOperations\": true,\r\n
-        \       \"requireGuestProvisionSignal\": true\r\n      },\r\n      \"storageProfile\":
+        \               \"path\": \"/home/rhoover/.ssh/authorized_keys\",\r\n                \"keyData\":
+        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+        REDMOND+rhoover@DESKTOP-XVFR7ID\\n\"\r\n              }\r\n            ]\r\n
+        \         },\r\n          \"provisionVMAgent\": true,\r\n          \"enableVMAgentPlatformUpdates\":
+        false\r\n        },\r\n        \"secrets\": [],\r\n        \"allowExtensionOperations\":
+        true,\r\n        \"requireGuestProvisionSignal\": true\r\n      },\r\n      \"storageProfile\":
         {\r\n        \"osDisk\": {\r\n          \"osType\": \"Linux\",\r\n          \"createOption\":
         \"FromImage\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\":
         {\r\n            \"storageAccountType\": \"Premium_LRS\"\r\n          },\r\n
         \         \"diskSizeGB\": 30\r\n        },\r\n        \"imageReference\":
         {\r\n          \"publisher\": \"Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n
         \         \"sku\": \"18.04-LTS\",\r\n          \"version\": \"latest\"\r\n
-        \       }\r\n      },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"cli5o787eNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"disableTcpStateTracking\":false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\":[{\"name\":\"cli5o787eIPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET/subnets/cli000003Subnet\"},\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/backendAddressPools/cli000003LBBEPool\"}],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/inboundNatPools/cli000003LBNatPool\"}]}}]}}]},\r\n
+        \       }\r\n      },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"cliuz26deNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"disableTcpStateTracking\":false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\":[{\"name\":\"cliuz26deIPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET/subnets/cli000003Subnet\"},\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/backendAddressPools/cli000003LBBEPool\"}],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/inboundNatPools/cli000003LBNatPool\"}]}}]}}]},\r\n
         \     \"diagnosticsProfile\": {\r\n        \"bootDiagnostics\": {\r\n          \"enabled\":
         true,\r\n          \"storageUri\": \"https://cli000002.blob.core.windows.net/\"\r\n
         \       }\r\n      },\r\n      \"extensionProfile\": {\r\n        \"extensions\":
@@ -3533,21 +3410,21 @@ interactions:
         {\"enableGenevaUpload\":true,\"enableAutoConfig\":true,\"reportSuccessOnUnsupportedDistro\":true}\r\n
         \           }\r\n          }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\":
         \"Updating\",\r\n    \"overprovision\": true,\r\n    \"doNotRunExtensionsOnOverprovisionedVMs\":
-        false,\r\n    \"uniqueId\": \"c72549ea-142c-4eb1-8178-a7442e2bc6db\",\r\n
-        \   \"timeCreated\": \"2022-12-13T22:58:32.1880141+00:00\"\r\n  }\r\n}"
+        false,\r\n    \"uniqueId\": \"6aa1f17d-1da0-4dfe-b11e-b77e59e02135\",\r\n
+        \   \"timeCreated\": \"2023-03-06T15:01:24.7059254+00:00\"\r\n  }\r\n}"
     headers:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/61bc503a-56b9-4133-87ab-c486ed258d0a?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/4baf492f-f076-408e-82ca-eded6a1782f1?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
       cache-control:
       - no-cache
       content-length:
-      - '5240'
+      - '5539'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:05:52 GMT
+      - Mon, 06 Mar 2023 15:10:23 GMT
       expires:
       - '-1'
       pragma:
@@ -3564,7 +3441,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/CreateVMScaleSet3Min;149,Microsoft.Compute/CreateVMScaleSet30Min;752,Microsoft.Compute/VmssQueuedVMOperations;0
+      - Microsoft.Compute/CreateVMScaleSet3Min;150,Microsoft.Compute/CreateVMScaleSet30Min;747,Microsoft.Compute/VmssQueuedVMOperations;0
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-ms-request-charge:
@@ -3586,14 +3463,14 @@ interactions:
       ParameterSetName:
       - --name --resource-group --set
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/61bc503a-56b9-4133-87ab-c486ed258d0a?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/4baf492f-f076-408e-82ca-eded6a1782f1?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:05:52.1080598+00:00\",\r\n  \"endTime\":
-        \"2022-12-13T23:05:52.5455042+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"name\": \"61bc503a-56b9-4133-87ab-c486ed258d0a\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T15:10:23.8444102+00:00\",\r\n  \"endTime\":
+        \"2023-03-06T15:10:24.2037525+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"name\": \"4baf492f-f076-408e-82ca-eded6a1782f1\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -3602,7 +3479,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:05:52 GMT
+      - Mon, 06 Mar 2023 15:10:34 GMT
       expires:
       - '-1'
       pragma:
@@ -3619,7 +3496,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14977,Microsoft.Compute/GetOperation30Min;29917
+      - Microsoft.Compute/GetOperation3Min;14979,Microsoft.Compute/GetOperation30Min;29768
     status:
       code: 200
       message: OK
@@ -3637,9 +3514,9 @@ interactions:
       ParameterSetName:
       - --name --resource-group --set
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003?api-version=2022-11-01
   response:
     body:
       string: "{\r\n  \"name\": \"cli000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003\",\r\n
@@ -3655,23 +3532,24 @@ interactions:
         {\r\n      \"mode\": \"Manual\",\r\n      \"rollingUpgradePolicy\": {\r\n
         \       \"maxBatchInstancePercent\": 20,\r\n        \"maxUnhealthyInstancePercent\":
         20,\r\n        \"maxUnhealthyUpgradedInstancePercent\": 20,\r\n        \"pauseTimeBetweenBatches\":
-        \"PT0S\"\r\n      }\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\":
-        {\r\n        \"computerNamePrefix\": \"cli5o787e\",\r\n        \"adminUsername\":
-        \"rhl\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\":
+        \"PT0S\",\r\n        \"maxSurge\": false,\r\n        \"rollbackFailedInstancesOnPolicyBreach\":
+        false\r\n      }\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\":
+        {\r\n        \"computerNamePrefix\": \"cliuz26de\",\r\n        \"adminUsername\":
+        \"rhoover\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\":
         true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n              {\r\n
-        \               \"path\": \"/home/rhl/.ssh/authorized_keys\",\r\n                \"keyData\":
-        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h\"\r\n
-        \             }\r\n            ]\r\n          },\r\n          \"provisionVMAgent\":
-        true,\r\n          \"enableVMAgentPlatformUpdates\": false\r\n        },\r\n
-        \       \"secrets\": [],\r\n        \"allowExtensionOperations\": true,\r\n
-        \       \"requireGuestProvisionSignal\": true\r\n      },\r\n      \"storageProfile\":
+        \               \"path\": \"/home/rhoover/.ssh/authorized_keys\",\r\n                \"keyData\":
+        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+        REDMOND+rhoover@DESKTOP-XVFR7ID\\n\"\r\n              }\r\n            ]\r\n
+        \         },\r\n          \"provisionVMAgent\": true,\r\n          \"enableVMAgentPlatformUpdates\":
+        false\r\n        },\r\n        \"secrets\": [],\r\n        \"allowExtensionOperations\":
+        true,\r\n        \"requireGuestProvisionSignal\": true\r\n      },\r\n      \"storageProfile\":
         {\r\n        \"osDisk\": {\r\n          \"osType\": \"Linux\",\r\n          \"createOption\":
         \"FromImage\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\":
         {\r\n            \"storageAccountType\": \"Premium_LRS\"\r\n          },\r\n
         \         \"diskSizeGB\": 30\r\n        },\r\n        \"imageReference\":
         {\r\n          \"publisher\": \"Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n
         \         \"sku\": \"18.04-LTS\",\r\n          \"version\": \"latest\"\r\n
-        \       }\r\n      },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"cli5o787eNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"disableTcpStateTracking\":false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\":[{\"name\":\"cli5o787eIPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET/subnets/cli000003Subnet\"},\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/backendAddressPools/cli000003LBBEPool\"}],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/inboundNatPools/cli000003LBNatPool\"}]}}]}}]},\r\n
+        \       }\r\n      },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"cliuz26deNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"disableTcpStateTracking\":false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\":[{\"name\":\"cliuz26deIPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET/subnets/cli000003Subnet\"},\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/backendAddressPools/cli000003LBBEPool\"}],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/inboundNatPools/cli000003LBNatPool\"}]}}]}}]},\r\n
         \     \"diagnosticsProfile\": {\r\n        \"bootDiagnostics\": {\r\n          \"enabled\":
         true,\r\n          \"storageUri\": \"https://cli000002.blob.core.windows.net/\"\r\n
         \       }\r\n      },\r\n      \"extensionProfile\": {\r\n        \"extensions\":
@@ -3689,17 +3567,17 @@ interactions:
         {\"enableGenevaUpload\":true,\"enableAutoConfig\":true,\"reportSuccessOnUnsupportedDistro\":true}\r\n
         \           }\r\n          }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\":
         \"Succeeded\",\r\n    \"overprovision\": true,\r\n    \"doNotRunExtensionsOnOverprovisionedVMs\":
-        false,\r\n    \"uniqueId\": \"c72549ea-142c-4eb1-8178-a7442e2bc6db\",\r\n
-        \   \"timeCreated\": \"2022-12-13T22:58:32.1880141+00:00\"\r\n  }\r\n}"
+        false,\r\n    \"uniqueId\": \"6aa1f17d-1da0-4dfe-b11e-b77e59e02135\",\r\n
+        \   \"timeCreated\": \"2023-03-06T15:01:24.7059254+00:00\"\r\n  }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '5241'
+      - '5540'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:05:52 GMT
+      - Mon, 06 Mar 2023 15:10:34 GMT
       expires:
       - '-1'
       pragma:
@@ -3716,12 +3594,12 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetVMScaleSet3Min;386,Microsoft.Compute/GetVMScaleSet30Min;2574
+      - Microsoft.Compute/GetVMScaleSet3Min;380,Microsoft.Compute/GetVMScaleSet30Min;2481
     status:
       code: 200
       message: OK
 - request:
-    body: '{"instanceIds": ["2"]}'
+    body: '{"instanceIds": ["3"]}'
     headers:
       Accept:
       - application/json
@@ -3738,9 +3616,9 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/manualupgrade?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/manualupgrade?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -3748,17 +3626,17 @@ interactions:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/5b00d8da-93be-45e1-a488-9233b22f2eca?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/2b0703e1-0726-4546-b706-01964862fbe6?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Tue, 13 Dec 2022 23:05:53 GMT
+      - Mon, 06 Mar 2023 15:10:35 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/5b00d8da-93be-45e1-a488-9233b22f2eca?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/2b0703e1-0726-4546-b706-01964862fbe6?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-11-01
       pragma:
       - no-cache
       server:
@@ -3769,7 +3647,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/VMScaleSetActions3Min;235,Microsoft.Compute/VMScaleSetActions30Min;1194,Microsoft.Compute/VMScaleSetBatchedVMRequests5Min;3020,Microsoft.Compute/VmssQueuedVMOperations;0
+      - Microsoft.Compute/VMScaleSetActions3Min;237,Microsoft.Compute/VMScaleSetActions30Min;1185,Microsoft.Compute/VMScaleSetBatchedVMRequests5Min;3043,Microsoft.Compute/VmssQueuedVMOperations;0
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-ms-request-charge:
@@ -3791,22 +3669,23 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/5b00d8da-93be-45e1-a488-9233b22f2eca?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/2b0703e1-0726-4546-b706-01964862fbe6?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:05:53.764266+00:00\",\r\n  \"status\":
-        \"InProgress\",\r\n  \"name\": \"5b00d8da-93be-45e1-a488-9233b22f2eca\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T15:10:35.6099415+00:00\",\r\n  \"endTime\":
+        \"2023-03-06T15:10:40.8442921+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"name\": \"2b0703e1-0726-4546-b706-01964862fbe6\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '133'
+      - '184'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:05:53 GMT
+      - Mon, 06 Mar 2023 15:11:05 GMT
       expires:
       - '-1'
       pragma:
@@ -3823,7 +3702,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14976,Microsoft.Compute/GetOperation30Min;29916
+      - Microsoft.Compute/GetOperation3Min;14982,Microsoft.Compute/GetOperation30Min;29766
     status:
       code: 200
       message: OK
@@ -3841,60 +3720,9 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/5b00d8da-93be-45e1-a488-9233b22f2eca?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
-  response:
-    body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:05:53.764266+00:00\",\r\n  \"endTime\":
-        \"2022-12-13T23:06:20.1391178+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"name\": \"5b00d8da-93be-45e1-a488-9233b22f2eca\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '183'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 13 Dec 2022 23:06:23 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14975,Microsoft.Compute/GetOperation30Min;29913
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vmss update-instances
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --instance-ids
-      User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/5b00d8da-93be-45e1-a488-9233b22f2eca?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/2b0703e1-0726-4546-b706-01964862fbe6?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-11-01
   response:
     body:
       string: ''
@@ -3904,7 +3732,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 13 Dec 2022 23:06:23 GMT
+      - Mon, 06 Mar 2023 15:11:05 GMT
       expires:
       - '-1'
       pragma:
@@ -3917,7 +3745,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14974,Microsoft.Compute/GetOperation30Min;29912
+      - Microsoft.Compute/GetOperation3Min;14981,Microsoft.Compute/GetOperation30Min;29765
     status:
       code: 200
       message: OK
@@ -3935,21 +3763,21 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/2/instanceView?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/3/instanceView?api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"placementGroupId\": \"b12ec8ba-0f67-45f7-a5b3-5e94f2268933\",\r\n
+      string: "{\r\n  \"placementGroupId\": \"fe2728fc-c0cb-4cea-8d91-bb960a1e6c3b\",\r\n
         \ \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n  \"computerName\":
-        \"cli5o787e000002\",\r\n  \"osName\": \"ubuntu\",\r\n  \"osVersion\": \"18.04\",\r\n
+        \"cliuz26de000003\",\r\n  \"osName\": \"ubuntu\",\r\n  \"osVersion\": \"18.04\",\r\n
         \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"2.9.0.4\",\r\n    \"statuses\":
         [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\",\r\n        \"level\":
         \"Info\",\r\n        \"displayStatus\": \"Ready\",\r\n        \"message\":
-        \"Guest Agent is running\",\r\n        \"time\": \"2022-12-13T23:06:11+00:00\"\r\n
+        \"Guest Agent is running\",\r\n        \"time\": \"2023-03-06T15:10:46+00:00\"\r\n
         \     }\r\n    ],\r\n    \"extensionHandlers\": [\r\n      {\r\n        \"type\":
         \"Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n        \"typeHandlerVersion\":
-        \"1.24.2\",\r\n        \"status\": {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \"1.25.1\",\r\n        \"status\": {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Ready\",\r\n
         \         \"message\": \"Plugin enabled\"\r\n        }\r\n      },\r\n      {\r\n
         \       \"type\": \"Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent\",\r\n
@@ -3957,16 +3785,16 @@ interactions:
         \         \"code\": \"ProvisioningState/succeeded\",\r\n          \"level\":
         \"Info\",\r\n          \"displayStatus\": \"Ready\",\r\n          \"message\":
         \"Plugin enabled\"\r\n        }\r\n      }\r\n    ]\r\n  },\r\n  \"disks\":
-        [\r\n    {\r\n      \"name\": \"cli5oqyn2zpljvxqcitncli5oqyn2zpljvxqcitnmOS__1_fc2a2b19ddde4a019629d326a068caf5\",\r\n
+        [\r\n    {\r\n      \"name\": \"cliuztvtdw4jbve2omq7cliuztvtdw4jbve2omq73OS__1_023d79a2b12548fba5c6e457bd338d14\",\r\n
         \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2022-12-13T23:05:54.857998+00:00\"\r\n
+        succeeded\",\r\n          \"time\": \"2023-03-06T15:10:36.6255965+00:00\"\r\n
         \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
-        \"https://cli000002.blob.core.windows.net/bootdiagnostics-cli5oqyn2-a19f6f91-7994-467b-a23e-a6660ca2db24/cli000003_2.a19f6f91-7994-467b-a23e-a6660ca2db24.screenshot.bmp\",\r\n
-        \   \"serialConsoleLogBlobUri\": \"https://cli000002.blob.core.windows.net/bootdiagnostics-cli5oqyn2-a19f6f91-7994-467b-a23e-a6660ca2db24/cli000003_2.a19f6f91-7994-467b-a23e-a6660ca2db24.serialconsole.log\"\r\n
+        \"https://cli000002.blob.core.windows.net/bootdiagnostics-cliuztvtd-ffa83b08-9cdf-4ddd-8c22-38ec3747c4fa/cli000003_3.ffa83b08-9cdf-4ddd-8c22-38ec3747c4fa.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://cli000002.blob.core.windows.net/bootdiagnostics-cliuztvtd-ffa83b08-9cdf-4ddd-8c22-38ec3747c4fa/cli000003_3.ffa83b08-9cdf-4ddd-8c22-38ec3747c4fa.serialconsole.log\"\r\n
         \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n
         \     \"type\": \"Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n      \"typeHandlerVersion\":
-        \"1.24.2\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \"1.25.1\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
         succeeded\",\r\n          \"message\": \"Enable succeeded\"\r\n        }\r\n
         \     ]\r\n    },\r\n    {\r\n      \"name\": \"Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent\",\r\n
@@ -3978,18 +3806,18 @@ interactions:
         \   }\r\n  ],\r\n  \"hyperVGeneration\": \"V1\",\r\n  \"statuses\": [\r\n
         \   {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n      \"level\":
         \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n      \"time\":
-        \"2022-12-13T23:06:20.1078865+00:00\"\r\n    },\r\n    {\r\n      \"code\":
+        \"2023-03-06T15:10:40.7974713+00:00\"\r\n    },\r\n    {\r\n      \"code\":
         \"PowerState/running\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\":
         \"VM running\"\r\n    }\r\n  ]\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3218'
+      - '3219'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:06:23 GMT
+      - Mon, 06 Mar 2023 15:11:06 GMT
       expires:
       - '-1'
       pragma:
@@ -4006,7 +3834,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetVMScaleSetVM3Min;497,Microsoft.Compute/GetVMScaleSetVM30Min;2496,Microsoft.Compute/VMScaleSetVMViews3Min;4997
+      - Microsoft.Compute/GetVMScaleSetVM3Min;498,Microsoft.Compute/GetVMScaleSetVM30Min;2470,Microsoft.Compute/VMScaleSetVMViews3Min;4998
       x-ms-request-charge:
       - '1'
     status:
@@ -4026,12 +3854,63 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/storageAccounts?api-version=2022-09-01
+  response:
+    body:
+      string: '{"value":[{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloud-shell-storage-eastus/providers/Microsoft.Storage/storageAccounts/cs210032001f4814ba9","name":"cs210032001f4814ba9","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"ms-resource-usage":"azure-cloud-shell"},"properties":{"keyCreationTime":{"key1":"2022-05-16T14:16:22.3477819Z","key2":"2022-05-16T14:16:22.3477819Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-16T14:16:22.3477819Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-16T14:16:22.3477819Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-05-16T14:16:22.2227752Z","primaryEndpoints":{"dfs":"https://cs210032001f4814ba9.dfs.core.windows.net/","web":"https://cs210032001f4814ba9.z13.web.core.windows.net/","blob":"https://cs210032001f4814ba9.blob.core.windows.net/","queue":"https://cs210032001f4814ba9.queue.core.windows.net/","table":"https://cs210032001f4814ba9.table.core.windows.net/","file":"https://cs210032001f4814ba9.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/kustoflow/providers/Microsoft.Storage/storageAccounts/csslinuxkustoflow","name":"csslinuxkustoflow","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"CreatedBy":"craigw"},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-02-01T20:08:38.6849654Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-02-01T20:08:38.6849654Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2019-02-01T20:08:38.5912170Z","primaryEndpoints":{"dfs":"https://csslinuxkustoflow.dfs.core.windows.net/","web":"https://csslinuxkustoflow.z13.web.core.windows.net/","blob":"https://csslinuxkustoflow.blob.core.windows.net/","queue":"https://csslinuxkustoflow.queue.core.windows.net/","table":"https://csslinuxkustoflow.table.core.windows.net/","file":"https://csslinuxkustoflow.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://csslinuxkustoflow-secondary.dfs.core.windows.net/","web":"https://csslinuxkustoflow-secondary.z13.web.core.windows.net/","blob":"https://csslinuxkustoflow-secondary.blob.core.windows.net/","queue":"https://csslinuxkustoflow-secondary.queue.core.windows.net/","table":"https://csslinuxkustoflow-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guidomassonitest-rg/providers/Microsoft.Storage/storageAccounts/guidomassonitestrg88ad","name":"guidomassonitestrg88ad","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-01-23T18:52:02.5484088Z","key2":"2023-01-23T18:52:02.5484088Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-01-23T18:52:02.5484088Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-01-23T18:52:02.5484088Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-01-23T18:52:02.4077698Z","primaryEndpoints":{"blob":"https://guidomassonitestrg88ad.blob.core.windows.net/","queue":"https://guidomassonitestrg88ad.queue.core.windows.net/","table":"https://guidomassonitestrg88ad.table.core.windows.net/","file":"https://guidomassonitestrg88ad.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guidomtesttrafficmanagerrg/providers/Microsoft.Storage/storageAccounts/guidomteststoraccfortm","name":"guidomteststoraccfortm","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-10-18T18:01:13.5231266Z","key2":"2022-10-18T18:01:13.5231266Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-10-18T18:01:13.5387607Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-10-18T18:01:13.5387607Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-10-18T18:01:13.3825002Z","primaryEndpoints":{"dfs":"https://guidomteststoraccfortm.dfs.core.windows.net/","web":"https://guidomteststoraccfortm.z13.web.core.windows.net/","blob":"https://guidomteststoraccfortm.blob.core.windows.net/","queue":"https://guidomteststoraccfortm.queue.core.windows.net/","table":"https://guidomteststoraccfortm.table.core.windows.net/","file":"https://guidomteststoraccfortm.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://guidomteststoraccfortm-secondary.dfs.core.windows.net/","web":"https://guidomteststoraccfortm-secondary.z13.web.core.windows.net/","blob":"https://guidomteststoraccfortm-secondary.blob.core.windows.net/","queue":"https://guidomteststoraccfortm-secondary.queue.core.windows.net/","table":"https://guidomteststoraccfortm-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnertestvmrg-eastus/providers/Microsoft.Storage/storageAccounts/scrunnercrkwpdn5nhtgg","name":"scrunnercrkwpdn5nhtgg","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-05-12T20:03:57.6389684Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-05-12T20:03:57.6389684Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-05-12T20:03:57.5451905Z","primaryEndpoints":{"blob":"https://scrunnercrkwpdn5nhtgg.blob.core.windows.net/","queue":"https://scrunnercrkwpdn5nhtgg.queue.core.windows.net/","table":"https://scrunnercrkwpdn5nhtgg.table.core.windows.net/","file":"https://scrunnercrkwpdn5nhtgg.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnervmrg-eastus/providers/Microsoft.Storage/storageAccounts/scrunneri2ezqh4xu2wqq","name":"scrunneri2ezqh4xu2wqq","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-02-11T08:01:12.9383535Z","key2":"2023-02-11T08:01:12.9383535Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:01:12.9383535Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:01:12.9383535Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-02-11T08:01:12.6883669Z","primaryEndpoints":{"blob":"https://scrunneri2ezqh4xu2wqq.blob.core.windows.net/","queue":"https://scrunneri2ezqh4xu2wqq.queue.core.windows.net/","table":"https://scrunneri2ezqh4xu2wqq.table.core.windows.net/","file":"https://scrunneri2ezqh4xu2wqq.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/serialTest-EastUS/providers/Microsoft.Storage/storageAccounts/serialtesta8d7fdee41","name":"serialtesta8d7fdee41","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-07-11T00:38:13.5389932Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-07-11T00:38:13.5389932Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2019-07-11T00:38:13.4452119Z","primaryEndpoints":{"blob":"https://serialtesta8d7fdee41.blob.core.windows.net/","queue":"https://serialtesta8d7fdee41.queue.core.windows.net/","table":"https://serialtesta8d7fdee41.table.core.windows.net/","file":"https://serialtesta8d7fdee41.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/storage-RG/providers/Microsoft.Storage/storageAccounts/serialtestbootdiag123","name":"serialtestbootdiag123","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-01-23T04:03:01.3263151Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-01-23T04:03:01.3263151Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2018-01-23T04:03:01.2951106Z","primaryEndpoints":{"blob":"https://serialtestbootdiag123.blob.core.windows.net/","queue":"https://serialtestbootdiag123.queue.core.windows.net/","table":"https://serialtestbootdiag123.table.core.windows.net/","file":"https://serialtestbootdiag123.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yuas-rg/providers/Microsoft.Storage/storageAccounts/yuasstorageacct","name":"yuasstorageacct","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-08-02T12:18:18.8547131Z","key2":"2022-08-02T12:18:18.8547131Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-08-02T12:18:18.8547131Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-08-02T12:18:18.8547131Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-08-02T12:18:18.7140969Z","primaryEndpoints":{"dfs":"https://yuasstorageacct.dfs.core.windows.net/","web":"https://yuasstorageacct.z13.web.core.windows.net/","blob":"https://yuasstorageacct.blob.core.windows.net/","queue":"https://yuasstorageacct.queue.core.windows.net/","table":"https://yuasstorageacct.table.core.windows.net/","file":"https://yuasstorageacct.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://yuasstorageacct-secondary.dfs.core.windows.net/","web":"https://yuasstorageacct-secondary.z13.web.core.windows.net/","blob":"https://yuasstorageacct-secondary.blob.core.windows.net/","queue":"https://yuasstorageacct-secondary.queue.core.windows.net/","table":"https://yuasstorageacct-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/bkerrigan-dev-rg/providers/Microsoft.Storage/storageAccounts/bktestsa2","name":"bktestsa2","type":"Microsoft.Storage/storageAccounts","location":"eastus2","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","immutableStorageWithVersioning":{"enabled":true},"keyCreationTime":{"key1":"2022-09-27T23:58:45.6496284Z","key2":"2022-09-27T23:58:45.6496284Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-09-27T23:58:46.2902461Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-09-27T23:58:46.2902461Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Cool","provisioningState":"Succeeded","creationTime":"2022-09-27T23:58:45.5558609Z","primaryEndpoints":{"dfs":"https://bktestsa2.dfs.core.windows.net/","web":"https://bktestsa2.z20.web.core.windows.net/","blob":"https://bktestsa2.blob.core.windows.net/","queue":"https://bktestsa2.queue.core.windows.net/","table":"https://bktestsa2.table.core.windows.net/","file":"https://bktestsa2.file.core.windows.net/"},"primaryLocation":"eastus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rhel-test/providers/Microsoft.Storage/storageAccounts/rhel77acct","name":"rhel77acct","type":"Microsoft.Storage/storageAccounts","location":"eastus2","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-08-13T20:31:30.8995173Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-08-13T20:31:30.8995173Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-08-13T20:31:30.8215811Z","primaryEndpoints":{"blob":"https://rhel77acct.blob.core.windows.net/","queue":"https://rhel77acct.queue.core.windows.net/","table":"https://rhel77acct.table.core.windows.net/","file":"https://rhel77acct.file.core.windows.net/"},"primaryLocation":"eastus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SCRunner/providers/Microsoft.Storage/storageAccounts/scrunnerstorage","name":"scrunnerstorage","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-03-06T00:42:11.7016543Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-03-06T00:42:11.7016543Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2018-03-06T00:42:11.6234985Z","primaryEndpoints":{"blob":"https://scrunnerstorage.blob.core.windows.net/","queue":"https://scrunnerstorage.queue.core.windows.net/","table":"https://scrunnerstorage.table.core.windows.net/","file":"https://scrunnerstorage.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rhoover/providers/Microsoft.Storage/storageAccounts/rhooverstorage","name":"rhooverstorage","type":"Microsoft.Storage/storageAccounts","location":"southcentralus","tags":{"ms-resource-usage":"azure-cloud-shell"},"properties":{"keyCreationTime":{"key1":"2022-05-26T17:14:23.5085026Z","key2":"2022-05-26T17:14:23.5085026Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-26T17:14:23.5241285Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-26T17:14:23.5241285Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-05-26T17:14:23.4147520Z","primaryEndpoints":{"dfs":"https://rhooverstorage.dfs.core.windows.net/","web":"https://rhooverstorage.z21.web.core.windows.net/","blob":"https://rhooverstorage.blob.core.windows.net/","queue":"https://rhooverstorage.queue.core.windows.net/","table":"https://rhooverstorage.table.core.windows.net/","file":"https://rhooverstorage.file.core.windows.net/"},"primaryLocation":"southcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SCRunnertestvmrg-AustraliaEast/providers/Microsoft.Storage/storageAccounts/scrunner4p3t72mzheluc","name":"scrunner4p3t72mzheluc","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{},"properties":{"keyCreationTime":{"key1":"2021-04-13T22:35:36.6210942Z","key2":"2021-04-13T22:35:36.6210942Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2021-04-13T22:35:36.6210942Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2021-04-13T22:35:36.6210942Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2021-04-13T22:35:36.5429508Z","primaryEndpoints":{"blob":"https://scrunner4p3t72mzheluc.blob.core.windows.net/","queue":"https://scrunner4p3t72mzheluc.queue.core.windows.net/","table":"https://scrunner4p3t72mzheluc.table.core.windows.net/","file":"https://scrunner4p3t72mzheluc.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnervmrg-australiaeast/providers/Microsoft.Storage/storageAccounts/scrunner56hymyctm4kw2","name":"scrunner56hymyctm4kw2","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{},"properties":{"keyCreationTime":{"key1":"2023-02-11T08:42:58.2414102Z","key2":"2023-02-11T08:42:58.2414102Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:42:59.3196006Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:42:59.3196006Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-02-11T08:42:58.1476588Z","primaryEndpoints":{"blob":"https://scrunner56hymyctm4kw2.blob.core.windows.net/","queue":"https://scrunner56hymyctm4kw2.queue.core.windows.net/","table":"https://scrunner56hymyctm4kw2.table.core.windows.net/","file":"https://scrunner56hymyctm4kw2.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002","name":"cli000002","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T15:00:46.5594874Z","key2":"2023-03-06T15:00:46.5594874Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T15:00:46.8094615Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T15:00:46.8094615Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T15:00:46.4501501Z","primaryEndpoints":{"blob":"https://cli000002.blob.core.windows.net/","queue":"https://cli000002.queue.core.windows.net/","table":"https://cli000002.table.core.windows.net/","file":"https://cli000002.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsolex4geueyy52iloaspyxz3rrqwxv2syvnkjiljxbv522buwxqpiljme/providers/Microsoft.Storage/storageAccounts/clipf6qz5nxegbgku5yqzkd2","name":"clipf6qz5nxegbgku5yqzkd2","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T07:45:44.7937561Z","key2":"2023-03-06T07:45:44.7937561Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:45:45.1687946Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:45:45.1687946Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T07:45:44.7000168Z","primaryEndpoints":{"blob":"https://clipf6qz5nxegbgku5yqzkd2.blob.core.windows.net/","queue":"https://clipf6qz5nxegbgku5yqzkd2.queue.core.windows.net/","table":"https://clipf6qz5nxegbgku5yqzkd2.table.core.windows.net/","file":"https://clipf6qz5nxegbgku5yqzkd2.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsoledcvrpndxic4emeqq5apwkns4qa5owpy4jn3b536ks35zdrmn7bl5k/providers/Microsoft.Storage/storageAccounts/cliwqnm2fo7pftnxlk7c734i","name":"cliwqnm2fo7pftnxlk7c734i","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T07:34:57.7461613Z","key2":"2023-03-06T07:34:57.7461613Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:34:57.9961851Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:34:57.9961851Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T07:34:57.6368148Z","primaryEndpoints":{"blob":"https://cliwqnm2fo7pftnxlk7c734i.blob.core.windows.net/","queue":"https://cliwqnm2fo7pftnxlk7c734i.queue.core.windows.net/","table":"https://cliwqnm2fo7pftnxlk7c734i.table.core.windows.net/","file":"https://cliwqnm2fo7pftnxlk7c734i.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guptar2/providers/Microsoft.Storage/storageAccounts/guptar2diagnosticsv1","name":"guptar2diagnosticsv1","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2022-04-05T17:21:41.8250582Z","key2":"2022-04-05T17:21:41.8250582Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:21:41.8250582Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:21:41.8250582Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-04-05T17:21:41.7313240Z","primaryEndpoints":{"blob":"https://guptar2diagnosticsv1.blob.core.windows.net/","queue":"https://guptar2diagnosticsv1.queue.core.windows.net/","table":"https://guptar2diagnosticsv1.table.core.windows.net/","file":"https://guptar2diagnosticsv1.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guptar2/providers/Microsoft.Storage/storageAccounts/guptar2diagnosticsv2","name":"guptar2diagnosticsv2","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-04-05T17:22:55.8411567Z","key2":"2022-04-05T17:22:55.8411567Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"resourceAccessRules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[{"value":"20.98.146.84","action":"Allow"},{"value":"20.83.222.102","action":"Allow"},{"value":"20.98.194.64","action":"Allow"},{"value":"20.69.5.162","action":"Allow"}],"defaultAction":"Deny"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:22:55.8411567Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:22:55.8411567Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-04-05T17:22:55.7318000Z","primaryEndpoints":{"dfs":"https://guptar2diagnosticsv2.dfs.core.windows.net/","web":"https://guptar2diagnosticsv2.z5.web.core.windows.net/","blob":"https://guptar2diagnosticsv2.blob.core.windows.net/","queue":"https://guptar2diagnosticsv2.queue.core.windows.net/","table":"https://guptar2diagnosticsv2.table.core.windows.net/","file":"https://guptar2diagnosticsv2.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sericonrp-trafficmanager/providers/Microsoft.Storage/storageAccounts/sericonrpdevtmstorage","name":"sericonrpdevtmstorage","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-11-30T19:15:41.5013570Z","key2":"2022-11-30T19:15:41.5013570Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-11-30T19:15:42.0638737Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-11-30T19:15:42.0638737Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-11-30T19:15:41.4075777Z","primaryEndpoints":{"dfs":"https://sericonrpdevtmstorage.dfs.core.windows.net/","web":"https://sericonrpdevtmstorage.z5.web.core.windows.net/","blob":"https://sericonrpdevtmstorage.blob.core.windows.net/","queue":"https://sericonrpdevtmstorage.queue.core.windows.net/","table":"https://sericonrpdevtmstorage.table.core.windows.net/","file":"https://sericonrpdevtmstorage.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available","secondaryLocation":"westcentralus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://sericonrpdevtmstorage-secondary.dfs.core.windows.net/","web":"https://sericonrpdevtmstorage-secondary.z5.web.core.windows.net/","blob":"https://sericonrpdevtmstorage-secondary.blob.core.windows.net/","queue":"https://sericonrpdevtmstorage-secondary.queue.core.windows.net/","table":"https://sericonrpdevtmstorage-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ops/providers/Microsoft.Storage/storageAccounts/sericonstorage","name":"sericonstorage","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2023-03-05T19:58:00.4355863Z","key2":"2023-03-05T19:58:00.4355863Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-05T19:58:00.9824831Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-05T19:58:00.9824831Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2023-03-05T19:58:00.3262342Z","primaryEndpoints":{"dfs":"https://sericonstorage.dfs.core.windows.net/","web":"https://sericonstorage.z5.web.core.windows.net/","blob":"https://sericonstorage.blob.core.windows.net/","queue":"https://sericonstorage.queue.core.windows.net/","table":"https://sericonstorage.table.core.windows.net/","file":"https://sericonstorage.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rhoover-dev-rg/providers/Microsoft.Storage/storageAccounts/rhooverdevrgdiag","name":"rhooverdevrgdiag","type":"Microsoft.Storage/storageAccounts","location":"westcentralus","tags":{},"properties":{"defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-06-20T19:39:24.4605968Z","key2":"2022-06-20T19:39:24.4605968Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":false,"networkAcls":{"resourceAccessRules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[{"value":"20.98.146.84","action":"Allow"},{"value":"20.98.194.64","action":"Allow"},{"value":"20.69.5.162","action":"Allow"},{"value":"20.83.222.102","action":"Allow"},{"value":"76.197.206.105","action":"Allow"}],"defaultAction":"Deny"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-06-20T19:39:24.4762287Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-06-20T19:39:24.4762287Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-06-20T19:39:24.4137057Z","primaryEndpoints":{"blob":"https://rhooverdevrgdiag.blob.core.windows.net/","queue":"https://rhooverdevrgdiag.queue.core.windows.net/","table":"https://rhooverdevrgdiag.table.core.windows.net/","file":"https://rhooverdevrgdiag.file.core.windows.net/"},"primaryLocation":"westcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnervmrg-westcentralus/providers/Microsoft.Storage/storageAccounts/scrunneraoptpjec4skce","name":"scrunneraoptpjec4skce","type":"Microsoft.Storage/storageAccounts","location":"westcentralus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-02-11T08:40:40.0686467Z","key2":"2023-02-11T08:40:40.0686467Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:40:40.5842822Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:40:40.5842822Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-02-11T08:40:40.0061730Z","primaryEndpoints":{"blob":"https://scrunneraoptpjec4skce.blob.core.windows.net/","queue":"https://scrunneraoptpjec4skce.queue.core.windows.net/","table":"https://scrunneraoptpjec4skce.table.core.windows.net/","file":"https://scrunneraoptpjec4skce.file.core.windows.net/"},"primaryLocation":"westcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnertestvmrg-westcentralus/providers/Microsoft.Storage/storageAccounts/scrunnerrfscmqxeni3uq","name":"scrunnerrfscmqxeni3uq","type":"Microsoft.Storage/storageAccounts","location":"westcentralus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-04-10T22:28:55.2104910Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-04-10T22:28:55.2104910Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-04-10T22:28:55.1479670Z","primaryEndpoints":{"blob":"https://scrunnerrfscmqxeni3uq.blob.core.windows.net/","queue":"https://scrunnerrfscmqxeni3uq.queue.core.windows.net/","table":"https://scrunnerrfscmqxeni3uq.table.core.windows.net/","file":"https://scrunnerrfscmqxeni3uq.file.core.windows.net/"},"primaryLocation":"westcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ubuntu-westus3_group/providers/Microsoft.Storage/storageAccounts/ubuntuwestus3groupdiag","name":"ubuntuwestus3groupdiag","type":"Microsoft.Storage/storageAccounts","location":"westus3","tags":{},"properties":{"keyCreationTime":{"key1":"2022-04-18T19:48:38.9882588Z","key2":"2022-04-18T19:48:38.9882588Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-18T19:48:38.9882588Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-18T19:48:38.9882588Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-04-18T19:48:38.9258191Z","primaryEndpoints":{"blob":"https://ubuntuwestus3groupdiag.blob.core.windows.net/","queue":"https://ubuntuwestus3groupdiag.queue.core.windows.net/","table":"https://ubuntuwestus3groupdiag.table.core.windows.net/","file":"https://ubuntuwestus3groupdiag.file.core.windows.net/"},"primaryLocation":"westus3","statusOfPrimary":"available"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '38475'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 06 Mar 2023 15:11:06 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-original-request-ids:
+      - c6b1a6b4-c776-438a-bb49-4f48aa12dea2
+      - 5ee40fcc-a062-4937-8979-4d8d28966184
+      - be98f713-5f58-46d3-be6c-b05289d4e935
+      - afa121fe-f68f-451f-9f6c-8abdeb004fe0
+      - c1a954ca-e369-4a09-9466-947b2a20c503
+      - 686c4c83-e526-4008-aa2c-6c8f2dfb030c
+      - 9632ad54-587f-4fd0-8c7b-04aa77092f1f
+      - ea062859-bbaf-4326-909f-b32c47e018b7
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vmss update-instances
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --instance-ids
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002","name":"cli000002","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2022-12-13T22:57:52.2717456Z","key2":"2022-12-13T22:57:52.2717456Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-12-13T22:57:52.7873645Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-12-13T22:57:52.7873645Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-12-13T22:57:52.1623506Z","primaryEndpoints":{"blob":"https://cli000002.blob.core.windows.net/","queue":"https://cli000002.queue.core.windows.net/","table":"https://cli000002.table.core.windows.net/","file":"https://cli000002.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002","name":"cli000002","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T15:00:46.5594874Z","key2":"2023-03-06T15:00:46.5594874Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T15:00:46.8094615Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T15:00:46.8094615Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T15:00:46.4501501Z","primaryEndpoints":{"blob":"https://cli000002.blob.core.windows.net/","queue":"https://cli000002.queue.core.windows.net/","table":"https://cli000002.table.core.windows.net/","file":"https://cli000002.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -4040,7 +3919,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 13 Dec 2022 23:06:25 GMT
+      - Mon, 06 Mar 2023 15:11:06 GMT
       expires:
       - '-1'
       pragma:
@@ -4072,8 +3951,8 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
-        (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.SerialConsole/consoleServices/default?api-version=2018-05-01
   response:
@@ -4087,7 +3966,7 @@ interactions:
       content-type:
       - application/json; charset=UTF-8
       date:
-      - Tue, 13 Dec 2022 23:06:24 GMT
+      - Mon, 06 Mar 2023 15:11:07 GMT
       expires:
       - '-1'
       pragma:
@@ -4123,8 +4002,8 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
-        (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
+        (Windows-10-10.0.22621-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.SerialConsole/consoleServices/default/disableConsole?api-version=2018-05-01
   response:
@@ -4138,7 +4017,7 @@ interactions:
       content-type:
       - application/json; charset=UTF-8
       date:
-      - Tue, 13 Dec 2022 23:06:26 GMT
+      - Mon, 06 Mar 2023 15:11:08 GMT
       expires:
       - '-1'
       pragma:
@@ -4172,21 +4051,21 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/2/instanceView?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/3/instanceView?api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"placementGroupId\": \"b12ec8ba-0f67-45f7-a5b3-5e94f2268933\",\r\n
+      string: "{\r\n  \"placementGroupId\": \"fe2728fc-c0cb-4cea-8d91-bb960a1e6c3b\",\r\n
         \ \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n  \"computerName\":
-        \"cli5o787e000002\",\r\n  \"osName\": \"ubuntu\",\r\n  \"osVersion\": \"18.04\",\r\n
+        \"cliuz26de000003\",\r\n  \"osName\": \"ubuntu\",\r\n  \"osVersion\": \"18.04\",\r\n
         \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"2.9.0.4\",\r\n    \"statuses\":
         [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\",\r\n        \"level\":
         \"Info\",\r\n        \"displayStatus\": \"Ready\",\r\n        \"message\":
-        \"Guest Agent is running\",\r\n        \"time\": \"2022-12-13T23:06:11+00:00\"\r\n
+        \"Guest Agent is running\",\r\n        \"time\": \"2023-03-06T15:10:46+00:00\"\r\n
         \     }\r\n    ],\r\n    \"extensionHandlers\": [\r\n      {\r\n        \"type\":
         \"Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n        \"typeHandlerVersion\":
-        \"1.24.2\",\r\n        \"status\": {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \"1.25.1\",\r\n        \"status\": {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Ready\",\r\n
         \         \"message\": \"Plugin enabled\"\r\n        }\r\n      },\r\n      {\r\n
         \       \"type\": \"Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent\",\r\n
@@ -4194,16 +4073,16 @@ interactions:
         \         \"code\": \"ProvisioningState/succeeded\",\r\n          \"level\":
         \"Info\",\r\n          \"displayStatus\": \"Ready\",\r\n          \"message\":
         \"Plugin enabled\"\r\n        }\r\n      }\r\n    ]\r\n  },\r\n  \"disks\":
-        [\r\n    {\r\n      \"name\": \"cli5oqyn2zpljvxqcitncli5oqyn2zpljvxqcitnmOS__1_fc2a2b19ddde4a019629d326a068caf5\",\r\n
+        [\r\n    {\r\n      \"name\": \"cliuztvtdw4jbve2omq7cliuztvtdw4jbve2omq73OS__1_023d79a2b12548fba5c6e457bd338d14\",\r\n
         \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2022-12-13T23:05:54.857998+00:00\"\r\n
+        succeeded\",\r\n          \"time\": \"2023-03-06T15:10:36.6255965+00:00\"\r\n
         \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
-        \"https://cli000002.blob.core.windows.net/bootdiagnostics-cli5oqyn2-a19f6f91-7994-467b-a23e-a6660ca2db24/cli000003_2.a19f6f91-7994-467b-a23e-a6660ca2db24.screenshot.bmp\",\r\n
-        \   \"serialConsoleLogBlobUri\": \"https://cli000002.blob.core.windows.net/bootdiagnostics-cli5oqyn2-a19f6f91-7994-467b-a23e-a6660ca2db24/cli000003_2.a19f6f91-7994-467b-a23e-a6660ca2db24.serialconsole.log\"\r\n
+        \"https://cli000002.blob.core.windows.net/bootdiagnostics-cliuztvtd-ffa83b08-9cdf-4ddd-8c22-38ec3747c4fa/cli000003_3.ffa83b08-9cdf-4ddd-8c22-38ec3747c4fa.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://cli000002.blob.core.windows.net/bootdiagnostics-cliuztvtd-ffa83b08-9cdf-4ddd-8c22-38ec3747c4fa/cli000003_3.ffa83b08-9cdf-4ddd-8c22-38ec3747c4fa.serialconsole.log\"\r\n
         \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n
         \     \"type\": \"Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n      \"typeHandlerVersion\":
-        \"1.24.2\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \"1.25.1\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
         succeeded\",\r\n          \"message\": \"Enable succeeded\"\r\n        }\r\n
         \     ]\r\n    },\r\n    {\r\n      \"name\": \"Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent\",\r\n
@@ -4215,18 +4094,18 @@ interactions:
         \   }\r\n  ],\r\n  \"hyperVGeneration\": \"V1\",\r\n  \"statuses\": [\r\n
         \   {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n      \"level\":
         \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n      \"time\":
-        \"2022-12-13T23:06:20.1078865+00:00\"\r\n    },\r\n    {\r\n      \"code\":
+        \"2023-03-06T15:10:40.7974713+00:00\"\r\n    },\r\n    {\r\n      \"code\":
         \"PowerState/running\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\":
         \"VM running\"\r\n    }\r\n  ]\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3218'
+      - '3219'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:06:27 GMT
+      - Mon, 06 Mar 2023 15:11:08 GMT
       expires:
       - '-1'
       pragma:
@@ -4243,7 +4122,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetVMScaleSetVM3Min;496,Microsoft.Compute/GetVMScaleSetVM30Min;2495,Microsoft.Compute/VMScaleSetVMViews3Min;4996
+      - Microsoft.Compute/GetVMScaleSetVM3Min;497,Microsoft.Compute/GetVMScaleSetVM30Min;2469,Microsoft.Compute/VMScaleSetVMViews3Min;4997
       x-ms-request-charge:
       - '1'
     status:
@@ -4261,12 +4140,61 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/storageAccounts?api-version=2022-09-01
+  response:
+    body:
+      string: '{"value":[{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloud-shell-storage-eastus/providers/Microsoft.Storage/storageAccounts/cs210032001f4814ba9","name":"cs210032001f4814ba9","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"ms-resource-usage":"azure-cloud-shell"},"properties":{"keyCreationTime":{"key1":"2022-05-16T14:16:22.3477819Z","key2":"2022-05-16T14:16:22.3477819Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-16T14:16:22.3477819Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-16T14:16:22.3477819Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-05-16T14:16:22.2227752Z","primaryEndpoints":{"dfs":"https://cs210032001f4814ba9.dfs.core.windows.net/","web":"https://cs210032001f4814ba9.z13.web.core.windows.net/","blob":"https://cs210032001f4814ba9.blob.core.windows.net/","queue":"https://cs210032001f4814ba9.queue.core.windows.net/","table":"https://cs210032001f4814ba9.table.core.windows.net/","file":"https://cs210032001f4814ba9.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/kustoflow/providers/Microsoft.Storage/storageAccounts/csslinuxkustoflow","name":"csslinuxkustoflow","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"CreatedBy":"craigw"},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-02-01T20:08:38.6849654Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-02-01T20:08:38.6849654Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2019-02-01T20:08:38.5912170Z","primaryEndpoints":{"dfs":"https://csslinuxkustoflow.dfs.core.windows.net/","web":"https://csslinuxkustoflow.z13.web.core.windows.net/","blob":"https://csslinuxkustoflow.blob.core.windows.net/","queue":"https://csslinuxkustoflow.queue.core.windows.net/","table":"https://csslinuxkustoflow.table.core.windows.net/","file":"https://csslinuxkustoflow.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://csslinuxkustoflow-secondary.dfs.core.windows.net/","web":"https://csslinuxkustoflow-secondary.z13.web.core.windows.net/","blob":"https://csslinuxkustoflow-secondary.blob.core.windows.net/","queue":"https://csslinuxkustoflow-secondary.queue.core.windows.net/","table":"https://csslinuxkustoflow-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guidomassonitest-rg/providers/Microsoft.Storage/storageAccounts/guidomassonitestrg88ad","name":"guidomassonitestrg88ad","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-01-23T18:52:02.5484088Z","key2":"2023-01-23T18:52:02.5484088Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-01-23T18:52:02.5484088Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-01-23T18:52:02.5484088Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-01-23T18:52:02.4077698Z","primaryEndpoints":{"blob":"https://guidomassonitestrg88ad.blob.core.windows.net/","queue":"https://guidomassonitestrg88ad.queue.core.windows.net/","table":"https://guidomassonitestrg88ad.table.core.windows.net/","file":"https://guidomassonitestrg88ad.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guidomtesttrafficmanagerrg/providers/Microsoft.Storage/storageAccounts/guidomteststoraccfortm","name":"guidomteststoraccfortm","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-10-18T18:01:13.5231266Z","key2":"2022-10-18T18:01:13.5231266Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-10-18T18:01:13.5387607Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-10-18T18:01:13.5387607Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-10-18T18:01:13.3825002Z","primaryEndpoints":{"dfs":"https://guidomteststoraccfortm.dfs.core.windows.net/","web":"https://guidomteststoraccfortm.z13.web.core.windows.net/","blob":"https://guidomteststoraccfortm.blob.core.windows.net/","queue":"https://guidomteststoraccfortm.queue.core.windows.net/","table":"https://guidomteststoraccfortm.table.core.windows.net/","file":"https://guidomteststoraccfortm.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://guidomteststoraccfortm-secondary.dfs.core.windows.net/","web":"https://guidomteststoraccfortm-secondary.z13.web.core.windows.net/","blob":"https://guidomteststoraccfortm-secondary.blob.core.windows.net/","queue":"https://guidomteststoraccfortm-secondary.queue.core.windows.net/","table":"https://guidomteststoraccfortm-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnertestvmrg-eastus/providers/Microsoft.Storage/storageAccounts/scrunnercrkwpdn5nhtgg","name":"scrunnercrkwpdn5nhtgg","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-05-12T20:03:57.6389684Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-05-12T20:03:57.6389684Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-05-12T20:03:57.5451905Z","primaryEndpoints":{"blob":"https://scrunnercrkwpdn5nhtgg.blob.core.windows.net/","queue":"https://scrunnercrkwpdn5nhtgg.queue.core.windows.net/","table":"https://scrunnercrkwpdn5nhtgg.table.core.windows.net/","file":"https://scrunnercrkwpdn5nhtgg.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnervmrg-eastus/providers/Microsoft.Storage/storageAccounts/scrunneri2ezqh4xu2wqq","name":"scrunneri2ezqh4xu2wqq","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-02-11T08:01:12.9383535Z","key2":"2023-02-11T08:01:12.9383535Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:01:12.9383535Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:01:12.9383535Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-02-11T08:01:12.6883669Z","primaryEndpoints":{"blob":"https://scrunneri2ezqh4xu2wqq.blob.core.windows.net/","queue":"https://scrunneri2ezqh4xu2wqq.queue.core.windows.net/","table":"https://scrunneri2ezqh4xu2wqq.table.core.windows.net/","file":"https://scrunneri2ezqh4xu2wqq.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/serialTest-EastUS/providers/Microsoft.Storage/storageAccounts/serialtesta8d7fdee41","name":"serialtesta8d7fdee41","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-07-11T00:38:13.5389932Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-07-11T00:38:13.5389932Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2019-07-11T00:38:13.4452119Z","primaryEndpoints":{"blob":"https://serialtesta8d7fdee41.blob.core.windows.net/","queue":"https://serialtesta8d7fdee41.queue.core.windows.net/","table":"https://serialtesta8d7fdee41.table.core.windows.net/","file":"https://serialtesta8d7fdee41.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/storage-RG/providers/Microsoft.Storage/storageAccounts/serialtestbootdiag123","name":"serialtestbootdiag123","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-01-23T04:03:01.3263151Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-01-23T04:03:01.3263151Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2018-01-23T04:03:01.2951106Z","primaryEndpoints":{"blob":"https://serialtestbootdiag123.blob.core.windows.net/","queue":"https://serialtestbootdiag123.queue.core.windows.net/","table":"https://serialtestbootdiag123.table.core.windows.net/","file":"https://serialtestbootdiag123.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yuas-rg/providers/Microsoft.Storage/storageAccounts/yuasstorageacct","name":"yuasstorageacct","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-08-02T12:18:18.8547131Z","key2":"2022-08-02T12:18:18.8547131Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-08-02T12:18:18.8547131Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-08-02T12:18:18.8547131Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-08-02T12:18:18.7140969Z","primaryEndpoints":{"dfs":"https://yuasstorageacct.dfs.core.windows.net/","web":"https://yuasstorageacct.z13.web.core.windows.net/","blob":"https://yuasstorageacct.blob.core.windows.net/","queue":"https://yuasstorageacct.queue.core.windows.net/","table":"https://yuasstorageacct.table.core.windows.net/","file":"https://yuasstorageacct.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://yuasstorageacct-secondary.dfs.core.windows.net/","web":"https://yuasstorageacct-secondary.z13.web.core.windows.net/","blob":"https://yuasstorageacct-secondary.blob.core.windows.net/","queue":"https://yuasstorageacct-secondary.queue.core.windows.net/","table":"https://yuasstorageacct-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/bkerrigan-dev-rg/providers/Microsoft.Storage/storageAccounts/bktestsa2","name":"bktestsa2","type":"Microsoft.Storage/storageAccounts","location":"eastus2","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","immutableStorageWithVersioning":{"enabled":true},"keyCreationTime":{"key1":"2022-09-27T23:58:45.6496284Z","key2":"2022-09-27T23:58:45.6496284Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-09-27T23:58:46.2902461Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-09-27T23:58:46.2902461Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Cool","provisioningState":"Succeeded","creationTime":"2022-09-27T23:58:45.5558609Z","primaryEndpoints":{"dfs":"https://bktestsa2.dfs.core.windows.net/","web":"https://bktestsa2.z20.web.core.windows.net/","blob":"https://bktestsa2.blob.core.windows.net/","queue":"https://bktestsa2.queue.core.windows.net/","table":"https://bktestsa2.table.core.windows.net/","file":"https://bktestsa2.file.core.windows.net/"},"primaryLocation":"eastus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rhel-test/providers/Microsoft.Storage/storageAccounts/rhel77acct","name":"rhel77acct","type":"Microsoft.Storage/storageAccounts","location":"eastus2","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-08-13T20:31:30.8995173Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-08-13T20:31:30.8995173Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-08-13T20:31:30.8215811Z","primaryEndpoints":{"blob":"https://rhel77acct.blob.core.windows.net/","queue":"https://rhel77acct.queue.core.windows.net/","table":"https://rhel77acct.table.core.windows.net/","file":"https://rhel77acct.file.core.windows.net/"},"primaryLocation":"eastus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SCRunner/providers/Microsoft.Storage/storageAccounts/scrunnerstorage","name":"scrunnerstorage","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-03-06T00:42:11.7016543Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-03-06T00:42:11.7016543Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2018-03-06T00:42:11.6234985Z","primaryEndpoints":{"blob":"https://scrunnerstorage.blob.core.windows.net/","queue":"https://scrunnerstorage.queue.core.windows.net/","table":"https://scrunnerstorage.table.core.windows.net/","file":"https://scrunnerstorage.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rhoover/providers/Microsoft.Storage/storageAccounts/rhooverstorage","name":"rhooverstorage","type":"Microsoft.Storage/storageAccounts","location":"southcentralus","tags":{"ms-resource-usage":"azure-cloud-shell"},"properties":{"keyCreationTime":{"key1":"2022-05-26T17:14:23.5085026Z","key2":"2022-05-26T17:14:23.5085026Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-26T17:14:23.5241285Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-26T17:14:23.5241285Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-05-26T17:14:23.4147520Z","primaryEndpoints":{"dfs":"https://rhooverstorage.dfs.core.windows.net/","web":"https://rhooverstorage.z21.web.core.windows.net/","blob":"https://rhooverstorage.blob.core.windows.net/","queue":"https://rhooverstorage.queue.core.windows.net/","table":"https://rhooverstorage.table.core.windows.net/","file":"https://rhooverstorage.file.core.windows.net/"},"primaryLocation":"southcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SCRunnertestvmrg-AustraliaEast/providers/Microsoft.Storage/storageAccounts/scrunner4p3t72mzheluc","name":"scrunner4p3t72mzheluc","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{},"properties":{"keyCreationTime":{"key1":"2021-04-13T22:35:36.6210942Z","key2":"2021-04-13T22:35:36.6210942Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2021-04-13T22:35:36.6210942Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2021-04-13T22:35:36.6210942Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2021-04-13T22:35:36.5429508Z","primaryEndpoints":{"blob":"https://scrunner4p3t72mzheluc.blob.core.windows.net/","queue":"https://scrunner4p3t72mzheluc.queue.core.windows.net/","table":"https://scrunner4p3t72mzheluc.table.core.windows.net/","file":"https://scrunner4p3t72mzheluc.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnervmrg-australiaeast/providers/Microsoft.Storage/storageAccounts/scrunner56hymyctm4kw2","name":"scrunner56hymyctm4kw2","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{},"properties":{"keyCreationTime":{"key1":"2023-02-11T08:42:58.2414102Z","key2":"2023-02-11T08:42:58.2414102Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:42:59.3196006Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:42:59.3196006Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-02-11T08:42:58.1476588Z","primaryEndpoints":{"blob":"https://scrunner56hymyctm4kw2.blob.core.windows.net/","queue":"https://scrunner56hymyctm4kw2.queue.core.windows.net/","table":"https://scrunner56hymyctm4kw2.table.core.windows.net/","file":"https://scrunner56hymyctm4kw2.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002","name":"cli000002","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T15:00:46.5594874Z","key2":"2023-03-06T15:00:46.5594874Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T15:00:46.8094615Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T15:00:46.8094615Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T15:00:46.4501501Z","primaryEndpoints":{"blob":"https://cli000002.blob.core.windows.net/","queue":"https://cli000002.queue.core.windows.net/","table":"https://cli000002.table.core.windows.net/","file":"https://cli000002.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsolex4geueyy52iloaspyxz3rrqwxv2syvnkjiljxbv522buwxqpiljme/providers/Microsoft.Storage/storageAccounts/clipf6qz5nxegbgku5yqzkd2","name":"clipf6qz5nxegbgku5yqzkd2","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T07:45:44.7937561Z","key2":"2023-03-06T07:45:44.7937561Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:45:45.1687946Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:45:45.1687946Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T07:45:44.7000168Z","primaryEndpoints":{"blob":"https://clipf6qz5nxegbgku5yqzkd2.blob.core.windows.net/","queue":"https://clipf6qz5nxegbgku5yqzkd2.queue.core.windows.net/","table":"https://clipf6qz5nxegbgku5yqzkd2.table.core.windows.net/","file":"https://clipf6qz5nxegbgku5yqzkd2.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsoledcvrpndxic4emeqq5apwkns4qa5owpy4jn3b536ks35zdrmn7bl5k/providers/Microsoft.Storage/storageAccounts/cliwqnm2fo7pftnxlk7c734i","name":"cliwqnm2fo7pftnxlk7c734i","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T07:34:57.7461613Z","key2":"2023-03-06T07:34:57.7461613Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:34:57.9961851Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:34:57.9961851Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T07:34:57.6368148Z","primaryEndpoints":{"blob":"https://cliwqnm2fo7pftnxlk7c734i.blob.core.windows.net/","queue":"https://cliwqnm2fo7pftnxlk7c734i.queue.core.windows.net/","table":"https://cliwqnm2fo7pftnxlk7c734i.table.core.windows.net/","file":"https://cliwqnm2fo7pftnxlk7c734i.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guptar2/providers/Microsoft.Storage/storageAccounts/guptar2diagnosticsv1","name":"guptar2diagnosticsv1","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2022-04-05T17:21:41.8250582Z","key2":"2022-04-05T17:21:41.8250582Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:21:41.8250582Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:21:41.8250582Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-04-05T17:21:41.7313240Z","primaryEndpoints":{"blob":"https://guptar2diagnosticsv1.blob.core.windows.net/","queue":"https://guptar2diagnosticsv1.queue.core.windows.net/","table":"https://guptar2diagnosticsv1.table.core.windows.net/","file":"https://guptar2diagnosticsv1.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guptar2/providers/Microsoft.Storage/storageAccounts/guptar2diagnosticsv2","name":"guptar2diagnosticsv2","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-04-05T17:22:55.8411567Z","key2":"2022-04-05T17:22:55.8411567Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"resourceAccessRules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[{"value":"20.98.146.84","action":"Allow"},{"value":"20.83.222.102","action":"Allow"},{"value":"20.98.194.64","action":"Allow"},{"value":"20.69.5.162","action":"Allow"}],"defaultAction":"Deny"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:22:55.8411567Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:22:55.8411567Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-04-05T17:22:55.7318000Z","primaryEndpoints":{"dfs":"https://guptar2diagnosticsv2.dfs.core.windows.net/","web":"https://guptar2diagnosticsv2.z5.web.core.windows.net/","blob":"https://guptar2diagnosticsv2.blob.core.windows.net/","queue":"https://guptar2diagnosticsv2.queue.core.windows.net/","table":"https://guptar2diagnosticsv2.table.core.windows.net/","file":"https://guptar2diagnosticsv2.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sericonrp-trafficmanager/providers/Microsoft.Storage/storageAccounts/sericonrpdevtmstorage","name":"sericonrpdevtmstorage","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-11-30T19:15:41.5013570Z","key2":"2022-11-30T19:15:41.5013570Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-11-30T19:15:42.0638737Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-11-30T19:15:42.0638737Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-11-30T19:15:41.4075777Z","primaryEndpoints":{"dfs":"https://sericonrpdevtmstorage.dfs.core.windows.net/","web":"https://sericonrpdevtmstorage.z5.web.core.windows.net/","blob":"https://sericonrpdevtmstorage.blob.core.windows.net/","queue":"https://sericonrpdevtmstorage.queue.core.windows.net/","table":"https://sericonrpdevtmstorage.table.core.windows.net/","file":"https://sericonrpdevtmstorage.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available","secondaryLocation":"westcentralus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://sericonrpdevtmstorage-secondary.dfs.core.windows.net/","web":"https://sericonrpdevtmstorage-secondary.z5.web.core.windows.net/","blob":"https://sericonrpdevtmstorage-secondary.blob.core.windows.net/","queue":"https://sericonrpdevtmstorage-secondary.queue.core.windows.net/","table":"https://sericonrpdevtmstorage-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ops/providers/Microsoft.Storage/storageAccounts/sericonstorage","name":"sericonstorage","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2023-03-05T19:58:00.4355863Z","key2":"2023-03-05T19:58:00.4355863Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-05T19:58:00.9824831Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-05T19:58:00.9824831Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2023-03-05T19:58:00.3262342Z","primaryEndpoints":{"dfs":"https://sericonstorage.dfs.core.windows.net/","web":"https://sericonstorage.z5.web.core.windows.net/","blob":"https://sericonstorage.blob.core.windows.net/","queue":"https://sericonstorage.queue.core.windows.net/","table":"https://sericonstorage.table.core.windows.net/","file":"https://sericonstorage.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rhoover-dev-rg/providers/Microsoft.Storage/storageAccounts/rhooverdevrgdiag","name":"rhooverdevrgdiag","type":"Microsoft.Storage/storageAccounts","location":"westcentralus","tags":{},"properties":{"defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-06-20T19:39:24.4605968Z","key2":"2022-06-20T19:39:24.4605968Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":false,"networkAcls":{"resourceAccessRules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[{"value":"20.98.146.84","action":"Allow"},{"value":"20.98.194.64","action":"Allow"},{"value":"20.69.5.162","action":"Allow"},{"value":"20.83.222.102","action":"Allow"},{"value":"76.197.206.105","action":"Allow"}],"defaultAction":"Deny"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-06-20T19:39:24.4762287Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-06-20T19:39:24.4762287Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-06-20T19:39:24.4137057Z","primaryEndpoints":{"blob":"https://rhooverdevrgdiag.blob.core.windows.net/","queue":"https://rhooverdevrgdiag.queue.core.windows.net/","table":"https://rhooverdevrgdiag.table.core.windows.net/","file":"https://rhooverdevrgdiag.file.core.windows.net/"},"primaryLocation":"westcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnervmrg-westcentralus/providers/Microsoft.Storage/storageAccounts/scrunneraoptpjec4skce","name":"scrunneraoptpjec4skce","type":"Microsoft.Storage/storageAccounts","location":"westcentralus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-02-11T08:40:40.0686467Z","key2":"2023-02-11T08:40:40.0686467Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:40:40.5842822Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:40:40.5842822Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-02-11T08:40:40.0061730Z","primaryEndpoints":{"blob":"https://scrunneraoptpjec4skce.blob.core.windows.net/","queue":"https://scrunneraoptpjec4skce.queue.core.windows.net/","table":"https://scrunneraoptpjec4skce.table.core.windows.net/","file":"https://scrunneraoptpjec4skce.file.core.windows.net/"},"primaryLocation":"westcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnertestvmrg-westcentralus/providers/Microsoft.Storage/storageAccounts/scrunnerrfscmqxeni3uq","name":"scrunnerrfscmqxeni3uq","type":"Microsoft.Storage/storageAccounts","location":"westcentralus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-04-10T22:28:55.2104910Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-04-10T22:28:55.2104910Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-04-10T22:28:55.1479670Z","primaryEndpoints":{"blob":"https://scrunnerrfscmqxeni3uq.blob.core.windows.net/","queue":"https://scrunnerrfscmqxeni3uq.queue.core.windows.net/","table":"https://scrunnerrfscmqxeni3uq.table.core.windows.net/","file":"https://scrunnerrfscmqxeni3uq.file.core.windows.net/"},"primaryLocation":"westcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ubuntu-westus3_group/providers/Microsoft.Storage/storageAccounts/ubuntuwestus3groupdiag","name":"ubuntuwestus3groupdiag","type":"Microsoft.Storage/storageAccounts","location":"westus3","tags":{},"properties":{"keyCreationTime":{"key1":"2022-04-18T19:48:38.9882588Z","key2":"2022-04-18T19:48:38.9882588Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-18T19:48:38.9882588Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-18T19:48:38.9882588Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-04-18T19:48:38.9258191Z","primaryEndpoints":{"blob":"https://ubuntuwestus3groupdiag.blob.core.windows.net/","queue":"https://ubuntuwestus3groupdiag.queue.core.windows.net/","table":"https://ubuntuwestus3groupdiag.table.core.windows.net/","file":"https://ubuntuwestus3groupdiag.file.core.windows.net/"},"primaryLocation":"westus3","statusOfPrimary":"available"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '38475'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 06 Mar 2023 15:11:08 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-original-request-ids:
+      - e534d969-01f6-4b37-b929-404197a0d261
+      - a0c1fb6a-1139-48e5-bcc4-288bfda9250b
+      - 89fb819a-0f6c-438f-ae97-a580e1294ccd
+      - 06862b97-4ac8-4a3a-8c5d-396871f77926
+      - 34e99496-313a-412a-8f63-25aa34f25d2e
+      - 7521cb9a-4487-4caa-8fd1-862898df554c
+      - 9fe39fba-e556-4e9c-9b1d-d5d7f376d1ad
+      - a957de0f-1cb3-4aa5-97d4-a8f1afdc25b1
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - serial-console disable
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002","name":"cli000002","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2022-12-13T22:57:52.2717456Z","key2":"2022-12-13T22:57:52.2717456Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-12-13T22:57:52.7873645Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-12-13T22:57:52.7873645Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-12-13T22:57:52.1623506Z","primaryEndpoints":{"blob":"https://cli000002.blob.core.windows.net/","queue":"https://cli000002.queue.core.windows.net/","table":"https://cli000002.table.core.windows.net/","file":"https://cli000002.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002","name":"cli000002","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T15:00:46.5594874Z","key2":"2023-03-06T15:00:46.5594874Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T15:00:46.8094615Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T15:00:46.8094615Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T15:00:46.4501501Z","primaryEndpoints":{"blob":"https://cli000002.blob.core.windows.net/","queue":"https://cli000002.queue.core.windows.net/","table":"https://cli000002.table.core.windows.net/","file":"https://cli000002.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -4275,7 +4203,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 13 Dec 2022 23:06:27 GMT
+      - Mon, 06 Mar 2023 15:11:09 GMT
       expires:
       - '-1'
       pragma:
@@ -4305,8 +4233,8 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
-        (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.SerialConsole/consoleServices/default?api-version=2018-05-01
   response:
@@ -4320,7 +4248,7 @@ interactions:
       content-type:
       - application/json; charset=UTF-8
       date:
-      - Tue, 13 Dec 2022 23:06:27 GMT
+      - Mon, 06 Mar 2023 15:11:09 GMT
       expires:
       - '-1'
       pragma:
@@ -4356,8 +4284,8 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
-        (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
+        (Windows-10-10.0.22621-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.SerialConsole/consoleServices/default/enableConsole?api-version=2018-05-01
   response:
@@ -4371,7 +4299,7 @@ interactions:
       content-type:
       - application/json; charset=UTF-8
       date:
-      - Tue, 13 Dec 2022 23:06:28 GMT
+      - Mon, 06 Mar 2023 15:11:09 GMT
       expires:
       - '-1'
       pragma:
@@ -4389,7 +4317,7 @@ interactions:
       x-frame-options:
       - deny
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
     status:
       code: 200
       message: OK
@@ -4405,21 +4333,21 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/2/instanceView?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/3/instanceView?api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"placementGroupId\": \"b12ec8ba-0f67-45f7-a5b3-5e94f2268933\",\r\n
+      string: "{\r\n  \"placementGroupId\": \"fe2728fc-c0cb-4cea-8d91-bb960a1e6c3b\",\r\n
         \ \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n  \"computerName\":
-        \"cli5o787e000002\",\r\n  \"osName\": \"ubuntu\",\r\n  \"osVersion\": \"18.04\",\r\n
+        \"cliuz26de000003\",\r\n  \"osName\": \"ubuntu\",\r\n  \"osVersion\": \"18.04\",\r\n
         \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"2.9.0.4\",\r\n    \"statuses\":
         [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\",\r\n        \"level\":
         \"Info\",\r\n        \"displayStatus\": \"Ready\",\r\n        \"message\":
-        \"Guest Agent is running\",\r\n        \"time\": \"2022-12-13T23:06:11+00:00\"\r\n
+        \"Guest Agent is running\",\r\n        \"time\": \"2023-03-06T15:10:46+00:00\"\r\n
         \     }\r\n    ],\r\n    \"extensionHandlers\": [\r\n      {\r\n        \"type\":
         \"Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n        \"typeHandlerVersion\":
-        \"1.24.2\",\r\n        \"status\": {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \"1.25.1\",\r\n        \"status\": {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Ready\",\r\n
         \         \"message\": \"Plugin enabled\"\r\n        }\r\n      },\r\n      {\r\n
         \       \"type\": \"Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent\",\r\n
@@ -4427,16 +4355,16 @@ interactions:
         \         \"code\": \"ProvisioningState/succeeded\",\r\n          \"level\":
         \"Info\",\r\n          \"displayStatus\": \"Ready\",\r\n          \"message\":
         \"Plugin enabled\"\r\n        }\r\n      }\r\n    ]\r\n  },\r\n  \"disks\":
-        [\r\n    {\r\n      \"name\": \"cli5oqyn2zpljvxqcitncli5oqyn2zpljvxqcitnmOS__1_fc2a2b19ddde4a019629d326a068caf5\",\r\n
+        [\r\n    {\r\n      \"name\": \"cliuztvtdw4jbve2omq7cliuztvtdw4jbve2omq73OS__1_023d79a2b12548fba5c6e457bd338d14\",\r\n
         \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2022-12-13T23:05:54.857998+00:00\"\r\n
+        succeeded\",\r\n          \"time\": \"2023-03-06T15:10:36.6255965+00:00\"\r\n
         \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
-        \"https://cli000002.blob.core.windows.net/bootdiagnostics-cli5oqyn2-a19f6f91-7994-467b-a23e-a6660ca2db24/cli000003_2.a19f6f91-7994-467b-a23e-a6660ca2db24.screenshot.bmp\",\r\n
-        \   \"serialConsoleLogBlobUri\": \"https://cli000002.blob.core.windows.net/bootdiagnostics-cli5oqyn2-a19f6f91-7994-467b-a23e-a6660ca2db24/cli000003_2.a19f6f91-7994-467b-a23e-a6660ca2db24.serialconsole.log\"\r\n
+        \"https://cli000002.blob.core.windows.net/bootdiagnostics-cliuztvtd-ffa83b08-9cdf-4ddd-8c22-38ec3747c4fa/cli000003_3.ffa83b08-9cdf-4ddd-8c22-38ec3747c4fa.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://cli000002.blob.core.windows.net/bootdiagnostics-cliuztvtd-ffa83b08-9cdf-4ddd-8c22-38ec3747c4fa/cli000003_3.ffa83b08-9cdf-4ddd-8c22-38ec3747c4fa.serialconsole.log\"\r\n
         \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n
         \     \"type\": \"Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n      \"typeHandlerVersion\":
-        \"1.24.2\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \"1.25.1\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
         succeeded\",\r\n          \"message\": \"Enable succeeded\"\r\n        }\r\n
         \     ]\r\n    },\r\n    {\r\n      \"name\": \"Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent\",\r\n
@@ -4448,18 +4376,18 @@ interactions:
         \   }\r\n  ],\r\n  \"hyperVGeneration\": \"V1\",\r\n  \"statuses\": [\r\n
         \   {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n      \"level\":
         \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n      \"time\":
-        \"2022-12-13T23:06:20.1078865+00:00\"\r\n    },\r\n    {\r\n      \"code\":
+        \"2023-03-06T15:10:40.7974713+00:00\"\r\n    },\r\n    {\r\n      \"code\":
         \"PowerState/running\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\":
         \"VM running\"\r\n    }\r\n  ]\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3218'
+      - '3219'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:06:28 GMT
+      - Mon, 06 Mar 2023 15:11:10 GMT
       expires:
       - '-1'
       pragma:
@@ -4476,7 +4404,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetVMScaleSetVM3Min;495,Microsoft.Compute/GetVMScaleSetVM30Min;2494,Microsoft.Compute/VMScaleSetVMViews3Min;4995
+      - Microsoft.Compute/GetVMScaleSetVM3Min;496,Microsoft.Compute/GetVMScaleSetVM30Min;2468,Microsoft.Compute/VMScaleSetVMViews3Min;4996
       x-ms-request-charge:
       - '1'
     status:
@@ -4494,12 +4422,61 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/storageAccounts?api-version=2022-09-01
+  response:
+    body:
+      string: '{"value":[{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloud-shell-storage-eastus/providers/Microsoft.Storage/storageAccounts/cs210032001f4814ba9","name":"cs210032001f4814ba9","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"ms-resource-usage":"azure-cloud-shell"},"properties":{"keyCreationTime":{"key1":"2022-05-16T14:16:22.3477819Z","key2":"2022-05-16T14:16:22.3477819Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-16T14:16:22.3477819Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-16T14:16:22.3477819Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-05-16T14:16:22.2227752Z","primaryEndpoints":{"dfs":"https://cs210032001f4814ba9.dfs.core.windows.net/","web":"https://cs210032001f4814ba9.z13.web.core.windows.net/","blob":"https://cs210032001f4814ba9.blob.core.windows.net/","queue":"https://cs210032001f4814ba9.queue.core.windows.net/","table":"https://cs210032001f4814ba9.table.core.windows.net/","file":"https://cs210032001f4814ba9.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/kustoflow/providers/Microsoft.Storage/storageAccounts/csslinuxkustoflow","name":"csslinuxkustoflow","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"CreatedBy":"craigw"},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-02-01T20:08:38.6849654Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-02-01T20:08:38.6849654Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2019-02-01T20:08:38.5912170Z","primaryEndpoints":{"dfs":"https://csslinuxkustoflow.dfs.core.windows.net/","web":"https://csslinuxkustoflow.z13.web.core.windows.net/","blob":"https://csslinuxkustoflow.blob.core.windows.net/","queue":"https://csslinuxkustoflow.queue.core.windows.net/","table":"https://csslinuxkustoflow.table.core.windows.net/","file":"https://csslinuxkustoflow.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://csslinuxkustoflow-secondary.dfs.core.windows.net/","web":"https://csslinuxkustoflow-secondary.z13.web.core.windows.net/","blob":"https://csslinuxkustoflow-secondary.blob.core.windows.net/","queue":"https://csslinuxkustoflow-secondary.queue.core.windows.net/","table":"https://csslinuxkustoflow-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guidomassonitest-rg/providers/Microsoft.Storage/storageAccounts/guidomassonitestrg88ad","name":"guidomassonitestrg88ad","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-01-23T18:52:02.5484088Z","key2":"2023-01-23T18:52:02.5484088Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-01-23T18:52:02.5484088Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-01-23T18:52:02.5484088Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-01-23T18:52:02.4077698Z","primaryEndpoints":{"blob":"https://guidomassonitestrg88ad.blob.core.windows.net/","queue":"https://guidomassonitestrg88ad.queue.core.windows.net/","table":"https://guidomassonitestrg88ad.table.core.windows.net/","file":"https://guidomassonitestrg88ad.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guidomtesttrafficmanagerrg/providers/Microsoft.Storage/storageAccounts/guidomteststoraccfortm","name":"guidomteststoraccfortm","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-10-18T18:01:13.5231266Z","key2":"2022-10-18T18:01:13.5231266Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-10-18T18:01:13.5387607Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-10-18T18:01:13.5387607Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-10-18T18:01:13.3825002Z","primaryEndpoints":{"dfs":"https://guidomteststoraccfortm.dfs.core.windows.net/","web":"https://guidomteststoraccfortm.z13.web.core.windows.net/","blob":"https://guidomteststoraccfortm.blob.core.windows.net/","queue":"https://guidomteststoraccfortm.queue.core.windows.net/","table":"https://guidomteststoraccfortm.table.core.windows.net/","file":"https://guidomteststoraccfortm.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://guidomteststoraccfortm-secondary.dfs.core.windows.net/","web":"https://guidomteststoraccfortm-secondary.z13.web.core.windows.net/","blob":"https://guidomteststoraccfortm-secondary.blob.core.windows.net/","queue":"https://guidomteststoraccfortm-secondary.queue.core.windows.net/","table":"https://guidomteststoraccfortm-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnertestvmrg-eastus/providers/Microsoft.Storage/storageAccounts/scrunnercrkwpdn5nhtgg","name":"scrunnercrkwpdn5nhtgg","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-05-12T20:03:57.6389684Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-05-12T20:03:57.6389684Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-05-12T20:03:57.5451905Z","primaryEndpoints":{"blob":"https://scrunnercrkwpdn5nhtgg.blob.core.windows.net/","queue":"https://scrunnercrkwpdn5nhtgg.queue.core.windows.net/","table":"https://scrunnercrkwpdn5nhtgg.table.core.windows.net/","file":"https://scrunnercrkwpdn5nhtgg.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnervmrg-eastus/providers/Microsoft.Storage/storageAccounts/scrunneri2ezqh4xu2wqq","name":"scrunneri2ezqh4xu2wqq","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-02-11T08:01:12.9383535Z","key2":"2023-02-11T08:01:12.9383535Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:01:12.9383535Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:01:12.9383535Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-02-11T08:01:12.6883669Z","primaryEndpoints":{"blob":"https://scrunneri2ezqh4xu2wqq.blob.core.windows.net/","queue":"https://scrunneri2ezqh4xu2wqq.queue.core.windows.net/","table":"https://scrunneri2ezqh4xu2wqq.table.core.windows.net/","file":"https://scrunneri2ezqh4xu2wqq.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/serialTest-EastUS/providers/Microsoft.Storage/storageAccounts/serialtesta8d7fdee41","name":"serialtesta8d7fdee41","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-07-11T00:38:13.5389932Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-07-11T00:38:13.5389932Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2019-07-11T00:38:13.4452119Z","primaryEndpoints":{"blob":"https://serialtesta8d7fdee41.blob.core.windows.net/","queue":"https://serialtesta8d7fdee41.queue.core.windows.net/","table":"https://serialtesta8d7fdee41.table.core.windows.net/","file":"https://serialtesta8d7fdee41.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/storage-RG/providers/Microsoft.Storage/storageAccounts/serialtestbootdiag123","name":"serialtestbootdiag123","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-01-23T04:03:01.3263151Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-01-23T04:03:01.3263151Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2018-01-23T04:03:01.2951106Z","primaryEndpoints":{"blob":"https://serialtestbootdiag123.blob.core.windows.net/","queue":"https://serialtestbootdiag123.queue.core.windows.net/","table":"https://serialtestbootdiag123.table.core.windows.net/","file":"https://serialtestbootdiag123.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yuas-rg/providers/Microsoft.Storage/storageAccounts/yuasstorageacct","name":"yuasstorageacct","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-08-02T12:18:18.8547131Z","key2":"2022-08-02T12:18:18.8547131Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-08-02T12:18:18.8547131Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-08-02T12:18:18.8547131Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-08-02T12:18:18.7140969Z","primaryEndpoints":{"dfs":"https://yuasstorageacct.dfs.core.windows.net/","web":"https://yuasstorageacct.z13.web.core.windows.net/","blob":"https://yuasstorageacct.blob.core.windows.net/","queue":"https://yuasstorageacct.queue.core.windows.net/","table":"https://yuasstorageacct.table.core.windows.net/","file":"https://yuasstorageacct.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://yuasstorageacct-secondary.dfs.core.windows.net/","web":"https://yuasstorageacct-secondary.z13.web.core.windows.net/","blob":"https://yuasstorageacct-secondary.blob.core.windows.net/","queue":"https://yuasstorageacct-secondary.queue.core.windows.net/","table":"https://yuasstorageacct-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/bkerrigan-dev-rg/providers/Microsoft.Storage/storageAccounts/bktestsa2","name":"bktestsa2","type":"Microsoft.Storage/storageAccounts","location":"eastus2","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","immutableStorageWithVersioning":{"enabled":true},"keyCreationTime":{"key1":"2022-09-27T23:58:45.6496284Z","key2":"2022-09-27T23:58:45.6496284Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-09-27T23:58:46.2902461Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-09-27T23:58:46.2902461Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Cool","provisioningState":"Succeeded","creationTime":"2022-09-27T23:58:45.5558609Z","primaryEndpoints":{"dfs":"https://bktestsa2.dfs.core.windows.net/","web":"https://bktestsa2.z20.web.core.windows.net/","blob":"https://bktestsa2.blob.core.windows.net/","queue":"https://bktestsa2.queue.core.windows.net/","table":"https://bktestsa2.table.core.windows.net/","file":"https://bktestsa2.file.core.windows.net/"},"primaryLocation":"eastus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rhel-test/providers/Microsoft.Storage/storageAccounts/rhel77acct","name":"rhel77acct","type":"Microsoft.Storage/storageAccounts","location":"eastus2","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-08-13T20:31:30.8995173Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-08-13T20:31:30.8995173Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-08-13T20:31:30.8215811Z","primaryEndpoints":{"blob":"https://rhel77acct.blob.core.windows.net/","queue":"https://rhel77acct.queue.core.windows.net/","table":"https://rhel77acct.table.core.windows.net/","file":"https://rhel77acct.file.core.windows.net/"},"primaryLocation":"eastus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SCRunner/providers/Microsoft.Storage/storageAccounts/scrunnerstorage","name":"scrunnerstorage","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-03-06T00:42:11.7016543Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-03-06T00:42:11.7016543Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2018-03-06T00:42:11.6234985Z","primaryEndpoints":{"blob":"https://scrunnerstorage.blob.core.windows.net/","queue":"https://scrunnerstorage.queue.core.windows.net/","table":"https://scrunnerstorage.table.core.windows.net/","file":"https://scrunnerstorage.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rhoover/providers/Microsoft.Storage/storageAccounts/rhooverstorage","name":"rhooverstorage","type":"Microsoft.Storage/storageAccounts","location":"southcentralus","tags":{"ms-resource-usage":"azure-cloud-shell"},"properties":{"keyCreationTime":{"key1":"2022-05-26T17:14:23.5085026Z","key2":"2022-05-26T17:14:23.5085026Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-26T17:14:23.5241285Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-26T17:14:23.5241285Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-05-26T17:14:23.4147520Z","primaryEndpoints":{"dfs":"https://rhooverstorage.dfs.core.windows.net/","web":"https://rhooverstorage.z21.web.core.windows.net/","blob":"https://rhooverstorage.blob.core.windows.net/","queue":"https://rhooverstorage.queue.core.windows.net/","table":"https://rhooverstorage.table.core.windows.net/","file":"https://rhooverstorage.file.core.windows.net/"},"primaryLocation":"southcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SCRunnertestvmrg-AustraliaEast/providers/Microsoft.Storage/storageAccounts/scrunner4p3t72mzheluc","name":"scrunner4p3t72mzheluc","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{},"properties":{"keyCreationTime":{"key1":"2021-04-13T22:35:36.6210942Z","key2":"2021-04-13T22:35:36.6210942Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2021-04-13T22:35:36.6210942Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2021-04-13T22:35:36.6210942Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2021-04-13T22:35:36.5429508Z","primaryEndpoints":{"blob":"https://scrunner4p3t72mzheluc.blob.core.windows.net/","queue":"https://scrunner4p3t72mzheluc.queue.core.windows.net/","table":"https://scrunner4p3t72mzheluc.table.core.windows.net/","file":"https://scrunner4p3t72mzheluc.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnervmrg-australiaeast/providers/Microsoft.Storage/storageAccounts/scrunner56hymyctm4kw2","name":"scrunner56hymyctm4kw2","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{},"properties":{"keyCreationTime":{"key1":"2023-02-11T08:42:58.2414102Z","key2":"2023-02-11T08:42:58.2414102Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:42:59.3196006Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:42:59.3196006Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-02-11T08:42:58.1476588Z","primaryEndpoints":{"blob":"https://scrunner56hymyctm4kw2.blob.core.windows.net/","queue":"https://scrunner56hymyctm4kw2.queue.core.windows.net/","table":"https://scrunner56hymyctm4kw2.table.core.windows.net/","file":"https://scrunner56hymyctm4kw2.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002","name":"cli000002","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T15:00:46.5594874Z","key2":"2023-03-06T15:00:46.5594874Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T15:00:46.8094615Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T15:00:46.8094615Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T15:00:46.4501501Z","primaryEndpoints":{"blob":"https://cli000002.blob.core.windows.net/","queue":"https://cli000002.queue.core.windows.net/","table":"https://cli000002.table.core.windows.net/","file":"https://cli000002.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsolex4geueyy52iloaspyxz3rrqwxv2syvnkjiljxbv522buwxqpiljme/providers/Microsoft.Storage/storageAccounts/clipf6qz5nxegbgku5yqzkd2","name":"clipf6qz5nxegbgku5yqzkd2","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T07:45:44.7937561Z","key2":"2023-03-06T07:45:44.7937561Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:45:45.1687946Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:45:45.1687946Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T07:45:44.7000168Z","primaryEndpoints":{"blob":"https://clipf6qz5nxegbgku5yqzkd2.blob.core.windows.net/","queue":"https://clipf6qz5nxegbgku5yqzkd2.queue.core.windows.net/","table":"https://clipf6qz5nxegbgku5yqzkd2.table.core.windows.net/","file":"https://clipf6qz5nxegbgku5yqzkd2.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsoledcvrpndxic4emeqq5apwkns4qa5owpy4jn3b536ks35zdrmn7bl5k/providers/Microsoft.Storage/storageAccounts/cliwqnm2fo7pftnxlk7c734i","name":"cliwqnm2fo7pftnxlk7c734i","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T07:34:57.7461613Z","key2":"2023-03-06T07:34:57.7461613Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:34:57.9961851Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:34:57.9961851Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T07:34:57.6368148Z","primaryEndpoints":{"blob":"https://cliwqnm2fo7pftnxlk7c734i.blob.core.windows.net/","queue":"https://cliwqnm2fo7pftnxlk7c734i.queue.core.windows.net/","table":"https://cliwqnm2fo7pftnxlk7c734i.table.core.windows.net/","file":"https://cliwqnm2fo7pftnxlk7c734i.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guptar2/providers/Microsoft.Storage/storageAccounts/guptar2diagnosticsv1","name":"guptar2diagnosticsv1","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2022-04-05T17:21:41.8250582Z","key2":"2022-04-05T17:21:41.8250582Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:21:41.8250582Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:21:41.8250582Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-04-05T17:21:41.7313240Z","primaryEndpoints":{"blob":"https://guptar2diagnosticsv1.blob.core.windows.net/","queue":"https://guptar2diagnosticsv1.queue.core.windows.net/","table":"https://guptar2diagnosticsv1.table.core.windows.net/","file":"https://guptar2diagnosticsv1.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guptar2/providers/Microsoft.Storage/storageAccounts/guptar2diagnosticsv2","name":"guptar2diagnosticsv2","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-04-05T17:22:55.8411567Z","key2":"2022-04-05T17:22:55.8411567Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"resourceAccessRules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[{"value":"20.98.146.84","action":"Allow"},{"value":"20.83.222.102","action":"Allow"},{"value":"20.98.194.64","action":"Allow"},{"value":"20.69.5.162","action":"Allow"}],"defaultAction":"Deny"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:22:55.8411567Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:22:55.8411567Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-04-05T17:22:55.7318000Z","primaryEndpoints":{"dfs":"https://guptar2diagnosticsv2.dfs.core.windows.net/","web":"https://guptar2diagnosticsv2.z5.web.core.windows.net/","blob":"https://guptar2diagnosticsv2.blob.core.windows.net/","queue":"https://guptar2diagnosticsv2.queue.core.windows.net/","table":"https://guptar2diagnosticsv2.table.core.windows.net/","file":"https://guptar2diagnosticsv2.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sericonrp-trafficmanager/providers/Microsoft.Storage/storageAccounts/sericonrpdevtmstorage","name":"sericonrpdevtmstorage","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-11-30T19:15:41.5013570Z","key2":"2022-11-30T19:15:41.5013570Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-11-30T19:15:42.0638737Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-11-30T19:15:42.0638737Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-11-30T19:15:41.4075777Z","primaryEndpoints":{"dfs":"https://sericonrpdevtmstorage.dfs.core.windows.net/","web":"https://sericonrpdevtmstorage.z5.web.core.windows.net/","blob":"https://sericonrpdevtmstorage.blob.core.windows.net/","queue":"https://sericonrpdevtmstorage.queue.core.windows.net/","table":"https://sericonrpdevtmstorage.table.core.windows.net/","file":"https://sericonrpdevtmstorage.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available","secondaryLocation":"westcentralus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://sericonrpdevtmstorage-secondary.dfs.core.windows.net/","web":"https://sericonrpdevtmstorage-secondary.z5.web.core.windows.net/","blob":"https://sericonrpdevtmstorage-secondary.blob.core.windows.net/","queue":"https://sericonrpdevtmstorage-secondary.queue.core.windows.net/","table":"https://sericonrpdevtmstorage-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ops/providers/Microsoft.Storage/storageAccounts/sericonstorage","name":"sericonstorage","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2023-03-05T19:58:00.4355863Z","key2":"2023-03-05T19:58:00.4355863Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-05T19:58:00.9824831Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-05T19:58:00.9824831Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2023-03-05T19:58:00.3262342Z","primaryEndpoints":{"dfs":"https://sericonstorage.dfs.core.windows.net/","web":"https://sericonstorage.z5.web.core.windows.net/","blob":"https://sericonstorage.blob.core.windows.net/","queue":"https://sericonstorage.queue.core.windows.net/","table":"https://sericonstorage.table.core.windows.net/","file":"https://sericonstorage.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rhoover-dev-rg/providers/Microsoft.Storage/storageAccounts/rhooverdevrgdiag","name":"rhooverdevrgdiag","type":"Microsoft.Storage/storageAccounts","location":"westcentralus","tags":{},"properties":{"defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-06-20T19:39:24.4605968Z","key2":"2022-06-20T19:39:24.4605968Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":false,"networkAcls":{"resourceAccessRules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[{"value":"20.98.146.84","action":"Allow"},{"value":"20.98.194.64","action":"Allow"},{"value":"20.69.5.162","action":"Allow"},{"value":"20.83.222.102","action":"Allow"},{"value":"76.197.206.105","action":"Allow"}],"defaultAction":"Deny"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-06-20T19:39:24.4762287Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-06-20T19:39:24.4762287Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-06-20T19:39:24.4137057Z","primaryEndpoints":{"blob":"https://rhooverdevrgdiag.blob.core.windows.net/","queue":"https://rhooverdevrgdiag.queue.core.windows.net/","table":"https://rhooverdevrgdiag.table.core.windows.net/","file":"https://rhooverdevrgdiag.file.core.windows.net/"},"primaryLocation":"westcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnervmrg-westcentralus/providers/Microsoft.Storage/storageAccounts/scrunneraoptpjec4skce","name":"scrunneraoptpjec4skce","type":"Microsoft.Storage/storageAccounts","location":"westcentralus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-02-11T08:40:40.0686467Z","key2":"2023-02-11T08:40:40.0686467Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:40:40.5842822Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:40:40.5842822Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-02-11T08:40:40.0061730Z","primaryEndpoints":{"blob":"https://scrunneraoptpjec4skce.blob.core.windows.net/","queue":"https://scrunneraoptpjec4skce.queue.core.windows.net/","table":"https://scrunneraoptpjec4skce.table.core.windows.net/","file":"https://scrunneraoptpjec4skce.file.core.windows.net/"},"primaryLocation":"westcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnertestvmrg-westcentralus/providers/Microsoft.Storage/storageAccounts/scrunnerrfscmqxeni3uq","name":"scrunnerrfscmqxeni3uq","type":"Microsoft.Storage/storageAccounts","location":"westcentralus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-04-10T22:28:55.2104910Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-04-10T22:28:55.2104910Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-04-10T22:28:55.1479670Z","primaryEndpoints":{"blob":"https://scrunnerrfscmqxeni3uq.blob.core.windows.net/","queue":"https://scrunnerrfscmqxeni3uq.queue.core.windows.net/","table":"https://scrunnerrfscmqxeni3uq.table.core.windows.net/","file":"https://scrunnerrfscmqxeni3uq.file.core.windows.net/"},"primaryLocation":"westcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ubuntu-westus3_group/providers/Microsoft.Storage/storageAccounts/ubuntuwestus3groupdiag","name":"ubuntuwestus3groupdiag","type":"Microsoft.Storage/storageAccounts","location":"westus3","tags":{},"properties":{"keyCreationTime":{"key1":"2022-04-18T19:48:38.9882588Z","key2":"2022-04-18T19:48:38.9882588Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-18T19:48:38.9882588Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-18T19:48:38.9882588Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-04-18T19:48:38.9258191Z","primaryEndpoints":{"blob":"https://ubuntuwestus3groupdiag.blob.core.windows.net/","queue":"https://ubuntuwestus3groupdiag.queue.core.windows.net/","table":"https://ubuntuwestus3groupdiag.table.core.windows.net/","file":"https://ubuntuwestus3groupdiag.file.core.windows.net/"},"primaryLocation":"westus3","statusOfPrimary":"available"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '38475'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 06 Mar 2023 15:11:10 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-original-request-ids:
+      - bcee3351-8a9a-427a-9e82-6ae0f37add31
+      - 1c3d1b87-be4b-42c2-bfeb-cb93eca0887a
+      - 8639d47d-ffa1-4f34-b0f9-ca4687462735
+      - 9c61e80b-3127-4e45-a0ad-6b4642149408
+      - a444ae45-31bd-4c69-8b29-a42b075429e5
+      - 157af87b-466c-4db3-90d9-1d499d49566a
+      - 0f7f16c1-0c20-490d-b411-7f888c11342a
+      - 25cc4a3d-88c3-4c8a-8ecf-f6c65dab021a
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - serial-console enable
+      Connection:
+      - keep-alive
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002","name":"cli000002","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2022-12-13T22:57:52.2717456Z","key2":"2022-12-13T22:57:52.2717456Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-12-13T22:57:52.7873645Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-12-13T22:57:52.7873645Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-12-13T22:57:52.1623506Z","primaryEndpoints":{"blob":"https://cli000002.blob.core.windows.net/","queue":"https://cli000002.queue.core.windows.net/","table":"https://cli000002.table.core.windows.net/","file":"https://cli000002.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002","name":"cli000002","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T15:00:46.5594874Z","key2":"2023-03-06T15:00:46.5594874Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T15:00:46.8094615Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T15:00:46.8094615Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T15:00:46.4501501Z","primaryEndpoints":{"blob":"https://cli000002.blob.core.windows.net/","queue":"https://cli000002.queue.core.windows.net/","table":"https://cli000002.table.core.windows.net/","file":"https://cli000002.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -4508,7 +4485,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 13 Dec 2022 23:06:28 GMT
+      - Mon, 06 Mar 2023 15:11:10 GMT
       expires:
       - '-1'
       pragma:
@@ -4538,8 +4515,8 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
-        (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.SerialConsole/consoleServices/default?api-version=2018-05-01
   response:
@@ -4553,7 +4530,7 @@ interactions:
       content-type:
       - application/json; charset=UTF-8
       date:
-      - Tue, 13 Dec 2022 23:06:29 GMT
+      - Mon, 06 Mar 2023 15:11:11 GMT
       expires:
       - '-1'
       pragma:
@@ -4589,9 +4566,9 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/2/deallocate?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/3/deallocate?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -4599,17 +4576,17 @@ interactions:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/7c7f9155-b9be-4ed6-af07-50864a036960?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/bd3044a4-76e2-46c0-b7cf-30f426c45ea2?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Tue, 13 Dec 2022 23:06:30 GMT
+      - Mon, 06 Mar 2023 15:11:12 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/7c7f9155-b9be-4ed6-af07-50864a036960?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/bd3044a4-76e2-46c0-b7cf-30f426c45ea2?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-11-01
       pragma:
       - no-cache
       server:
@@ -4620,9 +4597,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/DeleteVMScaleSetVM3Min;239,Microsoft.Compute/DeleteVMScaleSetVM30Min;1198,Microsoft.Compute/VMScaleSetBatchedVMRequests5Min;3019,Microsoft.Compute/VmssQueuedVMOperations;0
+      - Microsoft.Compute/DeleteVMScaleSetVM3Min;239,Microsoft.Compute/DeleteVMScaleSetVM30Min;1196,Microsoft.Compute/VMScaleSetBatchedVMRequests5Min;3044,Microsoft.Compute/VmssQueuedVMOperations;0
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
       x-ms-request-charge:
       - '1'
     status:
@@ -4642,13 +4619,13 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/7c7f9155-b9be-4ed6-af07-50864a036960?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/bd3044a4-76e2-46c0-b7cf-30f426c45ea2?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:06:30.7172207+00:00\",\r\n  \"status\":
-        \"InProgress\",\r\n  \"name\": \"7c7f9155-b9be-4ed6-af07-50864a036960\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T15:11:12.4535958+00:00\",\r\n  \"status\":
+        \"InProgress\",\r\n  \"name\": \"bd3044a4-76e2-46c0-b7cf-30f426c45ea2\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -4657,7 +4634,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:06:30 GMT
+      - Mon, 06 Mar 2023 15:11:42 GMT
       expires:
       - '-1'
       pragma:
@@ -4674,7 +4651,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14979,Microsoft.Compute/GetOperation30Min;29911
+      - Microsoft.Compute/GetOperation3Min;14980,Microsoft.Compute/GetOperation30Min;29761
     status:
       code: 200
       message: OK
@@ -4692,13 +4669,13 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/7c7f9155-b9be-4ed6-af07-50864a036960?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/bd3044a4-76e2-46c0-b7cf-30f426c45ea2?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:06:30.7172207+00:00\",\r\n  \"status\":
-        \"InProgress\",\r\n  \"name\": \"7c7f9155-b9be-4ed6-af07-50864a036960\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T15:11:12.4535958+00:00\",\r\n  \"status\":
+        \"InProgress\",\r\n  \"name\": \"bd3044a4-76e2-46c0-b7cf-30f426c45ea2\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -4707,7 +4684,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:07:00 GMT
+      - Mon, 06 Mar 2023 15:12:11 GMT
       expires:
       - '-1'
       pragma:
@@ -4724,7 +4701,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14978,Microsoft.Compute/GetOperation30Min;29908
+      - Microsoft.Compute/GetOperation3Min;14983,Microsoft.Compute/GetOperation30Min;29760
     status:
       code: 200
       message: OK
@@ -4742,13 +4719,13 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/7c7f9155-b9be-4ed6-af07-50864a036960?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/bd3044a4-76e2-46c0-b7cf-30f426c45ea2?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:06:30.7172207+00:00\",\r\n  \"status\":
-        \"InProgress\",\r\n  \"name\": \"7c7f9155-b9be-4ed6-af07-50864a036960\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T15:11:12.4535958+00:00\",\r\n  \"status\":
+        \"InProgress\",\r\n  \"name\": \"bd3044a4-76e2-46c0-b7cf-30f426c45ea2\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -4757,7 +4734,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:07:31 GMT
+      - Mon, 06 Mar 2023 15:12:41 GMT
       expires:
       - '-1'
       pragma:
@@ -4774,7 +4751,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14982,Microsoft.Compute/GetOperation30Min;29907
+      - Microsoft.Compute/GetOperation3Min;14986,Microsoft.Compute/GetOperation30Min;29758
     status:
       code: 200
       message: OK
@@ -4792,13 +4769,13 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/7c7f9155-b9be-4ed6-af07-50864a036960?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/bd3044a4-76e2-46c0-b7cf-30f426c45ea2?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:06:30.7172207+00:00\",\r\n  \"status\":
-        \"InProgress\",\r\n  \"name\": \"7c7f9155-b9be-4ed6-af07-50864a036960\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T15:11:12.4535958+00:00\",\r\n  \"status\":
+        \"InProgress\",\r\n  \"name\": \"bd3044a4-76e2-46c0-b7cf-30f426c45ea2\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -4807,7 +4784,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:08:00 GMT
+      - Mon, 06 Mar 2023 15:13:12 GMT
       expires:
       - '-1'
       pragma:
@@ -4824,7 +4801,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14985,Microsoft.Compute/GetOperation30Min;29905
+      - Microsoft.Compute/GetOperation3Min;14988,Microsoft.Compute/GetOperation30Min;29757
     status:
       code: 200
       message: OK
@@ -4842,64 +4819,14 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/7c7f9155-b9be-4ed6-af07-50864a036960?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/bd3044a4-76e2-46c0-b7cf-30f426c45ea2?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:06:30.7172207+00:00\",\r\n  \"status\":
-        \"InProgress\",\r\n  \"name\": \"7c7f9155-b9be-4ed6-af07-50864a036960\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '134'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 13 Dec 2022 23:08:30 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14988,Microsoft.Compute/GetOperation30Min;29904
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vmss deallocate
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --instance-ids
-      User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/7c7f9155-b9be-4ed6-af07-50864a036960?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
-  response:
-    body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:06:30.7172207+00:00\",\r\n  \"endTime\":
-        \"2022-12-13T23:08:52.8570482+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"name\": \"7c7f9155-b9be-4ed6-af07-50864a036960\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T15:11:12.4535958+00:00\",\r\n  \"endTime\":
+        \"2023-03-06T15:13:41.9062266+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"name\": \"bd3044a4-76e2-46c0-b7cf-30f426c45ea2\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -4908,7 +4835,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:09:00 GMT
+      - Mon, 06 Mar 2023 15:13:42 GMT
       expires:
       - '-1'
       pragma:
@@ -4925,7 +4852,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14989,Microsoft.Compute/GetOperation30Min;29901
+      - Microsoft.Compute/GetOperation3Min;14988,Microsoft.Compute/GetOperation30Min;29755
     status:
       code: 200
       message: OK
@@ -4943,9 +4870,9 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/7c7f9155-b9be-4ed6-af07-50864a036960?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/bd3044a4-76e2-46c0-b7cf-30f426c45ea2?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-11-01
   response:
     body:
       string: ''
@@ -4955,7 +4882,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 13 Dec 2022 23:09:00 GMT
+      - Mon, 06 Mar 2023 15:13:43 GMT
       expires:
       - '-1'
       pragma:
@@ -4968,7 +4895,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14988,Microsoft.Compute/GetOperation30Min;29900
+      - Microsoft.Compute/GetOperation3Min;14986,Microsoft.Compute/GetOperation30Min;29753
     status:
       code: 200
       message: OK
@@ -4986,23 +4913,23 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/2/instanceView?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/3/instanceView?api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"placementGroupId\": \"b12ec8ba-0f67-45f7-a5b3-5e94f2268933\",\r\n
+      string: "{\r\n  \"placementGroupId\": \"fe2728fc-c0cb-4cea-8d91-bb960a1e6c3b\",\r\n
         \ \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n  \"disks\":
-        [\r\n    {\r\n      \"name\": \"cli5oqyn2zpljvxqcitncli5oqyn2zpljvxqcitnmOS__1_fc2a2b19ddde4a019629d326a068caf5\",\r\n
+        [\r\n    {\r\n      \"name\": \"cliuztvtdw4jbve2omq7cliuztvtdw4jbve2omq73OS__1_023d79a2b12548fba5c6e457bd338d14\",\r\n
         \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2022-12-13T23:08:52.7945412+00:00\"\r\n
+        succeeded\",\r\n          \"time\": \"2023-03-06T15:13:41.8280786+00:00\"\r\n
         \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
-        \"https://cli000002.blob.core.windows.net/bootdiagnostics-cli5oqyn2-a19f6f91-7994-467b-a23e-a6660ca2db24/cli000003_2.a19f6f91-7994-467b-a23e-a6660ca2db24.screenshot.bmp\",\r\n
-        \   \"serialConsoleLogBlobUri\": \"https://cli000002.blob.core.windows.net/bootdiagnostics-cli5oqyn2-a19f6f91-7994-467b-a23e-a6660ca2db24/cli000003_2.a19f6f91-7994-467b-a23e-a6660ca2db24.serialconsole.log\"\r\n
+        \"https://cli000002.blob.core.windows.net/bootdiagnostics-cliuztvtd-ffa83b08-9cdf-4ddd-8c22-38ec3747c4fa/cli000003_3.ffa83b08-9cdf-4ddd-8c22-38ec3747c4fa.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://cli000002.blob.core.windows.net/bootdiagnostics-cliuztvtd-ffa83b08-9cdf-4ddd-8c22-38ec3747c4fa/cli000003_3.ffa83b08-9cdf-4ddd-8c22-38ec3747c4fa.serialconsole.log\"\r\n
         \ },\r\n  \"hyperVGeneration\": \"V1\",\r\n  \"statuses\": [\r\n    {\r\n
         \     \"code\": \"ProvisioningState/succeeded\",\r\n      \"level\": \"Info\",\r\n
-        \     \"displayStatus\": \"Provisioning succeeded\",\r\n      \"time\": \"2022-12-13T23:08:52.8257976+00:00\"\r\n
+        \     \"displayStatus\": \"Provisioning succeeded\",\r\n      \"time\": \"2023-03-06T15:13:41.8593743+00:00\"\r\n
         \   },\r\n    {\r\n      \"code\": \"PowerState/deallocated\",\r\n      \"level\":
         \"Info\",\r\n      \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
     headers:
@@ -5013,7 +4940,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:09:02 GMT
+      - Mon, 06 Mar 2023 15:13:43 GMT
       expires:
       - '-1'
       pragma:
@@ -5030,7 +4957,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetVMScaleSetVM3Min;499,Microsoft.Compute/GetVMScaleSetVM30Min;2493,Microsoft.Compute/VMScaleSetVMViews3Min;4999
+      - Microsoft.Compute/GetVMScaleSetVM3Min;496,Microsoft.Compute/GetVMScaleSetVM30Min;2467,Microsoft.Compute/VMScaleSetVMViews3Min;4996
       x-ms-request-charge:
       - '1'
     status:
@@ -5050,12 +4977,63 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/storageAccounts?api-version=2022-09-01
+  response:
+    body:
+      string: '{"value":[{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloud-shell-storage-eastus/providers/Microsoft.Storage/storageAccounts/cs210032001f4814ba9","name":"cs210032001f4814ba9","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"ms-resource-usage":"azure-cloud-shell"},"properties":{"keyCreationTime":{"key1":"2022-05-16T14:16:22.3477819Z","key2":"2022-05-16T14:16:22.3477819Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-16T14:16:22.3477819Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-16T14:16:22.3477819Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-05-16T14:16:22.2227752Z","primaryEndpoints":{"dfs":"https://cs210032001f4814ba9.dfs.core.windows.net/","web":"https://cs210032001f4814ba9.z13.web.core.windows.net/","blob":"https://cs210032001f4814ba9.blob.core.windows.net/","queue":"https://cs210032001f4814ba9.queue.core.windows.net/","table":"https://cs210032001f4814ba9.table.core.windows.net/","file":"https://cs210032001f4814ba9.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/kustoflow/providers/Microsoft.Storage/storageAccounts/csslinuxkustoflow","name":"csslinuxkustoflow","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"CreatedBy":"craigw"},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-02-01T20:08:38.6849654Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-02-01T20:08:38.6849654Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2019-02-01T20:08:38.5912170Z","primaryEndpoints":{"dfs":"https://csslinuxkustoflow.dfs.core.windows.net/","web":"https://csslinuxkustoflow.z13.web.core.windows.net/","blob":"https://csslinuxkustoflow.blob.core.windows.net/","queue":"https://csslinuxkustoflow.queue.core.windows.net/","table":"https://csslinuxkustoflow.table.core.windows.net/","file":"https://csslinuxkustoflow.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://csslinuxkustoflow-secondary.dfs.core.windows.net/","web":"https://csslinuxkustoflow-secondary.z13.web.core.windows.net/","blob":"https://csslinuxkustoflow-secondary.blob.core.windows.net/","queue":"https://csslinuxkustoflow-secondary.queue.core.windows.net/","table":"https://csslinuxkustoflow-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guidomassonitest-rg/providers/Microsoft.Storage/storageAccounts/guidomassonitestrg88ad","name":"guidomassonitestrg88ad","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-01-23T18:52:02.5484088Z","key2":"2023-01-23T18:52:02.5484088Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-01-23T18:52:02.5484088Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-01-23T18:52:02.5484088Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-01-23T18:52:02.4077698Z","primaryEndpoints":{"blob":"https://guidomassonitestrg88ad.blob.core.windows.net/","queue":"https://guidomassonitestrg88ad.queue.core.windows.net/","table":"https://guidomassonitestrg88ad.table.core.windows.net/","file":"https://guidomassonitestrg88ad.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guidomtesttrafficmanagerrg/providers/Microsoft.Storage/storageAccounts/guidomteststoraccfortm","name":"guidomteststoraccfortm","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-10-18T18:01:13.5231266Z","key2":"2022-10-18T18:01:13.5231266Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-10-18T18:01:13.5387607Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-10-18T18:01:13.5387607Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-10-18T18:01:13.3825002Z","primaryEndpoints":{"dfs":"https://guidomteststoraccfortm.dfs.core.windows.net/","web":"https://guidomteststoraccfortm.z13.web.core.windows.net/","blob":"https://guidomteststoraccfortm.blob.core.windows.net/","queue":"https://guidomteststoraccfortm.queue.core.windows.net/","table":"https://guidomteststoraccfortm.table.core.windows.net/","file":"https://guidomteststoraccfortm.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://guidomteststoraccfortm-secondary.dfs.core.windows.net/","web":"https://guidomteststoraccfortm-secondary.z13.web.core.windows.net/","blob":"https://guidomteststoraccfortm-secondary.blob.core.windows.net/","queue":"https://guidomteststoraccfortm-secondary.queue.core.windows.net/","table":"https://guidomteststoraccfortm-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnertestvmrg-eastus/providers/Microsoft.Storage/storageAccounts/scrunnercrkwpdn5nhtgg","name":"scrunnercrkwpdn5nhtgg","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-05-12T20:03:57.6389684Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-05-12T20:03:57.6389684Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-05-12T20:03:57.5451905Z","primaryEndpoints":{"blob":"https://scrunnercrkwpdn5nhtgg.blob.core.windows.net/","queue":"https://scrunnercrkwpdn5nhtgg.queue.core.windows.net/","table":"https://scrunnercrkwpdn5nhtgg.table.core.windows.net/","file":"https://scrunnercrkwpdn5nhtgg.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnervmrg-eastus/providers/Microsoft.Storage/storageAccounts/scrunneri2ezqh4xu2wqq","name":"scrunneri2ezqh4xu2wqq","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-02-11T08:01:12.9383535Z","key2":"2023-02-11T08:01:12.9383535Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:01:12.9383535Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:01:12.9383535Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-02-11T08:01:12.6883669Z","primaryEndpoints":{"blob":"https://scrunneri2ezqh4xu2wqq.blob.core.windows.net/","queue":"https://scrunneri2ezqh4xu2wqq.queue.core.windows.net/","table":"https://scrunneri2ezqh4xu2wqq.table.core.windows.net/","file":"https://scrunneri2ezqh4xu2wqq.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/serialTest-EastUS/providers/Microsoft.Storage/storageAccounts/serialtesta8d7fdee41","name":"serialtesta8d7fdee41","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-07-11T00:38:13.5389932Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-07-11T00:38:13.5389932Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2019-07-11T00:38:13.4452119Z","primaryEndpoints":{"blob":"https://serialtesta8d7fdee41.blob.core.windows.net/","queue":"https://serialtesta8d7fdee41.queue.core.windows.net/","table":"https://serialtesta8d7fdee41.table.core.windows.net/","file":"https://serialtesta8d7fdee41.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/storage-RG/providers/Microsoft.Storage/storageAccounts/serialtestbootdiag123","name":"serialtestbootdiag123","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-01-23T04:03:01.3263151Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-01-23T04:03:01.3263151Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2018-01-23T04:03:01.2951106Z","primaryEndpoints":{"blob":"https://serialtestbootdiag123.blob.core.windows.net/","queue":"https://serialtestbootdiag123.queue.core.windows.net/","table":"https://serialtestbootdiag123.table.core.windows.net/","file":"https://serialtestbootdiag123.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yuas-rg/providers/Microsoft.Storage/storageAccounts/yuasstorageacct","name":"yuasstorageacct","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-08-02T12:18:18.8547131Z","key2":"2022-08-02T12:18:18.8547131Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-08-02T12:18:18.8547131Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-08-02T12:18:18.8547131Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-08-02T12:18:18.7140969Z","primaryEndpoints":{"dfs":"https://yuasstorageacct.dfs.core.windows.net/","web":"https://yuasstorageacct.z13.web.core.windows.net/","blob":"https://yuasstorageacct.blob.core.windows.net/","queue":"https://yuasstorageacct.queue.core.windows.net/","table":"https://yuasstorageacct.table.core.windows.net/","file":"https://yuasstorageacct.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://yuasstorageacct-secondary.dfs.core.windows.net/","web":"https://yuasstorageacct-secondary.z13.web.core.windows.net/","blob":"https://yuasstorageacct-secondary.blob.core.windows.net/","queue":"https://yuasstorageacct-secondary.queue.core.windows.net/","table":"https://yuasstorageacct-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/bkerrigan-dev-rg/providers/Microsoft.Storage/storageAccounts/bktestsa2","name":"bktestsa2","type":"Microsoft.Storage/storageAccounts","location":"eastus2","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","immutableStorageWithVersioning":{"enabled":true},"keyCreationTime":{"key1":"2022-09-27T23:58:45.6496284Z","key2":"2022-09-27T23:58:45.6496284Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-09-27T23:58:46.2902461Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-09-27T23:58:46.2902461Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Cool","provisioningState":"Succeeded","creationTime":"2022-09-27T23:58:45.5558609Z","primaryEndpoints":{"dfs":"https://bktestsa2.dfs.core.windows.net/","web":"https://bktestsa2.z20.web.core.windows.net/","blob":"https://bktestsa2.blob.core.windows.net/","queue":"https://bktestsa2.queue.core.windows.net/","table":"https://bktestsa2.table.core.windows.net/","file":"https://bktestsa2.file.core.windows.net/"},"primaryLocation":"eastus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rhel-test/providers/Microsoft.Storage/storageAccounts/rhel77acct","name":"rhel77acct","type":"Microsoft.Storage/storageAccounts","location":"eastus2","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-08-13T20:31:30.8995173Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-08-13T20:31:30.8995173Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-08-13T20:31:30.8215811Z","primaryEndpoints":{"blob":"https://rhel77acct.blob.core.windows.net/","queue":"https://rhel77acct.queue.core.windows.net/","table":"https://rhel77acct.table.core.windows.net/","file":"https://rhel77acct.file.core.windows.net/"},"primaryLocation":"eastus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SCRunner/providers/Microsoft.Storage/storageAccounts/scrunnerstorage","name":"scrunnerstorage","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-03-06T00:42:11.7016543Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-03-06T00:42:11.7016543Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2018-03-06T00:42:11.6234985Z","primaryEndpoints":{"blob":"https://scrunnerstorage.blob.core.windows.net/","queue":"https://scrunnerstorage.queue.core.windows.net/","table":"https://scrunnerstorage.table.core.windows.net/","file":"https://scrunnerstorage.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rhoover/providers/Microsoft.Storage/storageAccounts/rhooverstorage","name":"rhooverstorage","type":"Microsoft.Storage/storageAccounts","location":"southcentralus","tags":{"ms-resource-usage":"azure-cloud-shell"},"properties":{"keyCreationTime":{"key1":"2022-05-26T17:14:23.5085026Z","key2":"2022-05-26T17:14:23.5085026Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-26T17:14:23.5241285Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-26T17:14:23.5241285Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-05-26T17:14:23.4147520Z","primaryEndpoints":{"dfs":"https://rhooverstorage.dfs.core.windows.net/","web":"https://rhooverstorage.z21.web.core.windows.net/","blob":"https://rhooverstorage.blob.core.windows.net/","queue":"https://rhooverstorage.queue.core.windows.net/","table":"https://rhooverstorage.table.core.windows.net/","file":"https://rhooverstorage.file.core.windows.net/"},"primaryLocation":"southcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SCRunnertestvmrg-AustraliaEast/providers/Microsoft.Storage/storageAccounts/scrunner4p3t72mzheluc","name":"scrunner4p3t72mzheluc","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{},"properties":{"keyCreationTime":{"key1":"2021-04-13T22:35:36.6210942Z","key2":"2021-04-13T22:35:36.6210942Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2021-04-13T22:35:36.6210942Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2021-04-13T22:35:36.6210942Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2021-04-13T22:35:36.5429508Z","primaryEndpoints":{"blob":"https://scrunner4p3t72mzheluc.blob.core.windows.net/","queue":"https://scrunner4p3t72mzheluc.queue.core.windows.net/","table":"https://scrunner4p3t72mzheluc.table.core.windows.net/","file":"https://scrunner4p3t72mzheluc.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnervmrg-australiaeast/providers/Microsoft.Storage/storageAccounts/scrunner56hymyctm4kw2","name":"scrunner56hymyctm4kw2","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{},"properties":{"keyCreationTime":{"key1":"2023-02-11T08:42:58.2414102Z","key2":"2023-02-11T08:42:58.2414102Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:42:59.3196006Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:42:59.3196006Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-02-11T08:42:58.1476588Z","primaryEndpoints":{"blob":"https://scrunner56hymyctm4kw2.blob.core.windows.net/","queue":"https://scrunner56hymyctm4kw2.queue.core.windows.net/","table":"https://scrunner56hymyctm4kw2.table.core.windows.net/","file":"https://scrunner56hymyctm4kw2.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002","name":"cli000002","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T15:00:46.5594874Z","key2":"2023-03-06T15:00:46.5594874Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T15:00:46.8094615Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T15:00:46.8094615Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T15:00:46.4501501Z","primaryEndpoints":{"blob":"https://cli000002.blob.core.windows.net/","queue":"https://cli000002.queue.core.windows.net/","table":"https://cli000002.table.core.windows.net/","file":"https://cli000002.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsolex4geueyy52iloaspyxz3rrqwxv2syvnkjiljxbv522buwxqpiljme/providers/Microsoft.Storage/storageAccounts/clipf6qz5nxegbgku5yqzkd2","name":"clipf6qz5nxegbgku5yqzkd2","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T07:45:44.7937561Z","key2":"2023-03-06T07:45:44.7937561Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:45:45.1687946Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:45:45.1687946Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T07:45:44.7000168Z","primaryEndpoints":{"blob":"https://clipf6qz5nxegbgku5yqzkd2.blob.core.windows.net/","queue":"https://clipf6qz5nxegbgku5yqzkd2.queue.core.windows.net/","table":"https://clipf6qz5nxegbgku5yqzkd2.table.core.windows.net/","file":"https://clipf6qz5nxegbgku5yqzkd2.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsoledcvrpndxic4emeqq5apwkns4qa5owpy4jn3b536ks35zdrmn7bl5k/providers/Microsoft.Storage/storageAccounts/cliwqnm2fo7pftnxlk7c734i","name":"cliwqnm2fo7pftnxlk7c734i","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T07:34:57.7461613Z","key2":"2023-03-06T07:34:57.7461613Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:34:57.9961851Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:34:57.9961851Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T07:34:57.6368148Z","primaryEndpoints":{"blob":"https://cliwqnm2fo7pftnxlk7c734i.blob.core.windows.net/","queue":"https://cliwqnm2fo7pftnxlk7c734i.queue.core.windows.net/","table":"https://cliwqnm2fo7pftnxlk7c734i.table.core.windows.net/","file":"https://cliwqnm2fo7pftnxlk7c734i.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guptar2/providers/Microsoft.Storage/storageAccounts/guptar2diagnosticsv1","name":"guptar2diagnosticsv1","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2022-04-05T17:21:41.8250582Z","key2":"2022-04-05T17:21:41.8250582Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:21:41.8250582Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:21:41.8250582Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-04-05T17:21:41.7313240Z","primaryEndpoints":{"blob":"https://guptar2diagnosticsv1.blob.core.windows.net/","queue":"https://guptar2diagnosticsv1.queue.core.windows.net/","table":"https://guptar2diagnosticsv1.table.core.windows.net/","file":"https://guptar2diagnosticsv1.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guptar2/providers/Microsoft.Storage/storageAccounts/guptar2diagnosticsv2","name":"guptar2diagnosticsv2","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-04-05T17:22:55.8411567Z","key2":"2022-04-05T17:22:55.8411567Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"resourceAccessRules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[{"value":"20.98.146.84","action":"Allow"},{"value":"20.83.222.102","action":"Allow"},{"value":"20.98.194.64","action":"Allow"},{"value":"20.69.5.162","action":"Allow"}],"defaultAction":"Deny"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:22:55.8411567Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:22:55.8411567Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-04-05T17:22:55.7318000Z","primaryEndpoints":{"dfs":"https://guptar2diagnosticsv2.dfs.core.windows.net/","web":"https://guptar2diagnosticsv2.z5.web.core.windows.net/","blob":"https://guptar2diagnosticsv2.blob.core.windows.net/","queue":"https://guptar2diagnosticsv2.queue.core.windows.net/","table":"https://guptar2diagnosticsv2.table.core.windows.net/","file":"https://guptar2diagnosticsv2.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sericonrp-trafficmanager/providers/Microsoft.Storage/storageAccounts/sericonrpdevtmstorage","name":"sericonrpdevtmstorage","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-11-30T19:15:41.5013570Z","key2":"2022-11-30T19:15:41.5013570Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-11-30T19:15:42.0638737Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-11-30T19:15:42.0638737Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-11-30T19:15:41.4075777Z","primaryEndpoints":{"dfs":"https://sericonrpdevtmstorage.dfs.core.windows.net/","web":"https://sericonrpdevtmstorage.z5.web.core.windows.net/","blob":"https://sericonrpdevtmstorage.blob.core.windows.net/","queue":"https://sericonrpdevtmstorage.queue.core.windows.net/","table":"https://sericonrpdevtmstorage.table.core.windows.net/","file":"https://sericonrpdevtmstorage.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available","secondaryLocation":"westcentralus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://sericonrpdevtmstorage-secondary.dfs.core.windows.net/","web":"https://sericonrpdevtmstorage-secondary.z5.web.core.windows.net/","blob":"https://sericonrpdevtmstorage-secondary.blob.core.windows.net/","queue":"https://sericonrpdevtmstorage-secondary.queue.core.windows.net/","table":"https://sericonrpdevtmstorage-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ops/providers/Microsoft.Storage/storageAccounts/sericonstorage","name":"sericonstorage","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2023-03-05T19:58:00.4355863Z","key2":"2023-03-05T19:58:00.4355863Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-05T19:58:00.9824831Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-05T19:58:00.9824831Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2023-03-05T19:58:00.3262342Z","primaryEndpoints":{"dfs":"https://sericonstorage.dfs.core.windows.net/","web":"https://sericonstorage.z5.web.core.windows.net/","blob":"https://sericonstorage.blob.core.windows.net/","queue":"https://sericonstorage.queue.core.windows.net/","table":"https://sericonstorage.table.core.windows.net/","file":"https://sericonstorage.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rhoover-dev-rg/providers/Microsoft.Storage/storageAccounts/rhooverdevrgdiag","name":"rhooverdevrgdiag","type":"Microsoft.Storage/storageAccounts","location":"westcentralus","tags":{},"properties":{"defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-06-20T19:39:24.4605968Z","key2":"2022-06-20T19:39:24.4605968Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":false,"networkAcls":{"resourceAccessRules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[{"value":"20.98.146.84","action":"Allow"},{"value":"20.98.194.64","action":"Allow"},{"value":"20.69.5.162","action":"Allow"},{"value":"20.83.222.102","action":"Allow"},{"value":"76.197.206.105","action":"Allow"}],"defaultAction":"Deny"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-06-20T19:39:24.4762287Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-06-20T19:39:24.4762287Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-06-20T19:39:24.4137057Z","primaryEndpoints":{"blob":"https://rhooverdevrgdiag.blob.core.windows.net/","queue":"https://rhooverdevrgdiag.queue.core.windows.net/","table":"https://rhooverdevrgdiag.table.core.windows.net/","file":"https://rhooverdevrgdiag.file.core.windows.net/"},"primaryLocation":"westcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnervmrg-westcentralus/providers/Microsoft.Storage/storageAccounts/scrunneraoptpjec4skce","name":"scrunneraoptpjec4skce","type":"Microsoft.Storage/storageAccounts","location":"westcentralus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-02-11T08:40:40.0686467Z","key2":"2023-02-11T08:40:40.0686467Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:40:40.5842822Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:40:40.5842822Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-02-11T08:40:40.0061730Z","primaryEndpoints":{"blob":"https://scrunneraoptpjec4skce.blob.core.windows.net/","queue":"https://scrunneraoptpjec4skce.queue.core.windows.net/","table":"https://scrunneraoptpjec4skce.table.core.windows.net/","file":"https://scrunneraoptpjec4skce.file.core.windows.net/"},"primaryLocation":"westcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnertestvmrg-westcentralus/providers/Microsoft.Storage/storageAccounts/scrunnerrfscmqxeni3uq","name":"scrunnerrfscmqxeni3uq","type":"Microsoft.Storage/storageAccounts","location":"westcentralus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-04-10T22:28:55.2104910Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-04-10T22:28:55.2104910Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-04-10T22:28:55.1479670Z","primaryEndpoints":{"blob":"https://scrunnerrfscmqxeni3uq.blob.core.windows.net/","queue":"https://scrunnerrfscmqxeni3uq.queue.core.windows.net/","table":"https://scrunnerrfscmqxeni3uq.table.core.windows.net/","file":"https://scrunnerrfscmqxeni3uq.file.core.windows.net/"},"primaryLocation":"westcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ubuntu-westus3_group/providers/Microsoft.Storage/storageAccounts/ubuntuwestus3groupdiag","name":"ubuntuwestus3groupdiag","type":"Microsoft.Storage/storageAccounts","location":"westus3","tags":{},"properties":{"keyCreationTime":{"key1":"2022-04-18T19:48:38.9882588Z","key2":"2022-04-18T19:48:38.9882588Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-18T19:48:38.9882588Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-18T19:48:38.9882588Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-04-18T19:48:38.9258191Z","primaryEndpoints":{"blob":"https://ubuntuwestus3groupdiag.blob.core.windows.net/","queue":"https://ubuntuwestus3groupdiag.queue.core.windows.net/","table":"https://ubuntuwestus3groupdiag.table.core.windows.net/","file":"https://ubuntuwestus3groupdiag.file.core.windows.net/"},"primaryLocation":"westus3","statusOfPrimary":"available"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '38475'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 06 Mar 2023 15:13:43 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-original-request-ids:
+      - b593b42b-beb6-4d3c-9e58-ab715c206523
+      - 0e7447f9-59b7-4ad8-81f9-a0956a3cb85f
+      - e780ba2f-d51c-4b28-aea3-f70305473503
+      - 54d37c0b-7de6-4707-97a0-f8d4c52cec32
+      - ff6bd177-f472-41f5-9aba-787471d91e00
+      - a0cdf220-f169-4b0f-a762-3dba8112aa72
+      - 06b9a644-7088-4117-9812-6032808214c5
+      - b320eb90-5999-453c-8c02-eabce1a54c97
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vmss deallocate
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --instance-ids
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002","name":"cli000002","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2022-12-13T22:57:52.2717456Z","key2":"2022-12-13T22:57:52.2717456Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-12-13T22:57:52.7873645Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-12-13T22:57:52.7873645Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-12-13T22:57:52.1623506Z","primaryEndpoints":{"blob":"https://cli000002.blob.core.windows.net/","queue":"https://cli000002.queue.core.windows.net/","table":"https://cli000002.table.core.windows.net/","file":"https://cli000002.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002","name":"cli000002","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T15:00:46.5594874Z","key2":"2023-03-06T15:00:46.5594874Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T15:00:46.8094615Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T15:00:46.8094615Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T15:00:46.4501501Z","primaryEndpoints":{"blob":"https://cli000002.blob.core.windows.net/","queue":"https://cli000002.queue.core.windows.net/","table":"https://cli000002.table.core.windows.net/","file":"https://cli000002.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -5064,7 +5042,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 13 Dec 2022 23:09:01 GMT
+      - Mon, 06 Mar 2023 15:13:44 GMT
       expires:
       - '-1'
       pragma:
@@ -5096,8 +5074,8 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
-        (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.SerialConsole/consoleServices/default?api-version=2018-05-01
   response:
@@ -5111,7 +5089,7 @@ interactions:
       content-type:
       - application/json; charset=UTF-8
       date:
-      - Tue, 13 Dec 2022 23:09:02 GMT
+      - Mon, 06 Mar 2023 15:13:44 GMT
       expires:
       - '-1'
       pragma:
@@ -5132,7 +5110,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"instanceIds": ["2"]}'
+    body: '{"instanceIds": ["3"]}'
     headers:
       Accept:
       - application/json
@@ -5149,9 +5127,9 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/start?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/start?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -5159,17 +5137,17 @@ interactions:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/bdac9bd3-4dde-4274-a969-1fdf80a68b1e?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/fe9c02e0-4bef-4ff4-818f-6c7e6cde36b9?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Tue, 13 Dec 2022 23:09:03 GMT
+      - Mon, 06 Mar 2023 15:13:45 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/bdac9bd3-4dde-4274-a969-1fdf80a68b1e?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/fe9c02e0-4bef-4ff4-818f-6c7e6cde36b9?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-11-01
       pragma:
       - no-cache
       server:
@@ -5180,9 +5158,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/VMScaleSetActions3Min;239,Microsoft.Compute/VMScaleSetActions30Min;1193,Microsoft.Compute/VMScaleSetBatchedVMRequests5Min;3022,Microsoft.Compute/VmssQueuedVMOperations;0
+      - Microsoft.Compute/VMScaleSetActions3Min;239,Microsoft.Compute/VMScaleSetActions30Min;1184,Microsoft.Compute/VMScaleSetBatchedVMRequests5Min;3046,Microsoft.Compute/VmssQueuedVMOperations;0
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
+      - '1198'
       x-ms-request-charge:
       - '1'
     status:
@@ -5202,22 +5180,22 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/bdac9bd3-4dde-4274-a969-1fdf80a68b1e?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/fe9c02e0-4bef-4ff4-818f-6c7e6cde36b9?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:09:03.763254+00:00\",\r\n  \"status\":
-        \"InProgress\",\r\n  \"name\": \"bdac9bd3-4dde-4274-a969-1fdf80a68b1e\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T15:13:45.5780684+00:00\",\r\n  \"status\":
+        \"InProgress\",\r\n  \"name\": \"fe9c02e0-4bef-4ff4-818f-6c7e6cde36b9\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '133'
+      - '134'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:09:03 GMT
+      - Mon, 06 Mar 2023 15:14:14 GMT
       expires:
       - '-1'
       pragma:
@@ -5234,7 +5212,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14987,Microsoft.Compute/GetOperation30Min;29899
+      - Microsoft.Compute/GetOperation3Min;14989,Microsoft.Compute/GetOperation30Min;29751
     status:
       code: 200
       message: OK
@@ -5252,22 +5230,23 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/bdac9bd3-4dde-4274-a969-1fdf80a68b1e?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/fe9c02e0-4bef-4ff4-818f-6c7e6cde36b9?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:09:03.763254+00:00\",\r\n  \"status\":
-        \"InProgress\",\r\n  \"name\": \"bdac9bd3-4dde-4274-a969-1fdf80a68b1e\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T15:13:45.5780684+00:00\",\r\n  \"endTime\":
+        \"2023-03-06T15:14:19.609217+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"name\": \"fe9c02e0-4bef-4ff4-818f-6c7e6cde36b9\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '133'
+      - '183'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:09:33 GMT
+      - Mon, 06 Mar 2023 15:14:45 GMT
       expires:
       - '-1'
       pragma:
@@ -5284,7 +5263,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14988,Microsoft.Compute/GetOperation30Min;29897
+      - Microsoft.Compute/GetOperation3Min;14988,Microsoft.Compute/GetOperation30Min;29749
     status:
       code: 200
       message: OK
@@ -5302,60 +5281,9 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/bdac9bd3-4dde-4274-a969-1fdf80a68b1e?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
-  response:
-    body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:09:03.763254+00:00\",\r\n  \"endTime\":
-        \"2022-12-13T23:09:39.41936+00:00\",\r\n  \"status\": \"Succeeded\",\r\n  \"name\":
-        \"bdac9bd3-4dde-4274-a969-1fdf80a68b1e\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '181'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 13 Dec 2022 23:10:03 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14987,Microsoft.Compute/GetOperation30Min;29895
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vmss start
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --instance-ids
-      User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/bdac9bd3-4dde-4274-a969-1fdf80a68b1e?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/fe9c02e0-4bef-4ff4-818f-6c7e6cde36b9?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-11-01
   response:
     body:
       string: ''
@@ -5365,7 +5293,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 13 Dec 2022 23:10:03 GMT
+      - Mon, 06 Mar 2023 15:14:45 GMT
       expires:
       - '-1'
       pragma:
@@ -5378,12 +5306,12 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14986,Microsoft.Compute/GetOperation30Min;29894
+      - Microsoft.Compute/GetOperation3Min;14987,Microsoft.Compute/GetOperation30Min;29748
     status:
       code: 200
       message: OK
 - request:
-    body: '{"instanceIds": ["2"]}'
+    body: '{"instanceIds": ["3"]}'
     headers:
       Accept:
       - application/json
@@ -5400,9 +5328,9 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/poweroff?skipShutdown=false&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/poweroff?skipShutdown=false&api-version=2022-11-01
   response:
     body:
       string: ''
@@ -5410,17 +5338,17 @@ interactions:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/a35f6e1b-5f44-47f4-aac8-3effdda480c3?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/3923b4e0-c4fc-43f8-924c-2f33e07f7815?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Tue, 13 Dec 2022 23:10:04 GMT
+      - Mon, 06 Mar 2023 15:14:46 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/a35f6e1b-5f44-47f4-aac8-3effdda480c3?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/3923b4e0-c4fc-43f8-924c-2f33e07f7815?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-11-01
       pragma:
       - no-cache
       server:
@@ -5431,7 +5359,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/DeleteVMScaleSet3Min;79,Microsoft.Compute/DeleteVMScaleSet30Min;398,Microsoft.Compute/VMScaleSetBatchedVMRequests5Min;3023,Microsoft.Compute/VmssQueuedVMOperations;0
+      - Microsoft.Compute/DeleteVMScaleSet3Min;79,Microsoft.Compute/DeleteVMScaleSet30Min;393,Microsoft.Compute/VMScaleSetBatchedVMRequests5Min;3047,Microsoft.Compute/VmssQueuedVMOperations;0
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-ms-request-charge:
@@ -5453,13 +5381,13 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/a35f6e1b-5f44-47f4-aac8-3effdda480c3?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/3923b4e0-c4fc-43f8-924c-2f33e07f7815?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:10:05.5285784+00:00\",\r\n  \"status\":
-        \"InProgress\",\r\n  \"name\": \"a35f6e1b-5f44-47f4-aac8-3effdda480c3\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T15:14:46.8122264+00:00\",\r\n  \"status\":
+        \"InProgress\",\r\n  \"name\": \"3923b4e0-c4fc-43f8-924c-2f33e07f7815\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -5468,7 +5396,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:10:04 GMT
+      - Mon, 06 Mar 2023 15:15:16 GMT
       expires:
       - '-1'
       pragma:
@@ -5485,7 +5413,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14985,Microsoft.Compute/GetOperation30Min;29893
+      - Microsoft.Compute/GetOperation3Min;14987,Microsoft.Compute/GetOperation30Min;29781
     status:
       code: 200
       message: OK
@@ -5503,13 +5431,13 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/a35f6e1b-5f44-47f4-aac8-3effdda480c3?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/3923b4e0-c4fc-43f8-924c-2f33e07f7815?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:10:05.5285784+00:00\",\r\n  \"status\":
-        \"InProgress\",\r\n  \"name\": \"a35f6e1b-5f44-47f4-aac8-3effdda480c3\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T15:14:46.8122264+00:00\",\r\n  \"status\":
+        \"InProgress\",\r\n  \"name\": \"3923b4e0-c4fc-43f8-924c-2f33e07f7815\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -5518,7 +5446,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:10:34 GMT
+      - Mon, 06 Mar 2023 15:15:46 GMT
       expires:
       - '-1'
       pragma:
@@ -5535,7 +5463,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14985,Microsoft.Compute/GetOperation30Min;29891
+      - Microsoft.Compute/GetOperation3Min;14987,Microsoft.Compute/GetOperation30Min;29780
     status:
       code: 200
       message: OK
@@ -5553,13 +5481,13 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/a35f6e1b-5f44-47f4-aac8-3effdda480c3?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/3923b4e0-c4fc-43f8-924c-2f33e07f7815?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:10:05.5285784+00:00\",\r\n  \"status\":
-        \"InProgress\",\r\n  \"name\": \"a35f6e1b-5f44-47f4-aac8-3effdda480c3\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T15:14:46.8122264+00:00\",\r\n  \"status\":
+        \"InProgress\",\r\n  \"name\": \"3923b4e0-c4fc-43f8-924c-2f33e07f7815\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -5568,7 +5496,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:11:05 GMT
+      - Mon, 06 Mar 2023 15:16:16 GMT
       expires:
       - '-1'
       pragma:
@@ -5585,7 +5513,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14985,Microsoft.Compute/GetOperation30Min;29890
+      - Microsoft.Compute/GetOperation3Min;14988,Microsoft.Compute/GetOperation30Min;29779
     status:
       code: 200
       message: OK
@@ -5603,13 +5531,13 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/a35f6e1b-5f44-47f4-aac8-3effdda480c3?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/3923b4e0-c4fc-43f8-924c-2f33e07f7815?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:10:05.5285784+00:00\",\r\n  \"status\":
-        \"InProgress\",\r\n  \"name\": \"a35f6e1b-5f44-47f4-aac8-3effdda480c3\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T15:14:46.8122264+00:00\",\r\n  \"status\":
+        \"InProgress\",\r\n  \"name\": \"3923b4e0-c4fc-43f8-924c-2f33e07f7815\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -5618,7 +5546,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:11:35 GMT
+      - Mon, 06 Mar 2023 15:16:47 GMT
       expires:
       - '-1'
       pragma:
@@ -5635,7 +5563,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14987,Microsoft.Compute/GetOperation30Min;29889
+      - Microsoft.Compute/GetOperation3Min;14990,Microsoft.Compute/GetOperation30Min;29778
     status:
       code: 200
       message: OK
@@ -5653,64 +5581,14 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/a35f6e1b-5f44-47f4-aac8-3effdda480c3?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/3923b4e0-c4fc-43f8-924c-2f33e07f7815?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:10:05.5285784+00:00\",\r\n  \"status\":
-        \"InProgress\",\r\n  \"name\": \"a35f6e1b-5f44-47f4-aac8-3effdda480c3\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '134'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 13 Dec 2022 23:12:05 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14990,Microsoft.Compute/GetOperation30Min;29888
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vmss stop
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --instance-ids
-      User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/a35f6e1b-5f44-47f4-aac8-3effdda480c3?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
-  response:
-    body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:10:05.5285784+00:00\",\r\n  \"endTime\":
-        \"2022-12-13T23:12:09.8717983+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"name\": \"a35f6e1b-5f44-47f4-aac8-3effdda480c3\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T15:14:46.8122264+00:00\",\r\n  \"endTime\":
+        \"2023-03-06T15:16:52.3118992+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"name\": \"3923b4e0-c4fc-43f8-924c-2f33e07f7815\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -5719,7 +5597,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:12:35 GMT
+      - Mon, 06 Mar 2023 15:17:17 GMT
       expires:
       - '-1'
       pragma:
@@ -5736,7 +5614,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14990,Microsoft.Compute/GetOperation30Min;29886
+      - Microsoft.Compute/GetOperation3Min;14991,Microsoft.Compute/GetOperation30Min;29776
     status:
       code: 200
       message: OK
@@ -5754,9 +5632,9 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/a35f6e1b-5f44-47f4-aac8-3effdda480c3?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/3923b4e0-c4fc-43f8-924c-2f33e07f7815?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-11-01
   response:
     body:
       string: ''
@@ -5766,7 +5644,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 13 Dec 2022 23:12:35 GMT
+      - Mon, 06 Mar 2023 15:17:17 GMT
       expires:
       - '-1'
       pragma:
@@ -5779,7 +5657,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14989,Microsoft.Compute/GetOperation30Min;29885
+      - Microsoft.Compute/GetOperation3Min;14990,Microsoft.Compute/GetOperation30Min;29775
     status:
       code: 200
       message: OK
@@ -5797,21 +5675,21 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/2/instanceView?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/3/instanceView?api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"placementGroupId\": \"b12ec8ba-0f67-45f7-a5b3-5e94f2268933\",\r\n
+      string: "{\r\n  \"placementGroupId\": \"fe2728fc-c0cb-4cea-8d91-bb960a1e6c3b\",\r\n
         \ \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n  \"computerName\":
-        \"cli5o787e000002\",\r\n  \"osName\": \"ubuntu\",\r\n  \"osVersion\": \"18.04\",\r\n
+        \"cliuz26de000003\",\r\n  \"osName\": \"ubuntu\",\r\n  \"osVersion\": \"18.04\",\r\n
         \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"2.9.0.4\",\r\n    \"statuses\":
         [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\",\r\n        \"level\":
         \"Info\",\r\n        \"displayStatus\": \"Ready\",\r\n        \"message\":
-        \"Guest Agent is running\",\r\n        \"time\": \"2022-12-13T23:09:38+00:00\"\r\n
+        \"Guest Agent is running\",\r\n        \"time\": \"2023-03-06T15:14:19+00:00\"\r\n
         \     }\r\n    ],\r\n    \"extensionHandlers\": [\r\n      {\r\n        \"type\":
         \"Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n        \"typeHandlerVersion\":
-        \"1.24.2\",\r\n        \"status\": {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \"1.25.1\",\r\n        \"status\": {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Ready\",\r\n
         \         \"message\": \"Plugin enabled\"\r\n        }\r\n      },\r\n      {\r\n
         \       \"type\": \"Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent\",\r\n
@@ -5819,16 +5697,16 @@ interactions:
         \         \"code\": \"ProvisioningState/succeeded\",\r\n          \"level\":
         \"Info\",\r\n          \"displayStatus\": \"Ready\",\r\n          \"message\":
         \"Plugin enabled\"\r\n        }\r\n      }\r\n    ]\r\n  },\r\n  \"disks\":
-        [\r\n    {\r\n      \"name\": \"cli5oqyn2zpljvxqcitncli5oqyn2zpljvxqcitnmOS__1_fc2a2b19ddde4a019629d326a068caf5\",\r\n
+        [\r\n    {\r\n      \"name\": \"cliuztvtdw4jbve2omq7cliuztvtdw4jbve2omq73OS__1_023d79a2b12548fba5c6e457bd338d14\",\r\n
         \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2022-12-13T23:09:04.6694815+00:00\"\r\n
+        succeeded\",\r\n          \"time\": \"2023-03-06T15:13:46.5311755+00:00\"\r\n
         \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
-        \"https://cli000002.blob.core.windows.net/bootdiagnostics-cli5oqyn2-a19f6f91-7994-467b-a23e-a6660ca2db24/cli000003_2.a19f6f91-7994-467b-a23e-a6660ca2db24.screenshot.bmp\",\r\n
-        \   \"serialConsoleLogBlobUri\": \"https://cli000002.blob.core.windows.net/bootdiagnostics-cli5oqyn2-a19f6f91-7994-467b-a23e-a6660ca2db24/cli000003_2.a19f6f91-7994-467b-a23e-a6660ca2db24.serialconsole.log\"\r\n
+        \"https://cli000002.blob.core.windows.net/bootdiagnostics-cliuztvtd-ffa83b08-9cdf-4ddd-8c22-38ec3747c4fa/cli000003_3.ffa83b08-9cdf-4ddd-8c22-38ec3747c4fa.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://cli000002.blob.core.windows.net/bootdiagnostics-cliuztvtd-ffa83b08-9cdf-4ddd-8c22-38ec3747c4fa/cli000003_3.ffa83b08-9cdf-4ddd-8c22-38ec3747c4fa.serialconsole.log\"\r\n
         \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n
         \     \"type\": \"Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n      \"typeHandlerVersion\":
-        \"1.24.2\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \"1.25.1\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
         succeeded\",\r\n          \"message\": \"Enable succeeded\"\r\n        }\r\n
         \     ]\r\n    },\r\n    {\r\n      \"name\": \"Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent\",\r\n
@@ -5840,7 +5718,7 @@ interactions:
         \   }\r\n  ],\r\n  \"hyperVGeneration\": \"V1\",\r\n  \"statuses\": [\r\n
         \   {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n      \"level\":
         \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n      \"time\":
-        \"2022-12-13T23:12:09.8406276+00:00\"\r\n    },\r\n    {\r\n      \"code\":
+        \"2023-03-06T15:16:52.2650032+00:00\"\r\n    },\r\n    {\r\n      \"code\":
         \"PowerState/stopped\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\":
         \"VM stopped\"\r\n    }\r\n  ]\r\n}"
     headers:
@@ -5851,7 +5729,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:12:37 GMT
+      - Mon, 06 Mar 2023 15:17:18 GMT
       expires:
       - '-1'
       pragma:
@@ -5868,7 +5746,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetVMScaleSetVM3Min;499,Microsoft.Compute/GetVMScaleSetVM30Min;2492,Microsoft.Compute/VMScaleSetVMViews3Min;4999
+      - Microsoft.Compute/GetVMScaleSetVM3Min;499,Microsoft.Compute/GetVMScaleSetVM30Min;2471,Microsoft.Compute/VMScaleSetVMViews3Min;4999
       x-ms-request-charge:
       - '1'
     status:
@@ -5888,12 +5766,63 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/storageAccounts?api-version=2022-09-01
+  response:
+    body:
+      string: '{"value":[{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloud-shell-storage-eastus/providers/Microsoft.Storage/storageAccounts/cs210032001f4814ba9","name":"cs210032001f4814ba9","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"ms-resource-usage":"azure-cloud-shell"},"properties":{"keyCreationTime":{"key1":"2022-05-16T14:16:22.3477819Z","key2":"2022-05-16T14:16:22.3477819Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-16T14:16:22.3477819Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-16T14:16:22.3477819Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-05-16T14:16:22.2227752Z","primaryEndpoints":{"dfs":"https://cs210032001f4814ba9.dfs.core.windows.net/","web":"https://cs210032001f4814ba9.z13.web.core.windows.net/","blob":"https://cs210032001f4814ba9.blob.core.windows.net/","queue":"https://cs210032001f4814ba9.queue.core.windows.net/","table":"https://cs210032001f4814ba9.table.core.windows.net/","file":"https://cs210032001f4814ba9.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/kustoflow/providers/Microsoft.Storage/storageAccounts/csslinuxkustoflow","name":"csslinuxkustoflow","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"CreatedBy":"craigw"},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-02-01T20:08:38.6849654Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-02-01T20:08:38.6849654Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2019-02-01T20:08:38.5912170Z","primaryEndpoints":{"dfs":"https://csslinuxkustoflow.dfs.core.windows.net/","web":"https://csslinuxkustoflow.z13.web.core.windows.net/","blob":"https://csslinuxkustoflow.blob.core.windows.net/","queue":"https://csslinuxkustoflow.queue.core.windows.net/","table":"https://csslinuxkustoflow.table.core.windows.net/","file":"https://csslinuxkustoflow.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://csslinuxkustoflow-secondary.dfs.core.windows.net/","web":"https://csslinuxkustoflow-secondary.z13.web.core.windows.net/","blob":"https://csslinuxkustoflow-secondary.blob.core.windows.net/","queue":"https://csslinuxkustoflow-secondary.queue.core.windows.net/","table":"https://csslinuxkustoflow-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guidomassonitest-rg/providers/Microsoft.Storage/storageAccounts/guidomassonitestrg88ad","name":"guidomassonitestrg88ad","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-01-23T18:52:02.5484088Z","key2":"2023-01-23T18:52:02.5484088Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-01-23T18:52:02.5484088Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-01-23T18:52:02.5484088Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-01-23T18:52:02.4077698Z","primaryEndpoints":{"blob":"https://guidomassonitestrg88ad.blob.core.windows.net/","queue":"https://guidomassonitestrg88ad.queue.core.windows.net/","table":"https://guidomassonitestrg88ad.table.core.windows.net/","file":"https://guidomassonitestrg88ad.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guidomtesttrafficmanagerrg/providers/Microsoft.Storage/storageAccounts/guidomteststoraccfortm","name":"guidomteststoraccfortm","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-10-18T18:01:13.5231266Z","key2":"2022-10-18T18:01:13.5231266Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-10-18T18:01:13.5387607Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-10-18T18:01:13.5387607Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-10-18T18:01:13.3825002Z","primaryEndpoints":{"dfs":"https://guidomteststoraccfortm.dfs.core.windows.net/","web":"https://guidomteststoraccfortm.z13.web.core.windows.net/","blob":"https://guidomteststoraccfortm.blob.core.windows.net/","queue":"https://guidomteststoraccfortm.queue.core.windows.net/","table":"https://guidomteststoraccfortm.table.core.windows.net/","file":"https://guidomteststoraccfortm.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://guidomteststoraccfortm-secondary.dfs.core.windows.net/","web":"https://guidomteststoraccfortm-secondary.z13.web.core.windows.net/","blob":"https://guidomteststoraccfortm-secondary.blob.core.windows.net/","queue":"https://guidomteststoraccfortm-secondary.queue.core.windows.net/","table":"https://guidomteststoraccfortm-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnertestvmrg-eastus/providers/Microsoft.Storage/storageAccounts/scrunnercrkwpdn5nhtgg","name":"scrunnercrkwpdn5nhtgg","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-05-12T20:03:57.6389684Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-05-12T20:03:57.6389684Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-05-12T20:03:57.5451905Z","primaryEndpoints":{"blob":"https://scrunnercrkwpdn5nhtgg.blob.core.windows.net/","queue":"https://scrunnercrkwpdn5nhtgg.queue.core.windows.net/","table":"https://scrunnercrkwpdn5nhtgg.table.core.windows.net/","file":"https://scrunnercrkwpdn5nhtgg.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnervmrg-eastus/providers/Microsoft.Storage/storageAccounts/scrunneri2ezqh4xu2wqq","name":"scrunneri2ezqh4xu2wqq","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-02-11T08:01:12.9383535Z","key2":"2023-02-11T08:01:12.9383535Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:01:12.9383535Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:01:12.9383535Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-02-11T08:01:12.6883669Z","primaryEndpoints":{"blob":"https://scrunneri2ezqh4xu2wqq.blob.core.windows.net/","queue":"https://scrunneri2ezqh4xu2wqq.queue.core.windows.net/","table":"https://scrunneri2ezqh4xu2wqq.table.core.windows.net/","file":"https://scrunneri2ezqh4xu2wqq.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/serialTest-EastUS/providers/Microsoft.Storage/storageAccounts/serialtesta8d7fdee41","name":"serialtesta8d7fdee41","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-07-11T00:38:13.5389932Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-07-11T00:38:13.5389932Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2019-07-11T00:38:13.4452119Z","primaryEndpoints":{"blob":"https://serialtesta8d7fdee41.blob.core.windows.net/","queue":"https://serialtesta8d7fdee41.queue.core.windows.net/","table":"https://serialtesta8d7fdee41.table.core.windows.net/","file":"https://serialtesta8d7fdee41.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/storage-RG/providers/Microsoft.Storage/storageAccounts/serialtestbootdiag123","name":"serialtestbootdiag123","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-01-23T04:03:01.3263151Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-01-23T04:03:01.3263151Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2018-01-23T04:03:01.2951106Z","primaryEndpoints":{"blob":"https://serialtestbootdiag123.blob.core.windows.net/","queue":"https://serialtestbootdiag123.queue.core.windows.net/","table":"https://serialtestbootdiag123.table.core.windows.net/","file":"https://serialtestbootdiag123.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yuas-rg/providers/Microsoft.Storage/storageAccounts/yuasstorageacct","name":"yuasstorageacct","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-08-02T12:18:18.8547131Z","key2":"2022-08-02T12:18:18.8547131Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-08-02T12:18:18.8547131Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-08-02T12:18:18.8547131Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-08-02T12:18:18.7140969Z","primaryEndpoints":{"dfs":"https://yuasstorageacct.dfs.core.windows.net/","web":"https://yuasstorageacct.z13.web.core.windows.net/","blob":"https://yuasstorageacct.blob.core.windows.net/","queue":"https://yuasstorageacct.queue.core.windows.net/","table":"https://yuasstorageacct.table.core.windows.net/","file":"https://yuasstorageacct.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://yuasstorageacct-secondary.dfs.core.windows.net/","web":"https://yuasstorageacct-secondary.z13.web.core.windows.net/","blob":"https://yuasstorageacct-secondary.blob.core.windows.net/","queue":"https://yuasstorageacct-secondary.queue.core.windows.net/","table":"https://yuasstorageacct-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/bkerrigan-dev-rg/providers/Microsoft.Storage/storageAccounts/bktestsa2","name":"bktestsa2","type":"Microsoft.Storage/storageAccounts","location":"eastus2","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","immutableStorageWithVersioning":{"enabled":true},"keyCreationTime":{"key1":"2022-09-27T23:58:45.6496284Z","key2":"2022-09-27T23:58:45.6496284Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-09-27T23:58:46.2902461Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-09-27T23:58:46.2902461Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Cool","provisioningState":"Succeeded","creationTime":"2022-09-27T23:58:45.5558609Z","primaryEndpoints":{"dfs":"https://bktestsa2.dfs.core.windows.net/","web":"https://bktestsa2.z20.web.core.windows.net/","blob":"https://bktestsa2.blob.core.windows.net/","queue":"https://bktestsa2.queue.core.windows.net/","table":"https://bktestsa2.table.core.windows.net/","file":"https://bktestsa2.file.core.windows.net/"},"primaryLocation":"eastus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rhel-test/providers/Microsoft.Storage/storageAccounts/rhel77acct","name":"rhel77acct","type":"Microsoft.Storage/storageAccounts","location":"eastus2","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-08-13T20:31:30.8995173Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-08-13T20:31:30.8995173Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-08-13T20:31:30.8215811Z","primaryEndpoints":{"blob":"https://rhel77acct.blob.core.windows.net/","queue":"https://rhel77acct.queue.core.windows.net/","table":"https://rhel77acct.table.core.windows.net/","file":"https://rhel77acct.file.core.windows.net/"},"primaryLocation":"eastus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SCRunner/providers/Microsoft.Storage/storageAccounts/scrunnerstorage","name":"scrunnerstorage","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-03-06T00:42:11.7016543Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-03-06T00:42:11.7016543Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2018-03-06T00:42:11.6234985Z","primaryEndpoints":{"blob":"https://scrunnerstorage.blob.core.windows.net/","queue":"https://scrunnerstorage.queue.core.windows.net/","table":"https://scrunnerstorage.table.core.windows.net/","file":"https://scrunnerstorage.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rhoover/providers/Microsoft.Storage/storageAccounts/rhooverstorage","name":"rhooverstorage","type":"Microsoft.Storage/storageAccounts","location":"southcentralus","tags":{"ms-resource-usage":"azure-cloud-shell"},"properties":{"keyCreationTime":{"key1":"2022-05-26T17:14:23.5085026Z","key2":"2022-05-26T17:14:23.5085026Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-26T17:14:23.5241285Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-26T17:14:23.5241285Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-05-26T17:14:23.4147520Z","primaryEndpoints":{"dfs":"https://rhooverstorage.dfs.core.windows.net/","web":"https://rhooverstorage.z21.web.core.windows.net/","blob":"https://rhooverstorage.blob.core.windows.net/","queue":"https://rhooverstorage.queue.core.windows.net/","table":"https://rhooverstorage.table.core.windows.net/","file":"https://rhooverstorage.file.core.windows.net/"},"primaryLocation":"southcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SCRunnertestvmrg-AustraliaEast/providers/Microsoft.Storage/storageAccounts/scrunner4p3t72mzheluc","name":"scrunner4p3t72mzheluc","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{},"properties":{"keyCreationTime":{"key1":"2021-04-13T22:35:36.6210942Z","key2":"2021-04-13T22:35:36.6210942Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2021-04-13T22:35:36.6210942Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2021-04-13T22:35:36.6210942Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2021-04-13T22:35:36.5429508Z","primaryEndpoints":{"blob":"https://scrunner4p3t72mzheluc.blob.core.windows.net/","queue":"https://scrunner4p3t72mzheluc.queue.core.windows.net/","table":"https://scrunner4p3t72mzheluc.table.core.windows.net/","file":"https://scrunner4p3t72mzheluc.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnervmrg-australiaeast/providers/Microsoft.Storage/storageAccounts/scrunner56hymyctm4kw2","name":"scrunner56hymyctm4kw2","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{},"properties":{"keyCreationTime":{"key1":"2023-02-11T08:42:58.2414102Z","key2":"2023-02-11T08:42:58.2414102Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:42:59.3196006Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:42:59.3196006Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-02-11T08:42:58.1476588Z","primaryEndpoints":{"blob":"https://scrunner56hymyctm4kw2.blob.core.windows.net/","queue":"https://scrunner56hymyctm4kw2.queue.core.windows.net/","table":"https://scrunner56hymyctm4kw2.table.core.windows.net/","file":"https://scrunner56hymyctm4kw2.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002","name":"cli000002","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T15:00:46.5594874Z","key2":"2023-03-06T15:00:46.5594874Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T15:00:46.8094615Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T15:00:46.8094615Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T15:00:46.4501501Z","primaryEndpoints":{"blob":"https://cli000002.blob.core.windows.net/","queue":"https://cli000002.queue.core.windows.net/","table":"https://cli000002.table.core.windows.net/","file":"https://cli000002.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsolex4geueyy52iloaspyxz3rrqwxv2syvnkjiljxbv522buwxqpiljme/providers/Microsoft.Storage/storageAccounts/clipf6qz5nxegbgku5yqzkd2","name":"clipf6qz5nxegbgku5yqzkd2","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T07:45:44.7937561Z","key2":"2023-03-06T07:45:44.7937561Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:45:45.1687946Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:45:45.1687946Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T07:45:44.7000168Z","primaryEndpoints":{"blob":"https://clipf6qz5nxegbgku5yqzkd2.blob.core.windows.net/","queue":"https://clipf6qz5nxegbgku5yqzkd2.queue.core.windows.net/","table":"https://clipf6qz5nxegbgku5yqzkd2.table.core.windows.net/","file":"https://clipf6qz5nxegbgku5yqzkd2.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsoledcvrpndxic4emeqq5apwkns4qa5owpy4jn3b536ks35zdrmn7bl5k/providers/Microsoft.Storage/storageAccounts/cliwqnm2fo7pftnxlk7c734i","name":"cliwqnm2fo7pftnxlk7c734i","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T07:34:57.7461613Z","key2":"2023-03-06T07:34:57.7461613Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:34:57.9961851Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:34:57.9961851Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T07:34:57.6368148Z","primaryEndpoints":{"blob":"https://cliwqnm2fo7pftnxlk7c734i.blob.core.windows.net/","queue":"https://cliwqnm2fo7pftnxlk7c734i.queue.core.windows.net/","table":"https://cliwqnm2fo7pftnxlk7c734i.table.core.windows.net/","file":"https://cliwqnm2fo7pftnxlk7c734i.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guptar2/providers/Microsoft.Storage/storageAccounts/guptar2diagnosticsv1","name":"guptar2diagnosticsv1","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2022-04-05T17:21:41.8250582Z","key2":"2022-04-05T17:21:41.8250582Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:21:41.8250582Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:21:41.8250582Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-04-05T17:21:41.7313240Z","primaryEndpoints":{"blob":"https://guptar2diagnosticsv1.blob.core.windows.net/","queue":"https://guptar2diagnosticsv1.queue.core.windows.net/","table":"https://guptar2diagnosticsv1.table.core.windows.net/","file":"https://guptar2diagnosticsv1.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guptar2/providers/Microsoft.Storage/storageAccounts/guptar2diagnosticsv2","name":"guptar2diagnosticsv2","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-04-05T17:22:55.8411567Z","key2":"2022-04-05T17:22:55.8411567Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"resourceAccessRules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[{"value":"20.98.146.84","action":"Allow"},{"value":"20.83.222.102","action":"Allow"},{"value":"20.98.194.64","action":"Allow"},{"value":"20.69.5.162","action":"Allow"}],"defaultAction":"Deny"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:22:55.8411567Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:22:55.8411567Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-04-05T17:22:55.7318000Z","primaryEndpoints":{"dfs":"https://guptar2diagnosticsv2.dfs.core.windows.net/","web":"https://guptar2diagnosticsv2.z5.web.core.windows.net/","blob":"https://guptar2diagnosticsv2.blob.core.windows.net/","queue":"https://guptar2diagnosticsv2.queue.core.windows.net/","table":"https://guptar2diagnosticsv2.table.core.windows.net/","file":"https://guptar2diagnosticsv2.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sericonrp-trafficmanager/providers/Microsoft.Storage/storageAccounts/sericonrpdevtmstorage","name":"sericonrpdevtmstorage","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-11-30T19:15:41.5013570Z","key2":"2022-11-30T19:15:41.5013570Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-11-30T19:15:42.0638737Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-11-30T19:15:42.0638737Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-11-30T19:15:41.4075777Z","primaryEndpoints":{"dfs":"https://sericonrpdevtmstorage.dfs.core.windows.net/","web":"https://sericonrpdevtmstorage.z5.web.core.windows.net/","blob":"https://sericonrpdevtmstorage.blob.core.windows.net/","queue":"https://sericonrpdevtmstorage.queue.core.windows.net/","table":"https://sericonrpdevtmstorage.table.core.windows.net/","file":"https://sericonrpdevtmstorage.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available","secondaryLocation":"westcentralus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://sericonrpdevtmstorage-secondary.dfs.core.windows.net/","web":"https://sericonrpdevtmstorage-secondary.z5.web.core.windows.net/","blob":"https://sericonrpdevtmstorage-secondary.blob.core.windows.net/","queue":"https://sericonrpdevtmstorage-secondary.queue.core.windows.net/","table":"https://sericonrpdevtmstorage-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ops/providers/Microsoft.Storage/storageAccounts/sericonstorage","name":"sericonstorage","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2023-03-05T19:58:00.4355863Z","key2":"2023-03-05T19:58:00.4355863Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-05T19:58:00.9824831Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-05T19:58:00.9824831Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2023-03-05T19:58:00.3262342Z","primaryEndpoints":{"dfs":"https://sericonstorage.dfs.core.windows.net/","web":"https://sericonstorage.z5.web.core.windows.net/","blob":"https://sericonstorage.blob.core.windows.net/","queue":"https://sericonstorage.queue.core.windows.net/","table":"https://sericonstorage.table.core.windows.net/","file":"https://sericonstorage.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rhoover-dev-rg/providers/Microsoft.Storage/storageAccounts/rhooverdevrgdiag","name":"rhooverdevrgdiag","type":"Microsoft.Storage/storageAccounts","location":"westcentralus","tags":{},"properties":{"defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-06-20T19:39:24.4605968Z","key2":"2022-06-20T19:39:24.4605968Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":false,"networkAcls":{"resourceAccessRules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[{"value":"20.98.146.84","action":"Allow"},{"value":"20.98.194.64","action":"Allow"},{"value":"20.69.5.162","action":"Allow"},{"value":"20.83.222.102","action":"Allow"},{"value":"76.197.206.105","action":"Allow"}],"defaultAction":"Deny"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-06-20T19:39:24.4762287Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-06-20T19:39:24.4762287Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-06-20T19:39:24.4137057Z","primaryEndpoints":{"blob":"https://rhooverdevrgdiag.blob.core.windows.net/","queue":"https://rhooverdevrgdiag.queue.core.windows.net/","table":"https://rhooverdevrgdiag.table.core.windows.net/","file":"https://rhooverdevrgdiag.file.core.windows.net/"},"primaryLocation":"westcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnervmrg-westcentralus/providers/Microsoft.Storage/storageAccounts/scrunneraoptpjec4skce","name":"scrunneraoptpjec4skce","type":"Microsoft.Storage/storageAccounts","location":"westcentralus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-02-11T08:40:40.0686467Z","key2":"2023-02-11T08:40:40.0686467Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:40:40.5842822Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:40:40.5842822Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-02-11T08:40:40.0061730Z","primaryEndpoints":{"blob":"https://scrunneraoptpjec4skce.blob.core.windows.net/","queue":"https://scrunneraoptpjec4skce.queue.core.windows.net/","table":"https://scrunneraoptpjec4skce.table.core.windows.net/","file":"https://scrunneraoptpjec4skce.file.core.windows.net/"},"primaryLocation":"westcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnertestvmrg-westcentralus/providers/Microsoft.Storage/storageAccounts/scrunnerrfscmqxeni3uq","name":"scrunnerrfscmqxeni3uq","type":"Microsoft.Storage/storageAccounts","location":"westcentralus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-04-10T22:28:55.2104910Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-04-10T22:28:55.2104910Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-04-10T22:28:55.1479670Z","primaryEndpoints":{"blob":"https://scrunnerrfscmqxeni3uq.blob.core.windows.net/","queue":"https://scrunnerrfscmqxeni3uq.queue.core.windows.net/","table":"https://scrunnerrfscmqxeni3uq.table.core.windows.net/","file":"https://scrunnerrfscmqxeni3uq.file.core.windows.net/"},"primaryLocation":"westcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ubuntu-westus3_group/providers/Microsoft.Storage/storageAccounts/ubuntuwestus3groupdiag","name":"ubuntuwestus3groupdiag","type":"Microsoft.Storage/storageAccounts","location":"westus3","tags":{},"properties":{"keyCreationTime":{"key1":"2022-04-18T19:48:38.9882588Z","key2":"2022-04-18T19:48:38.9882588Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-18T19:48:38.9882588Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-18T19:48:38.9882588Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-04-18T19:48:38.9258191Z","primaryEndpoints":{"blob":"https://ubuntuwestus3groupdiag.blob.core.windows.net/","queue":"https://ubuntuwestus3groupdiag.queue.core.windows.net/","table":"https://ubuntuwestus3groupdiag.table.core.windows.net/","file":"https://ubuntuwestus3groupdiag.file.core.windows.net/"},"primaryLocation":"westus3","statusOfPrimary":"available"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '38475'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 06 Mar 2023 15:17:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-original-request-ids:
+      - 34e9dbd0-147e-45cd-9ca8-d076fed8cb94
+      - 88e57620-9adc-48bb-ae00-9e4c242de9af
+      - 89d38f2b-4cde-4b01-8d6f-b09e85833fb6
+      - 007e0d88-ceaa-41c2-85bf-0d3484e1cd7b
+      - cc938a28-83d9-4bc8-81f7-979f342f0ff8
+      - 94a7c867-00bf-46c0-9ec9-6cefbb50e6ef
+      - 0c15aef3-ef0f-47b6-bcae-9f9882839e20
+      - 0fedc39a-ac7f-4ff3-85be-8b82a8362b8a
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vmss stop
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --instance-ids
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002","name":"cli000002","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2022-12-13T22:57:52.2717456Z","key2":"2022-12-13T22:57:52.2717456Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-12-13T22:57:52.7873645Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-12-13T22:57:52.7873645Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-12-13T22:57:52.1623506Z","primaryEndpoints":{"blob":"https://cli000002.blob.core.windows.net/","queue":"https://cli000002.queue.core.windows.net/","table":"https://cli000002.table.core.windows.net/","file":"https://cli000002.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002","name":"cli000002","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T15:00:46.5594874Z","key2":"2023-03-06T15:00:46.5594874Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T15:00:46.8094615Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T15:00:46.8094615Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T15:00:46.4501501Z","primaryEndpoints":{"blob":"https://cli000002.blob.core.windows.net/","queue":"https://cli000002.queue.core.windows.net/","table":"https://cli000002.table.core.windows.net/","file":"https://cli000002.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -5902,7 +5831,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 13 Dec 2022 23:12:36 GMT
+      - Mon, 06 Mar 2023 15:17:19 GMT
       expires:
       - '-1'
       pragma:
@@ -5934,8 +5863,8 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
-        (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.SerialConsole/consoleServices/default?api-version=2018-05-01
   response:
@@ -5949,7 +5878,7 @@ interactions:
       content-type:
       - application/json; charset=UTF-8
       date:
-      - Tue, 13 Dec 2022 23:12:36 GMT
+      - Mon, 06 Mar 2023 15:17:19 GMT
       expires:
       - '-1'
       pragma:
@@ -5970,7 +5899,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"instanceIds": ["2"]}'
+    body: '{"instanceIds": ["3"]}'
     headers:
       Accept:
       - application/json
@@ -5987,9 +5916,9 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/start?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/start?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -5997,17 +5926,17 @@ interactions:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/45095115-106f-4ba8-ad57-be1352e36d50?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/01357510-ca89-48be-b04a-648d14558427?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Tue, 13 Dec 2022 23:12:38 GMT
+      - Mon, 06 Mar 2023 15:17:20 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/45095115-106f-4ba8-ad57-be1352e36d50?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/01357510-ca89-48be-b04a-648d14558427?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-11-01
       pragma:
       - no-cache
       server:
@@ -6018,7 +5947,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/VMScaleSetActions3Min;239,Microsoft.Compute/VMScaleSetActions30Min;1192,Microsoft.Compute/VMScaleSetBatchedVMRequests5Min;3023,Microsoft.Compute/VmssQueuedVMOperations;0
+      - Microsoft.Compute/VMScaleSetActions3Min;239,Microsoft.Compute/VMScaleSetActions30Min;1188,Microsoft.Compute/VMScaleSetBatchedVMRequests5Min;3048,Microsoft.Compute/VmssQueuedVMOperations;0
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-ms-request-charge:
@@ -6040,64 +5969,14 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/45095115-106f-4ba8-ad57-be1352e36d50?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/01357510-ca89-48be-b04a-648d14558427?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:12:38.7466722+00:00\",\r\n  \"status\":
-        \"InProgress\",\r\n  \"name\": \"45095115-106f-4ba8-ad57-be1352e36d50\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '134'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 13 Dec 2022 23:12:38 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14988,Microsoft.Compute/GetOperation30Min;29884
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vmss start
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --instance-ids
-      User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/45095115-106f-4ba8-ad57-be1352e36d50?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
-  response:
-    body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:12:38.7466722+00:00\",\r\n  \"endTime\":
-        \"2022-12-13T23:12:46.4497632+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"name\": \"45095115-106f-4ba8-ad57-be1352e36d50\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T15:17:20.1555021+00:00\",\r\n  \"endTime\":
+        \"2023-03-06T15:17:29.7961077+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"name\": \"01357510-ca89-48be-b04a-648d14558427\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -6106,7 +5985,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:13:08 GMT
+      - Mon, 06 Mar 2023 15:17:50 GMT
       expires:
       - '-1'
       pragma:
@@ -6123,7 +6002,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14990,Microsoft.Compute/GetOperation30Min;29882
+      - Microsoft.Compute/GetOperation3Min;14990,Microsoft.Compute/GetOperation30Min;29773
     status:
       code: 200
       message: OK
@@ -6141,9 +6020,9 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/45095115-106f-4ba8-ad57-be1352e36d50?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/01357510-ca89-48be-b04a-648d14558427?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-11-01
   response:
     body:
       string: ''
@@ -6153,7 +6032,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 13 Dec 2022 23:13:08 GMT
+      - Mon, 06 Mar 2023 15:17:50 GMT
       expires:
       - '-1'
       pragma:
@@ -6166,7 +6045,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14989,Microsoft.Compute/GetOperation30Min;29881
+      - Microsoft.Compute/GetOperation3Min;14989,Microsoft.Compute/GetOperation30Min;29772
     status:
       code: 200
       message: OK
@@ -6184,9 +6063,9 @@ interactions:
       ParameterSetName:
       - --name --resource-group --set
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003?api-version=2022-11-01
   response:
     body:
       string: "{\r\n  \"name\": \"cli000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003\",\r\n
@@ -6202,23 +6081,24 @@ interactions:
         {\r\n      \"mode\": \"Manual\",\r\n      \"rollingUpgradePolicy\": {\r\n
         \       \"maxBatchInstancePercent\": 20,\r\n        \"maxUnhealthyInstancePercent\":
         20,\r\n        \"maxUnhealthyUpgradedInstancePercent\": 20,\r\n        \"pauseTimeBetweenBatches\":
-        \"PT0S\"\r\n      }\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\":
-        {\r\n        \"computerNamePrefix\": \"cli5o787e\",\r\n        \"adminUsername\":
-        \"rhl\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\":
+        \"PT0S\",\r\n        \"maxSurge\": false,\r\n        \"rollbackFailedInstancesOnPolicyBreach\":
+        false\r\n      }\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\":
+        {\r\n        \"computerNamePrefix\": \"cliuz26de\",\r\n        \"adminUsername\":
+        \"rhoover\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\":
         true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n              {\r\n
-        \               \"path\": \"/home/rhl/.ssh/authorized_keys\",\r\n                \"keyData\":
-        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h\"\r\n
-        \             }\r\n            ]\r\n          },\r\n          \"provisionVMAgent\":
-        true,\r\n          \"enableVMAgentPlatformUpdates\": false\r\n        },\r\n
-        \       \"secrets\": [],\r\n        \"allowExtensionOperations\": true,\r\n
-        \       \"requireGuestProvisionSignal\": true\r\n      },\r\n      \"storageProfile\":
+        \               \"path\": \"/home/rhoover/.ssh/authorized_keys\",\r\n                \"keyData\":
+        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+        REDMOND+rhoover@DESKTOP-XVFR7ID\\n\"\r\n              }\r\n            ]\r\n
+        \         },\r\n          \"provisionVMAgent\": true,\r\n          \"enableVMAgentPlatformUpdates\":
+        false\r\n        },\r\n        \"secrets\": [],\r\n        \"allowExtensionOperations\":
+        true,\r\n        \"requireGuestProvisionSignal\": true\r\n      },\r\n      \"storageProfile\":
         {\r\n        \"osDisk\": {\r\n          \"osType\": \"Linux\",\r\n          \"createOption\":
         \"FromImage\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\":
         {\r\n            \"storageAccountType\": \"Premium_LRS\"\r\n          },\r\n
         \         \"diskSizeGB\": 30\r\n        },\r\n        \"imageReference\":
         {\r\n          \"publisher\": \"Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n
         \         \"sku\": \"18.04-LTS\",\r\n          \"version\": \"latest\"\r\n
-        \       }\r\n      },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"cli5o787eNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"disableTcpStateTracking\":false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\":[{\"name\":\"cli5o787eIPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET/subnets/cli000003Subnet\"},\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/backendAddressPools/cli000003LBBEPool\"}],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/inboundNatPools/cli000003LBNatPool\"}]}}]}}]},\r\n
+        \       }\r\n      },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"cliuz26deNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"disableTcpStateTracking\":false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\":[{\"name\":\"cliuz26deIPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET/subnets/cli000003Subnet\"},\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/backendAddressPools/cli000003LBBEPool\"}],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/inboundNatPools/cli000003LBNatPool\"}]}}]}}]},\r\n
         \     \"diagnosticsProfile\": {\r\n        \"bootDiagnostics\": {\r\n          \"enabled\":
         true,\r\n          \"storageUri\": \"https://cli000002.blob.core.windows.net/\"\r\n
         \       }\r\n      },\r\n      \"extensionProfile\": {\r\n        \"extensions\":
@@ -6236,17 +6116,17 @@ interactions:
         {\"enableGenevaUpload\":true,\"enableAutoConfig\":true,\"reportSuccessOnUnsupportedDistro\":true}\r\n
         \           }\r\n          }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\":
         \"Succeeded\",\r\n    \"overprovision\": true,\r\n    \"doNotRunExtensionsOnOverprovisionedVMs\":
-        false,\r\n    \"uniqueId\": \"c72549ea-142c-4eb1-8178-a7442e2bc6db\",\r\n
-        \   \"timeCreated\": \"2022-12-13T22:58:32.1880141+00:00\"\r\n  }\r\n}"
+        false,\r\n    \"uniqueId\": \"6aa1f17d-1da0-4dfe-b11e-b77e59e02135\",\r\n
+        \   \"timeCreated\": \"2023-03-06T15:01:24.7059254+00:00\"\r\n  }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '5241'
+      - '5540'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:13:10 GMT
+      - Mon, 06 Mar 2023 15:17:50 GMT
       expires:
       - '-1'
       pragma:
@@ -6263,7 +6143,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetVMScaleSet3Min;398,Microsoft.Compute/GetVMScaleSet30Min;2570
+      - Microsoft.Compute/GetVMScaleSet3Min;398,Microsoft.Compute/GetVMScaleSet30Min;2493
     status:
       code: 200
       message: OK
@@ -6273,17 +6153,19 @@ interactions:
       2}, "identity": {"type": "UserAssigned", "userAssignedIdentities": {"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/AzSecPackAutoConfigUA-westus2":
       {}}}, "properties": {"upgradePolicy": {"mode": "Manual", "rollingUpgradePolicy":
       {"maxBatchInstancePercent": 20, "maxUnhealthyInstancePercent": 20, "maxUnhealthyUpgradedInstancePercent":
-      20, "pauseTimeBetweenBatches": "PT0S"}}, "virtualMachineProfile": {"osProfile":
-      {"computerNamePrefix": "cli5o787e", "adminUsername": "rhl", "linuxConfiguration":
-      {"disablePasswordAuthentication": true, "ssh": {"publicKeys": [{"path": "/home/rhl/.ssh/authorized_keys",
-      "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h"}]},
-      "provisionVMAgent": true, "enableVMAgentPlatformUpdates": false}, "secrets":
-      [], "allowExtensionOperations": true}, "storageProfile": {"osDisk": {"caching":
-      "ReadWrite", "createOption": "FromImage", "diskSizeGB": 30, "osType": "Linux",
-      "managedDisk": {"storageAccountType": "Premium_LRS"}}}, "networkProfile": {"networkInterfaceConfigurations":
-      [{"name": "cli5o787eNic", "properties": {"primary": true, "enableAcceleratedNetworking":
+      20, "pauseTimeBetweenBatches": "PT0S", "rollbackFailedInstancesOnPolicyBreach":
+      false, "maxSurge": false}}, "virtualMachineProfile": {"osProfile": {"computerNamePrefix":
+      "cliuz26de", "adminUsername": "rhoover", "linuxConfiguration": {"disablePasswordAuthentication":
+      true, "ssh": {"publicKeys": [{"path": "/home/rhoover/.ssh/authorized_keys",
+      "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+      REDMOND+rhoover@DESKTOP-XVFR7ID\n"}]}, "provisionVMAgent": true, "enableVMAgentPlatformUpdates":
+      false}, "secrets": [], "allowExtensionOperations": true, "requireGuestProvisionSignal":
+      true}, "storageProfile": {"osDisk": {"caching": "ReadWrite", "createOption":
+      "FromImage", "diskSizeGB": 30, "osType": "Linux", "managedDisk": {"storageAccountType":
+      "Premium_LRS"}}}, "networkProfile": {"networkInterfaceConfigurations": [{"name":
+      "cliuz26deNic", "properties": {"primary": true, "enableAcceleratedNetworking":
       false, "disableTcpStateTracking": false, "dnsSettings": {"dnsServers": []},
-      "ipConfigurations": [{"name": "cli5o787eIPConfig", "properties": {"subnet":
+      "ipConfigurations": [{"name": "cliuz26deIPConfig", "properties": {"subnet":
       {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET/subnets/cli000003Subnet"},
       "privateIPAddressVersion": "IPv4", "loadBalancerBackendAddressPools": [{"id":
       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/backendAddressPools/cli000003LBBEPool"}],
@@ -6308,15 +6190,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '3521'
+      - '3839'
       Content-Type:
       - application/json
       ParameterSetName:
       - --name --resource-group --set
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003?api-version=2022-11-01
   response:
     body:
       string: "{\r\n  \"name\": \"cli000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003\",\r\n
@@ -6332,23 +6214,24 @@ interactions:
         {\r\n      \"mode\": \"Manual\",\r\n      \"rollingUpgradePolicy\": {\r\n
         \       \"maxBatchInstancePercent\": 20,\r\n        \"maxUnhealthyInstancePercent\":
         20,\r\n        \"maxUnhealthyUpgradedInstancePercent\": 20,\r\n        \"pauseTimeBetweenBatches\":
-        \"PT0S\"\r\n      }\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\":
-        {\r\n        \"computerNamePrefix\": \"cli5o787e\",\r\n        \"adminUsername\":
-        \"rhl\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\":
+        \"PT0S\",\r\n        \"maxSurge\": false,\r\n        \"rollbackFailedInstancesOnPolicyBreach\":
+        false\r\n      }\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\":
+        {\r\n        \"computerNamePrefix\": \"cliuz26de\",\r\n        \"adminUsername\":
+        \"rhoover\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\":
         true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n              {\r\n
-        \               \"path\": \"/home/rhl/.ssh/authorized_keys\",\r\n                \"keyData\":
-        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h\"\r\n
-        \             }\r\n            ]\r\n          },\r\n          \"provisionVMAgent\":
-        true,\r\n          \"enableVMAgentPlatformUpdates\": false\r\n        },\r\n
-        \       \"secrets\": [],\r\n        \"allowExtensionOperations\": true,\r\n
-        \       \"requireGuestProvisionSignal\": true\r\n      },\r\n      \"storageProfile\":
+        \               \"path\": \"/home/rhoover/.ssh/authorized_keys\",\r\n                \"keyData\":
+        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+        REDMOND+rhoover@DESKTOP-XVFR7ID\\n\"\r\n              }\r\n            ]\r\n
+        \         },\r\n          \"provisionVMAgent\": true,\r\n          \"enableVMAgentPlatformUpdates\":
+        false\r\n        },\r\n        \"secrets\": [],\r\n        \"allowExtensionOperations\":
+        true,\r\n        \"requireGuestProvisionSignal\": true\r\n      },\r\n      \"storageProfile\":
         {\r\n        \"osDisk\": {\r\n          \"osType\": \"Linux\",\r\n          \"createOption\":
         \"FromImage\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\":
         {\r\n            \"storageAccountType\": \"Premium_LRS\"\r\n          },\r\n
         \         \"diskSizeGB\": 30\r\n        },\r\n        \"imageReference\":
         {\r\n          \"publisher\": \"Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n
         \         \"sku\": \"18.04-LTS\",\r\n          \"version\": \"latest\"\r\n
-        \       }\r\n      },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"cli5o787eNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"disableTcpStateTracking\":false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\":[{\"name\":\"cli5o787eIPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET/subnets/cli000003Subnet\"},\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/backendAddressPools/cli000003LBBEPool\"}],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/inboundNatPools/cli000003LBNatPool\"}]}}]}}]},\r\n
+        \       }\r\n      },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"cliuz26deNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"disableTcpStateTracking\":false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\":[{\"name\":\"cliuz26deIPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET/subnets/cli000003Subnet\"},\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/backendAddressPools/cli000003LBBEPool\"}],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/inboundNatPools/cli000003LBNatPool\"}]}}]}}]},\r\n
         \     \"diagnosticsProfile\": {\r\n        \"bootDiagnostics\": {\r\n          \"enabled\":
         false,\r\n          \"storageUri\": \"https://cli000002.blob.core.windows.net/\"\r\n
         \       }\r\n      },\r\n      \"extensionProfile\": {\r\n        \"extensions\":
@@ -6366,21 +6249,21 @@ interactions:
         {\"enableGenevaUpload\":true,\"enableAutoConfig\":true,\"reportSuccessOnUnsupportedDistro\":true}\r\n
         \           }\r\n          }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\":
         \"Updating\",\r\n    \"overprovision\": true,\r\n    \"doNotRunExtensionsOnOverprovisionedVMs\":
-        false,\r\n    \"uniqueId\": \"c72549ea-142c-4eb1-8178-a7442e2bc6db\",\r\n
-        \   \"timeCreated\": \"2022-12-13T22:58:32.1880141+00:00\"\r\n  }\r\n}"
+        false,\r\n    \"uniqueId\": \"6aa1f17d-1da0-4dfe-b11e-b77e59e02135\",\r\n
+        \   \"timeCreated\": \"2023-03-06T15:01:24.7059254+00:00\"\r\n  }\r\n}"
     headers:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/f808ec37-7e99-4beb-9245-63a6cad60358?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/333ea9a0-12bd-4653-af62-c7543032d356?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
       cache-control:
       - no-cache
       content-length:
-      - '5241'
+      - '5540'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:13:12 GMT
+      - Mon, 06 Mar 2023 15:17:54 GMT
       expires:
       - '-1'
       pragma:
@@ -6397,9 +6280,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/CreateVMScaleSet3Min;150,Microsoft.Compute/CreateVMScaleSet30Min;751,Microsoft.Compute/VmssQueuedVMOperations;0
+      - Microsoft.Compute/CreateVMScaleSet3Min;151,Microsoft.Compute/CreateVMScaleSet30Min;748,Microsoft.Compute/VmssQueuedVMOperations;0
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
       x-ms-request-charge:
       - '0'
     status:
@@ -6419,14 +6302,14 @@ interactions:
       ParameterSetName:
       - --name --resource-group --set
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/f808ec37-7e99-4beb-9245-63a6cad60358?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/333ea9a0-12bd-4653-af62-c7543032d356?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:13:12.9809017+00:00\",\r\n  \"endTime\":
-        \"2022-12-13T23:13:13.3090127+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"name\": \"f808ec37-7e99-4beb-9245-63a6cad60358\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T15:17:54.6554122+00:00\",\r\n  \"endTime\":
+        \"2023-03-06T15:17:54.9835776+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"name\": \"333ea9a0-12bd-4653-af62-c7543032d356\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -6435,7 +6318,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:13:12 GMT
+      - Mon, 06 Mar 2023 15:18:04 GMT
       expires:
       - '-1'
       pragma:
@@ -6452,7 +6335,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14988,Microsoft.Compute/GetOperation30Min;29880
+      - Microsoft.Compute/GetOperation3Min;14990,Microsoft.Compute/GetOperation30Min;29771
     status:
       code: 200
       message: OK
@@ -6470,9 +6353,9 @@ interactions:
       ParameterSetName:
       - --name --resource-group --set
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003?api-version=2022-11-01
   response:
     body:
       string: "{\r\n  \"name\": \"cli000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003\",\r\n
@@ -6488,23 +6371,24 @@ interactions:
         {\r\n      \"mode\": \"Manual\",\r\n      \"rollingUpgradePolicy\": {\r\n
         \       \"maxBatchInstancePercent\": 20,\r\n        \"maxUnhealthyInstancePercent\":
         20,\r\n        \"maxUnhealthyUpgradedInstancePercent\": 20,\r\n        \"pauseTimeBetweenBatches\":
-        \"PT0S\"\r\n      }\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\":
-        {\r\n        \"computerNamePrefix\": \"cli5o787e\",\r\n        \"adminUsername\":
-        \"rhl\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\":
+        \"PT0S\",\r\n        \"maxSurge\": false,\r\n        \"rollbackFailedInstancesOnPolicyBreach\":
+        false\r\n      }\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\":
+        {\r\n        \"computerNamePrefix\": \"cliuz26de\",\r\n        \"adminUsername\":
+        \"rhoover\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\":
         true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n              {\r\n
-        \               \"path\": \"/home/rhl/.ssh/authorized_keys\",\r\n                \"keyData\":
-        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h\"\r\n
-        \             }\r\n            ]\r\n          },\r\n          \"provisionVMAgent\":
-        true,\r\n          \"enableVMAgentPlatformUpdates\": false\r\n        },\r\n
-        \       \"secrets\": [],\r\n        \"allowExtensionOperations\": true,\r\n
-        \       \"requireGuestProvisionSignal\": true\r\n      },\r\n      \"storageProfile\":
+        \               \"path\": \"/home/rhoover/.ssh/authorized_keys\",\r\n                \"keyData\":
+        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+        REDMOND+rhoover@DESKTOP-XVFR7ID\\n\"\r\n              }\r\n            ]\r\n
+        \         },\r\n          \"provisionVMAgent\": true,\r\n          \"enableVMAgentPlatformUpdates\":
+        false\r\n        },\r\n        \"secrets\": [],\r\n        \"allowExtensionOperations\":
+        true,\r\n        \"requireGuestProvisionSignal\": true\r\n      },\r\n      \"storageProfile\":
         {\r\n        \"osDisk\": {\r\n          \"osType\": \"Linux\",\r\n          \"createOption\":
         \"FromImage\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\":
         {\r\n            \"storageAccountType\": \"Premium_LRS\"\r\n          },\r\n
         \         \"diskSizeGB\": 30\r\n        },\r\n        \"imageReference\":
         {\r\n          \"publisher\": \"Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n
         \         \"sku\": \"18.04-LTS\",\r\n          \"version\": \"latest\"\r\n
-        \       }\r\n      },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"cli5o787eNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"disableTcpStateTracking\":false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\":[{\"name\":\"cli5o787eIPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET/subnets/cli000003Subnet\"},\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/backendAddressPools/cli000003LBBEPool\"}],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/inboundNatPools/cli000003LBNatPool\"}]}}]}}]},\r\n
+        \       }\r\n      },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"cliuz26deNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"disableTcpStateTracking\":false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\":[{\"name\":\"cliuz26deIPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET/subnets/cli000003Subnet\"},\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/backendAddressPools/cli000003LBBEPool\"}],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/inboundNatPools/cli000003LBNatPool\"}]}}]}}]},\r\n
         \     \"diagnosticsProfile\": {\r\n        \"bootDiagnostics\": {\r\n          \"enabled\":
         false,\r\n          \"storageUri\": \"https://cli000002.blob.core.windows.net/\"\r\n
         \       }\r\n      },\r\n      \"extensionProfile\": {\r\n        \"extensions\":
@@ -6522,17 +6406,17 @@ interactions:
         {\"enableGenevaUpload\":true,\"enableAutoConfig\":true,\"reportSuccessOnUnsupportedDistro\":true}\r\n
         \           }\r\n          }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\":
         \"Succeeded\",\r\n    \"overprovision\": true,\r\n    \"doNotRunExtensionsOnOverprovisionedVMs\":
-        false,\r\n    \"uniqueId\": \"c72549ea-142c-4eb1-8178-a7442e2bc6db\",\r\n
-        \   \"timeCreated\": \"2022-12-13T22:58:32.1880141+00:00\"\r\n  }\r\n}"
+        false,\r\n    \"uniqueId\": \"6aa1f17d-1da0-4dfe-b11e-b77e59e02135\",\r\n
+        \   \"timeCreated\": \"2023-03-06T15:01:24.7059254+00:00\"\r\n  }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '5242'
+      - '5541'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:13:12 GMT
+      - Mon, 06 Mar 2023 15:18:05 GMT
       expires:
       - '-1'
       pragma:
@@ -6549,7 +6433,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetVMScaleSet3Min;395,Microsoft.Compute/GetVMScaleSet30Min;2567
+      - Microsoft.Compute/GetVMScaleSet3Min;394,Microsoft.Compute/GetVMScaleSet30Min;2489
     status:
       code: 200
       message: OK
@@ -6567,21 +6451,21 @@ interactions:
       ParameterSetName:
       - --name --resource-group --set
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/2/instanceView?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/3/instanceView?api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"placementGroupId\": \"b12ec8ba-0f67-45f7-a5b3-5e94f2268933\",\r\n
+      string: "{\r\n  \"placementGroupId\": \"fe2728fc-c0cb-4cea-8d91-bb960a1e6c3b\",\r\n
         \ \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n  \"computerName\":
-        \"cli5o787e000002\",\r\n  \"osName\": \"ubuntu\",\r\n  \"osVersion\": \"18.04\",\r\n
+        \"cliuz26de000003\",\r\n  \"osName\": \"ubuntu\",\r\n  \"osVersion\": \"18.04\",\r\n
         \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"2.9.0.4\",\r\n    \"statuses\":
         [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\",\r\n        \"level\":
         \"Info\",\r\n        \"displayStatus\": \"Ready\",\r\n        \"message\":
-        \"Guest Agent is running\",\r\n        \"time\": \"2022-12-13T23:13:04+00:00\"\r\n
+        \"Guest Agent is running\",\r\n        \"time\": \"2023-03-06T15:17:46+00:00\"\r\n
         \     }\r\n    ],\r\n    \"extensionHandlers\": [\r\n      {\r\n        \"type\":
         \"Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n        \"typeHandlerVersion\":
-        \"1.24.2\",\r\n        \"status\": {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \"1.25.1\",\r\n        \"status\": {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Ready\",\r\n
         \         \"message\": \"Plugin enabled\"\r\n        }\r\n      },\r\n      {\r\n
         \       \"type\": \"Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent\",\r\n
@@ -6589,16 +6473,16 @@ interactions:
         \         \"code\": \"ProvisioningState/succeeded\",\r\n          \"level\":
         \"Info\",\r\n          \"displayStatus\": \"Ready\",\r\n          \"message\":
         \"Plugin enabled\"\r\n        }\r\n      }\r\n    ]\r\n  },\r\n  \"disks\":
-        [\r\n    {\r\n      \"name\": \"cli5oqyn2zpljvxqcitncli5oqyn2zpljvxqcitnmOS__1_fc2a2b19ddde4a019629d326a068caf5\",\r\n
+        [\r\n    {\r\n      \"name\": \"cliuztvtdw4jbve2omq7cliuztvtdw4jbve2omq73OS__1_023d79a2b12548fba5c6e457bd338d14\",\r\n
         \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2022-12-13T23:09:04.6694815+00:00\"\r\n
+        succeeded\",\r\n          \"time\": \"2023-03-06T15:13:46.5311755+00:00\"\r\n
         \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
-        \"https://cli000002.blob.core.windows.net/bootdiagnostics-cli5oqyn2-a19f6f91-7994-467b-a23e-a6660ca2db24/cli000003_2.a19f6f91-7994-467b-a23e-a6660ca2db24.screenshot.bmp\",\r\n
-        \   \"serialConsoleLogBlobUri\": \"https://cli000002.blob.core.windows.net/bootdiagnostics-cli5oqyn2-a19f6f91-7994-467b-a23e-a6660ca2db24/cli000003_2.a19f6f91-7994-467b-a23e-a6660ca2db24.serialconsole.log\"\r\n
+        \"https://cli000002.blob.core.windows.net/bootdiagnostics-cliuztvtd-ffa83b08-9cdf-4ddd-8c22-38ec3747c4fa/cli000003_3.ffa83b08-9cdf-4ddd-8c22-38ec3747c4fa.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://cli000002.blob.core.windows.net/bootdiagnostics-cliuztvtd-ffa83b08-9cdf-4ddd-8c22-38ec3747c4fa/cli000003_3.ffa83b08-9cdf-4ddd-8c22-38ec3747c4fa.serialconsole.log\"\r\n
         \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n
         \     \"type\": \"Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n      \"typeHandlerVersion\":
-        \"1.24.2\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \"1.25.1\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
         succeeded\",\r\n          \"message\": \"Enable succeeded\"\r\n        }\r\n
         \     ]\r\n    },\r\n    {\r\n      \"name\": \"Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent\",\r\n
@@ -6610,7 +6494,7 @@ interactions:
         \   }\r\n  ],\r\n  \"hyperVGeneration\": \"V1\",\r\n  \"statuses\": [\r\n
         \   {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n      \"level\":
         \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n      \"time\":
-        \"2022-12-13T23:12:46.4185126+00:00\"\r\n    },\r\n    {\r\n      \"code\":
+        \"2023-03-06T15:17:29.7648653+00:00\"\r\n    },\r\n    {\r\n      \"code\":
         \"PowerState/running\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\":
         \"VM running\"\r\n    }\r\n  ]\r\n}"
     headers:
@@ -6621,7 +6505,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:13:13 GMT
+      - Mon, 06 Mar 2023 15:18:06 GMT
       expires:
       - '-1'
       pragma:
@@ -6638,7 +6522,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetVMScaleSetVM3Min;498,Microsoft.Compute/GetVMScaleSetVM30Min;2491,Microsoft.Compute/VMScaleSetVMViews3Min;4998
+      - Microsoft.Compute/GetVMScaleSetVM3Min;498,Microsoft.Compute/GetVMScaleSetVM30Min;2470,Microsoft.Compute/VMScaleSetVMViews3Min;4998
       x-ms-request-charge:
       - '1'
     status:
@@ -6658,12 +6542,63 @@ interactions:
       ParameterSetName:
       - --name --resource-group --set
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/storageAccounts?api-version=2022-09-01
+  response:
+    body:
+      string: '{"value":[{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloud-shell-storage-eastus/providers/Microsoft.Storage/storageAccounts/cs210032001f4814ba9","name":"cs210032001f4814ba9","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"ms-resource-usage":"azure-cloud-shell"},"properties":{"keyCreationTime":{"key1":"2022-05-16T14:16:22.3477819Z","key2":"2022-05-16T14:16:22.3477819Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-16T14:16:22.3477819Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-16T14:16:22.3477819Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-05-16T14:16:22.2227752Z","primaryEndpoints":{"dfs":"https://cs210032001f4814ba9.dfs.core.windows.net/","web":"https://cs210032001f4814ba9.z13.web.core.windows.net/","blob":"https://cs210032001f4814ba9.blob.core.windows.net/","queue":"https://cs210032001f4814ba9.queue.core.windows.net/","table":"https://cs210032001f4814ba9.table.core.windows.net/","file":"https://cs210032001f4814ba9.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/kustoflow/providers/Microsoft.Storage/storageAccounts/csslinuxkustoflow","name":"csslinuxkustoflow","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"CreatedBy":"craigw"},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-02-01T20:08:38.6849654Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-02-01T20:08:38.6849654Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2019-02-01T20:08:38.5912170Z","primaryEndpoints":{"dfs":"https://csslinuxkustoflow.dfs.core.windows.net/","web":"https://csslinuxkustoflow.z13.web.core.windows.net/","blob":"https://csslinuxkustoflow.blob.core.windows.net/","queue":"https://csslinuxkustoflow.queue.core.windows.net/","table":"https://csslinuxkustoflow.table.core.windows.net/","file":"https://csslinuxkustoflow.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://csslinuxkustoflow-secondary.dfs.core.windows.net/","web":"https://csslinuxkustoflow-secondary.z13.web.core.windows.net/","blob":"https://csslinuxkustoflow-secondary.blob.core.windows.net/","queue":"https://csslinuxkustoflow-secondary.queue.core.windows.net/","table":"https://csslinuxkustoflow-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guidomassonitest-rg/providers/Microsoft.Storage/storageAccounts/guidomassonitestrg88ad","name":"guidomassonitestrg88ad","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-01-23T18:52:02.5484088Z","key2":"2023-01-23T18:52:02.5484088Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-01-23T18:52:02.5484088Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-01-23T18:52:02.5484088Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-01-23T18:52:02.4077698Z","primaryEndpoints":{"blob":"https://guidomassonitestrg88ad.blob.core.windows.net/","queue":"https://guidomassonitestrg88ad.queue.core.windows.net/","table":"https://guidomassonitestrg88ad.table.core.windows.net/","file":"https://guidomassonitestrg88ad.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guidomtesttrafficmanagerrg/providers/Microsoft.Storage/storageAccounts/guidomteststoraccfortm","name":"guidomteststoraccfortm","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-10-18T18:01:13.5231266Z","key2":"2022-10-18T18:01:13.5231266Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-10-18T18:01:13.5387607Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-10-18T18:01:13.5387607Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-10-18T18:01:13.3825002Z","primaryEndpoints":{"dfs":"https://guidomteststoraccfortm.dfs.core.windows.net/","web":"https://guidomteststoraccfortm.z13.web.core.windows.net/","blob":"https://guidomteststoraccfortm.blob.core.windows.net/","queue":"https://guidomteststoraccfortm.queue.core.windows.net/","table":"https://guidomteststoraccfortm.table.core.windows.net/","file":"https://guidomteststoraccfortm.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://guidomteststoraccfortm-secondary.dfs.core.windows.net/","web":"https://guidomteststoraccfortm-secondary.z13.web.core.windows.net/","blob":"https://guidomteststoraccfortm-secondary.blob.core.windows.net/","queue":"https://guidomteststoraccfortm-secondary.queue.core.windows.net/","table":"https://guidomteststoraccfortm-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnertestvmrg-eastus/providers/Microsoft.Storage/storageAccounts/scrunnercrkwpdn5nhtgg","name":"scrunnercrkwpdn5nhtgg","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-05-12T20:03:57.6389684Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-05-12T20:03:57.6389684Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-05-12T20:03:57.5451905Z","primaryEndpoints":{"blob":"https://scrunnercrkwpdn5nhtgg.blob.core.windows.net/","queue":"https://scrunnercrkwpdn5nhtgg.queue.core.windows.net/","table":"https://scrunnercrkwpdn5nhtgg.table.core.windows.net/","file":"https://scrunnercrkwpdn5nhtgg.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnervmrg-eastus/providers/Microsoft.Storage/storageAccounts/scrunneri2ezqh4xu2wqq","name":"scrunneri2ezqh4xu2wqq","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-02-11T08:01:12.9383535Z","key2":"2023-02-11T08:01:12.9383535Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:01:12.9383535Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:01:12.9383535Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-02-11T08:01:12.6883669Z","primaryEndpoints":{"blob":"https://scrunneri2ezqh4xu2wqq.blob.core.windows.net/","queue":"https://scrunneri2ezqh4xu2wqq.queue.core.windows.net/","table":"https://scrunneri2ezqh4xu2wqq.table.core.windows.net/","file":"https://scrunneri2ezqh4xu2wqq.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/serialTest-EastUS/providers/Microsoft.Storage/storageAccounts/serialtesta8d7fdee41","name":"serialtesta8d7fdee41","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-07-11T00:38:13.5389932Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2019-07-11T00:38:13.5389932Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2019-07-11T00:38:13.4452119Z","primaryEndpoints":{"blob":"https://serialtesta8d7fdee41.blob.core.windows.net/","queue":"https://serialtesta8d7fdee41.queue.core.windows.net/","table":"https://serialtesta8d7fdee41.table.core.windows.net/","file":"https://serialtesta8d7fdee41.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/storage-RG/providers/Microsoft.Storage/storageAccounts/serialtestbootdiag123","name":"serialtestbootdiag123","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-01-23T04:03:01.3263151Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-01-23T04:03:01.3263151Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2018-01-23T04:03:01.2951106Z","primaryEndpoints":{"blob":"https://serialtestbootdiag123.blob.core.windows.net/","queue":"https://serialtestbootdiag123.queue.core.windows.net/","table":"https://serialtestbootdiag123.table.core.windows.net/","file":"https://serialtestbootdiag123.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yuas-rg/providers/Microsoft.Storage/storageAccounts/yuasstorageacct","name":"yuasstorageacct","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-08-02T12:18:18.8547131Z","key2":"2022-08-02T12:18:18.8547131Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-08-02T12:18:18.8547131Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-08-02T12:18:18.8547131Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-08-02T12:18:18.7140969Z","primaryEndpoints":{"dfs":"https://yuasstorageacct.dfs.core.windows.net/","web":"https://yuasstorageacct.z13.web.core.windows.net/","blob":"https://yuasstorageacct.blob.core.windows.net/","queue":"https://yuasstorageacct.queue.core.windows.net/","table":"https://yuasstorageacct.table.core.windows.net/","file":"https://yuasstorageacct.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://yuasstorageacct-secondary.dfs.core.windows.net/","web":"https://yuasstorageacct-secondary.z13.web.core.windows.net/","blob":"https://yuasstorageacct-secondary.blob.core.windows.net/","queue":"https://yuasstorageacct-secondary.queue.core.windows.net/","table":"https://yuasstorageacct-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/bkerrigan-dev-rg/providers/Microsoft.Storage/storageAccounts/bktestsa2","name":"bktestsa2","type":"Microsoft.Storage/storageAccounts","location":"eastus2","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","immutableStorageWithVersioning":{"enabled":true},"keyCreationTime":{"key1":"2022-09-27T23:58:45.6496284Z","key2":"2022-09-27T23:58:45.6496284Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-09-27T23:58:46.2902461Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-09-27T23:58:46.2902461Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Cool","provisioningState":"Succeeded","creationTime":"2022-09-27T23:58:45.5558609Z","primaryEndpoints":{"dfs":"https://bktestsa2.dfs.core.windows.net/","web":"https://bktestsa2.z20.web.core.windows.net/","blob":"https://bktestsa2.blob.core.windows.net/","queue":"https://bktestsa2.queue.core.windows.net/","table":"https://bktestsa2.table.core.windows.net/","file":"https://bktestsa2.file.core.windows.net/"},"primaryLocation":"eastus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rhel-test/providers/Microsoft.Storage/storageAccounts/rhel77acct","name":"rhel77acct","type":"Microsoft.Storage/storageAccounts","location":"eastus2","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-08-13T20:31:30.8995173Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-08-13T20:31:30.8995173Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-08-13T20:31:30.8215811Z","primaryEndpoints":{"blob":"https://rhel77acct.blob.core.windows.net/","queue":"https://rhel77acct.queue.core.windows.net/","table":"https://rhel77acct.table.core.windows.net/","file":"https://rhel77acct.file.core.windows.net/"},"primaryLocation":"eastus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SCRunner/providers/Microsoft.Storage/storageAccounts/scrunnerstorage","name":"scrunnerstorage","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-03-06T00:42:11.7016543Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2018-03-06T00:42:11.7016543Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2018-03-06T00:42:11.6234985Z","primaryEndpoints":{"blob":"https://scrunnerstorage.blob.core.windows.net/","queue":"https://scrunnerstorage.queue.core.windows.net/","table":"https://scrunnerstorage.table.core.windows.net/","file":"https://scrunnerstorage.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rhoover/providers/Microsoft.Storage/storageAccounts/rhooverstorage","name":"rhooverstorage","type":"Microsoft.Storage/storageAccounts","location":"southcentralus","tags":{"ms-resource-usage":"azure-cloud-shell"},"properties":{"keyCreationTime":{"key1":"2022-05-26T17:14:23.5085026Z","key2":"2022-05-26T17:14:23.5085026Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-26T17:14:23.5241285Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-05-26T17:14:23.5241285Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-05-26T17:14:23.4147520Z","primaryEndpoints":{"dfs":"https://rhooverstorage.dfs.core.windows.net/","web":"https://rhooverstorage.z21.web.core.windows.net/","blob":"https://rhooverstorage.blob.core.windows.net/","queue":"https://rhooverstorage.queue.core.windows.net/","table":"https://rhooverstorage.table.core.windows.net/","file":"https://rhooverstorage.file.core.windows.net/"},"primaryLocation":"southcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SCRunnertestvmrg-AustraliaEast/providers/Microsoft.Storage/storageAccounts/scrunner4p3t72mzheluc","name":"scrunner4p3t72mzheluc","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{},"properties":{"keyCreationTime":{"key1":"2021-04-13T22:35:36.6210942Z","key2":"2021-04-13T22:35:36.6210942Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2021-04-13T22:35:36.6210942Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2021-04-13T22:35:36.6210942Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2021-04-13T22:35:36.5429508Z","primaryEndpoints":{"blob":"https://scrunner4p3t72mzheluc.blob.core.windows.net/","queue":"https://scrunner4p3t72mzheluc.queue.core.windows.net/","table":"https://scrunner4p3t72mzheluc.table.core.windows.net/","file":"https://scrunner4p3t72mzheluc.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnervmrg-australiaeast/providers/Microsoft.Storage/storageAccounts/scrunner56hymyctm4kw2","name":"scrunner56hymyctm4kw2","type":"Microsoft.Storage/storageAccounts","location":"australiaeast","tags":{},"properties":{"keyCreationTime":{"key1":"2023-02-11T08:42:58.2414102Z","key2":"2023-02-11T08:42:58.2414102Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:42:59.3196006Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:42:59.3196006Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-02-11T08:42:58.1476588Z","primaryEndpoints":{"blob":"https://scrunner56hymyctm4kw2.blob.core.windows.net/","queue":"https://scrunner56hymyctm4kw2.queue.core.windows.net/","table":"https://scrunner56hymyctm4kw2.table.core.windows.net/","file":"https://scrunner56hymyctm4kw2.file.core.windows.net/"},"primaryLocation":"australiaeast","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002","name":"cli000002","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T15:00:46.5594874Z","key2":"2023-03-06T15:00:46.5594874Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T15:00:46.8094615Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T15:00:46.8094615Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T15:00:46.4501501Z","primaryEndpoints":{"blob":"https://cli000002.blob.core.windows.net/","queue":"https://cli000002.queue.core.windows.net/","table":"https://cli000002.table.core.windows.net/","file":"https://cli000002.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsolex4geueyy52iloaspyxz3rrqwxv2syvnkjiljxbv522buwxqpiljme/providers/Microsoft.Storage/storageAccounts/clipf6qz5nxegbgku5yqzkd2","name":"clipf6qz5nxegbgku5yqzkd2","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T07:45:44.7937561Z","key2":"2023-03-06T07:45:44.7937561Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:45:45.1687946Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:45:45.1687946Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T07:45:44.7000168Z","primaryEndpoints":{"blob":"https://clipf6qz5nxegbgku5yqzkd2.blob.core.windows.net/","queue":"https://clipf6qz5nxegbgku5yqzkd2.queue.core.windows.net/","table":"https://clipf6qz5nxegbgku5yqzkd2.table.core.windows.net/","file":"https://clipf6qz5nxegbgku5yqzkd2.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsoledcvrpndxic4emeqq5apwkns4qa5owpy4jn3b536ks35zdrmn7bl5k/providers/Microsoft.Storage/storageAccounts/cliwqnm2fo7pftnxlk7c734i","name":"cliwqnm2fo7pftnxlk7c734i","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T07:34:57.7461613Z","key2":"2023-03-06T07:34:57.7461613Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:34:57.9961851Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T07:34:57.9961851Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T07:34:57.6368148Z","primaryEndpoints":{"blob":"https://cliwqnm2fo7pftnxlk7c734i.blob.core.windows.net/","queue":"https://cliwqnm2fo7pftnxlk7c734i.queue.core.windows.net/","table":"https://cliwqnm2fo7pftnxlk7c734i.table.core.windows.net/","file":"https://cliwqnm2fo7pftnxlk7c734i.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guptar2/providers/Microsoft.Storage/storageAccounts/guptar2diagnosticsv1","name":"guptar2diagnosticsv1","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2022-04-05T17:21:41.8250582Z","key2":"2022-04-05T17:21:41.8250582Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:21:41.8250582Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:21:41.8250582Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-04-05T17:21:41.7313240Z","primaryEndpoints":{"blob":"https://guptar2diagnosticsv1.blob.core.windows.net/","queue":"https://guptar2diagnosticsv1.queue.core.windows.net/","table":"https://guptar2diagnosticsv1.table.core.windows.net/","file":"https://guptar2diagnosticsv1.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/guptar2/providers/Microsoft.Storage/storageAccounts/guptar2diagnosticsv2","name":"guptar2diagnosticsv2","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-04-05T17:22:55.8411567Z","key2":"2022-04-05T17:22:55.8411567Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"resourceAccessRules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[{"value":"20.98.146.84","action":"Allow"},{"value":"20.83.222.102","action":"Allow"},{"value":"20.98.194.64","action":"Allow"},{"value":"20.69.5.162","action":"Allow"}],"defaultAction":"Deny"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:22:55.8411567Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-05T17:22:55.8411567Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-04-05T17:22:55.7318000Z","primaryEndpoints":{"dfs":"https://guptar2diagnosticsv2.dfs.core.windows.net/","web":"https://guptar2diagnosticsv2.z5.web.core.windows.net/","blob":"https://guptar2diagnosticsv2.blob.core.windows.net/","queue":"https://guptar2diagnosticsv2.queue.core.windows.net/","table":"https://guptar2diagnosticsv2.table.core.windows.net/","file":"https://guptar2diagnosticsv2.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sericonrp-trafficmanager/providers/Microsoft.Storage/storageAccounts/sericonrpdevtmstorage","name":"sericonrpdevtmstorage","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-11-30T19:15:41.5013570Z","key2":"2022-11-30T19:15:41.5013570Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-11-30T19:15:42.0638737Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-11-30T19:15:42.0638737Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-11-30T19:15:41.4075777Z","primaryEndpoints":{"dfs":"https://sericonrpdevtmstorage.dfs.core.windows.net/","web":"https://sericonrpdevtmstorage.z5.web.core.windows.net/","blob":"https://sericonrpdevtmstorage.blob.core.windows.net/","queue":"https://sericonrpdevtmstorage.queue.core.windows.net/","table":"https://sericonrpdevtmstorage.table.core.windows.net/","file":"https://sericonrpdevtmstorage.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available","secondaryLocation":"westcentralus","statusOfSecondary":"available","secondaryEndpoints":{"dfs":"https://sericonrpdevtmstorage-secondary.dfs.core.windows.net/","web":"https://sericonrpdevtmstorage-secondary.z5.web.core.windows.net/","blob":"https://sericonrpdevtmstorage-secondary.blob.core.windows.net/","queue":"https://sericonrpdevtmstorage-secondary.queue.core.windows.net/","table":"https://sericonrpdevtmstorage-secondary.table.core.windows.net/"}}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ops/providers/Microsoft.Storage/storageAccounts/sericonstorage","name":"sericonstorage","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"dnsEndpointType":"Standard","defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2023-03-05T19:58:00.4355863Z","key2":"2023-03-05T19:58:00.4355863Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-05T19:58:00.9824831Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-05T19:58:00.9824831Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2023-03-05T19:58:00.3262342Z","primaryEndpoints":{"dfs":"https://sericonstorage.dfs.core.windows.net/","web":"https://sericonstorage.z5.web.core.windows.net/","blob":"https://sericonstorage.blob.core.windows.net/","queue":"https://sericonstorage.queue.core.windows.net/","table":"https://sericonstorage.table.core.windows.net/","file":"https://sericonstorage.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rhoover-dev-rg/providers/Microsoft.Storage/storageAccounts/rhooverdevrgdiag","name":"rhooverdevrgdiag","type":"Microsoft.Storage/storageAccounts","location":"westcentralus","tags":{},"properties":{"defaultToOAuthAuthentication":false,"publicNetworkAccess":"Enabled","keyCreationTime":{"key1":"2022-06-20T19:39:24.4605968Z","key2":"2022-06-20T19:39:24.4605968Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"allowSharedKeyAccess":false,"networkAcls":{"resourceAccessRules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[{"value":"20.98.146.84","action":"Allow"},{"value":"20.98.194.64","action":"Allow"},{"value":"20.69.5.162","action":"Allow"},{"value":"20.83.222.102","action":"Allow"},{"value":"76.197.206.105","action":"Allow"}],"defaultAction":"Deny"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-06-20T19:39:24.4762287Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-06-20T19:39:24.4762287Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-06-20T19:39:24.4137057Z","primaryEndpoints":{"blob":"https://rhooverdevrgdiag.blob.core.windows.net/","queue":"https://rhooverdevrgdiag.queue.core.windows.net/","table":"https://rhooverdevrgdiag.table.core.windows.net/","file":"https://rhooverdevrgdiag.file.core.windows.net/"},"primaryLocation":"westcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnervmrg-westcentralus/providers/Microsoft.Storage/storageAccounts/scrunneraoptpjec4skce","name":"scrunneraoptpjec4skce","type":"Microsoft.Storage/storageAccounts","location":"westcentralus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-02-11T08:40:40.0686467Z","key2":"2023-02-11T08:40:40.0686467Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:40:40.5842822Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-02-11T08:40:40.5842822Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-02-11T08:40:40.0061730Z","primaryEndpoints":{"blob":"https://scrunneraoptpjec4skce.blob.core.windows.net/","queue":"https://scrunneraoptpjec4skce.queue.core.windows.net/","table":"https://scrunneraoptpjec4skce.table.core.windows.net/","file":"https://scrunneraoptpjec4skce.file.core.windows.net/"},"primaryLocation":"westcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scrunnertestvmrg-westcentralus/providers/Microsoft.Storage/storageAccounts/scrunnerrfscmqxeni3uq","name":"scrunnerrfscmqxeni3uq","type":"Microsoft.Storage/storageAccounts","location":"westcentralus","tags":{},"properties":{"keyCreationTime":{"key1":null,"key2":null},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-04-10T22:28:55.2104910Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-04-10T22:28:55.2104910Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-04-10T22:28:55.1479670Z","primaryEndpoints":{"blob":"https://scrunnerrfscmqxeni3uq.blob.core.windows.net/","queue":"https://scrunnerrfscmqxeni3uq.queue.core.windows.net/","table":"https://scrunnerrfscmqxeni3uq.table.core.windows.net/","file":"https://scrunnerrfscmqxeni3uq.file.core.windows.net/"},"primaryLocation":"westcentralus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ubuntu-westus3_group/providers/Microsoft.Storage/storageAccounts/ubuntuwestus3groupdiag","name":"ubuntuwestus3groupdiag","type":"Microsoft.Storage/storageAccounts","location":"westus3","tags":{},"properties":{"keyCreationTime":{"key1":"2022-04-18T19:48:38.9882588Z","key2":"2022-04-18T19:48:38.9882588Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-18T19:48:38.9882588Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-18T19:48:38.9882588Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-04-18T19:48:38.9258191Z","primaryEndpoints":{"blob":"https://ubuntuwestus3groupdiag.blob.core.windows.net/","queue":"https://ubuntuwestus3groupdiag.queue.core.windows.net/","table":"https://ubuntuwestus3groupdiag.table.core.windows.net/","file":"https://ubuntuwestus3groupdiag.file.core.windows.net/"},"primaryLocation":"westus3","statusOfPrimary":"available"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '38475'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 06 Mar 2023 15:18:06 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-original-request-ids:
+      - de42fc45-1aef-4a58-aa1f-98a7eff455c3
+      - e69d0c99-4b80-4c82-a464-2cb65a7b94eb
+      - 1735b19b-cd33-4f62-bd7a-26ede2b1aee9
+      - 6c056d29-7ed9-4fd3-b239-4b457c763b33
+      - a2fb6c2d-20e7-4d30-b062-65f6ed4dcf6f
+      - 84ca1fc0-a320-4126-955f-b349051893d1
+      - 2b6c792d-9060-4734-a19c-1b12cda900fd
+      - 2b7f8cfd-f30c-4b28-8481-fd6d90dbd9f8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vmss update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --set
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002?api-version=2022-09-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002","name":"cli000002","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2022-12-13T22:57:52.2717456Z","key2":"2022-12-13T22:57:52.2717456Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-12-13T22:57:52.7873645Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-12-13T22:57:52.7873645Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-12-13T22:57:52.1623506Z","primaryEndpoints":{"blob":"https://cli000002.blob.core.windows.net/","queue":"https://cli000002.queue.core.windows.net/","table":"https://cli000002.table.core.windows.net/","file":"https://cli000002.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Storage/storageAccounts/cli000002","name":"cli000002","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2023-03-06T15:00:46.5594874Z","key2":"2023-03-06T15:00:46.5594874Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T15:00:46.8094615Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-03-06T15:00:46.8094615Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-03-06T15:00:46.4501501Z","primaryEndpoints":{"blob":"https://cli000002.blob.core.windows.net/","queue":"https://cli000002.queue.core.windows.net/","table":"https://cli000002.table.core.windows.net/","file":"https://cli000002.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -6672,7 +6607,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 13 Dec 2022 23:13:14 GMT
+      - Mon, 06 Mar 2023 15:18:06 GMT
       expires:
       - '-1'
       pragma:
@@ -6704,8 +6639,8 @@ interactions:
       ParameterSetName:
       - --name --resource-group --set
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
-        (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.SerialConsole/consoleServices/default?api-version=2018-05-01
   response:
@@ -6719,7 +6654,7 @@ interactions:
       content-type:
       - application/json; charset=UTF-8
       date:
-      - Tue, 13 Dec 2022 23:13:14 GMT
+      - Mon, 06 Mar 2023 15:18:06 GMT
       expires:
       - '-1'
       pragma:
@@ -6740,7 +6675,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"instanceIds": ["2"]}'
+    body: '{"instanceIds": ["3"]}'
     headers:
       Accept:
       - application/json
@@ -6757,9 +6692,9 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/manualupgrade?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/manualupgrade?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -6767,17 +6702,17 @@ interactions:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/da846bf5-666e-4052-af94-0e0c22ccec27?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/0221ee02-41b7-4778-a898-f00f2e388a09?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Tue, 13 Dec 2022 23:13:15 GMT
+      - Mon, 06 Mar 2023 15:18:07 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/da846bf5-666e-4052-af94-0e0c22ccec27?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/0221ee02-41b7-4778-a898-f00f2e388a09?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-11-01
       pragma:
       - no-cache
       server:
@@ -6788,7 +6723,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/VMScaleSetActions3Min;238,Microsoft.Compute/VMScaleSetActions30Min;1191,Microsoft.Compute/VMScaleSetBatchedVMRequests5Min;3022,Microsoft.Compute/VmssQueuedVMOperations;0
+      - Microsoft.Compute/VMScaleSetActions3Min;238,Microsoft.Compute/VMScaleSetActions30Min;1187,Microsoft.Compute/VMScaleSetBatchedVMRequests5Min;3048,Microsoft.Compute/VmssQueuedVMOperations;0
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-ms-request-charge:
@@ -6810,64 +6745,14 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/da846bf5-666e-4052-af94-0e0c22ccec27?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/0221ee02-41b7-4778-a898-f00f2e388a09?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:13:15.3871001+00:00\",\r\n  \"status\":
-        \"InProgress\",\r\n  \"name\": \"da846bf5-666e-4052-af94-0e0c22ccec27\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '134'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 13 Dec 2022 23:13:15 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14987,Microsoft.Compute/GetOperation30Min;29879
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vmss update-instances
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --instance-ids
-      User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/da846bf5-666e-4052-af94-0e0c22ccec27?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
-  response:
-    body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:13:15.3871001+00:00\",\r\n  \"endTime\":
-        \"2022-12-13T23:13:20.9027519+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"name\": \"da846bf5-666e-4052-af94-0e0c22ccec27\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T15:18:07.5147301+00:00\",\r\n  \"endTime\":
+        \"2023-03-06T15:18:17.5303198+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"name\": \"0221ee02-41b7-4778-a898-f00f2e388a09\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -6876,7 +6761,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:13:45 GMT
+      - Mon, 06 Mar 2023 15:18:37 GMT
       expires:
       - '-1'
       pragma:
@@ -6893,7 +6778,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14986,Microsoft.Compute/GetOperation30Min;29877
+      - Microsoft.Compute/GetOperation3Min;14989,Microsoft.Compute/GetOperation30Min;29769
     status:
       code: 200
       message: OK
@@ -6911,9 +6796,9 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/da846bf5-666e-4052-af94-0e0c22ccec27?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/0221ee02-41b7-4778-a898-f00f2e388a09?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-11-01
   response:
     body:
       string: ''
@@ -6923,7 +6808,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 13 Dec 2022 23:13:45 GMT
+      - Mon, 06 Mar 2023 15:18:37 GMT
       expires:
       - '-1'
       pragma:
@@ -6936,7 +6821,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14985,Microsoft.Compute/GetOperation30Min;29876
+      - Microsoft.Compute/GetOperation3Min;14988,Microsoft.Compute/GetOperation30Min;29768
     status:
       code: 200
       message: OK
@@ -6954,21 +6839,21 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/2/instanceView?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/3/instanceView?api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"placementGroupId\": \"b12ec8ba-0f67-45f7-a5b3-5e94f2268933\",\r\n
+      string: "{\r\n  \"placementGroupId\": \"fe2728fc-c0cb-4cea-8d91-bb960a1e6c3b\",\r\n
         \ \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n  \"computerName\":
-        \"cli5o787e000002\",\r\n  \"osName\": \"ubuntu\",\r\n  \"osVersion\": \"18.04\",\r\n
+        \"cliuz26de000003\",\r\n  \"osName\": \"ubuntu\",\r\n  \"osVersion\": \"18.04\",\r\n
         \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"2.9.0.4\",\r\n    \"statuses\":
         [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\",\r\n        \"level\":
         \"Info\",\r\n        \"displayStatus\": \"Ready\",\r\n        \"message\":
-        \"Guest Agent is running\",\r\n        \"time\": \"2022-12-13T23:13:27+00:00\"\r\n
+        \"Guest Agent is running\",\r\n        \"time\": \"2023-03-06T15:18:21+00:00\"\r\n
         \     }\r\n    ],\r\n    \"extensionHandlers\": [\r\n      {\r\n        \"type\":
         \"Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n        \"typeHandlerVersion\":
-        \"1.24.2\",\r\n        \"status\": {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \"1.25.1\",\r\n        \"status\": {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Ready\",\r\n
         \         \"message\": \"Plugin enabled\"\r\n        }\r\n      },\r\n      {\r\n
         \       \"type\": \"Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent\",\r\n
@@ -6976,14 +6861,14 @@ interactions:
         \         \"code\": \"ProvisioningState/succeeded\",\r\n          \"level\":
         \"Info\",\r\n          \"displayStatus\": \"Ready\",\r\n          \"message\":
         \"Plugin enabled\"\r\n        }\r\n      }\r\n    ]\r\n  },\r\n  \"disks\":
-        [\r\n    {\r\n      \"name\": \"cli5oqyn2zpljvxqcitncli5oqyn2zpljvxqcitnmOS__1_fc2a2b19ddde4a019629d326a068caf5\",\r\n
+        [\r\n    {\r\n      \"name\": \"cliuztvtdw4jbve2omq7cliuztvtdw4jbve2omq73OS__1_023d79a2b12548fba5c6e457bd338d14\",\r\n
         \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2022-12-13T23:09:04.6694815+00:00\"\r\n
+        succeeded\",\r\n          \"time\": \"2023-03-06T15:13:46.5311755+00:00\"\r\n
         \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"extensions\": [\r\n    {\r\n
         \     \"name\": \"Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n      \"type\":
         \"Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n      \"typeHandlerVersion\":
-        \"1.24.2\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \"1.25.1\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
         succeeded\",\r\n          \"message\": \"Enable succeeded\"\r\n        }\r\n
         \     ]\r\n    },\r\n    {\r\n      \"name\": \"Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent\",\r\n
@@ -6995,7 +6880,7 @@ interactions:
         \   }\r\n  ],\r\n  \"hyperVGeneration\": \"V1\",\r\n  \"statuses\": [\r\n
         \   {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n      \"level\":
         \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n      \"time\":
-        \"2022-12-13T23:13:20.8558535+00:00\"\r\n    },\r\n    {\r\n      \"code\":
+        \"2023-03-06T15:18:17.4834931+00:00\"\r\n    },\r\n    {\r\n      \"code\":
         \"PowerState/running\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\":
         \"VM running\"\r\n    }\r\n  ]\r\n}"
     headers:
@@ -7006,7 +6891,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:13:46 GMT
+      - Mon, 06 Mar 2023 15:18:37 GMT
       expires:
       - '-1'
       pragma:
@@ -7023,7 +6908,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetVMScaleSetVM3Min;497,Microsoft.Compute/GetVMScaleSetVM30Min;2490,Microsoft.Compute/VMScaleSetVMViews3Min;4997
+      - Microsoft.Compute/GetVMScaleSetVM3Min;497,Microsoft.Compute/GetVMScaleSetVM30Min;2469,Microsoft.Compute/VMScaleSetVMViews3Min;4997
       x-ms-request-charge:
       - '1'
     status:
@@ -7045,9 +6930,9 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/2/deallocate?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/3/deallocate?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -7055,17 +6940,17 @@ interactions:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/2a41379c-9898-4491-b29e-1aa3d554e8ec?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/23eca364-f00f-4c86-a879-0a9d4a851f19?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Tue, 13 Dec 2022 23:13:47 GMT
+      - Mon, 06 Mar 2023 15:18:39 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/2a41379c-9898-4491-b29e-1aa3d554e8ec?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/23eca364-f00f-4c86-a879-0a9d4a851f19?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-11-01
       pragma:
       - no-cache
       server:
@@ -7076,7 +6961,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/DeleteVMScaleSetVM3Min;239,Microsoft.Compute/DeleteVMScaleSetVM30Min;1197,Microsoft.Compute/VMScaleSetBatchedVMRequests5Min;3021,Microsoft.Compute/VmssQueuedVMOperations;0
+      - Microsoft.Compute/DeleteVMScaleSetVM3Min;239,Microsoft.Compute/DeleteVMScaleSetVM30Min;1196,Microsoft.Compute/VMScaleSetBatchedVMRequests5Min;3047,Microsoft.Compute/VmssQueuedVMOperations;0
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-ms-request-charge:
@@ -7098,13 +6983,13 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/2a41379c-9898-4491-b29e-1aa3d554e8ec?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/23eca364-f00f-4c86-a879-0a9d4a851f19?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:13:47.5432427+00:00\",\r\n  \"status\":
-        \"InProgress\",\r\n  \"name\": \"2a41379c-9898-4491-b29e-1aa3d554e8ec\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T15:18:39.6083923+00:00\",\r\n  \"status\":
+        \"InProgress\",\r\n  \"name\": \"23eca364-f00f-4c86-a879-0a9d4a851f19\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -7113,7 +6998,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:13:47 GMT
+      - Mon, 06 Mar 2023 15:19:09 GMT
       expires:
       - '-1'
       pragma:
@@ -7130,7 +7015,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14984,Microsoft.Compute/GetOperation30Min;29875
+      - Microsoft.Compute/GetOperation3Min;14986,Microsoft.Compute/GetOperation30Min;29765
     status:
       code: 200
       message: OK
@@ -7148,13 +7033,13 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/2a41379c-9898-4491-b29e-1aa3d554e8ec?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/23eca364-f00f-4c86-a879-0a9d4a851f19?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:13:47.5432427+00:00\",\r\n  \"status\":
-        \"InProgress\",\r\n  \"name\": \"2a41379c-9898-4491-b29e-1aa3d554e8ec\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T15:18:39.6083923+00:00\",\r\n  \"status\":
+        \"InProgress\",\r\n  \"name\": \"23eca364-f00f-4c86-a879-0a9d4a851f19\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -7163,7 +7048,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:14:17 GMT
+      - Mon, 06 Mar 2023 15:19:38 GMT
       expires:
       - '-1'
       pragma:
@@ -7180,7 +7065,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14982,Microsoft.Compute/GetOperation30Min;29872
+      - Microsoft.Compute/GetOperation3Min;14987,Microsoft.Compute/GetOperation30Min;29764
     status:
       code: 200
       message: OK
@@ -7198,14 +7083,114 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/2a41379c-9898-4491-b29e-1aa3d554e8ec?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/23eca364-f00f-4c86-a879-0a9d4a851f19?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:13:47.5432427+00:00\",\r\n  \"endTime\":
-        \"2022-12-13T23:14:34.4024454+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"name\": \"2a41379c-9898-4491-b29e-1aa3d554e8ec\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T15:18:39.6083923+00:00\",\r\n  \"status\":
+        \"InProgress\",\r\n  \"name\": \"23eca364-f00f-4c86-a879-0a9d4a851f19\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '134'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 06 Mar 2023 15:20:09 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/GetOperation3Min;14987,Microsoft.Compute/GetOperation30Min;29779
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vmss deallocate
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --instance-ids
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/23eca364-f00f-4c86-a879-0a9d4a851f19?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
+  response:
+    body:
+      string: "{\r\n  \"startTime\": \"2023-03-06T15:18:39.6083923+00:00\",\r\n  \"status\":
+        \"InProgress\",\r\n  \"name\": \"23eca364-f00f-4c86-a879-0a9d4a851f19\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '134'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 06 Mar 2023 15:20:39 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/GetOperation3Min;14989,Microsoft.Compute/GetOperation30Min;29778
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vmss deallocate
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --instance-ids
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/23eca364-f00f-4c86-a879-0a9d4a851f19?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
+  response:
+    body:
+      string: "{\r\n  \"startTime\": \"2023-03-06T15:18:39.6083923+00:00\",\r\n  \"endTime\":
+        \"2023-03-06T15:21:04.1386836+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"name\": \"23eca364-f00f-4c86-a879-0a9d4a851f19\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -7214,7 +7199,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:14:47 GMT
+      - Mon, 06 Mar 2023 15:21:09 GMT
       expires:
       - '-1'
       pragma:
@@ -7231,7 +7216,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14981,Microsoft.Compute/GetOperation30Min;29870
+      - Microsoft.Compute/GetOperation3Min;14988,Microsoft.Compute/GetOperation30Min;29775
     status:
       code: 200
       message: OK
@@ -7249,9 +7234,9 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/2a41379c-9898-4491-b29e-1aa3d554e8ec?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/23eca364-f00f-4c86-a879-0a9d4a851f19?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-11-01
   response:
     body:
       string: ''
@@ -7261,7 +7246,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 13 Dec 2022 23:14:47 GMT
+      - Mon, 06 Mar 2023 15:21:09 GMT
       expires:
       - '-1'
       pragma:
@@ -7274,7 +7259,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14980,Microsoft.Compute/GetOperation30Min;29869
+      - Microsoft.Compute/GetOperation3Min;14987,Microsoft.Compute/GetOperation30Min;29774
     status:
       code: 200
       message: OK
@@ -7292,32 +7277,32 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/2/instanceView?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/3/instanceView?api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"placementGroupId\": \"b12ec8ba-0f67-45f7-a5b3-5e94f2268933\",\r\n
+      string: "{\r\n  \"placementGroupId\": \"fe2728fc-c0cb-4cea-8d91-bb960a1e6c3b\",\r\n
         \ \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n  \"disks\":
-        [\r\n    {\r\n      \"name\": \"cli5oqyn2zpljvxqcitncli5oqyn2zpljvxqcitnmOS__1_fc2a2b19ddde4a019629d326a068caf5\",\r\n
+        [\r\n    {\r\n      \"name\": \"cliuztvtdw4jbve2omq7cliuztvtdw4jbve2omq73OS__1_023d79a2b12548fba5c6e457bd338d14\",\r\n
         \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2022-12-13T23:14:34.339913+00:00\"\r\n
+        succeeded\",\r\n          \"time\": \"2023-03-06T15:21:04.0292941+00:00\"\r\n
         \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"hyperVGeneration\": \"V1\",\r\n
         \ \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
         \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \     \"time\": \"2022-12-13T23:14:34.3555432+00:00\"\r\n    },\r\n    {\r\n
+        \     \"time\": \"2023-03-06T15:21:04.0605472+00:00\"\r\n    },\r\n    {\r\n
         \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
         \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '853'
+      - '854'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:14:47 GMT
+      - Mon, 06 Mar 2023 15:21:10 GMT
       expires:
       - '-1'
       pragma:
@@ -7334,14 +7319,14 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetVMScaleSetVM3Min;496,Microsoft.Compute/GetVMScaleSetVM30Min;2489,Microsoft.Compute/VMScaleSetVMViews3Min;4996
+      - Microsoft.Compute/GetVMScaleSetVM3Min;498,Microsoft.Compute/GetVMScaleSetVM30Min;2470,Microsoft.Compute/VMScaleSetVMViews3Min;4998
       x-ms-request-charge:
       - '1'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"instanceIds": ["2"]}'
+    body: '{"instanceIds": ["3"]}'
     headers:
       Accept:
       - application/json
@@ -7358,9 +7343,9 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/start?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/start?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -7368,17 +7353,17 @@ interactions:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/6f10b06a-07cc-43f5-81eb-6285cef0c572?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/9bacbc77-19a6-4e08-8e9b-346f0e99214d?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Tue, 13 Dec 2022 23:14:48 GMT
+      - Mon, 06 Mar 2023 15:21:10 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/6f10b06a-07cc-43f5-81eb-6285cef0c572?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/9bacbc77-19a6-4e08-8e9b-346f0e99214d?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-11-01
       pragma:
       - no-cache
       server:
@@ -7389,9 +7374,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/VMScaleSetActions3Min;237,Microsoft.Compute/VMScaleSetActions30Min;1190,Microsoft.Compute/VMScaleSetBatchedVMRequests5Min;3021,Microsoft.Compute/VmssQueuedVMOperations;0
+      - Microsoft.Compute/VMScaleSetActions3Min;239,Microsoft.Compute/VMScaleSetActions30Min;1187,Microsoft.Compute/VMScaleSetBatchedVMRequests5Min;3047,Microsoft.Compute/VmssQueuedVMOperations;0
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
+      - '1199'
       x-ms-request-charge:
       - '1'
     status:
@@ -7411,13 +7396,13 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/6f10b06a-07cc-43f5-81eb-6285cef0c572?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/9bacbc77-19a6-4e08-8e9b-346f0e99214d?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:14:49.6054659+00:00\",\r\n  \"status\":
-        \"InProgress\",\r\n  \"name\": \"6f10b06a-07cc-43f5-81eb-6285cef0c572\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T15:21:11.5450763+00:00\",\r\n  \"status\":
+        \"InProgress\",\r\n  \"name\": \"9bacbc77-19a6-4e08-8e9b-346f0e99214d\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -7426,7 +7411,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:14:49 GMT
+      - Mon, 06 Mar 2023 15:21:41 GMT
       expires:
       - '-1'
       pragma:
@@ -7443,7 +7428,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14979,Microsoft.Compute/GetOperation30Min;29868
+      - Microsoft.Compute/GetOperation3Min;14989,Microsoft.Compute/GetOperation30Min;29772
     status:
       code: 200
       message: OK
@@ -7461,64 +7446,14 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/6f10b06a-07cc-43f5-81eb-6285cef0c572?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/9bacbc77-19a6-4e08-8e9b-346f0e99214d?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:14:49.6054659+00:00\",\r\n  \"status\":
-        \"InProgress\",\r\n  \"name\": \"6f10b06a-07cc-43f5-81eb-6285cef0c572\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '134'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 13 Dec 2022 23:15:19 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14978,Microsoft.Compute/GetOperation30Min;29865
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vmss start
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --instance-ids
-      User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/6f10b06a-07cc-43f5-81eb-6285cef0c572?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
-  response:
-    body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:14:49.6054659+00:00\",\r\n  \"endTime\":
-        \"2022-12-13T23:15:38.5896527+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"name\": \"6f10b06a-07cc-43f5-81eb-6285cef0c572\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T15:21:11.5450763+00:00\",\r\n  \"endTime\":
+        \"2023-03-06T15:21:44.6702338+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"name\": \"9bacbc77-19a6-4e08-8e9b-346f0e99214d\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -7527,7 +7462,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:15:49 GMT
+      - Mon, 06 Mar 2023 15:22:11 GMT
       expires:
       - '-1'
       pragma:
@@ -7544,7 +7479,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14980,Microsoft.Compute/GetOperation30Min;29863
+      - Microsoft.Compute/GetOperation3Min;14988,Microsoft.Compute/GetOperation30Min;29770
     status:
       code: 200
       message: OK
@@ -7562,9 +7497,9 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/6f10b06a-07cc-43f5-81eb-6285cef0c572?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/9bacbc77-19a6-4e08-8e9b-346f0e99214d?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-11-01
   response:
     body:
       string: ''
@@ -7574,7 +7509,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 13 Dec 2022 23:15:49 GMT
+      - Mon, 06 Mar 2023 15:22:11 GMT
       expires:
       - '-1'
       pragma:
@@ -7587,7 +7522,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14979,Microsoft.Compute/GetOperation30Min;29862
+      - Microsoft.Compute/GetOperation3Min;14987,Microsoft.Compute/GetOperation30Min;29769
     status:
       code: 200
       message: OK
@@ -7605,9 +7540,9 @@ interactions:
       ParameterSetName:
       - --name --resource-group --set
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003?api-version=2022-11-01
   response:
     body:
       string: "{\r\n  \"name\": \"cli000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003\",\r\n
@@ -7623,23 +7558,24 @@ interactions:
         {\r\n      \"mode\": \"Manual\",\r\n      \"rollingUpgradePolicy\": {\r\n
         \       \"maxBatchInstancePercent\": 20,\r\n        \"maxUnhealthyInstancePercent\":
         20,\r\n        \"maxUnhealthyUpgradedInstancePercent\": 20,\r\n        \"pauseTimeBetweenBatches\":
-        \"PT0S\"\r\n      }\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\":
-        {\r\n        \"computerNamePrefix\": \"cli5o787e\",\r\n        \"adminUsername\":
-        \"rhl\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\":
+        \"PT0S\",\r\n        \"maxSurge\": false,\r\n        \"rollbackFailedInstancesOnPolicyBreach\":
+        false\r\n      }\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\":
+        {\r\n        \"computerNamePrefix\": \"cliuz26de\",\r\n        \"adminUsername\":
+        \"rhoover\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\":
         true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n              {\r\n
-        \               \"path\": \"/home/rhl/.ssh/authorized_keys\",\r\n                \"keyData\":
-        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h\"\r\n
-        \             }\r\n            ]\r\n          },\r\n          \"provisionVMAgent\":
-        true,\r\n          \"enableVMAgentPlatformUpdates\": false\r\n        },\r\n
-        \       \"secrets\": [],\r\n        \"allowExtensionOperations\": true,\r\n
-        \       \"requireGuestProvisionSignal\": true\r\n      },\r\n      \"storageProfile\":
+        \               \"path\": \"/home/rhoover/.ssh/authorized_keys\",\r\n                \"keyData\":
+        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+        REDMOND+rhoover@DESKTOP-XVFR7ID\\n\"\r\n              }\r\n            ]\r\n
+        \         },\r\n          \"provisionVMAgent\": true,\r\n          \"enableVMAgentPlatformUpdates\":
+        false\r\n        },\r\n        \"secrets\": [],\r\n        \"allowExtensionOperations\":
+        true,\r\n        \"requireGuestProvisionSignal\": true\r\n      },\r\n      \"storageProfile\":
         {\r\n        \"osDisk\": {\r\n          \"osType\": \"Linux\",\r\n          \"createOption\":
         \"FromImage\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\":
         {\r\n            \"storageAccountType\": \"Premium_LRS\"\r\n          },\r\n
         \         \"diskSizeGB\": 30\r\n        },\r\n        \"imageReference\":
         {\r\n          \"publisher\": \"Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n
         \         \"sku\": \"18.04-LTS\",\r\n          \"version\": \"latest\"\r\n
-        \       }\r\n      },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"cli5o787eNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"disableTcpStateTracking\":false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\":[{\"name\":\"cli5o787eIPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET/subnets/cli000003Subnet\"},\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/backendAddressPools/cli000003LBBEPool\"}],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/inboundNatPools/cli000003LBNatPool\"}]}}]}}]},\r\n
+        \       }\r\n      },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"cliuz26deNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"disableTcpStateTracking\":false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\":[{\"name\":\"cliuz26deIPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET/subnets/cli000003Subnet\"},\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/backendAddressPools/cli000003LBBEPool\"}],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/inboundNatPools/cli000003LBNatPool\"}]}}]}}]},\r\n
         \     \"diagnosticsProfile\": {\r\n        \"bootDiagnostics\": {\r\n          \"enabled\":
         false,\r\n          \"storageUri\": \"https://cli000002.blob.core.windows.net/\"\r\n
         \       }\r\n      },\r\n      \"extensionProfile\": {\r\n        \"extensions\":
@@ -7657,17 +7593,17 @@ interactions:
         {\"enableGenevaUpload\":true,\"enableAutoConfig\":true,\"reportSuccessOnUnsupportedDistro\":true}\r\n
         \           }\r\n          }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\":
         \"Succeeded\",\r\n    \"overprovision\": true,\r\n    \"doNotRunExtensionsOnOverprovisionedVMs\":
-        false,\r\n    \"uniqueId\": \"c72549ea-142c-4eb1-8178-a7442e2bc6db\",\r\n
-        \   \"timeCreated\": \"2022-12-13T22:58:32.1880141+00:00\"\r\n  }\r\n}"
+        false,\r\n    \"uniqueId\": \"6aa1f17d-1da0-4dfe-b11e-b77e59e02135\",\r\n
+        \   \"timeCreated\": \"2023-03-06T15:01:24.7059254+00:00\"\r\n  }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '5242'
+      - '5541'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:15:50 GMT
+      - Mon, 06 Mar 2023 15:22:12 GMT
       expires:
       - '-1'
       pragma:
@@ -7684,7 +7620,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetVMScaleSet3Min;392,Microsoft.Compute/GetVMScaleSet30Min;2563
+      - Microsoft.Compute/GetVMScaleSet3Min;396,Microsoft.Compute/GetVMScaleSet30Min;2487
     status:
       code: 200
       message: OK
@@ -7694,17 +7630,19 @@ interactions:
       2}, "identity": {"type": "UserAssigned", "userAssignedIdentities": {"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AzSecPackAutoConfigRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/AzSecPackAutoConfigUA-westus2":
       {}}}, "properties": {"upgradePolicy": {"mode": "Manual", "rollingUpgradePolicy":
       {"maxBatchInstancePercent": 20, "maxUnhealthyInstancePercent": 20, "maxUnhealthyUpgradedInstancePercent":
-      20, "pauseTimeBetweenBatches": "PT0S"}}, "virtualMachineProfile": {"osProfile":
-      {"computerNamePrefix": "cli5o787e", "adminUsername": "rhl", "linuxConfiguration":
-      {"disablePasswordAuthentication": true, "ssh": {"publicKeys": [{"path": "/home/rhl/.ssh/authorized_keys",
-      "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h"}]},
-      "provisionVMAgent": true, "enableVMAgentPlatformUpdates": false}, "secrets":
-      [], "allowExtensionOperations": true}, "storageProfile": {"osDisk": {"caching":
-      "ReadWrite", "createOption": "FromImage", "diskSizeGB": 30, "osType": "Linux",
-      "managedDisk": {"storageAccountType": "Premium_LRS"}}}, "networkProfile": {"networkInterfaceConfigurations":
-      [{"name": "cli5o787eNic", "properties": {"primary": true, "enableAcceleratedNetworking":
+      20, "pauseTimeBetweenBatches": "PT0S", "rollbackFailedInstancesOnPolicyBreach":
+      false, "maxSurge": false}}, "virtualMachineProfile": {"osProfile": {"computerNamePrefix":
+      "cliuz26de", "adminUsername": "rhoover", "linuxConfiguration": {"disablePasswordAuthentication":
+      true, "ssh": {"publicKeys": [{"path": "/home/rhoover/.ssh/authorized_keys",
+      "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+      REDMOND+rhoover@DESKTOP-XVFR7ID\n"}]}, "provisionVMAgent": true, "enableVMAgentPlatformUpdates":
+      false}, "secrets": [], "allowExtensionOperations": true, "requireGuestProvisionSignal":
+      true}, "storageProfile": {"osDisk": {"caching": "ReadWrite", "createOption":
+      "FromImage", "diskSizeGB": 30, "osType": "Linux", "managedDisk": {"storageAccountType":
+      "Premium_LRS"}}}, "networkProfile": {"networkInterfaceConfigurations": [{"name":
+      "cliuz26deNic", "properties": {"primary": true, "enableAcceleratedNetworking":
       false, "disableTcpStateTracking": false, "dnsSettings": {"dnsServers": []},
-      "ipConfigurations": [{"name": "cli5o787eIPConfig", "properties": {"subnet":
+      "ipConfigurations": [{"name": "cliuz26deIPConfig", "properties": {"subnet":
       {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET/subnets/cli000003Subnet"},
       "privateIPAddressVersion": "IPv4", "loadBalancerBackendAddressPools": [{"id":
       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/backendAddressPools/cli000003LBBEPool"}],
@@ -7729,15 +7667,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '3520'
+      - '3838'
       Content-Type:
       - application/json
       ParameterSetName:
       - --name --resource-group --set
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003?api-version=2022-11-01
   response:
     body:
       string: "{\r\n  \"name\": \"cli000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003\",\r\n
@@ -7753,23 +7691,24 @@ interactions:
         {\r\n      \"mode\": \"Manual\",\r\n      \"rollingUpgradePolicy\": {\r\n
         \       \"maxBatchInstancePercent\": 20,\r\n        \"maxUnhealthyInstancePercent\":
         20,\r\n        \"maxUnhealthyUpgradedInstancePercent\": 20,\r\n        \"pauseTimeBetweenBatches\":
-        \"PT0S\"\r\n      }\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\":
-        {\r\n        \"computerNamePrefix\": \"cli5o787e\",\r\n        \"adminUsername\":
-        \"rhl\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\":
+        \"PT0S\",\r\n        \"maxSurge\": false,\r\n        \"rollbackFailedInstancesOnPolicyBreach\":
+        false\r\n      }\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\":
+        {\r\n        \"computerNamePrefix\": \"cliuz26de\",\r\n        \"adminUsername\":
+        \"rhoover\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\":
         true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n              {\r\n
-        \               \"path\": \"/home/rhl/.ssh/authorized_keys\",\r\n                \"keyData\":
-        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h\"\r\n
-        \             }\r\n            ]\r\n          },\r\n          \"provisionVMAgent\":
-        true,\r\n          \"enableVMAgentPlatformUpdates\": false\r\n        },\r\n
-        \       \"secrets\": [],\r\n        \"allowExtensionOperations\": true,\r\n
-        \       \"requireGuestProvisionSignal\": true\r\n      },\r\n      \"storageProfile\":
+        \               \"path\": \"/home/rhoover/.ssh/authorized_keys\",\r\n                \"keyData\":
+        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+        REDMOND+rhoover@DESKTOP-XVFR7ID\\n\"\r\n              }\r\n            ]\r\n
+        \         },\r\n          \"provisionVMAgent\": true,\r\n          \"enableVMAgentPlatformUpdates\":
+        false\r\n        },\r\n        \"secrets\": [],\r\n        \"allowExtensionOperations\":
+        true,\r\n        \"requireGuestProvisionSignal\": true\r\n      },\r\n      \"storageProfile\":
         {\r\n        \"osDisk\": {\r\n          \"osType\": \"Linux\",\r\n          \"createOption\":
         \"FromImage\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\":
         {\r\n            \"storageAccountType\": \"Premium_LRS\"\r\n          },\r\n
         \         \"diskSizeGB\": 30\r\n        },\r\n        \"imageReference\":
         {\r\n          \"publisher\": \"Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n
         \         \"sku\": \"18.04-LTS\",\r\n          \"version\": \"latest\"\r\n
-        \       }\r\n      },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"cli5o787eNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"disableTcpStateTracking\":false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\":[{\"name\":\"cli5o787eIPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET/subnets/cli000003Subnet\"},\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/backendAddressPools/cli000003LBBEPool\"}],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/inboundNatPools/cli000003LBNatPool\"}]}}]}}]},\r\n
+        \       }\r\n      },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"cliuz26deNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"disableTcpStateTracking\":false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\":[{\"name\":\"cliuz26deIPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET/subnets/cli000003Subnet\"},\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/backendAddressPools/cli000003LBBEPool\"}],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/inboundNatPools/cli000003LBNatPool\"}]}}]}}]},\r\n
         \     \"diagnosticsProfile\": {\r\n        \"bootDiagnostics\": {\r\n          \"enabled\":
         true\r\n        }\r\n      },\r\n      \"extensionProfile\": {\r\n        \"extensions\":
         [\r\n          {\r\n            \"name\": \"Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n
@@ -7786,21 +7725,21 @@ interactions:
         {\"enableGenevaUpload\":true,\"enableAutoConfig\":true,\"reportSuccessOnUnsupportedDistro\":true}\r\n
         \           }\r\n          }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\":
         \"Updating\",\r\n    \"overprovision\": true,\r\n    \"doNotRunExtensionsOnOverprovisionedVMs\":
-        false,\r\n    \"uniqueId\": \"c72549ea-142c-4eb1-8178-a7442e2bc6db\",\r\n
-        \   \"timeCreated\": \"2022-12-13T22:58:32.1880141+00:00\"\r\n  }\r\n}"
+        false,\r\n    \"uniqueId\": \"6aa1f17d-1da0-4dfe-b11e-b77e59e02135\",\r\n
+        \   \"timeCreated\": \"2023-03-06T15:01:24.7059254+00:00\"\r\n  }\r\n}"
     headers:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/505c88eb-551e-4352-af33-93e3611afeee?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/f2bbedf8-37cd-469e-a78a-f426ee1da2f3?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
       cache-control:
       - no-cache
       content-length:
-      - '5171'
+      - '5470'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:15:54 GMT
+      - Mon, 06 Mar 2023 15:22:16 GMT
       expires:
       - '-1'
       pragma:
@@ -7817,7 +7756,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/CreateVMScaleSet3Min;149,Microsoft.Compute/CreateVMScaleSet30Min;750,Microsoft.Compute/VmssQueuedVMOperations;0
+      - Microsoft.Compute/CreateVMScaleSet3Min;151,Microsoft.Compute/CreateVMScaleSet30Min;747,Microsoft.Compute/VmssQueuedVMOperations;0
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-ms-request-charge:
@@ -7839,23 +7778,23 @@ interactions:
       ParameterSetName:
       - --name --resource-group --set
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/505c88eb-551e-4352-af33-93e3611afeee?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/f2bbedf8-37cd-469e-a78a-f426ee1da2f3?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:15:54.3708637+00:00\",\r\n  \"endTime\":
-        \"2022-12-13T23:15:54.745861+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"name\": \"505c88eb-551e-4352-af33-93e3611afeee\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T15:22:15.9826698+00:00\",\r\n  \"endTime\":
+        \"2023-03-06T15:22:16.3107656+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"name\": \"f2bbedf8-37cd-469e-a78a-f426ee1da2f3\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '183'
+      - '184'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:15:54 GMT
+      - Mon, 06 Mar 2023 15:22:26 GMT
       expires:
       - '-1'
       pragma:
@@ -7872,7 +7811,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14978,Microsoft.Compute/GetOperation30Min;29861
+      - Microsoft.Compute/GetOperation3Min;14986,Microsoft.Compute/GetOperation30Min;29768
     status:
       code: 200
       message: OK
@@ -7890,9 +7829,9 @@ interactions:
       ParameterSetName:
       - --name --resource-group --set
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003?api-version=2022-11-01
   response:
     body:
       string: "{\r\n  \"name\": \"cli000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003\",\r\n
@@ -7908,23 +7847,24 @@ interactions:
         {\r\n      \"mode\": \"Manual\",\r\n      \"rollingUpgradePolicy\": {\r\n
         \       \"maxBatchInstancePercent\": 20,\r\n        \"maxUnhealthyInstancePercent\":
         20,\r\n        \"maxUnhealthyUpgradedInstancePercent\": 20,\r\n        \"pauseTimeBetweenBatches\":
-        \"PT0S\"\r\n      }\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\":
-        {\r\n        \"computerNamePrefix\": \"cli5o787e\",\r\n        \"adminUsername\":
-        \"rhl\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\":
+        \"PT0S\",\r\n        \"maxSurge\": false,\r\n        \"rollbackFailedInstancesOnPolicyBreach\":
+        false\r\n      }\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\":
+        {\r\n        \"computerNamePrefix\": \"cliuz26de\",\r\n        \"adminUsername\":
+        \"rhoover\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\":
         true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n              {\r\n
-        \               \"path\": \"/home/rhl/.ssh/authorized_keys\",\r\n                \"keyData\":
-        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKoLabWE4Qpo2PsUA6UH9DCgCt2rd8x4/vphopMBrOpvW3xJCbgIuyh7OXIzahI+rPjdKmFDu138wlT/hbc55E+E7QKg1ZNtfPU3WDiGXEzmpJVcUlTaDXek7UeZNQliz08A9dhw+ofjWPGyABUK+zBSdVcTM5rAdfPjIsvYaWSkseEnBCHN8c64fzCkH/KX82+LBrV+vCcaE/zNjb9RiXyJw7xsHJ2m2boadXRdKigxip2i6zSV9TKv6c7muaLbXKGGsA6asqrfhh6m7jNGurY3P3rLb+ZBEbBmi3y9YS4FCipPNt77YoLejk9sF/JSmvYeYFiQ29ZFPIgISvR09h\"\r\n
-        \             }\r\n            ]\r\n          },\r\n          \"provisionVMAgent\":
-        true,\r\n          \"enableVMAgentPlatformUpdates\": false\r\n        },\r\n
-        \       \"secrets\": [],\r\n        \"allowExtensionOperations\": true,\r\n
-        \       \"requireGuestProvisionSignal\": true\r\n      },\r\n      \"storageProfile\":
+        \               \"path\": \"/home/rhoover/.ssh/authorized_keys\",\r\n                \"keyData\":
+        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCrHifgj/9+LNm4uSfBlu1TRKHJnzYliXOibEchXa7ZutI+6B1N9KimFIcDfCwhIMKX2R2OIc1d547W1TJYXUBhGWzOUKBmHxb+WQAAgcP4z8dg4ae1aY8QpqynplBuiPCdvlvc4GbAFjY+uxUzajiR8MP/aRTfB3YNrs2XzDvXwaBZBDaR0wUuJUs+234pOdJnLVF1R2qxz3dV0IPh67CPXFfA2kY652rJJlUJZyOwpUck1CnEW98GgaBMGpvdwx6cL1CgSU5JISgZ64FGS6D1OBr1f4dAynrcvvkEt5AKYlHj42kgdBmJJzsIQV4f8TPOELw7gTZ+nybGbwZy5xxmUdLJgIR/GzGbaZ08cX2GuYQTN9HKHCzoWddxCURtnSXbH0RAuCqTZc9C8kCYvulvIqEG5OBamRXwRatXYDT2x2yY5eS2A7j16/GUZoJ6tw7VQfbnIlD1cBVYWwd5FlmRJziU0tLnIDiKkHhzZ6nvefP/iQuUfsGvfym+LZ3w4SU=
+        REDMOND+rhoover@DESKTOP-XVFR7ID\\n\"\r\n              }\r\n            ]\r\n
+        \         },\r\n          \"provisionVMAgent\": true,\r\n          \"enableVMAgentPlatformUpdates\":
+        false\r\n        },\r\n        \"secrets\": [],\r\n        \"allowExtensionOperations\":
+        true,\r\n        \"requireGuestProvisionSignal\": true\r\n      },\r\n      \"storageProfile\":
         {\r\n        \"osDisk\": {\r\n          \"osType\": \"Linux\",\r\n          \"createOption\":
         \"FromImage\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\":
         {\r\n            \"storageAccountType\": \"Premium_LRS\"\r\n          },\r\n
         \         \"diskSizeGB\": 30\r\n        },\r\n        \"imageReference\":
         {\r\n          \"publisher\": \"Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n
         \         \"sku\": \"18.04-LTS\",\r\n          \"version\": \"latest\"\r\n
-        \       }\r\n      },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"cli5o787eNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"disableTcpStateTracking\":false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\":[{\"name\":\"cli5o787eIPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET/subnets/cli000003Subnet\"},\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/backendAddressPools/cli000003LBBEPool\"}],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/inboundNatPools/cli000003LBNatPool\"}]}}]}}]},\r\n
+        \       }\r\n      },\r\n      \"networkProfile\": {\"networkInterfaceConfigurations\":[{\"name\":\"cliuz26deNic\",\"properties\":{\"primary\":true,\"enableAcceleratedNetworking\":false,\"disableTcpStateTracking\":false,\"dnsSettings\":{\"dnsServers\":[]},\"enableIPForwarding\":false,\"ipConfigurations\":[{\"name\":\"cliuz26deIPConfig\",\"properties\":{\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/virtualNetworks/cli000003VNET/subnets/cli000003Subnet\"},\"privateIPAddressVersion\":\"IPv4\",\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/backendAddressPools/cli000003LBBEPool\"}],\"loadBalancerInboundNatPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Network/loadBalancers/cli000003LB/inboundNatPools/cli000003LBNatPool\"}]}}]}}]},\r\n
         \     \"diagnosticsProfile\": {\r\n        \"bootDiagnostics\": {\r\n          \"enabled\":
         true\r\n        }\r\n      },\r\n      \"extensionProfile\": {\r\n        \"extensions\":
         [\r\n          {\r\n            \"name\": \"Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n
@@ -7941,17 +7881,17 @@ interactions:
         {\"enableGenevaUpload\":true,\"enableAutoConfig\":true,\"reportSuccessOnUnsupportedDistro\":true}\r\n
         \           }\r\n          }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\":
         \"Succeeded\",\r\n    \"overprovision\": true,\r\n    \"doNotRunExtensionsOnOverprovisionedVMs\":
-        false,\r\n    \"uniqueId\": \"c72549ea-142c-4eb1-8178-a7442e2bc6db\",\r\n
-        \   \"timeCreated\": \"2022-12-13T22:58:32.1880141+00:00\"\r\n  }\r\n}"
+        false,\r\n    \"uniqueId\": \"6aa1f17d-1da0-4dfe-b11e-b77e59e02135\",\r\n
+        \   \"timeCreated\": \"2023-03-06T15:01:24.7059254+00:00\"\r\n  }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '5172'
+      - '5471'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:15:54 GMT
+      - Mon, 06 Mar 2023 15:22:26 GMT
       expires:
       - '-1'
       pragma:
@@ -7968,7 +7908,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetVMScaleSet3Min;389,Microsoft.Compute/GetVMScaleSet30Min;2560
+      - Microsoft.Compute/GetVMScaleSet3Min;392,Microsoft.Compute/GetVMScaleSet30Min;2483
     status:
       code: 200
       message: OK
@@ -7986,21 +7926,21 @@ interactions:
       ParameterSetName:
       - --name --resource-group --set
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/2/instanceView?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/3/instanceView?api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"placementGroupId\": \"b12ec8ba-0f67-45f7-a5b3-5e94f2268933\",\r\n
+      string: "{\r\n  \"placementGroupId\": \"fe2728fc-c0cb-4cea-8d91-bb960a1e6c3b\",\r\n
         \ \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n  \"computerName\":
-        \"cli5o787e000002\",\r\n  \"osName\": \"ubuntu\",\r\n  \"osVersion\": \"18.04\",\r\n
+        \"cliuz26de000003\",\r\n  \"osName\": \"ubuntu\",\r\n  \"osVersion\": \"18.04\",\r\n
         \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"2.9.0.4\",\r\n    \"statuses\":
         [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\",\r\n        \"level\":
         \"Info\",\r\n        \"displayStatus\": \"Ready\",\r\n        \"message\":
-        \"Guest Agent is running\",\r\n        \"time\": \"2022-12-13T23:15:33+00:00\"\r\n
+        \"Guest Agent is running\",\r\n        \"time\": \"2023-03-06T15:21:42+00:00\"\r\n
         \     }\r\n    ],\r\n    \"extensionHandlers\": [\r\n      {\r\n        \"type\":
         \"Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n        \"typeHandlerVersion\":
-        \"1.24.2\",\r\n        \"status\": {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \"1.25.1\",\r\n        \"status\": {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Ready\",\r\n
         \         \"message\": \"Plugin enabled\"\r\n        }\r\n      },\r\n      {\r\n
         \       \"type\": \"Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent\",\r\n
@@ -8008,14 +7948,14 @@ interactions:
         \         \"code\": \"ProvisioningState/succeeded\",\r\n          \"level\":
         \"Info\",\r\n          \"displayStatus\": \"Ready\",\r\n          \"message\":
         \"Plugin enabled\"\r\n        }\r\n      }\r\n    ]\r\n  },\r\n  \"disks\":
-        [\r\n    {\r\n      \"name\": \"cli5oqyn2zpljvxqcitncli5oqyn2zpljvxqcitnmOS__1_fc2a2b19ddde4a019629d326a068caf5\",\r\n
+        [\r\n    {\r\n      \"name\": \"cliuztvtdw4jbve2omq7cliuztvtdw4jbve2omq73OS__1_023d79a2b12548fba5c6e457bd338d14\",\r\n
         \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2022-12-13T23:14:50.402536+00:00\"\r\n
+        succeeded\",\r\n          \"time\": \"2023-03-06T15:21:12.3107222+00:00\"\r\n
         \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"extensions\": [\r\n    {\r\n
         \     \"name\": \"Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n      \"type\":
         \"Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n      \"typeHandlerVersion\":
-        \"1.24.2\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \"1.25.1\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
         succeeded\",\r\n          \"message\": \"Enable succeeded\"\r\n        }\r\n
         \     ]\r\n    },\r\n    {\r\n      \"name\": \"Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent\",\r\n
@@ -8027,18 +7967,18 @@ interactions:
         \   }\r\n  ],\r\n  \"hyperVGeneration\": \"V1\",\r\n  \"statuses\": [\r\n
         \   {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n      \"level\":
         \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n      \"time\":
-        \"2022-12-13T23:15:38.5583954+00:00\"\r\n    },\r\n    {\r\n      \"code\":
+        \"2023-03-06T15:21:44.6233417+00:00\"\r\n    },\r\n    {\r\n      \"code\":
         \"PowerState/running\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\":
         \"VM running\"\r\n    }\r\n  ]\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '2781'
+      - '2782'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:15:55 GMT
+      - Mon, 06 Mar 2023 15:22:27 GMT
       expires:
       - '-1'
       pragma:
@@ -8055,14 +7995,14 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetVMScaleSetVM3Min;496,Microsoft.Compute/GetVMScaleSetVM30Min;2488,Microsoft.Compute/VMScaleSetVMViews3Min;4996
+      - Microsoft.Compute/GetVMScaleSetVM3Min;498,Microsoft.Compute/GetVMScaleSetVM30Min;2469,Microsoft.Compute/VMScaleSetVMViews3Min;4998
       x-ms-request-charge:
       - '1'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"instanceIds": ["2"]}'
+    body: '{"instanceIds": ["3"]}'
     headers:
       Accept:
       - application/json
@@ -8079,9 +8019,9 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/manualupgrade?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/manualupgrade?api-version=2022-11-01
   response:
     body:
       string: ''
@@ -8089,17 +8029,17 @@ interactions:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/558afcc0-10be-405f-9b3f-87a084ef158c?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/81c8160c-0e3d-4509-a373-aa5754cac563?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Tue, 13 Dec 2022 23:15:55 GMT
+      - Mon, 06 Mar 2023 15:22:28 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/558afcc0-10be-405f-9b3f-87a084ef158c?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/81c8160c-0e3d-4509-a373-aa5754cac563?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-11-01
       pragma:
       - no-cache
       server:
@@ -8110,9 +8050,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/VMScaleSetActions3Min;237,Microsoft.Compute/VMScaleSetActions30Min;1189,Microsoft.Compute/VMScaleSetBatchedVMRequests5Min;3021,Microsoft.Compute/VmssQueuedVMOperations;0
+      - Microsoft.Compute/VMScaleSetActions3Min;238,Microsoft.Compute/VMScaleSetActions30Min;1186,Microsoft.Compute/VMScaleSetBatchedVMRequests5Min;3047,Microsoft.Compute/VmssQueuedVMOperations;0
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
       x-ms-request-charge:
       - '1'
     status:
@@ -8132,64 +8072,14 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/558afcc0-10be-405f-9b3f-87a084ef158c?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/81c8160c-0e3d-4509-a373-aa5754cac563?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:15:55.8708738+00:00\",\r\n  \"status\":
-        \"InProgress\",\r\n  \"name\": \"558afcc0-10be-405f-9b3f-87a084ef158c\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '134'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 13 Dec 2022 23:15:55 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14977,Microsoft.Compute/GetOperation30Min;29860
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vmss update-instances
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --instance-ids
-      User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/558afcc0-10be-405f-9b3f-87a084ef158c?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&api-version=2022-08-01
-  response:
-    body:
-      string: "{\r\n  \"startTime\": \"2022-12-13T23:15:55.8708738+00:00\",\r\n  \"endTime\":
-        \"2022-12-13T23:16:03.4020376+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"name\": \"558afcc0-10be-405f-9b3f-87a084ef158c\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2023-03-06T15:22:28.2326161+00:00\",\r\n  \"endTime\":
+        \"2023-03-06T15:22:35.6388806+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"name\": \"81c8160c-0e3d-4509-a373-aa5754cac563\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -8198,7 +8088,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:16:26 GMT
+      - Mon, 06 Mar 2023 15:22:57 GMT
       expires:
       - '-1'
       pragma:
@@ -8215,7 +8105,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14980,Microsoft.Compute/GetOperation30Min;29858
+      - Microsoft.Compute/GetOperation3Min;14986,Microsoft.Compute/GetOperation30Min;29766
     status:
       code: 200
       message: OK
@@ -8233,9 +8123,9 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/558afcc0-10be-405f-9b3f-87a084ef158c?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus2/operations/81c8160c-0e3d-4509-a373-aa5754cac563?p=c49d4c35-fce9-4992-b8a6-5d4f3bc79110&monitor=true&api-version=2022-11-01
   response:
     body:
       string: ''
@@ -8245,7 +8135,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 13 Dec 2022 23:16:26 GMT
+      - Mon, 06 Mar 2023 15:22:58 GMT
       expires:
       - '-1'
       pragma:
@@ -8258,7 +8148,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;14979,Microsoft.Compute/GetOperation30Min;29857
+      - Microsoft.Compute/GetOperation3Min;14985,Microsoft.Compute/GetOperation30Min;29765
     status:
       code: 200
       message: OK
@@ -8276,21 +8166,21 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-compute/29.0.0 Python/3.8.10 (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-compute/29.1.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/2/instanceView?api-version=2022-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_serialconsole000001/providers/Microsoft.Compute/virtualMachineScaleSets/cli000003/virtualMachines/3/instanceView?api-version=2022-11-01
   response:
     body:
-      string: "{\r\n  \"placementGroupId\": \"b12ec8ba-0f67-45f7-a5b3-5e94f2268933\",\r\n
+      string: "{\r\n  \"placementGroupId\": \"fe2728fc-c0cb-4cea-8d91-bb960a1e6c3b\",\r\n
         \ \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n  \"computerName\":
-        \"cli5o787e000002\",\r\n  \"osName\": \"ubuntu\",\r\n  \"osVersion\": \"18.04\",\r\n
+        \"cliuz26de000003\",\r\n  \"osName\": \"ubuntu\",\r\n  \"osVersion\": \"18.04\",\r\n
         \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"2.9.0.4\",\r\n    \"statuses\":
         [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\",\r\n        \"level\":
         \"Info\",\r\n        \"displayStatus\": \"Ready\",\r\n        \"message\":
-        \"Guest Agent is running\",\r\n        \"time\": \"2022-12-13T23:16:08+00:00\"\r\n
+        \"Guest Agent is running\",\r\n        \"time\": \"2023-03-06T15:22:41+00:00\"\r\n
         \     }\r\n    ],\r\n    \"extensionHandlers\": [\r\n      {\r\n        \"type\":
         \"Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n        \"typeHandlerVersion\":
-        \"1.24.2\",\r\n        \"status\": {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \"1.25.1\",\r\n        \"status\": {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Ready\",\r\n
         \         \"message\": \"Plugin enabled\"\r\n        }\r\n      },\r\n      {\r\n
         \       \"type\": \"Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent\",\r\n
@@ -8298,14 +8188,14 @@ interactions:
         \         \"code\": \"ProvisioningState/succeeded\",\r\n          \"level\":
         \"Info\",\r\n          \"displayStatus\": \"Ready\",\r\n          \"message\":
         \"Plugin enabled\"\r\n        }\r\n      }\r\n    ]\r\n  },\r\n  \"disks\":
-        [\r\n    {\r\n      \"name\": \"cli5oqyn2zpljvxqcitncli5oqyn2zpljvxqcitnmOS__1_fc2a2b19ddde4a019629d326a068caf5\",\r\n
+        [\r\n    {\r\n      \"name\": \"cliuztvtdw4jbve2omq7cliuztvtdw4jbve2omq73OS__1_023d79a2b12548fba5c6e457bd338d14\",\r\n
         \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2022-12-13T23:15:56.9333022+00:00\"\r\n
+        succeeded\",\r\n          \"time\": \"2023-03-06T15:22:29.2013533+00:00\"\r\n
         \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {},\r\n  \"extensions\":
         [\r\n    {\r\n      \"name\": \"Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n
         \     \"type\": \"Microsoft.Azure.Monitor.AzureMonitorLinuxAgent\",\r\n      \"typeHandlerVersion\":
-        \"1.24.2\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \"1.25.1\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
         succeeded\",\r\n          \"message\": \"Enable succeeded\"\r\n        }\r\n
         \     ]\r\n    },\r\n    {\r\n      \"name\": \"Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent\",\r\n
@@ -8317,18 +8207,18 @@ interactions:
         \   }\r\n  ],\r\n  \"hyperVGeneration\": \"V1\",\r\n  \"statuses\": [\r\n
         \   {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n      \"level\":
         \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n      \"time\":
-        \"2022-12-13T23:16:03.3395623+00:00\"\r\n    },\r\n    {\r\n      \"code\":
+        \"2023-03-06T15:22:35.60761+00:00\"\r\n    },\r\n    {\r\n      \"code\":
         \"PowerState/running\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\":
         \"VM running\"\r\n    }\r\n  ]\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '2808'
+      - '2806'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 13 Dec 2022 23:16:26 GMT
+      - Mon, 06 Mar 2023 15:22:59 GMT
       expires:
       - '-1'
       pragma:
@@ -8345,7 +8235,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetVMScaleSetVM3Min;496,Microsoft.Compute/GetVMScaleSetVM30Min;2487,Microsoft.Compute/VMScaleSetVMViews3Min;4996
+      - Microsoft.Compute/GetVMScaleSetVM3Min;497,Microsoft.Compute/GetVMScaleSetVM30Min;2468,Microsoft.Compute/VMScaleSetVMViews3Min;4997
       x-ms-request-charge:
       - '1'
     status:
@@ -8365,8 +8255,8 @@ interactions:
       ParameterSetName:
       - -g -n --instance-ids
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
-        (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.SerialConsole/consoleServices/default?api-version=2018-05-01
   response:
@@ -8380,7 +8270,7 @@ interactions:
       content-type:
       - application/json; charset=UTF-8
       date:
-      - Tue, 13 Dec 2022 23:16:26 GMT
+      - Mon, 06 Mar 2023 15:22:59 GMT
       expires:
       - '-1'
       pragma:

--- a/src/serial-console/azext_serialconsole/tests/latest/recordings/test_enable_disable.yaml
+++ b/src/serial-console/azext_serialconsole/tests/latest/recordings/test_enable_disable.yaml
@@ -15,8 +15,8 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
-        (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
+        (Windows-10-10.0.22621-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.SerialConsole/consoleServices/default/disableConsole?api-version=2018-05-01
   response:
@@ -30,7 +30,7 @@ interactions:
       content-type:
       - application/json; charset=UTF-8
       date:
-      - Tue, 13 Dec 2022 22:51:12 GMT
+      - Mon, 06 Mar 2023 14:54:20 GMT
       expires:
       - '-1'
       pragma:
@@ -68,8 +68,8 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
-        (Linux-5.15.79.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.46.0 azsdk-python-microsoftserialconsoleclient/unknown Python/3.8.10
+        (Windows-10-10.0.22621-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.SerialConsole/consoleServices/default/enableConsole?api-version=2018-05-01
   response:
@@ -83,7 +83,7 @@ interactions:
       content-type:
       - application/json; charset=UTF-8
       date:
-      - Tue, 13 Dec 2022 22:51:13 GMT
+      - Mon, 06 Mar 2023 14:54:21 GMT
       expires:
       - '-1'
       pragma:
@@ -101,7 +101,7 @@ interactions:
       x-frame-options:
       - deny
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
     status:
       code: 200
       message: OK

--- a/src/serial-console/setup.py
+++ b/src/serial-console/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
-VERSION = '0.1.4'
+VERSION = '0.1.5'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
The changes in the pull request are to address a problem found in the azure cli serial-console extension where the wrong resource group was being found if the storage account belong to a different resource group.  The code fixes this issue by using the correct resource group based on where the storage account gets created.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
az serial-console connect -g MyResourceGroup -n MyVmName


### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [x] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
