### PR TITLE
fix bug for a parameter as a list

### DIFF
--- a/src/datamigration/HISTORY.rst
+++ b/src/datamigration/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.4.1
+++++++
+* Bug fix for list-logins parameter in command "az datamigration login-migration".
+
 0.4.0
 ++++++
 * [NEW COMMAND] `az datamigration login-migration` : Migrate logins from the source Sql Servers to the target Azure Sql Servers.

--- a/src/datamigration/azext_datamigration/manual/custom.py
+++ b/src/datamigration/azext_datamigration/manual/custom.py
@@ -271,9 +271,15 @@ def datamigration_login_migration(src_sql_connection_str=None,
             # joining paramaters together in a string
             cmd = f'{exePath} LoginsMigration --sourceSqlConnectionString {src_sql_connection_str}'
 
+            # formating the parameter list into a string
             for param in parameterList:
-                if parameterList[param] is not None:
+                if parameterList[param] is not None and not param.__contains__("list"):
                     cmd += f' {param} "{parameterList[param]}"'
+
+                # in case the parameter input is list format it accordingly
+                elif param.__contains__("list") and parameterList[param] is not None:
+                    parameterList[param] = " ".join(f"\"{i}\"" for i in parameterList[param])
+                    cmd += f' {param} {parameterList[param]}'
             subprocess.call(cmd, shell=False)
 
         # When Config file.

--- a/src/datamigration/setup.py
+++ b/src/datamigration/setup.py
@@ -10,7 +10,7 @@ from codecs import open
 from setuptools import setup, find_packages
 
 # HISTORY.rst entry.
-VERSION = '0.4.0'
+VERSION = '0.4.1'
 try:
     from azext_datamigration.manual.version import VERSION
 except ImportError:


### PR DESCRIPTION
The PR is to fix a bug for the new CLI commands "az datamigration login-migration".

Local Test:
with this fix, it can migrate logins of source database to the target database.

Below image is the logins of target MI server, the new logins are from the source database by running this CLI command:
![image](https://user-images.githubusercontent.com/110877660/226477002-b1461ae6-430f-488a-99aa-bd3d753d7ccd.png)


---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
