### PR TITLE
{AKS} `az aks trustedaccess rolebinding create`: Change the short name of option `--source-resource-id` to `-r`

### DIFF
--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -12,6 +12,8 @@ To release a new version, please select a new version number (usually plus 1 to 
 Pending
 +++++++
 
+* Change the short name of option `--source-resource-id` in command `az aks trustedaccess rolebinding create` from `-s` to `-r`.
+
 0.5.131
 +++++++
 * Allow updating the ssh key value if cluster was created without ssh key

--- a/src/aks-preview/azext_aks_preview/_help.py
+++ b/src/aks-preview/azext_aks_preview/_help.py
@@ -2174,13 +2174,13 @@ helps['aks trustedaccess rolebinding create'] = """
         - name: --roles
           type: string
           short-summary: Specify the space-separated roles.
-        - name: --source-resource-id -s
+        - name: --source-resource-id -r
           type: string
           short-summary: Specify the source resource id of the binding.
 
     examples:
         - name: Create a new trusted access role binding
-          text: az aks trustedaccess rolebinding create -g myResourceGroup --cluster-name myCluster -n bindingName -s /subscriptions/0000/resourceGroups/myResourceGroup/providers/Microsoft.Demo/samples --roles Microsoft.Demo/samples/reader,Microsoft.Demo/samples/writer
+          text: az aks trustedaccess rolebinding create -g myResourceGroup --cluster-name myCluster -n bindingName --source-resource-id /subscriptions/0000/resourceGroups/myResourceGroup/providers/Microsoft.Demo/samples --roles Microsoft.Demo/samples/reader,Microsoft.Demo/samples/writer
 """
 
 helps['aks trustedaccess rolebinding update'] = """

--- a/src/aks-preview/azext_aks_preview/_params.py
+++ b/src/aks-preview/azext_aks_preview/_params.py
@@ -830,7 +830,7 @@ def load_arguments(self, _):
 
     with self.argument_context('aks trustedaccess rolebinding create') as c:
         c.argument('roles', help='comma-separated roles: Microsoft.Demo/samples/reader,Microsoft.Demo/samples/writer,...')
-        c.argument('source_resource_id', options_list=['--source-resource-id', '-r', c.deprecate(target='-s', redirect='--source-resource-id', expiration='2.47.0', hide=True)], help='The source resource id of the binding')
+        c.argument('source_resource_id', options_list=['--source-resource-id', '-r', c.deprecate(target='-s', redirect='--source-resource-id', hide=True)], help='The source resource id of the binding')
 
     with self.argument_context('aks trustedaccess rolebinding update') as c:
         c.argument('roles', help='comma-separated roles: Microsoft.Demo/samples/reader,Microsoft.Demo/samples/writer,...')

--- a/src/aks-preview/azext_aks_preview/_params.py
+++ b/src/aks-preview/azext_aks_preview/_params.py
@@ -830,7 +830,7 @@ def load_arguments(self, _):
 
     with self.argument_context('aks trustedaccess rolebinding create') as c:
         c.argument('roles', help='comma-separated roles: Microsoft.Demo/samples/reader,Microsoft.Demo/samples/writer,...')
-        c.argument('source_resource_id', options_list=['--source-resource-id', '-s'], help='The source resource id of the binding')
+        c.argument('source_resource_id', options_list=['--source-resource-id', '-r', c.deprecate(target='-s', redirect='--source-resource-id', expiration='2.47.0', hide=True)], help='The source resource id of the binding')
 
     with self.argument_context('aks trustedaccess rolebinding update') as c:
         c.argument('roles', help='comma-separated roles: Microsoft.Demo/samples/reader,Microsoft.Demo/samples/writer,...')


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

Change the short name of option `--source-resource-id` in command `az aks trustedaccess rolebinding create` from `-s` to `-r`.
The deprecated short name `-s` is hidden by default and will be completely removed when aks-preview's dependency on the cli core version is updated to [2.47.0](https://github.com/Azure/azure-cli/milestone/128). For current dependency, see [doc](https://github.com/Azure/azure-cli-extensions/tree/main/src/aks-preview#dependency-between-aks-preview-and-azure-cliacs-azure-cli-core).

![image](https://user-images.githubusercontent.com/81607949/223309882-787dc220-9c80-420a-99e2-e9c739612ab0.png)
![image](https://user-images.githubusercontent.com/81607949/224596464-4472a4b5-2b1c-46f4-a65f-f9b614a7f7c6.png)

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

- `az aks trustedaccess rolebinding create`

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
