### PR TITLE
[ContainerApp] Fix #6050: `az containerapp ingress update`: Add Command to Update Container App Ingress

### DIFF
--- a/src/containerapp/HISTORY.rst
+++ b/src/containerapp/HISTORY.rst
@@ -6,6 +6,7 @@ Upcoming
 +++++++
 * Fix YAML create with user-assigned identity
 * Fix polling logic for long running operations.
+* Add `az containerapp ingress update` Command to Update Container App Ingress
 
 0.3.24
 ++++++

--- a/src/containerapp/azext_containerapp/_help.py
+++ b/src/containerapp/azext_containerapp/_help.py
@@ -654,6 +654,16 @@ helps['containerapp ingress disable'] = """
           az containerapp ingress disable -n MyContainerapp -g MyResourceGroup
 """
 
+helps['containerapp ingress update'] = """
+    type: command
+    short-summary: Update ingress for a container app.
+    examples:
+    - name: Update ingress for a container app.
+      text: |
+          az containerapp ingress update -n MyContainerapp -g MyResourceGroup \\
+              --target-port 8080
+"""
+
 helps['containerapp ingress traffic'] = """
     type: group
     short-summary: Commands to manage traffic-splitting.

--- a/src/containerapp/azext_containerapp/_params.py
+++ b/src/containerapp/azext_containerapp/_params.py
@@ -250,7 +250,7 @@ def load_arguments(self, _):
         c.argument('target_label', options_list=['--target'], help='Target label to be swapped to.')
 
     with self.argument_context('containerapp ingress') as c:
-        c.argument('allow_insecure', help='Allow insecure connections for ingress traffic.')
+        c.argument('allow_insecure', arg_type=get_three_state_flag(), help='Allow insecure connections for ingress traffic.')
         c.argument('type', validator=validate_ingress, arg_type=get_enum_type(['internal', 'external']), help="The ingress type.")
         c.argument('transport', arg_type=get_enum_type(['auto', 'http', 'http2', 'tcp']), help="The transport protocol used for ingress traffic.")
         c.argument('target_port', type=int, validator=validate_target_port, help="The application port used for ingress traffic.")

--- a/src/containerapp/azext_containerapp/commands.py
+++ b/src/containerapp/azext_containerapp/commands.py
@@ -115,6 +115,7 @@ def load_command_table(self, _):
     with self.command_group('containerapp ingress') as g:
         g.custom_command('enable', 'enable_ingress', exception_handler=ex_handler_factory())
         g.custom_command('disable', 'disable_ingress', exception_handler=ex_handler_factory())
+        g.custom_command('update', 'update_ingress', exception_handler=ex_handler_factory())
         g.custom_show_command('show', 'show_ingress')
 
     with self.command_group('containerapp ingress traffic') as g:

--- a/src/containerapp/azext_containerapp/custom.py
+++ b/src/containerapp/azext_containerapp/custom.py
@@ -1903,6 +1903,9 @@ def update_ingress(cmd, name, resource_group_name, type=None, target_port=None, 
     if not containerapp_def:
         raise ResourceNotFoundError("The containerapp '{}' does not exist".format(name))
 
+    if containerapp_def["properties"]["configuration"]["ingress"] is None:
+        raise ValidationError("The containerapp '{}' does not have ingress enabled. Try running `az containerapp ingress -h` for more info.".format(name))
+
     external_ingress = None
     if type is not None:
         if type.lower() == "internal":

--- a/src/containerapp/azext_containerapp/custom.py
+++ b/src/containerapp/azext_containerapp/custom.py
@@ -1890,6 +1890,7 @@ def disable_ingress(cmd, name, resource_group_name, no_wait=False):
     except Exception as e:
         handle_raw_exception(e)
 
+
 def update_ingress(cmd, name, resource_group_name, type=None, target_port=None, transport=None, exposed_port=None, allow_insecure=False, disable_warnings=False, no_wait=False):
     _validate_subscription_registered(cmd, CONTAINER_APPS_RP)
 
@@ -1901,7 +1902,7 @@ def update_ingress(cmd, name, resource_group_name, type=None, target_port=None, 
 
     if not containerapp_def:
         raise ResourceNotFoundError("The containerapp '{}' does not exist".format(name))
-    
+
     external_ingress = None
     if type is not None:
         if type.lower() == "internal":
@@ -1915,10 +1916,14 @@ def update_ingress(cmd, name, resource_group_name, type=None, target_port=None, 
     containerapp_patch_def['properties']['configuration']['ingress'] = {}
 
     ingress_def = {}
-    if external_ingress is not None: ingress_def["external"] = external_ingress
-    if target_port is not None: ingress_def["targetPort"] = target_port
-    if transport is not None: ingress_def["transport"] = transport
-    if allow_insecure is not None: ingress_def["allowInsecure"] = allow_insecure
+    if external_ingress is not None:
+        ingress_def["external"] = external_ingress
+    if target_port is not None:
+        ingress_def["targetPort"] = target_port
+    if transport is not None:
+        ingress_def["transport"] = transport
+    if allow_insecure is not None:
+        ingress_def["allowInsecure"] = allow_insecure
 
     if "transport" in ingress_def and ingress_def["transport"] == "tcp":
         if exposed_port is not None:

--- a/src/containerapp/azext_containerapp/custom.py
+++ b/src/containerapp/azext_containerapp/custom.py
@@ -1890,6 +1890,52 @@ def disable_ingress(cmd, name, resource_group_name, no_wait=False):
     except Exception as e:
         handle_raw_exception(e)
 
+def update_ingress(cmd, name, resource_group_name, type=None, target_port=None, transport=None, exposed_port=None, allow_insecure=False, disable_warnings=False, no_wait=False):
+    _validate_subscription_registered(cmd, CONTAINER_APPS_RP)
+
+    containerapp_def = None
+    try:
+        containerapp_def = ContainerAppClient.show(cmd=cmd, resource_group_name=resource_group_name, name=name)
+    except:
+        pass
+
+    if not containerapp_def:
+        raise ResourceNotFoundError("The containerapp '{}' does not exist".format(name))
+    
+    external_ingress = None
+    if type is not None:
+        if type.lower() == "internal":
+            external_ingress = False
+        elif type.lower() == "external":
+            external_ingress = True
+
+    containerapp_patch_def = {}
+    containerapp_patch_def['properties'] = {}
+    containerapp_patch_def['properties']['configuration'] = {}
+    containerapp_patch_def['properties']['configuration']['ingress'] = {}
+
+    ingress_def = {}
+    if external_ingress is not None: ingress_def["external"] = external_ingress
+    if target_port is not None: ingress_def["targetPort"] = target_port
+    if transport is not None: ingress_def["transport"] = transport
+    if allow_insecure is not None: ingress_def["allowInsecure"] = allow_insecure
+
+    if "transport" in ingress_def and ingress_def["transport"] == "tcp":
+        if exposed_port is not None:
+            ingress_def["exposedPort"] = exposed_port
+    else:
+        ingress_def["exposedPort"] = None
+
+    containerapp_patch_def["properties"]["configuration"]["ingress"] = ingress_def
+
+    try:
+        r = ContainerAppClient.update(
+            cmd=cmd, resource_group_name=resource_group_name, name=name, container_app_envelope=containerapp_patch_def, no_wait=no_wait)
+        not disable_warnings and logger.warning("\nIngress Updated. Access your app at https://{}/\n".format(r["properties"]["configuration"]["ingress"]["fqdn"]))
+        return r["properties"]["configuration"]["ingress"]
+    except Exception as e:
+        handle_raw_exception(e)
+
 
 def set_ingress_traffic(cmd, name, resource_group_name, label_weights=None, revision_weights=None, no_wait=False):
     _validate_subscription_registered(cmd, CONTAINER_APPS_RP)

--- a/src/containerapp/azext_containerapp/tests/latest/recordings/test_containerapp_ingress_e2e.yaml
+++ b/src/containerapp/azext_containerapp/tests/latest/recordings/test_containerapp_ingress_e2e.yaml
@@ -18,36 +18,29 @@ interactions:
       ParameterSetName:
       - -g -n -l
       User-Agent:
-      - AZURECLI/2.46.0 (AAZ) azsdk-python-core/1.24.0 Python/3.10.10 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.46.0 (AAZ) azsdk-python-core/1.24.0 Python/3.10.3 (Windows-10-10.0.22621-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.OperationalInsights/workspaces/containerapp-env000004?api-version=2021-12-01-preview
   response:
     body:
-      string: "{\r\n  \"properties\": {\r\n    \"source\": \"Azure\",\r\n    \"customerId\":
-        \"8ee99494-3cd0-412d-a93b-6bf0c0785f1e\",\r\n    \"provisioningState\": \"Creating\",\r\n
-        \   \"sku\": {\r\n      \"name\": \"pergb2018\",\r\n      \"lastSkuUpdate\":
-        \"Tue, 14 Mar 2023 07:14:33 GMT\"\r\n    },\r\n    \"retentionInDays\": 30,\r\n
-        \   \"features\": {\r\n      \"legacy\": 0,\r\n      \"searchVersion\": 1,\r\n
-        \     \"enableLogAccessUsingOnlyResourcePermissions\": true\r\n    },\r\n
-        \   \"workspaceCapping\": {\r\n      \"dailyQuotaGb\": -1.0,\r\n      \"quotaNextResetTime\":
-        \"Tue, 14 Mar 2023 09:00:00 GMT\",\r\n      \"dataIngestionStatus\": \"RespectQuota\"\r\n
-        \   },\r\n    \"publicNetworkAccessForIngestion\": \"Enabled\",\r\n    \"publicNetworkAccessForQuery\":
-        \"Enabled\",\r\n    \"createdDate\": \"Tue, 14 Mar 2023 07:14:33 GMT\",\r\n
-        \   \"modifiedDate\": \"Tue, 14 Mar 2023 07:14:33 GMT\"\r\n  },\r\n  \"id\":
-        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/microsoft.operationalinsights/workspaces/containerapp-env000004\",\r\n
-        \ \"name\": \"containerapp-env000004\",\r\n  \"type\": \"Microsoft.OperationalInsights/workspaces\",\r\n
-        \ \"location\": \"eastus\"\r\n}"
+      string: '{"properties":{"customerId":"b8eb8147-36a1-4ace-b422-5e6367a8f732","provisioningState":"Creating","sku":{"name":"PerGB2018","lastSkuUpdate":"2023-03-24T21:36:30.0949002Z"},"retentionInDays":30,"features":{"legacy":0,"searchVersion":1,"enableLogAccessUsingOnlyResourcePermissions":true},"workspaceCapping":{"dailyQuotaGb":-1.0,"quotaNextResetTime":"2023-03-25T11:00:00Z","dataIngestionStatus":"RespectQuota"},"publicNetworkAccessForIngestion":"Enabled","publicNetworkAccessForQuery":"Enabled","createdDate":"2023-03-24T21:36:30.0949002Z","modifiedDate":"2023-03-24T21:36:30.0949002Z"},"location":"eastus","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.OperationalInsights/workspaces/containerapp-env000004","name":"containerapp-env000004","type":"Microsoft.OperationalInsights/workspaces"}'
     headers:
       access-control-allow-origin:
       - '*'
+      api-supported-versions:
+      - 2021-12-01-preview
       cache-control:
       - no-cache
       content-length:
-      - '1078'
+      - '851'
       content-type:
-      - application/json
+      - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:14:34 GMT
+      - Fri, 24 Mar 2023 21:36:31 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.OperationalInsights/workspaces/containerapp-env000004?api-version=2021-12-01-preview
       pragma:
       - no-cache
       request-context:
@@ -61,7 +54,6 @@ interactions:
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-powered-by:
-      - ASP.NET
       - ASP.NET
     status:
       code: 201
@@ -80,36 +72,27 @@ interactions:
       ParameterSetName:
       - -g -n -l
       User-Agent:
-      - AZURECLI/2.46.0 (AAZ) azsdk-python-core/1.24.0 Python/3.10.10 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.46.0 (AAZ) azsdk-python-core/1.24.0 Python/3.10.3 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.OperationalInsights/workspaces/containerapp-env000004?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.OperationalInsights/workspaces/containerapp-env000004?api-version=2021-12-01-preview
   response:
     body:
-      string: "{\r\n  \"properties\": {\r\n    \"source\": \"Azure\",\r\n    \"customerId\":
-        \"8ee99494-3cd0-412d-a93b-6bf0c0785f1e\",\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"sku\": {\r\n      \"name\": \"pergb2018\",\r\n      \"lastSkuUpdate\":
-        \"Tue, 14 Mar 2023 07:14:33 GMT\"\r\n    },\r\n    \"retentionInDays\": 30,\r\n
-        \   \"features\": {\r\n      \"legacy\": 0,\r\n      \"searchVersion\": 1,\r\n
-        \     \"enableLogAccessUsingOnlyResourcePermissions\": true\r\n    },\r\n
-        \   \"workspaceCapping\": {\r\n      \"dailyQuotaGb\": -1.0,\r\n      \"quotaNextResetTime\":
-        \"Tue, 14 Mar 2023 09:00:00 GMT\",\r\n      \"dataIngestionStatus\": \"RespectQuota\"\r\n
-        \   },\r\n    \"publicNetworkAccessForIngestion\": \"Enabled\",\r\n    \"publicNetworkAccessForQuery\":
-        \"Enabled\",\r\n    \"createdDate\": \"Tue, 14 Mar 2023 07:14:33 GMT\",\r\n
-        \   \"modifiedDate\": \"Tue, 14 Mar 2023 07:14:35 GMT\"\r\n  },\r\n  \"id\":
-        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/microsoft.operationalinsights/workspaces/containerapp-env000004\",\r\n
-        \ \"name\": \"containerapp-env000004\",\r\n  \"type\": \"Microsoft.OperationalInsights/workspaces\",\r\n
-        \ \"location\": \"eastus\"\r\n}"
+      string: '{"properties":{"customerId":"b8eb8147-36a1-4ace-b422-5e6367a8f732","provisioningState":"Succeeded","sku":{"name":"PerGB2018","lastSkuUpdate":"2023-03-24T21:36:30.0949002Z"},"retentionInDays":30,"features":{"legacy":0,"searchVersion":1,"enableLogAccessUsingOnlyResourcePermissions":true},"workspaceCapping":{"dailyQuotaGb":-1.0,"quotaNextResetTime":"2023-03-25T11:00:00Z","dataIngestionStatus":"RespectQuota"},"publicNetworkAccessForIngestion":"Enabled","publicNetworkAccessForQuery":"Enabled","createdDate":"2023-03-24T21:36:30.0949002Z","modifiedDate":"2023-03-24T21:36:30.0949002Z"},"location":"eastus","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.OperationalInsights/workspaces/containerapp-env000004","name":"containerapp-env000004","type":"Microsoft.OperationalInsights/workspaces"}'
     headers:
       access-control-allow-origin:
       - '*'
+      api-supported-versions:
+      - 2021-12-01-preview
       cache-control:
       - no-cache
       content-length:
-      - '1079'
+      - '852'
       content-type:
-      - application/json
+      - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:15:04 GMT
+      - Fri, 24 Mar 2023 21:37:01 GMT
+      expires:
+      - '-1'
       pragma:
       - no-cache
       request-context:
@@ -118,14 +101,9 @@ interactions:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-content-type-options:
       - nosniff
       x-powered-by:
-      - ASP.NET
       - ASP.NET
     status:
       code: 200
@@ -146,26 +124,25 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.46.0 (AAZ) azsdk-python-core/1.24.0 Python/3.10.10 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.46.0 (AAZ) azsdk-python-core/1.24.0 Python/3.10.3 (Windows-10-10.0.22621-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.OperationalInsights/workspaces/containerapp-env000004/sharedKeys?api-version=2020-08-01
   response:
     body:
-      string: "{\r\n  \"primarySharedKey\": \"on0x3bctmrvfpZFzncUejpVZisNYIiyoTnjFaPO96sewFIr71+vJwsT/4C7wglU0XhxxPTER4n5T+TlI/G9B6g==\",\r\n
-        \ \"secondarySharedKey\": \"ALaifioLvu0U0365cdA0U+lg/KmCwZ0ogv+I1CVA8ZgDhpP0US8ilrglmw76upW72lPLuOWolxuJwluD1TBFvA==\"\r\n}"
+      string: '{"primarySharedKey":"Tv/Iqwao8FtA+b4qAPvc0Bdm1DKHEsuhYOVZiLcaN2xp1VwhL/8HaDJLWn4Q+99gt7YOg9rqLM8EPrtrBTijKw==","secondarySharedKey":"JnZN6kUkc1jZikESemldv9BfzFlkS8OwC1togP+PJAZGFHe6z3k5wI4EhA26tX2vXGi7mnm4b8dL3NKGs5msIw=="}'
     headers:
       access-control-allow-origin:
       - '*'
+      api-supported-versions:
+      - 2015-03-20, 2020-08-01, 2020-10-01, 2021-06-01, 2022-10-01
       cache-control:
       - no-cache
-      cachecontrol:
-      - no-cache
       content-length:
-      - '235'
+      - '223'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:15:07 GMT
+      - Fri, 24 Mar 2023 21:37:02 GMT
       expires:
       - '-1'
       pragma:
@@ -180,15 +157,12 @@ interactions:
       - chunked
       vary:
       - Accept-Encoding
-      x-ams-apiversion:
-      - WebAPI1.0
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-powered-by:
       - ASP.NET
-      - ASP.NET
     status:
       code: 200
       message: OK
@@ -206,94 +180,90 @@ interactions:
       ParameterSetName:
       - -g -n --logs-workspace-id --logs-workspace-key
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.10.10 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.3 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App","namespace":"Microsoft.App","authorizations":[{"applicationId":"7e3bc4fd-85a3-4192-b177-5b8bfc87f42c","roleDefinitionId":"39a74f72-b40f-4bdc-b639-562fe2260bf0"},{"applicationId":"3734c1a4-2bed-4998-a37a-ff1a9e7bf019","roleDefinitionId":"5c779a4f-5cb2-4547-8c41-478d9be8ba90"},{"applicationId":"55ebbb62-3b9c-49fd-9b87-9595226dd4ac","roleDefinitionId":"e49ca620-7992-4561-a7df-4ed67dad77b5","managedByRoleDefinitionId":"9e3af657-a8ff-583c-a75c-2fe7c4bcb635"}],"resourceTypes":[{"resourceType":"operations","locations":["North
-        Central US (Stage)","Central US EUAP","East US 2 EUAP","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/connectedEnvironmentOperationResults","locations":["North
-        Central US (Stage)","North Central US","East US","East Asia","West Europe","Central
-        US EUAP","East US 2 EUAP"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"managedEnvironments","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/certificates","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/managedCertificates","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"containerApps","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App","namespace":"Microsoft.App","authorizations":[{"applicationId":"7e3bc4fd-85a3-4192-b177-5b8bfc87f42c","roleDefinitionId":"39a74f72-b40f-4bdc-b639-562fe2260bf0"},{"applicationId":"3734c1a4-2bed-4998-a37a-ff1a9e7bf019","roleDefinitionId":"5c779a4f-5cb2-4547-8c41-478d9be8ba90"},{"applicationId":"55ebbb62-3b9c-49fd-9b87-9595226dd4ac","roleDefinitionId":"e49ca620-7992-4561-a7df-4ed67dad77b5","managedByRoleDefinitionId":"9e3af657-a8ff-583c-a75c-2fe7c4bcb635"}],"resourceTypes":[{"resourceType":"managedEnvironments","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/certificates","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/managedCertificates","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"containerApps","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
-        SupportsLocation"},{"resourceType":"jobs","locations":["Central US EUAP","East
-        US 2 EUAP","North Central US (Stage)","Canada Central","West Europe","North
-        Europe","East US","East US 2","East Asia","Australia East","Germany West Central","Japan
+        SupportsLocation"},{"resourceType":"jobs","locations":["North Central US (Stage)","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationResults","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationStatuses","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"operations","locations":["North
+        Central US (Stage)","Central US EUAP","East US 2 EUAP","West US 2","Southeast
+        Asia","Sweden Central","Canada Central","West Europe","North Europe","East
+        US","East US 2","East Asia","Australia East","Germany West Central","Japan
         East","UK South","West US","Central US","North Central US","South Central
         US","Korea Central","Brazil South","West US 3","France Central","South Africa
-        North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
-        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationResults","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationStatuses","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationResults","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationStatuses","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"connectedEnvironments","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","North Central US","East
-        US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectedEnvironments/certificates","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","North Central US","East
-        US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectedEnvironmentOperationStatuses","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","North Central US","East
-        US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/billingMeters","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Australia East","North
-        Central US","East US 2","West Europe","Central US","East US","North Europe","South
-        Central US","UK South","West US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/availableManagedEnvironmentsWorkloadProfileTypes","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Australia East","North
-        Central US","East US 2","West Europe","Central US","East US","North Europe","South
-        Central US","UK South","West US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+        North","Norway East","Switzerland North","UAE North"],"apiVersions":["2023-02-01","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"connectedEnvironments","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectedEnvironments/certificates","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/connectedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/billingMeters","locations":["North
+        Central US (Stage)","Australia East","North Central US","East US 2","West
+        Europe","Central US","East US","North Europe","South Central US","UK South","West
+        US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/availableManagedEnvironmentsWorkloadProfileTypes","locations":["North
+        Central US (Stage)","Australia East","North Central US","East US 2","West
+        Europe","Central US","East US","North Europe","South Central US","UK South","West
+        US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '9060'
+      - '8594'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:15:09 GMT
+      - Fri, 24 Mar 2023 21:37:03 GMT
       expires:
       - '-1'
       pragma:
@@ -321,94 +291,90 @@ interactions:
       ParameterSetName:
       - -g -n --logs-workspace-id --logs-workspace-key
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.10.10 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.3 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App","namespace":"Microsoft.App","authorizations":[{"applicationId":"7e3bc4fd-85a3-4192-b177-5b8bfc87f42c","roleDefinitionId":"39a74f72-b40f-4bdc-b639-562fe2260bf0"},{"applicationId":"3734c1a4-2bed-4998-a37a-ff1a9e7bf019","roleDefinitionId":"5c779a4f-5cb2-4547-8c41-478d9be8ba90"},{"applicationId":"55ebbb62-3b9c-49fd-9b87-9595226dd4ac","roleDefinitionId":"e49ca620-7992-4561-a7df-4ed67dad77b5","managedByRoleDefinitionId":"9e3af657-a8ff-583c-a75c-2fe7c4bcb635"}],"resourceTypes":[{"resourceType":"operations","locations":["North
-        Central US (Stage)","Central US EUAP","East US 2 EUAP","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/connectedEnvironmentOperationResults","locations":["North
-        Central US (Stage)","North Central US","East US","East Asia","West Europe","Central
-        US EUAP","East US 2 EUAP"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"managedEnvironments","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/certificates","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/managedCertificates","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"containerApps","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App","namespace":"Microsoft.App","authorizations":[{"applicationId":"7e3bc4fd-85a3-4192-b177-5b8bfc87f42c","roleDefinitionId":"39a74f72-b40f-4bdc-b639-562fe2260bf0"},{"applicationId":"3734c1a4-2bed-4998-a37a-ff1a9e7bf019","roleDefinitionId":"5c779a4f-5cb2-4547-8c41-478d9be8ba90"},{"applicationId":"55ebbb62-3b9c-49fd-9b87-9595226dd4ac","roleDefinitionId":"e49ca620-7992-4561-a7df-4ed67dad77b5","managedByRoleDefinitionId":"9e3af657-a8ff-583c-a75c-2fe7c4bcb635"}],"resourceTypes":[{"resourceType":"managedEnvironments","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/certificates","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/managedCertificates","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"containerApps","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
-        SupportsLocation"},{"resourceType":"jobs","locations":["Central US EUAP","East
-        US 2 EUAP","North Central US (Stage)","Canada Central","West Europe","North
-        Europe","East US","East US 2","East Asia","Australia East","Germany West Central","Japan
+        SupportsLocation"},{"resourceType":"jobs","locations":["North Central US (Stage)","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationResults","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationStatuses","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"operations","locations":["North
+        Central US (Stage)","Central US EUAP","East US 2 EUAP","West US 2","Southeast
+        Asia","Sweden Central","Canada Central","West Europe","North Europe","East
+        US","East US 2","East Asia","Australia East","Germany West Central","Japan
         East","UK South","West US","Central US","North Central US","South Central
         US","Korea Central","Brazil South","West US 3","France Central","South Africa
-        North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
-        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationResults","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationStatuses","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationResults","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationStatuses","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"connectedEnvironments","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","North Central US","East
-        US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectedEnvironments/certificates","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","North Central US","East
-        US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectedEnvironmentOperationStatuses","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","North Central US","East
-        US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/billingMeters","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Australia East","North
-        Central US","East US 2","West Europe","Central US","East US","North Europe","South
-        Central US","UK South","West US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/availableManagedEnvironmentsWorkloadProfileTypes","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Australia East","North
-        Central US","East US 2","West Europe","Central US","East US","North Europe","South
-        Central US","UK South","West US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+        North","Norway East","Switzerland North","UAE North"],"apiVersions":["2023-02-01","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"connectedEnvironments","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectedEnvironments/certificates","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/connectedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/billingMeters","locations":["North
+        Central US (Stage)","Australia East","North Central US","East US 2","West
+        Europe","Central US","East US","North Europe","South Central US","UK South","West
+        US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/availableManagedEnvironmentsWorkloadProfileTypes","locations":["North
+        Central US (Stage)","Australia East","North Central US","East US 2","West
+        Europe","Central US","East US","North Europe","South Central US","UK South","West
+        US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '9060'
+      - '8594'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:15:09 GMT
+      - Fri, 24 Mar 2023 21:37:04 GMT
       expires:
       - '-1'
       pragma:
@@ -436,94 +402,90 @@ interactions:
       ParameterSetName:
       - -g -n --logs-workspace-id --logs-workspace-key
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.10.10 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.3 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App","namespace":"Microsoft.App","authorizations":[{"applicationId":"7e3bc4fd-85a3-4192-b177-5b8bfc87f42c","roleDefinitionId":"39a74f72-b40f-4bdc-b639-562fe2260bf0"},{"applicationId":"3734c1a4-2bed-4998-a37a-ff1a9e7bf019","roleDefinitionId":"5c779a4f-5cb2-4547-8c41-478d9be8ba90"},{"applicationId":"55ebbb62-3b9c-49fd-9b87-9595226dd4ac","roleDefinitionId":"e49ca620-7992-4561-a7df-4ed67dad77b5","managedByRoleDefinitionId":"9e3af657-a8ff-583c-a75c-2fe7c4bcb635"}],"resourceTypes":[{"resourceType":"operations","locations":["North
-        Central US (Stage)","Central US EUAP","East US 2 EUAP","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/connectedEnvironmentOperationResults","locations":["North
-        Central US (Stage)","North Central US","East US","East Asia","West Europe","Central
-        US EUAP","East US 2 EUAP"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"managedEnvironments","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/certificates","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/managedCertificates","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"containerApps","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App","namespace":"Microsoft.App","authorizations":[{"applicationId":"7e3bc4fd-85a3-4192-b177-5b8bfc87f42c","roleDefinitionId":"39a74f72-b40f-4bdc-b639-562fe2260bf0"},{"applicationId":"3734c1a4-2bed-4998-a37a-ff1a9e7bf019","roleDefinitionId":"5c779a4f-5cb2-4547-8c41-478d9be8ba90"},{"applicationId":"55ebbb62-3b9c-49fd-9b87-9595226dd4ac","roleDefinitionId":"e49ca620-7992-4561-a7df-4ed67dad77b5","managedByRoleDefinitionId":"9e3af657-a8ff-583c-a75c-2fe7c4bcb635"}],"resourceTypes":[{"resourceType":"managedEnvironments","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/certificates","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/managedCertificates","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"containerApps","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
-        SupportsLocation"},{"resourceType":"jobs","locations":["Central US EUAP","East
-        US 2 EUAP","North Central US (Stage)","Canada Central","West Europe","North
-        Europe","East US","East US 2","East Asia","Australia East","Germany West Central","Japan
+        SupportsLocation"},{"resourceType":"jobs","locations":["North Central US (Stage)","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationResults","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationStatuses","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"operations","locations":["North
+        Central US (Stage)","Central US EUAP","East US 2 EUAP","West US 2","Southeast
+        Asia","Sweden Central","Canada Central","West Europe","North Europe","East
+        US","East US 2","East Asia","Australia East","Germany West Central","Japan
         East","UK South","West US","Central US","North Central US","South Central
         US","Korea Central","Brazil South","West US 3","France Central","South Africa
-        North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
-        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationResults","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationStatuses","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationResults","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationStatuses","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"connectedEnvironments","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","North Central US","East
-        US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectedEnvironments/certificates","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","North Central US","East
-        US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectedEnvironmentOperationStatuses","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","North Central US","East
-        US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/billingMeters","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Australia East","North
-        Central US","East US 2","West Europe","Central US","East US","North Europe","South
-        Central US","UK South","West US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/availableManagedEnvironmentsWorkloadProfileTypes","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Australia East","North
-        Central US","East US 2","West Europe","Central US","East US","North Europe","South
-        Central US","UK South","West US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+        North","Norway East","Switzerland North","UAE North"],"apiVersions":["2023-02-01","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"connectedEnvironments","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectedEnvironments/certificates","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/connectedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/billingMeters","locations":["North
+        Central US (Stage)","Australia East","North Central US","East US 2","West
+        Europe","Central US","East US","North Europe","South Central US","UK South","West
+        US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/availableManagedEnvironmentsWorkloadProfileTypes","locations":["North
+        Central US (Stage)","Australia East","North Central US","East US 2","West
+        Europe","Central US","East US","North Europe","South Central US","UK South","West
+        US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '9060'
+      - '8594'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:15:10 GMT
+      - Fri, 24 Mar 2023 21:37:04 GMT
       expires:
       - '-1'
       pragma:
@@ -551,94 +513,90 @@ interactions:
       ParameterSetName:
       - -g -n --logs-workspace-id --logs-workspace-key
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.10.10 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.3 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App","namespace":"Microsoft.App","authorizations":[{"applicationId":"7e3bc4fd-85a3-4192-b177-5b8bfc87f42c","roleDefinitionId":"39a74f72-b40f-4bdc-b639-562fe2260bf0"},{"applicationId":"3734c1a4-2bed-4998-a37a-ff1a9e7bf019","roleDefinitionId":"5c779a4f-5cb2-4547-8c41-478d9be8ba90"},{"applicationId":"55ebbb62-3b9c-49fd-9b87-9595226dd4ac","roleDefinitionId":"e49ca620-7992-4561-a7df-4ed67dad77b5","managedByRoleDefinitionId":"9e3af657-a8ff-583c-a75c-2fe7c4bcb635"}],"resourceTypes":[{"resourceType":"operations","locations":["North
-        Central US (Stage)","Central US EUAP","East US 2 EUAP","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/connectedEnvironmentOperationResults","locations":["North
-        Central US (Stage)","North Central US","East US","East Asia","West Europe","Central
-        US EUAP","East US 2 EUAP"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"managedEnvironments","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/certificates","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/managedCertificates","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"containerApps","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App","namespace":"Microsoft.App","authorizations":[{"applicationId":"7e3bc4fd-85a3-4192-b177-5b8bfc87f42c","roleDefinitionId":"39a74f72-b40f-4bdc-b639-562fe2260bf0"},{"applicationId":"3734c1a4-2bed-4998-a37a-ff1a9e7bf019","roleDefinitionId":"5c779a4f-5cb2-4547-8c41-478d9be8ba90"},{"applicationId":"55ebbb62-3b9c-49fd-9b87-9595226dd4ac","roleDefinitionId":"e49ca620-7992-4561-a7df-4ed67dad77b5","managedByRoleDefinitionId":"9e3af657-a8ff-583c-a75c-2fe7c4bcb635"}],"resourceTypes":[{"resourceType":"managedEnvironments","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/certificates","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/managedCertificates","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"containerApps","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
-        SupportsLocation"},{"resourceType":"jobs","locations":["Central US EUAP","East
-        US 2 EUAP","North Central US (Stage)","Canada Central","West Europe","North
-        Europe","East US","East US 2","East Asia","Australia East","Germany West Central","Japan
+        SupportsLocation"},{"resourceType":"jobs","locations":["North Central US (Stage)","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationResults","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationStatuses","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"operations","locations":["North
+        Central US (Stage)","Central US EUAP","East US 2 EUAP","West US 2","Southeast
+        Asia","Sweden Central","Canada Central","West Europe","North Europe","East
+        US","East US 2","East Asia","Australia East","Germany West Central","Japan
         East","UK South","West US","Central US","North Central US","South Central
         US","Korea Central","Brazil South","West US 3","France Central","South Africa
-        North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
-        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationResults","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationStatuses","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationResults","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationStatuses","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"connectedEnvironments","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","North Central US","East
-        US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectedEnvironments/certificates","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","North Central US","East
-        US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectedEnvironmentOperationStatuses","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","North Central US","East
-        US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/billingMeters","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Australia East","North
-        Central US","East US 2","West Europe","Central US","East US","North Europe","South
-        Central US","UK South","West US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/availableManagedEnvironmentsWorkloadProfileTypes","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Australia East","North
-        Central US","East US 2","West Europe","Central US","East US","North Europe","South
-        Central US","UK South","West US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+        North","Norway East","Switzerland North","UAE North"],"apiVersions":["2023-02-01","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"connectedEnvironments","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectedEnvironments/certificates","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/connectedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/billingMeters","locations":["North
+        Central US (Stage)","Australia East","North Central US","East US 2","West
+        Europe","Central US","East US","North Europe","South Central US","UK South","West
+        US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/availableManagedEnvironmentsWorkloadProfileTypes","locations":["North
+        Central US (Stage)","Australia East","North Central US","East US 2","West
+        Europe","Central US","East US","North Europe","South Central US","UK South","West
+        US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '9060'
+      - '8594'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:15:10 GMT
+      - Fri, 24 Mar 2023 21:37:04 GMT
       expires:
       - '-1'
       pragma:
@@ -656,7 +614,7 @@ interactions:
     body: '{"location": "eastus", "tags": null, "sku": {"name": "Consumption"}, "properties":
       {"daprAIInstrumentationKey": null, "vnetConfiguration": null, "appLogsConfiguration":
       {"destination": "log-analytics", "logAnalyticsConfiguration": {"customerId":
-      "8ee99494-3cd0-412d-a93b-6bf0c0785f1e", "sharedKey": "on0x3bctmrvfpZFzncUejpVZisNYIiyoTnjFaPO96sewFIr71+vJwsT/4C7wglU0XhxxPTER4n5T+TlI/G9B6g=="}},
+      "b8eb8147-36a1-4ace-b422-5e6367a8f732", "sharedKey": "Tv/Iqwao8FtA+b4qAPvc0Bdm1DKHEsuhYOVZiLcaN2xp1VwhL/8HaDJLWn4Q+99gt7YOg9rqLM8EPrtrBTijKw=="}},
       "customDomainConfiguration": null, "zoneRedundant": false}}'
     headers:
       Accept:
@@ -674,26 +632,26 @@ interactions:
       ParameterSetName:
       - -g -n --logs-workspace-id --logs-workspace-key
       User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002?api-version=2022-10-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","name":"containerapp-env000002","type":"Microsoft.App/managedEnvironments","location":"eastus","systemData":{"createdBy":"xinyupang@microsoft.com","createdByType":"User","createdAt":"2023-03-14T07:15:14.7971491Z","lastModifiedBy":"xinyupang@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-03-14T07:15:14.7971491Z"},"properties":{"provisioningState":"Waiting","defaultDomain":"proudmushroom-29cefc29.eastus.azurecontainerapps.io","staticIp":"20.246.188.129","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"8ee99494-3cd0-412d-a93b-6bf0c0785f1e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://eastus.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerapp-env000002/eventstream","customDomainConfiguration":{"customDomainVerificationId":"D3F71C85EB6552E36A89A3E4A080C3CFB00181670B659B0003264FC673AA9B00"}}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","name":"containerapp-env000002","type":"Microsoft.App/managedEnvironments","location":"eastus","systemData":{"createdBy":"prvalav@microsoft.com","createdByType":"User","createdAt":"2023-03-24T21:37:06.0737655Z","lastModifiedBy":"prvalav@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-03-24T21:37:06.0737655Z"},"properties":{"provisioningState":"Waiting","defaultDomain":"victoriousflower-c5068f24.eastus.azurecontainerapps.io","staticIp":"20.121.86.5","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"b8eb8147-36a1-4ace-b422-5e6367a8f732"}},"zoneRedundant":false,"eventStreamEndpoint":"https://eastus.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerapp-env000002/eventstream","customDomainConfiguration":{"customDomainVerificationId":"A189264E60034F7C3E609ED4E5CC493CEEA6833044629E67A8D1AC75146808B3"}}}'
     headers:
       api-supported-versions:
       - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
         2023-02-01
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/dd6f0463-740d-4bb6-ae3d-ea527bb201fc?api-version=2022-10-01&azureAsyncOperation=true
       cache-control:
       - no-cache
       content-length:
-      - '1120'
+      - '1116'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:15:18 GMT
+      - Fri, 24 Mar 2023 21:37:06 GMT
       expires:
       - '-1'
       pragma:
@@ -727,12 +685,12 @@ interactions:
       ParameterSetName:
       - -g -n --logs-workspace-id --logs-workspace-key
       User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/dd6f0463-740d-4bb6-ae3d-ea527bb201fc?api-version=2022-10-01&azureAsyncOperation=true
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/dd6f0463-740d-4bb6-ae3d-ea527bb201fc","name":"dd6f0463-740d-4bb6-ae3d-ea527bb201fc","status":"InProgress","startTime":"2023-03-24T21:37:06.6792451"}'
     headers:
       api-supported-versions:
       - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
@@ -740,11 +698,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '282'
+      - '284'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:15:19 GMT
+      - Fri, 24 Mar 2023 21:37:06 GMT
       expires:
       - '-1'
       pragma:
@@ -778,12 +736,12 @@ interactions:
       ParameterSetName:
       - -g -n --logs-workspace-id --logs-workspace-key
       User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/dd6f0463-740d-4bb6-ae3d-ea527bb201fc?api-version=2022-10-01&azureAsyncOperation=true
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/dd6f0463-740d-4bb6-ae3d-ea527bb201fc","name":"dd6f0463-740d-4bb6-ae3d-ea527bb201fc","status":"InProgress","startTime":"2023-03-24T21:37:06.6792451"}'
     headers:
       api-supported-versions:
       - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
@@ -791,11 +749,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '282'
+      - '284'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:15:22 GMT
+      - Fri, 24 Mar 2023 21:37:09 GMT
       expires:
       - '-1'
       pragma:
@@ -829,12 +787,12 @@ interactions:
       ParameterSetName:
       - -g -n --logs-workspace-id --logs-workspace-key
       User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/dd6f0463-740d-4bb6-ae3d-ea527bb201fc?api-version=2022-10-01&azureAsyncOperation=true
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/dd6f0463-740d-4bb6-ae3d-ea527bb201fc","name":"dd6f0463-740d-4bb6-ae3d-ea527bb201fc","status":"InProgress","startTime":"2023-03-24T21:37:06.6792451"}'
     headers:
       api-supported-versions:
       - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
@@ -842,11 +800,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '282'
+      - '284'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:15:26 GMT
+      - Fri, 24 Mar 2023 21:37:11 GMT
       expires:
       - '-1'
       pragma:
@@ -880,12 +838,12 @@ interactions:
       ParameterSetName:
       - -g -n --logs-workspace-id --logs-workspace-key
       User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/dd6f0463-740d-4bb6-ae3d-ea527bb201fc?api-version=2022-10-01&azureAsyncOperation=true
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/dd6f0463-740d-4bb6-ae3d-ea527bb201fc","name":"dd6f0463-740d-4bb6-ae3d-ea527bb201fc","status":"InProgress","startTime":"2023-03-24T21:37:06.6792451"}'
     headers:
       api-supported-versions:
       - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
@@ -893,11 +851,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '282'
+      - '284'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:15:29 GMT
+      - Fri, 24 Mar 2023 21:37:13 GMT
       expires:
       - '-1'
       pragma:
@@ -931,12 +889,12 @@ interactions:
       ParameterSetName:
       - -g -n --logs-workspace-id --logs-workspace-key
       User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/dd6f0463-740d-4bb6-ae3d-ea527bb201fc?api-version=2022-10-01&azureAsyncOperation=true
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/dd6f0463-740d-4bb6-ae3d-ea527bb201fc","name":"dd6f0463-740d-4bb6-ae3d-ea527bb201fc","status":"InProgress","startTime":"2023-03-24T21:37:06.6792451"}'
     headers:
       api-supported-versions:
       - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
@@ -944,3632 +902,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '282'
+      - '284'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:15:33 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:15:36 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:15:40 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:15:44 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:15:48 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:15:52 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:15:54 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:15:56 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:15:59 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:16:03 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:16:07 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:16:11 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:16:14 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:16:17 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:16:19 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:16:24 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:16:26 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:16:30 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:16:32 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:16:35 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:16:37 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:16:40 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:16:42 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:16:45 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:16:48 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:16:51 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:16:55 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:16:58 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:17:01 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:17:03 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:17:06 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:17:10 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:17:14 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:17:16 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:17:19 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:17:22 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:17:26 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:17:28 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:17:33 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:17:37 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:17:39 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:17:42 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:17:45 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:17:48 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:17:52 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:17:55 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:17:59 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:18:01 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:18:03 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:18:07 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:18:10 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:18:13 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:18:16 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:18:19 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:18:23 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:18:26 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:18:29 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:18:31 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:18:34 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:18:37 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:18:40 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:18:43 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:18:47 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:18:50 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:18:53 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:18:56 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:18:58 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:19:00 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:19:03 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:19:06 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:19:10 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:19:12 GMT
+      - Fri, 24 Mar 2023 21:37:15 GMT
       expires:
       - '-1'
       pragma:
@@ -4601,12 +938,12 @@ interactions:
       ParameterSetName:
       - -g -n --logs-workspace-id --logs-workspace-key
       User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/dd6f0463-740d-4bb6-ae3d-ea527bb201fc?api-version=2022-10-01&azureAsyncOperation=true
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/dd6f0463-740d-4bb6-ae3d-ea527bb201fc","name":"dd6f0463-740d-4bb6-ae3d-ea527bb201fc","status":"InProgress","startTime":"2023-03-24T21:37:06.6792451"}'
     headers:
       api-supported-versions:
       - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
@@ -4614,11 +951,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '282'
+      - '284'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:19:15 GMT
+      - Fri, 24 Mar 2023 21:37:17 GMT
       expires:
       - '-1'
       pragma:
@@ -4652,12 +989,12 @@ interactions:
       ParameterSetName:
       - -g -n --logs-workspace-id --logs-workspace-key
       User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/dd6f0463-740d-4bb6-ae3d-ea527bb201fc?api-version=2022-10-01&azureAsyncOperation=true
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/dd6f0463-740d-4bb6-ae3d-ea527bb201fc","name":"dd6f0463-740d-4bb6-ae3d-ea527bb201fc","status":"InProgress","startTime":"2023-03-24T21:37:06.6792451"}'
     headers:
       api-supported-versions:
       - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
@@ -4665,11 +1002,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '282'
+      - '284'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:19:18 GMT
+      - Fri, 24 Mar 2023 21:37:20 GMT
       expires:
       - '-1'
       pragma:
@@ -4703,12 +1040,12 @@ interactions:
       ParameterSetName:
       - -g -n --logs-workspace-id --logs-workspace-key
       User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/dd6f0463-740d-4bb6-ae3d-ea527bb201fc?api-version=2022-10-01&azureAsyncOperation=true
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/dd6f0463-740d-4bb6-ae3d-ea527bb201fc","name":"dd6f0463-740d-4bb6-ae3d-ea527bb201fc","status":"InProgress","startTime":"2023-03-24T21:37:06.6792451"}'
     headers:
       api-supported-versions:
       - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
@@ -4716,11 +1053,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '282'
+      - '284'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:19:21 GMT
+      - Fri, 24 Mar 2023 21:37:22 GMT
       expires:
       - '-1'
       pragma:
@@ -4754,12 +1091,12 @@ interactions:
       ParameterSetName:
       - -g -n --logs-workspace-id --logs-workspace-key
       User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/dd6f0463-740d-4bb6-ae3d-ea527bb201fc?api-version=2022-10-01&azureAsyncOperation=true
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/dd6f0463-740d-4bb6-ae3d-ea527bb201fc","name":"dd6f0463-740d-4bb6-ae3d-ea527bb201fc","status":"InProgress","startTime":"2023-03-24T21:37:06.6792451"}'
     headers:
       api-supported-versions:
       - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
@@ -4767,11 +1104,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '282'
+      - '284'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:19:24 GMT
+      - Fri, 24 Mar 2023 21:37:24 GMT
       expires:
       - '-1'
       pragma:
@@ -4805,12 +1142,12 @@ interactions:
       ParameterSetName:
       - -g -n --logs-workspace-id --logs-workspace-key
       User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/dd6f0463-740d-4bb6-ae3d-ea527bb201fc?api-version=2022-10-01&azureAsyncOperation=true
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/dd6f0463-740d-4bb6-ae3d-ea527bb201fc","name":"dd6f0463-740d-4bb6-ae3d-ea527bb201fc","status":"InProgress","startTime":"2023-03-24T21:37:06.6792451"}'
     headers:
       api-supported-versions:
       - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
@@ -4818,11 +1155,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '282'
+      - '284'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:19:26 GMT
+      - Fri, 24 Mar 2023 21:37:26 GMT
       expires:
       - '-1'
       pragma:
@@ -4856,12 +1193,12 @@ interactions:
       ParameterSetName:
       - -g -n --logs-workspace-id --logs-workspace-key
       User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/dd6f0463-740d-4bb6-ae3d-ea527bb201fc?api-version=2022-10-01&azureAsyncOperation=true
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/dd6f0463-740d-4bb6-ae3d-ea527bb201fc","name":"dd6f0463-740d-4bb6-ae3d-ea527bb201fc","status":"InProgress","startTime":"2023-03-24T21:37:06.6792451"}'
     headers:
       api-supported-versions:
       - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
@@ -4869,11 +1206,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '282'
+      - '284'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:19:28 GMT
+      - Fri, 24 Mar 2023 21:37:29 GMT
       expires:
       - '-1'
       pragma:
@@ -4907,12 +1244,12 @@ interactions:
       ParameterSetName:
       - -g -n --logs-workspace-id --logs-workspace-key
       User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/dd6f0463-740d-4bb6-ae3d-ea527bb201fc?api-version=2022-10-01&azureAsyncOperation=true
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/dd6f0463-740d-4bb6-ae3d-ea527bb201fc","name":"dd6f0463-740d-4bb6-ae3d-ea527bb201fc","status":"Succeeded","startTime":"2023-03-24T21:37:06.6792451"}'
     headers:
       api-supported-versions:
       - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
@@ -4920,11 +1257,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '282'
+      - '283'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:19:31 GMT
+      - Fri, 24 Mar 2023 21:37:31 GMT
       expires:
       - '-1'
       pragma:
@@ -4958,1083 +1295,12 @@ interactions:
       ParameterSetName:
       - -g -n --logs-workspace-id --logs-workspace-key
       User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:19:34 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:19:38 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:19:41 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:19:43 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:19:46 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:19:50 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:19:54 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:19:56 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:20:00 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:20:04 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:20:07 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:20:11 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:20:15 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:20:19 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:20:21 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:20:25 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:20:29 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:20:32 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:20:35 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"InProgress","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '282'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:20:39 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1?api-version=2022-10-01&azureAsyncOperation=true
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationStatuses/eb49984a-19e7-4a84-9cc8-687fe83032f1","name":"eb49984a-19e7-4a84-9cc8-687fe83032f1","status":"Succeeded","startTime":"2023-03-14T07:15:16.84954"}'
-    headers:
-      api-supported-versions:
-      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
-        2023-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '281'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 14 Mar 2023 07:20:42 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - containerapp env create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --logs-workspace-id --logs-workspace-key
-      User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002?api-version=2022-10-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","name":"containerapp-env000002","type":"Microsoft.App/managedEnvironments","location":"eastus","systemData":{"createdBy":"xinyupang@microsoft.com","createdByType":"User","createdAt":"2023-03-14T07:15:14.7971491","lastModifiedBy":"xinyupang@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-03-14T07:15:14.7971491"},"properties":{"provisioningState":"Succeeded","defaultDomain":"proudmushroom-29cefc29.eastus.azurecontainerapps.io","staticIp":"20.246.188.129","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"8ee99494-3cd0-412d-a93b-6bf0c0785f1e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://eastus.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerapp-env000002/eventstream","customDomainConfiguration":{"customDomainVerificationId":"D3F71C85EB6552E36A89A3E4A080C3CFB00181670B659B0003264FC673AA9B00"}}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","name":"containerapp-env000002","type":"Microsoft.App/managedEnvironments","location":"eastus","systemData":{"createdBy":"prvalav@microsoft.com","createdByType":"User","createdAt":"2023-03-24T21:37:06.0737655","lastModifiedBy":"prvalav@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-03-24T21:37:06.0737655"},"properties":{"provisioningState":"Succeeded","defaultDomain":"victoriousflower-c5068f24.eastus.azurecontainerapps.io","staticIp":"20.121.86.5","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"b8eb8147-36a1-4ace-b422-5e6367a8f732"}},"zoneRedundant":false,"eventStreamEndpoint":"https://eastus.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerapp-env000002/eventstream","customDomainConfiguration":{"customDomainVerificationId":"A189264E60034F7C3E609ED4E5CC493CEEA6833044629E67A8D1AC75146808B3"}}}'
     headers:
       api-supported-versions:
       - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
@@ -6042,11 +1308,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '1120'
+      - '1116'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:20:42 GMT
+      - Fri, 24 Mar 2023 21:37:31 GMT
       expires:
       - '-1'
       pragma:
@@ -6080,94 +1346,90 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.10.10 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.3 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App","namespace":"Microsoft.App","authorizations":[{"applicationId":"7e3bc4fd-85a3-4192-b177-5b8bfc87f42c","roleDefinitionId":"39a74f72-b40f-4bdc-b639-562fe2260bf0"},{"applicationId":"3734c1a4-2bed-4998-a37a-ff1a9e7bf019","roleDefinitionId":"5c779a4f-5cb2-4547-8c41-478d9be8ba90"},{"applicationId":"55ebbb62-3b9c-49fd-9b87-9595226dd4ac","roleDefinitionId":"e49ca620-7992-4561-a7df-4ed67dad77b5","managedByRoleDefinitionId":"9e3af657-a8ff-583c-a75c-2fe7c4bcb635"}],"resourceTypes":[{"resourceType":"operations","locations":["North
-        Central US (Stage)","Central US EUAP","East US 2 EUAP","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/connectedEnvironmentOperationResults","locations":["North
-        Central US (Stage)","North Central US","East US","East Asia","West Europe","Central
-        US EUAP","East US 2 EUAP"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"managedEnvironments","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/certificates","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/managedCertificates","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"containerApps","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App","namespace":"Microsoft.App","authorizations":[{"applicationId":"7e3bc4fd-85a3-4192-b177-5b8bfc87f42c","roleDefinitionId":"39a74f72-b40f-4bdc-b639-562fe2260bf0"},{"applicationId":"3734c1a4-2bed-4998-a37a-ff1a9e7bf019","roleDefinitionId":"5c779a4f-5cb2-4547-8c41-478d9be8ba90"},{"applicationId":"55ebbb62-3b9c-49fd-9b87-9595226dd4ac","roleDefinitionId":"e49ca620-7992-4561-a7df-4ed67dad77b5","managedByRoleDefinitionId":"9e3af657-a8ff-583c-a75c-2fe7c4bcb635"}],"resourceTypes":[{"resourceType":"managedEnvironments","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/certificates","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/managedCertificates","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"containerApps","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
-        SupportsLocation"},{"resourceType":"jobs","locations":["Central US EUAP","East
-        US 2 EUAP","North Central US (Stage)","Canada Central","West Europe","North
-        Europe","East US","East US 2","East Asia","Australia East","Germany West Central","Japan
+        SupportsLocation"},{"resourceType":"jobs","locations":["North Central US (Stage)","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationResults","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationStatuses","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"operations","locations":["North
+        Central US (Stage)","Central US EUAP","East US 2 EUAP","West US 2","Southeast
+        Asia","Sweden Central","Canada Central","West Europe","North Europe","East
+        US","East US 2","East Asia","Australia East","Germany West Central","Japan
         East","UK South","West US","Central US","North Central US","South Central
         US","Korea Central","Brazil South","West US 3","France Central","South Africa
-        North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
-        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationResults","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationStatuses","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationResults","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationStatuses","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"connectedEnvironments","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","North Central US","East
-        US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectedEnvironments/certificates","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","North Central US","East
-        US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectedEnvironmentOperationStatuses","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","North Central US","East
-        US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/billingMeters","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Australia East","North
-        Central US","East US 2","West Europe","Central US","East US","North Europe","South
-        Central US","UK South","West US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/availableManagedEnvironmentsWorkloadProfileTypes","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Australia East","North
-        Central US","East US 2","West Europe","Central US","East US","North Europe","South
-        Central US","UK South","West US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+        North","Norway East","Switzerland North","UAE North"],"apiVersions":["2023-02-01","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"connectedEnvironments","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectedEnvironments/certificates","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/connectedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/billingMeters","locations":["North
+        Central US (Stage)","Australia East","North Central US","East US 2","West
+        Europe","Central US","East US","North Europe","South Central US","UK South","West
+        US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/availableManagedEnvironmentsWorkloadProfileTypes","locations":["North
+        Central US (Stage)","Australia East","North Central US","East US 2","West
+        Europe","Central US","East US","North Europe","South Central US","UK South","West
+        US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '9060'
+      - '8594'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:20:43 GMT
+      - Fri, 24 Mar 2023 21:37:32 GMT
       expires:
       - '-1'
       pragma:
@@ -6195,12 +1457,12 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002?api-version=2022-10-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","name":"containerapp-env000002","type":"Microsoft.App/managedEnvironments","location":"eastus","systemData":{"createdBy":"xinyupang@microsoft.com","createdByType":"User","createdAt":"2023-03-14T07:15:14.7971491","lastModifiedBy":"xinyupang@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-03-14T07:15:14.7971491"},"properties":{"provisioningState":"Succeeded","defaultDomain":"proudmushroom-29cefc29.eastus.azurecontainerapps.io","staticIp":"20.246.188.129","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"8ee99494-3cd0-412d-a93b-6bf0c0785f1e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://eastus.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerapp-env000002/eventstream","customDomainConfiguration":{"customDomainVerificationId":"D3F71C85EB6552E36A89A3E4A080C3CFB00181670B659B0003264FC673AA9B00"}}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","name":"containerapp-env000002","type":"Microsoft.App/managedEnvironments","location":"eastus","systemData":{"createdBy":"prvalav@microsoft.com","createdByType":"User","createdAt":"2023-03-24T21:37:06.0737655","lastModifiedBy":"prvalav@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-03-24T21:37:06.0737655"},"properties":{"provisioningState":"Succeeded","defaultDomain":"victoriousflower-c5068f24.eastus.azurecontainerapps.io","staticIp":"20.121.86.5","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"b8eb8147-36a1-4ace-b422-5e6367a8f732"}},"zoneRedundant":false,"eventStreamEndpoint":"https://eastus.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerapp-env000002/eventstream","customDomainConfiguration":{"customDomainVerificationId":"A189264E60034F7C3E609ED4E5CC493CEEA6833044629E67A8D1AC75146808B3"}}}'
     headers:
       api-supported-versions:
       - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
@@ -6208,11 +1470,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '1120'
+      - '1116'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:20:43 GMT
+      - Fri, 24 Mar 2023 21:37:33 GMT
       expires:
       - '-1'
       pragma:
@@ -6246,94 +1508,90 @@ interactions:
       ParameterSetName:
       - -g -n --environment --ingress --target-port
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.10.10 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.3 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App","namespace":"Microsoft.App","authorizations":[{"applicationId":"7e3bc4fd-85a3-4192-b177-5b8bfc87f42c","roleDefinitionId":"39a74f72-b40f-4bdc-b639-562fe2260bf0"},{"applicationId":"3734c1a4-2bed-4998-a37a-ff1a9e7bf019","roleDefinitionId":"5c779a4f-5cb2-4547-8c41-478d9be8ba90"},{"applicationId":"55ebbb62-3b9c-49fd-9b87-9595226dd4ac","roleDefinitionId":"e49ca620-7992-4561-a7df-4ed67dad77b5","managedByRoleDefinitionId":"9e3af657-a8ff-583c-a75c-2fe7c4bcb635"}],"resourceTypes":[{"resourceType":"operations","locations":["North
-        Central US (Stage)","Central US EUAP","East US 2 EUAP","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/connectedEnvironmentOperationResults","locations":["North
-        Central US (Stage)","North Central US","East US","East Asia","West Europe","Central
-        US EUAP","East US 2 EUAP"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"managedEnvironments","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/certificates","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/managedCertificates","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"containerApps","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App","namespace":"Microsoft.App","authorizations":[{"applicationId":"7e3bc4fd-85a3-4192-b177-5b8bfc87f42c","roleDefinitionId":"39a74f72-b40f-4bdc-b639-562fe2260bf0"},{"applicationId":"3734c1a4-2bed-4998-a37a-ff1a9e7bf019","roleDefinitionId":"5c779a4f-5cb2-4547-8c41-478d9be8ba90"},{"applicationId":"55ebbb62-3b9c-49fd-9b87-9595226dd4ac","roleDefinitionId":"e49ca620-7992-4561-a7df-4ed67dad77b5","managedByRoleDefinitionId":"9e3af657-a8ff-583c-a75c-2fe7c4bcb635"}],"resourceTypes":[{"resourceType":"managedEnvironments","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/certificates","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/managedCertificates","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"containerApps","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
-        SupportsLocation"},{"resourceType":"jobs","locations":["Central US EUAP","East
-        US 2 EUAP","North Central US (Stage)","Canada Central","West Europe","North
-        Europe","East US","East US 2","East Asia","Australia East","Germany West Central","Japan
+        SupportsLocation"},{"resourceType":"jobs","locations":["North Central US (Stage)","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationResults","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationStatuses","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"operations","locations":["North
+        Central US (Stage)","Central US EUAP","East US 2 EUAP","West US 2","Southeast
+        Asia","Sweden Central","Canada Central","West Europe","North Europe","East
+        US","East US 2","East Asia","Australia East","Germany West Central","Japan
         East","UK South","West US","Central US","North Central US","South Central
         US","Korea Central","Brazil South","West US 3","France Central","South Africa
-        North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
-        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationResults","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationStatuses","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationResults","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationStatuses","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"connectedEnvironments","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","North Central US","East
-        US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectedEnvironments/certificates","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","North Central US","East
-        US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectedEnvironmentOperationStatuses","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","North Central US","East
-        US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/billingMeters","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Australia East","North
-        Central US","East US 2","West Europe","Central US","East US","North Europe","South
-        Central US","UK South","West US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/availableManagedEnvironmentsWorkloadProfileTypes","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Australia East","North
-        Central US","East US 2","West Europe","Central US","East US","North Europe","South
-        Central US","UK South","West US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+        North","Norway East","Switzerland North","UAE North"],"apiVersions":["2023-02-01","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"connectedEnvironments","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectedEnvironments/certificates","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/connectedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/billingMeters","locations":["North
+        Central US (Stage)","Australia East","North Central US","East US 2","West
+        Europe","Central US","East US","North Europe","South Central US","UK South","West
+        US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/availableManagedEnvironmentsWorkloadProfileTypes","locations":["North
+        Central US (Stage)","Australia East","North Central US","East US 2","West
+        Europe","Central US","East US","North Europe","South Central US","UK South","West
+        US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '9060'
+      - '8594'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:20:44 GMT
+      - Fri, 24 Mar 2023 21:37:33 GMT
       expires:
       - '-1'
       pragma:
@@ -6361,12 +1619,12 @@ interactions:
       ParameterSetName:
       - -g -n --environment --ingress --target-port
       User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002?api-version=2022-10-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","name":"containerapp-env000002","type":"Microsoft.App/managedEnvironments","location":"eastus","systemData":{"createdBy":"xinyupang@microsoft.com","createdByType":"User","createdAt":"2023-03-14T07:15:14.7971491","lastModifiedBy":"xinyupang@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-03-14T07:15:14.7971491"},"properties":{"provisioningState":"Succeeded","defaultDomain":"proudmushroom-29cefc29.eastus.azurecontainerapps.io","staticIp":"20.246.188.129","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"8ee99494-3cd0-412d-a93b-6bf0c0785f1e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://eastus.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerapp-env000002/eventstream","customDomainConfiguration":{"customDomainVerificationId":"D3F71C85EB6552E36A89A3E4A080C3CFB00181670B659B0003264FC673AA9B00"}}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","name":"containerapp-env000002","type":"Microsoft.App/managedEnvironments","location":"eastus","systemData":{"createdBy":"prvalav@microsoft.com","createdByType":"User","createdAt":"2023-03-24T21:37:06.0737655","lastModifiedBy":"prvalav@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-03-24T21:37:06.0737655"},"properties":{"provisioningState":"Succeeded","defaultDomain":"victoriousflower-c5068f24.eastus.azurecontainerapps.io","staticIp":"20.121.86.5","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"b8eb8147-36a1-4ace-b422-5e6367a8f732"}},"zoneRedundant":false,"eventStreamEndpoint":"https://eastus.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerapp-env000002/eventstream","customDomainConfiguration":{"customDomainVerificationId":"A189264E60034F7C3E609ED4E5CC493CEEA6833044629E67A8D1AC75146808B3"}}}'
     headers:
       api-supported-versions:
       - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
@@ -6374,11 +1632,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '1120'
+      - '1116'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:20:47 GMT
+      - Fri, 24 Mar 2023 21:37:33 GMT
       expires:
       - '-1'
       pragma:
@@ -6412,94 +1670,90 @@ interactions:
       ParameterSetName:
       - -g -n --environment --ingress --target-port
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.10.10 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.3 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App","namespace":"Microsoft.App","authorizations":[{"applicationId":"7e3bc4fd-85a3-4192-b177-5b8bfc87f42c","roleDefinitionId":"39a74f72-b40f-4bdc-b639-562fe2260bf0"},{"applicationId":"3734c1a4-2bed-4998-a37a-ff1a9e7bf019","roleDefinitionId":"5c779a4f-5cb2-4547-8c41-478d9be8ba90"},{"applicationId":"55ebbb62-3b9c-49fd-9b87-9595226dd4ac","roleDefinitionId":"e49ca620-7992-4561-a7df-4ed67dad77b5","managedByRoleDefinitionId":"9e3af657-a8ff-583c-a75c-2fe7c4bcb635"}],"resourceTypes":[{"resourceType":"operations","locations":["North
-        Central US (Stage)","Central US EUAP","East US 2 EUAP","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/connectedEnvironmentOperationResults","locations":["North
-        Central US (Stage)","North Central US","East US","East Asia","West Europe","Central
-        US EUAP","East US 2 EUAP"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"managedEnvironments","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/certificates","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/managedCertificates","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"containerApps","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App","namespace":"Microsoft.App","authorizations":[{"applicationId":"7e3bc4fd-85a3-4192-b177-5b8bfc87f42c","roleDefinitionId":"39a74f72-b40f-4bdc-b639-562fe2260bf0"},{"applicationId":"3734c1a4-2bed-4998-a37a-ff1a9e7bf019","roleDefinitionId":"5c779a4f-5cb2-4547-8c41-478d9be8ba90"},{"applicationId":"55ebbb62-3b9c-49fd-9b87-9595226dd4ac","roleDefinitionId":"e49ca620-7992-4561-a7df-4ed67dad77b5","managedByRoleDefinitionId":"9e3af657-a8ff-583c-a75c-2fe7c4bcb635"}],"resourceTypes":[{"resourceType":"managedEnvironments","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/certificates","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/managedCertificates","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"containerApps","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
-        SupportsLocation"},{"resourceType":"jobs","locations":["Central US EUAP","East
-        US 2 EUAP","North Central US (Stage)","Canada Central","West Europe","North
-        Europe","East US","East US 2","East Asia","Australia East","Germany West Central","Japan
+        SupportsLocation"},{"resourceType":"jobs","locations":["North Central US (Stage)","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationResults","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationStatuses","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"operations","locations":["North
+        Central US (Stage)","Central US EUAP","East US 2 EUAP","West US 2","Southeast
+        Asia","Sweden Central","Canada Central","West Europe","North Europe","East
+        US","East US 2","East Asia","Australia East","Germany West Central","Japan
         East","UK South","West US","Central US","North Central US","South Central
         US","Korea Central","Brazil South","West US 3","France Central","South Africa
-        North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
-        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationResults","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationStatuses","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationResults","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationStatuses","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"connectedEnvironments","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","North Central US","East
-        US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectedEnvironments/certificates","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","North Central US","East
-        US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectedEnvironmentOperationStatuses","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","North Central US","East
-        US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/billingMeters","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Australia East","North
-        Central US","East US 2","West Europe","Central US","East US","North Europe","South
-        Central US","UK South","West US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/availableManagedEnvironmentsWorkloadProfileTypes","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Australia East","North
-        Central US","East US 2","West Europe","Central US","East US","North Europe","South
-        Central US","UK South","West US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+        North","Norway East","Switzerland North","UAE North"],"apiVersions":["2023-02-01","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"connectedEnvironments","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectedEnvironments/certificates","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/connectedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/billingMeters","locations":["North
+        Central US (Stage)","Australia East","North Central US","East US 2","West
+        Europe","Central US","East US","North Europe","South Central US","UK South","West
+        US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/availableManagedEnvironmentsWorkloadProfileTypes","locations":["North
+        Central US (Stage)","Australia East","North Central US","East US 2","West
+        Europe","Central US","East US","North Europe","South Central US","UK South","West
+        US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '9060'
+      - '8594'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:20:47 GMT
+      - Fri, 24 Mar 2023 21:37:33 GMT
       expires:
       - '-1'
       pragma:
@@ -6515,7 +1769,7 @@ interactions:
       message: OK
 - request:
     body: '{"location": "eastus", "identity": {"type": "None", "userAssignedIdentities":
-      null}, "properties": {"managedEnvironmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002",
+      null}, "properties": {"environmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002",
       "configuration": {"secrets": null, "activeRevisionsMode": "single", "ingress":
       {"fqdn": null, "external": true, "targetPort": 80, "transport": "auto", "exposedPort":
       null, "traffic": null, "customDomains": null, "ipSecurityRestrictions": null},
@@ -6534,33 +1788,33 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '871'
+      - '864'
       Content-Type:
       - application/json
       ParameterSetName:
       - -g -n --environment --ingress --target-port
       User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerApps/containerapp000003?api-version=2022-10-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerapps/containerapp000003","name":"containerapp000003","type":"Microsoft.App/containerApps","location":"East
-        US","systemData":{"createdBy":"xinyupang@microsoft.com","createdByType":"User","createdAt":"2023-03-14T07:20:52.432759Z","lastModifiedBy":"xinyupang@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-03-14T07:20:52.432759Z"},"properties":{"provisioningState":"InProgress","managedEnvironmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","environmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","workloadProfileType":null,"outboundIpAddresses":["20.246.184.58"],"latestRevisionName":"","latestReadyRevisionName":"","latestRevisionFqdn":"","customDomainVerificationId":"D3F71C85EB6552E36A89A3E4A080C3CFB00181670B659B0003264FC673AA9B00","configuration":{"secrets":null,"activeRevisionsMode":"Single","ingress":{"fqdn":"containerapp000003.proudmushroom-29cefc29.eastus.azurecontainerapps.io","external":true,"targetPort":80,"exposedPort":0,"transport":"Auto","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":false,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null},"registries":null,"dapr":null,"maxInactiveRevisions":null},"template":{"revisionSuffix":"","containers":[{"image":"mcr.microsoft.com/azuredocs/containerapps-helloworld:latest","name":"containerapp000003","resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":null,"maxReplicas":10,"rules":null},"volumes":null},"eventStreamEndpoint":"https://eastus.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/containerApps/containerapp000003/eventstream"},"identity":{"type":"None"}}'
+        US","systemData":{"createdBy":"prvalav@microsoft.com","createdByType":"User","createdAt":"2023-03-24T21:37:35.3226001Z","lastModifiedBy":"prvalav@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-03-24T21:37:35.3226001Z"},"properties":{"provisioningState":"InProgress","managedEnvironmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","environmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","workloadProfileType":null,"outboundIpAddresses":["20.121.85.239"],"latestRevisionName":"","latestReadyRevisionName":"","latestRevisionFqdn":"","customDomainVerificationId":"A189264E60034F7C3E609ED4E5CC493CEEA6833044629E67A8D1AC75146808B3","configuration":{"secrets":null,"activeRevisionsMode":"Single","ingress":{"fqdn":"containerapp000003.victoriousflower-c5068f24.eastus.azurecontainerapps.io","external":true,"targetPort":80,"exposedPort":0,"transport":"Auto","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":false,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null},"registries":null,"dapr":null,"maxInactiveRevisions":null},"template":{"revisionSuffix":"","containers":[{"image":"mcr.microsoft.com/azuredocs/containerapps-helloworld:latest","name":"containerapp000003","resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":null,"maxReplicas":10,"rules":null},"volumes":null},"eventStreamEndpoint":"https://eastus.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/containerApps/containerapp000003/eventstream"},"identity":{"type":"None"}}'
     headers:
       api-supported-versions:
       - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
         2023-02-01
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/a3955c8d-3fb0-46c1-a427-6754d56bbfd6?api-version=2022-10-01&azureAsyncOperation=true
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/1d9fafb5-f83e-4eb3-a6b0-40f16e0a76a9?api-version=2022-10-01&azureAsyncOperation=true
       cache-control:
       - no-cache
       content-length:
-      - '2079'
+      - '2080'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:20:54 GMT
+      - Fri, 24 Mar 2023 21:37:36 GMT
       expires:
       - '-1'
       pragma:
@@ -6574,7 +1828,7 @@ interactions:
       x-ms-async-operation-timeout:
       - PT15M
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '498'
+      - '699'
       x-powered-by:
       - ASP.NET
     status:
@@ -6594,12 +1848,12 @@ interactions:
       ParameterSetName:
       - -g -n --environment --ingress --target-port
       User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/a3955c8d-3fb0-46c1-a427-6754d56bbfd6?api-version=2022-10-01&azureAsyncOperation=true
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/1d9fafb5-f83e-4eb3-a6b0-40f16e0a76a9?api-version=2022-10-01&azureAsyncOperation=true
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/a3955c8d-3fb0-46c1-a427-6754d56bbfd6","name":"a3955c8d-3fb0-46c1-a427-6754d56bbfd6","status":"InProgress","startTime":"2023-03-14T07:20:52.5937584"}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/1d9fafb5-f83e-4eb3-a6b0-40f16e0a76a9","name":"1d9fafb5-f83e-4eb3-a6b0-40f16e0a76a9","status":"InProgress","startTime":"2023-03-24T21:37:35.4511938"}'
     headers:
       api-supported-versions:
       - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
@@ -6611,7 +1865,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:20:55 GMT
+      - Fri, 24 Mar 2023 21:37:35 GMT
       expires:
       - '-1'
       pragma:
@@ -6645,12 +1899,12 @@ interactions:
       ParameterSetName:
       - -g -n --environment --ingress --target-port
       User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/a3955c8d-3fb0-46c1-a427-6754d56bbfd6?api-version=2022-10-01&azureAsyncOperation=true
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/1d9fafb5-f83e-4eb3-a6b0-40f16e0a76a9?api-version=2022-10-01&azureAsyncOperation=true
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/a3955c8d-3fb0-46c1-a427-6754d56bbfd6","name":"a3955c8d-3fb0-46c1-a427-6754d56bbfd6","status":"InProgress","startTime":"2023-03-14T07:20:52.5937584"}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/1d9fafb5-f83e-4eb3-a6b0-40f16e0a76a9","name":"1d9fafb5-f83e-4eb3-a6b0-40f16e0a76a9","status":"InProgress","startTime":"2023-03-24T21:37:35.4511938"}'
     headers:
       api-supported-versions:
       - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
@@ -6662,7 +1916,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:20:58 GMT
+      - Fri, 24 Mar 2023 21:37:38 GMT
       expires:
       - '-1'
       pragma:
@@ -6696,12 +1950,316 @@ interactions:
       ParameterSetName:
       - -g -n --environment --ingress --target-port
       User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/a3955c8d-3fb0-46c1-a427-6754d56bbfd6?api-version=2022-10-01&azureAsyncOperation=true
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/1d9fafb5-f83e-4eb3-a6b0-40f16e0a76a9?api-version=2022-10-01&azureAsyncOperation=true
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/a3955c8d-3fb0-46c1-a427-6754d56bbfd6","name":"a3955c8d-3fb0-46c1-a427-6754d56bbfd6","status":"Succeeded","startTime":"2023-03-14T07:20:52.5937584"}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/1d9fafb5-f83e-4eb3-a6b0-40f16e0a76a9","name":"1d9fafb5-f83e-4eb3-a6b0-40f16e0a76a9","status":"InProgress","startTime":"2023-03-24T21:37:35.4511938"}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '278'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Mar 2023 21:37:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --environment --ingress --target-port
+      User-Agent:
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/1d9fafb5-f83e-4eb3-a6b0-40f16e0a76a9?api-version=2022-10-01&azureAsyncOperation=true
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/1d9fafb5-f83e-4eb3-a6b0-40f16e0a76a9","name":"1d9fafb5-f83e-4eb3-a6b0-40f16e0a76a9","status":"InProgress","startTime":"2023-03-24T21:37:35.4511938"}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '278'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Mar 2023 21:37:43 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --environment --ingress --target-port
+      User-Agent:
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/1d9fafb5-f83e-4eb3-a6b0-40f16e0a76a9?api-version=2022-10-01&azureAsyncOperation=true
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/1d9fafb5-f83e-4eb3-a6b0-40f16e0a76a9","name":"1d9fafb5-f83e-4eb3-a6b0-40f16e0a76a9","status":"InProgress","startTime":"2023-03-24T21:37:35.4511938"}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '278'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Mar 2023 21:37:45 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --environment --ingress --target-port
+      User-Agent:
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/1d9fafb5-f83e-4eb3-a6b0-40f16e0a76a9?api-version=2022-10-01&azureAsyncOperation=true
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/1d9fafb5-f83e-4eb3-a6b0-40f16e0a76a9","name":"1d9fafb5-f83e-4eb3-a6b0-40f16e0a76a9","status":"InProgress","startTime":"2023-03-24T21:37:35.4511938"}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '278'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Mar 2023 21:37:47 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --environment --ingress --target-port
+      User-Agent:
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/1d9fafb5-f83e-4eb3-a6b0-40f16e0a76a9?api-version=2022-10-01&azureAsyncOperation=true
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/1d9fafb5-f83e-4eb3-a6b0-40f16e0a76a9","name":"1d9fafb5-f83e-4eb3-a6b0-40f16e0a76a9","status":"InProgress","startTime":"2023-03-24T21:37:35.4511938"}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '278'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Mar 2023 21:37:49 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --environment --ingress --target-port
+      User-Agent:
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/1d9fafb5-f83e-4eb3-a6b0-40f16e0a76a9?api-version=2022-10-01&azureAsyncOperation=true
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/1d9fafb5-f83e-4eb3-a6b0-40f16e0a76a9","name":"1d9fafb5-f83e-4eb3-a6b0-40f16e0a76a9","status":"InProgress","startTime":"2023-03-24T21:37:35.4511938"}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '278'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Mar 2023 21:37:52 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --environment --ingress --target-port
+      User-Agent:
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/1d9fafb5-f83e-4eb3-a6b0-40f16e0a76a9?api-version=2022-10-01&azureAsyncOperation=true
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/1d9fafb5-f83e-4eb3-a6b0-40f16e0a76a9","name":"1d9fafb5-f83e-4eb3-a6b0-40f16e0a76a9","status":"Succeeded","startTime":"2023-03-24T21:37:35.4511938"}'
     headers:
       api-supported-versions:
       - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
@@ -6713,7 +2271,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:21:00 GMT
+      - Fri, 24 Mar 2023 21:37:54 GMT
       expires:
       - '-1'
       pragma:
@@ -6747,13 +2305,13 @@ interactions:
       ParameterSetName:
       - -g -n --environment --ingress --target-port
       User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerApps/containerapp000003?api-version=2022-10-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerapps/containerapp000003","name":"containerapp000003","type":"Microsoft.App/containerApps","location":"East
-        US","systemData":{"createdBy":"xinyupang@microsoft.com","createdByType":"User","createdAt":"2023-03-14T07:20:52.432759","lastModifiedBy":"xinyupang@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-03-14T07:20:52.432759"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","environmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","workloadProfileType":null,"outboundIpAddresses":["20.246.184.58"],"latestRevisionName":"containerapp000003--yu8mgc3","latestReadyRevisionName":"containerapp000003--yu8mgc3","latestRevisionFqdn":"containerapp000003--yu8mgc3.proudmushroom-29cefc29.eastus.azurecontainerapps.io","customDomainVerificationId":"D3F71C85EB6552E36A89A3E4A080C3CFB00181670B659B0003264FC673AA9B00","configuration":{"secrets":null,"activeRevisionsMode":"Single","ingress":{"fqdn":"containerapp000003.proudmushroom-29cefc29.eastus.azurecontainerapps.io","external":true,"targetPort":80,"exposedPort":0,"transport":"Auto","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":false,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null},"registries":null,"dapr":null,"maxInactiveRevisions":null},"template":{"revisionSuffix":"","containers":[{"image":"mcr.microsoft.com/azuredocs/containerapps-helloworld:latest","name":"containerapp000003","resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":null,"maxReplicas":10,"rules":null},"volumes":null},"eventStreamEndpoint":"https://eastus.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/containerApps/containerapp000003/eventstream"},"identity":{"type":"None"}}'
+        US","systemData":{"createdBy":"prvalav@microsoft.com","createdByType":"User","createdAt":"2023-03-24T21:37:35.3226001","lastModifiedBy":"prvalav@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-03-24T21:37:35.3226001"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","environmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","workloadProfileType":null,"outboundIpAddresses":["20.121.85.239"],"latestRevisionName":"containerapp000003--vm672yx","latestReadyRevisionName":"containerapp000003--vm672yx","latestRevisionFqdn":"containerapp000003--vm672yx.victoriousflower-c5068f24.eastus.azurecontainerapps.io","customDomainVerificationId":"A189264E60034F7C3E609ED4E5CC493CEEA6833044629E67A8D1AC75146808B3","configuration":{"secrets":null,"activeRevisionsMode":"Single","ingress":{"fqdn":"containerapp000003.victoriousflower-c5068f24.eastus.azurecontainerapps.io","external":true,"targetPort":80,"exposedPort":0,"transport":"Auto","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":false,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null},"registries":null,"dapr":null,"maxInactiveRevisions":null},"template":{"revisionSuffix":"","containers":[{"image":"mcr.microsoft.com/azuredocs/containerapps-helloworld:latest","name":"containerapp000003","resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":null,"maxReplicas":10,"rules":null},"volumes":null},"eventStreamEndpoint":"https://eastus.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/containerApps/containerapp000003/eventstream"},"identity":{"type":"None"}}'
     headers:
       api-supported-versions:
       - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
@@ -6761,11 +2319,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '2209'
+      - '2213'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:21:03 GMT
+      - Fri, 24 Mar 2023 21:37:56 GMT
       expires:
       - '-1'
       pragma:
@@ -6799,94 +2357,90 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.10.10 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.3 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App","namespace":"Microsoft.App","authorizations":[{"applicationId":"7e3bc4fd-85a3-4192-b177-5b8bfc87f42c","roleDefinitionId":"39a74f72-b40f-4bdc-b639-562fe2260bf0"},{"applicationId":"3734c1a4-2bed-4998-a37a-ff1a9e7bf019","roleDefinitionId":"5c779a4f-5cb2-4547-8c41-478d9be8ba90"},{"applicationId":"55ebbb62-3b9c-49fd-9b87-9595226dd4ac","roleDefinitionId":"e49ca620-7992-4561-a7df-4ed67dad77b5","managedByRoleDefinitionId":"9e3af657-a8ff-583c-a75c-2fe7c4bcb635"}],"resourceTypes":[{"resourceType":"operations","locations":["North
-        Central US (Stage)","Central US EUAP","East US 2 EUAP","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/connectedEnvironmentOperationResults","locations":["North
-        Central US (Stage)","North Central US","East US","East Asia","West Europe","Central
-        US EUAP","East US 2 EUAP"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"managedEnvironments","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/certificates","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/managedCertificates","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"containerApps","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App","namespace":"Microsoft.App","authorizations":[{"applicationId":"7e3bc4fd-85a3-4192-b177-5b8bfc87f42c","roleDefinitionId":"39a74f72-b40f-4bdc-b639-562fe2260bf0"},{"applicationId":"3734c1a4-2bed-4998-a37a-ff1a9e7bf019","roleDefinitionId":"5c779a4f-5cb2-4547-8c41-478d9be8ba90"},{"applicationId":"55ebbb62-3b9c-49fd-9b87-9595226dd4ac","roleDefinitionId":"e49ca620-7992-4561-a7df-4ed67dad77b5","managedByRoleDefinitionId":"9e3af657-a8ff-583c-a75c-2fe7c4bcb635"}],"resourceTypes":[{"resourceType":"managedEnvironments","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/certificates","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/managedCertificates","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"containerApps","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
-        SupportsLocation"},{"resourceType":"jobs","locations":["Central US EUAP","East
-        US 2 EUAP","North Central US (Stage)","Canada Central","West Europe","North
-        Europe","East US","East US 2","East Asia","Australia East","Germany West Central","Japan
+        SupportsLocation"},{"resourceType":"jobs","locations":["North Central US (Stage)","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationResults","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationStatuses","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"operations","locations":["North
+        Central US (Stage)","Central US EUAP","East US 2 EUAP","West US 2","Southeast
+        Asia","Sweden Central","Canada Central","West Europe","North Europe","East
+        US","East US 2","East Asia","Australia East","Germany West Central","Japan
         East","UK South","West US","Central US","North Central US","South Central
         US","Korea Central","Brazil South","West US 3","France Central","South Africa
-        North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
-        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationResults","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationStatuses","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationResults","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationStatuses","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"connectedEnvironments","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","North Central US","East
-        US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectedEnvironments/certificates","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","North Central US","East
-        US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectedEnvironmentOperationStatuses","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","North Central US","East
-        US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/billingMeters","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Australia East","North
-        Central US","East US 2","West Europe","Central US","East US","North Europe","South
-        Central US","UK South","West US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/availableManagedEnvironmentsWorkloadProfileTypes","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Australia East","North
-        Central US","East US 2","West Europe","Central US","East US","North Europe","South
-        Central US","UK South","West US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+        North","Norway East","Switzerland North","UAE North"],"apiVersions":["2023-02-01","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"connectedEnvironments","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectedEnvironments/certificates","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/connectedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/billingMeters","locations":["North
+        Central US (Stage)","Australia East","North Central US","East US 2","West
+        Europe","Central US","East US","North Europe","South Central US","UK South","West
+        US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/availableManagedEnvironmentsWorkloadProfileTypes","locations":["North
+        Central US (Stage)","Australia East","North Central US","East US 2","West
+        Europe","Central US","East US","North Europe","South Central US","UK South","West
+        US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '9060'
+      - '8594'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:21:03 GMT
+      - Fri, 24 Mar 2023 21:37:56 GMT
       expires:
       - '-1'
       pragma:
@@ -6914,13 +2468,13 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerApps/containerapp000003?api-version=2022-10-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerapps/containerapp000003","name":"containerapp000003","type":"Microsoft.App/containerApps","location":"East
-        US","systemData":{"createdBy":"xinyupang@microsoft.com","createdByType":"User","createdAt":"2023-03-14T07:20:52.432759","lastModifiedBy":"xinyupang@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-03-14T07:20:52.432759"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","environmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","workloadProfileType":null,"outboundIpAddresses":["20.246.184.58"],"latestRevisionName":"containerapp000003--yu8mgc3","latestReadyRevisionName":"containerapp000003--yu8mgc3","latestRevisionFqdn":"containerapp000003--yu8mgc3.proudmushroom-29cefc29.eastus.azurecontainerapps.io","customDomainVerificationId":"D3F71C85EB6552E36A89A3E4A080C3CFB00181670B659B0003264FC673AA9B00","configuration":{"secrets":null,"activeRevisionsMode":"Single","ingress":{"fqdn":"containerapp000003.proudmushroom-29cefc29.eastus.azurecontainerapps.io","external":true,"targetPort":80,"exposedPort":0,"transport":"Auto","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":false,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null},"registries":null,"dapr":null,"maxInactiveRevisions":null},"template":{"revisionSuffix":"","containers":[{"image":"mcr.microsoft.com/azuredocs/containerapps-helloworld:latest","name":"containerapp000003","resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":null,"maxReplicas":10,"rules":null},"volumes":null},"eventStreamEndpoint":"https://eastus.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/containerApps/containerapp000003/eventstream"},"identity":{"type":"None"}}'
+        US","systemData":{"createdBy":"prvalav@microsoft.com","createdByType":"User","createdAt":"2023-03-24T21:37:35.3226001","lastModifiedBy":"prvalav@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-03-24T21:37:35.3226001"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","environmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","workloadProfileType":null,"outboundIpAddresses":["20.121.85.239"],"latestRevisionName":"containerapp000003--vm672yx","latestReadyRevisionName":"containerapp000003--vm672yx","latestRevisionFqdn":"containerapp000003--vm672yx.victoriousflower-c5068f24.eastus.azurecontainerapps.io","customDomainVerificationId":"A189264E60034F7C3E609ED4E5CC493CEEA6833044629E67A8D1AC75146808B3","configuration":{"secrets":null,"activeRevisionsMode":"Single","ingress":{"fqdn":"containerapp000003.victoriousflower-c5068f24.eastus.azurecontainerapps.io","external":true,"targetPort":80,"exposedPort":0,"transport":"Auto","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":false,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null},"registries":null,"dapr":null,"maxInactiveRevisions":null},"template":{"revisionSuffix":"","containers":[{"image":"mcr.microsoft.com/azuredocs/containerapps-helloworld:latest","name":"containerapp000003","resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":null,"maxReplicas":10,"rules":null},"volumes":null},"eventStreamEndpoint":"https://eastus.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/containerApps/containerapp000003/eventstream"},"identity":{"type":"None"}}'
     headers:
       api-supported-versions:
       - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
@@ -6928,11 +2482,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '2209'
+      - '2213'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:21:04 GMT
+      - Fri, 24 Mar 2023 21:37:57 GMT
       expires:
       - '-1'
       pragma:
@@ -6966,94 +2520,90 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.10.10 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.3 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App","namespace":"Microsoft.App","authorizations":[{"applicationId":"7e3bc4fd-85a3-4192-b177-5b8bfc87f42c","roleDefinitionId":"39a74f72-b40f-4bdc-b639-562fe2260bf0"},{"applicationId":"3734c1a4-2bed-4998-a37a-ff1a9e7bf019","roleDefinitionId":"5c779a4f-5cb2-4547-8c41-478d9be8ba90"},{"applicationId":"55ebbb62-3b9c-49fd-9b87-9595226dd4ac","roleDefinitionId":"e49ca620-7992-4561-a7df-4ed67dad77b5","managedByRoleDefinitionId":"9e3af657-a8ff-583c-a75c-2fe7c4bcb635"}],"resourceTypes":[{"resourceType":"operations","locations":["North
-        Central US (Stage)","Central US EUAP","East US 2 EUAP","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/connectedEnvironmentOperationResults","locations":["North
-        Central US (Stage)","North Central US","East US","East Asia","West Europe","Central
-        US EUAP","East US 2 EUAP"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"managedEnvironments","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/certificates","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/managedCertificates","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"containerApps","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App","namespace":"Microsoft.App","authorizations":[{"applicationId":"7e3bc4fd-85a3-4192-b177-5b8bfc87f42c","roleDefinitionId":"39a74f72-b40f-4bdc-b639-562fe2260bf0"},{"applicationId":"3734c1a4-2bed-4998-a37a-ff1a9e7bf019","roleDefinitionId":"5c779a4f-5cb2-4547-8c41-478d9be8ba90"},{"applicationId":"55ebbb62-3b9c-49fd-9b87-9595226dd4ac","roleDefinitionId":"e49ca620-7992-4561-a7df-4ed67dad77b5","managedByRoleDefinitionId":"9e3af657-a8ff-583c-a75c-2fe7c4bcb635"}],"resourceTypes":[{"resourceType":"managedEnvironments","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/certificates","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/managedCertificates","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"containerApps","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
-        SupportsLocation"},{"resourceType":"jobs","locations":["Central US EUAP","East
-        US 2 EUAP","North Central US (Stage)","Canada Central","West Europe","North
-        Europe","East US","East US 2","East Asia","Australia East","Germany West Central","Japan
+        SupportsLocation"},{"resourceType":"jobs","locations":["North Central US (Stage)","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationResults","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationStatuses","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"operations","locations":["North
+        Central US (Stage)","Central US EUAP","East US 2 EUAP","West US 2","Southeast
+        Asia","Sweden Central","Canada Central","West Europe","North Europe","East
+        US","East US 2","East Asia","Australia East","Germany West Central","Japan
         East","UK South","West US","Central US","North Central US","South Central
         US","Korea Central","Brazil South","West US 3","France Central","South Africa
-        North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
-        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationResults","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationStatuses","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationResults","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationStatuses","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"connectedEnvironments","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","North Central US","East
-        US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectedEnvironments/certificates","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","North Central US","East
-        US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectedEnvironmentOperationStatuses","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","North Central US","East
-        US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/billingMeters","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Australia East","North
-        Central US","East US 2","West Europe","Central US","East US","North Europe","South
-        Central US","UK South","West US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/availableManagedEnvironmentsWorkloadProfileTypes","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Australia East","North
-        Central US","East US 2","West Europe","Central US","East US","North Europe","South
-        Central US","UK South","West US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+        North","Norway East","Switzerland North","UAE North"],"apiVersions":["2023-02-01","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"connectedEnvironments","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectedEnvironments/certificates","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/connectedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/billingMeters","locations":["North
+        Central US (Stage)","Australia East","North Central US","East US 2","West
+        Europe","Central US","East US","North Europe","South Central US","UK South","West
+        US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/availableManagedEnvironmentsWorkloadProfileTypes","locations":["North
+        Central US (Stage)","Australia East","North Central US","East US 2","West
+        Europe","Central US","East US","North Europe","South Central US","UK South","West
+        US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '9060'
+      - '8594'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:21:04 GMT
+      - Fri, 24 Mar 2023 21:37:57 GMT
       expires:
       - '-1'
       pragma:
@@ -7081,13 +2631,13 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerApps/containerapp000003?api-version=2022-10-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerapps/containerapp000003","name":"containerapp000003","type":"Microsoft.App/containerApps","location":"East
-        US","systemData":{"createdBy":"xinyupang@microsoft.com","createdByType":"User","createdAt":"2023-03-14T07:20:52.432759","lastModifiedBy":"xinyupang@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-03-14T07:20:52.432759"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","environmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","workloadProfileType":null,"outboundIpAddresses":["20.246.184.58"],"latestRevisionName":"containerapp000003--yu8mgc3","latestReadyRevisionName":"containerapp000003--yu8mgc3","latestRevisionFqdn":"containerapp000003--yu8mgc3.proudmushroom-29cefc29.eastus.azurecontainerapps.io","customDomainVerificationId":"D3F71C85EB6552E36A89A3E4A080C3CFB00181670B659B0003264FC673AA9B00","configuration":{"secrets":null,"activeRevisionsMode":"Single","ingress":{"fqdn":"containerapp000003.proudmushroom-29cefc29.eastus.azurecontainerapps.io","external":true,"targetPort":80,"exposedPort":0,"transport":"Auto","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":false,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null},"registries":null,"dapr":null,"maxInactiveRevisions":null},"template":{"revisionSuffix":"","containers":[{"image":"mcr.microsoft.com/azuredocs/containerapps-helloworld:latest","name":"containerapp000003","resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":null,"maxReplicas":10,"rules":null},"volumes":null},"eventStreamEndpoint":"https://eastus.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/containerApps/containerapp000003/eventstream"},"identity":{"type":"None"}}'
+        US","systemData":{"createdBy":"prvalav@microsoft.com","createdByType":"User","createdAt":"2023-03-24T21:37:35.3226001","lastModifiedBy":"prvalav@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-03-24T21:37:35.3226001"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","environmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","workloadProfileType":null,"outboundIpAddresses":["20.121.85.239"],"latestRevisionName":"containerapp000003--vm672yx","latestReadyRevisionName":"containerapp000003--vm672yx","latestRevisionFqdn":"containerapp000003--vm672yx.victoriousflower-c5068f24.eastus.azurecontainerapps.io","customDomainVerificationId":"A189264E60034F7C3E609ED4E5CC493CEEA6833044629E67A8D1AC75146808B3","configuration":{"secrets":null,"activeRevisionsMode":"Single","ingress":{"fqdn":"containerapp000003.victoriousflower-c5068f24.eastus.azurecontainerapps.io","external":true,"targetPort":80,"exposedPort":0,"transport":"Auto","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":false,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null},"registries":null,"dapr":null,"maxInactiveRevisions":null},"template":{"revisionSuffix":"","containers":[{"image":"mcr.microsoft.com/azuredocs/containerapps-helloworld:latest","name":"containerapp000003","resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":null,"maxReplicas":10,"rules":null},"volumes":null},"eventStreamEndpoint":"https://eastus.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/containerApps/containerapp000003/eventstream"},"identity":{"type":"None"}}'
     headers:
       api-supported-versions:
       - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
@@ -7095,11 +2645,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '2209'
+      - '2213'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:21:05 GMT
+      - Fri, 24 Mar 2023 21:37:57 GMT
       expires:
       - '-1'
       pragma:
@@ -7135,7 +2685,7 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerApps/containerapp000003/listSecrets?api-version=2022-10-01
   response:
@@ -7152,7 +2702,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:21:09 GMT
+      - Fri, 24 Mar 2023 21:37:59 GMT
       expires:
       - '-1'
       pragma:
@@ -7177,15 +2727,15 @@ interactions:
 - request:
     body: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerapps/containerapp000003",
       "name": "containerapp000003", "type": "Microsoft.App/containerApps", "location":
-      "East US", "systemData": {"createdBy": "xinyupang@microsoft.com", "createdByType":
-      "User", "createdAt": "2023-03-14T07:20:52.432759", "lastModifiedBy": "xinyupang@microsoft.com",
-      "lastModifiedByType": "User", "lastModifiedAt": "2023-03-14T07:20:52.432759"},
+      "East US", "systemData": {"createdBy": "prvalav@microsoft.com", "createdByType":
+      "User", "createdAt": "2023-03-24T21:37:35.3226001", "lastModifiedBy": "prvalav@microsoft.com",
+      "lastModifiedByType": "User", "lastModifiedAt": "2023-03-24T21:37:35.3226001"},
       "properties": {"provisioningState": "Succeeded", "managedEnvironmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002",
       "environmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002",
-      "workloadProfileType": null, "outboundIpAddresses": ["20.246.184.58"], "latestRevisionName":
-      "containerapp000003--yu8mgc3", "latestReadyRevisionName": "containerapp000003--yu8mgc3",
-      "latestRevisionFqdn": "containerapp000003--yu8mgc3.proudmushroom-29cefc29.eastus.azurecontainerapps.io",
-      "customDomainVerificationId": "D3F71C85EB6552E36A89A3E4A080C3CFB00181670B659B0003264FC673AA9B00",
+      "workloadProfileType": null, "outboundIpAddresses": ["20.121.85.239"], "latestRevisionName":
+      "containerapp000003--vm672yx", "latestReadyRevisionName": "containerapp000003--vm672yx",
+      "latestRevisionFqdn": "containerapp000003--vm672yx.victoriousflower-c5068f24.eastus.azurecontainerapps.io",
+      "customDomainVerificationId": "A189264E60034F7C3E609ED4E5CC493CEEA6833044629E67A8D1AC75146808B3",
       "configuration": {"secrets": [], "activeRevisionsMode": "Single", "ingress":
       null, "registries": null, "dapr": null, "maxInactiveRevisions": null}, "template":
       {"revisionSuffix": "", "containers": [{"image": "mcr.microsoft.com/azuredocs/containerapps-helloworld:latest",
@@ -7203,33 +2753,33 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1977'
+      - '1978'
       Content-Type:
       - application/json
       ParameterSetName:
       - -g -n
       User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerApps/containerapp000003?api-version=2022-10-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerapps/containerapp000003","name":"containerapp000003","type":"Microsoft.App/containerApps","location":"East
-        US","systemData":{"createdBy":"xinyupang@microsoft.com","createdByType":"User","createdAt":"2023-03-14T07:20:52.432759","lastModifiedBy":"xinyupang@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-03-14T07:21:10.7949584Z"},"properties":{"provisioningState":"InProgress","managedEnvironmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","environmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","workloadProfileType":null,"outboundIpAddresses":["20.246.184.58"],"latestRevisionName":"containerapp000003--yu8mgc3","latestReadyRevisionName":"containerapp000003--yu8mgc3","latestRevisionFqdn":"","customDomainVerificationId":"D3F71C85EB6552E36A89A3E4A080C3CFB00181670B659B0003264FC673AA9B00","configuration":{"secrets":null,"activeRevisionsMode":"Single","ingress":null,"registries":null,"dapr":null,"maxInactiveRevisions":null},"template":{"revisionSuffix":"","containers":[{"image":"mcr.microsoft.com/azuredocs/containerapps-helloworld:latest","name":"containerapp000003","resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":null,"maxReplicas":10,"rules":null},"volumes":null},"eventStreamEndpoint":"https://eastus.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/containerApps/containerapp000003/eventstream"},"identity":{"type":"None"}}'
+        US","systemData":{"createdBy":"prvalav@microsoft.com","createdByType":"User","createdAt":"2023-03-24T21:37:35.3226001","lastModifiedBy":"prvalav@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-03-24T21:38:00.3008777Z"},"properties":{"provisioningState":"InProgress","managedEnvironmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","environmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","workloadProfileType":null,"outboundIpAddresses":["20.121.85.239"],"latestRevisionName":"containerapp000003--vm672yx","latestReadyRevisionName":"containerapp000003--vm672yx","latestRevisionFqdn":"","customDomainVerificationId":"A189264E60034F7C3E609ED4E5CC493CEEA6833044629E67A8D1AC75146808B3","configuration":{"secrets":null,"activeRevisionsMode":"Single","ingress":null,"registries":null,"dapr":null,"maxInactiveRevisions":null},"template":{"revisionSuffix":"","containers":[{"image":"mcr.microsoft.com/azuredocs/containerapps-helloworld:latest","name":"containerapp000003","resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":null,"maxReplicas":10,"rules":null},"volumes":null},"eventStreamEndpoint":"https://eastus.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/containerApps/containerapp000003/eventstream"},"identity":{"type":"None"}}'
     headers:
       api-supported-versions:
       - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
         2023-02-01
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/2c8fdb20-4f30-4276-b25f-2486d2660b32?api-version=2022-10-01&azureAsyncOperation=true
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/d28be853-85fc-4fd8-bd71-9eb870be5c0f?api-version=2022-10-01&azureAsyncOperation=true
       cache-control:
       - no-cache
       content-length:
-      - '1820'
+      - '1817'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:21:11 GMT
+      - Fri, 24 Mar 2023 21:38:00 GMT
       expires:
       - '-1'
       pragma:
@@ -7243,7 +2793,7 @@ interactions:
       x-ms-async-operation-timeout:
       - PT15M
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '497'
+      - '699'
       x-powered-by:
       - ASP.NET
     status:
@@ -7263,12 +2813,12 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/2c8fdb20-4f30-4276-b25f-2486d2660b32?api-version=2022-10-01&azureAsyncOperation=true
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/d28be853-85fc-4fd8-bd71-9eb870be5c0f?api-version=2022-10-01&azureAsyncOperation=true
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/2c8fdb20-4f30-4276-b25f-2486d2660b32","name":"2c8fdb20-4f30-4276-b25f-2486d2660b32","status":"InProgress","startTime":"2023-03-14T07:21:10.9937093"}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/d28be853-85fc-4fd8-bd71-9eb870be5c0f","name":"d28be853-85fc-4fd8-bd71-9eb870be5c0f","status":"InProgress","startTime":"2023-03-24T21:38:00.3866036"}'
     headers:
       api-supported-versions:
       - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
@@ -7280,7 +2830,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:21:12 GMT
+      - Fri, 24 Mar 2023 21:38:00 GMT
       expires:
       - '-1'
       pragma:
@@ -7314,12 +2864,12 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/2c8fdb20-4f30-4276-b25f-2486d2660b32?api-version=2022-10-01&azureAsyncOperation=true
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/d28be853-85fc-4fd8-bd71-9eb870be5c0f?api-version=2022-10-01&azureAsyncOperation=true
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/2c8fdb20-4f30-4276-b25f-2486d2660b32","name":"2c8fdb20-4f30-4276-b25f-2486d2660b32","status":"InProgress","startTime":"2023-03-14T07:21:10.9937093"}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/d28be853-85fc-4fd8-bd71-9eb870be5c0f","name":"d28be853-85fc-4fd8-bd71-9eb870be5c0f","status":"InProgress","startTime":"2023-03-24T21:38:00.3866036"}'
     headers:
       api-supported-versions:
       - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
@@ -7331,7 +2881,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:21:16 GMT
+      - Fri, 24 Mar 2023 21:38:02 GMT
       expires:
       - '-1'
       pragma:
@@ -7365,12 +2915,265 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/2c8fdb20-4f30-4276-b25f-2486d2660b32?api-version=2022-10-01&azureAsyncOperation=true
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/d28be853-85fc-4fd8-bd71-9eb870be5c0f?api-version=2022-10-01&azureAsyncOperation=true
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/2c8fdb20-4f30-4276-b25f-2486d2660b32","name":"2c8fdb20-4f30-4276-b25f-2486d2660b32","status":"Succeeded","startTime":"2023-03-14T07:21:10.9937093"}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/d28be853-85fc-4fd8-bd71-9eb870be5c0f","name":"d28be853-85fc-4fd8-bd71-9eb870be5c0f","status":"InProgress","startTime":"2023-03-24T21:38:00.3866036"}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '278'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Mar 2023 21:38:05 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp ingress disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/d28be853-85fc-4fd8-bd71-9eb870be5c0f?api-version=2022-10-01&azureAsyncOperation=true
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/d28be853-85fc-4fd8-bd71-9eb870be5c0f","name":"d28be853-85fc-4fd8-bd71-9eb870be5c0f","status":"InProgress","startTime":"2023-03-24T21:38:00.3866036"}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '278'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Mar 2023 21:38:07 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp ingress disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/d28be853-85fc-4fd8-bd71-9eb870be5c0f?api-version=2022-10-01&azureAsyncOperation=true
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/d28be853-85fc-4fd8-bd71-9eb870be5c0f","name":"d28be853-85fc-4fd8-bd71-9eb870be5c0f","status":"InProgress","startTime":"2023-03-24T21:38:00.3866036"}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '278'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Mar 2023 21:38:09 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp ingress disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/d28be853-85fc-4fd8-bd71-9eb870be5c0f?api-version=2022-10-01&azureAsyncOperation=true
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/d28be853-85fc-4fd8-bd71-9eb870be5c0f","name":"d28be853-85fc-4fd8-bd71-9eb870be5c0f","status":"InProgress","startTime":"2023-03-24T21:38:00.3866036"}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '278'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Mar 2023 21:38:11 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp ingress disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/d28be853-85fc-4fd8-bd71-9eb870be5c0f?api-version=2022-10-01&azureAsyncOperation=true
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/d28be853-85fc-4fd8-bd71-9eb870be5c0f","name":"d28be853-85fc-4fd8-bd71-9eb870be5c0f","status":"InProgress","startTime":"2023-03-24T21:38:00.3866036"}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '278'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Mar 2023 21:38:14 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp ingress disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/d28be853-85fc-4fd8-bd71-9eb870be5c0f?api-version=2022-10-01&azureAsyncOperation=true
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/d28be853-85fc-4fd8-bd71-9eb870be5c0f","name":"d28be853-85fc-4fd8-bd71-9eb870be5c0f","status":"Succeeded","startTime":"2023-03-24T21:38:00.3866036"}'
     headers:
       api-supported-versions:
       - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
@@ -7382,7 +3185,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:21:18 GMT
+      - Fri, 24 Mar 2023 21:38:16 GMT
       expires:
       - '-1'
       pragma:
@@ -7416,13 +3219,13 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerApps/containerapp000003?api-version=2022-10-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerapps/containerapp000003","name":"containerapp000003","type":"Microsoft.App/containerApps","location":"East
-        US","systemData":{"createdBy":"xinyupang@microsoft.com","createdByType":"User","createdAt":"2023-03-14T07:20:52.432759","lastModifiedBy":"xinyupang@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-03-14T07:21:10.7949584"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","environmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","workloadProfileType":null,"outboundIpAddresses":["20.246.184.58"],"latestRevisionName":"containerapp000003--yu8mgc3","latestReadyRevisionName":"containerapp000003--yu8mgc3","latestRevisionFqdn":"","customDomainVerificationId":"D3F71C85EB6552E36A89A3E4A080C3CFB00181670B659B0003264FC673AA9B00","configuration":{"secrets":null,"activeRevisionsMode":"Single","ingress":null,"registries":null,"dapr":null,"maxInactiveRevisions":null},"template":{"revisionSuffix":"","containers":[{"image":"mcr.microsoft.com/azuredocs/containerapps-helloworld:latest","name":"containerapp000003","resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":null,"maxReplicas":10,"rules":null},"volumes":null},"eventStreamEndpoint":"https://eastus.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/containerApps/containerapp000003/eventstream"},"identity":{"type":"None"}}'
+        US","systemData":{"createdBy":"prvalav@microsoft.com","createdByType":"User","createdAt":"2023-03-24T21:37:35.3226001","lastModifiedBy":"prvalav@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-03-24T21:38:00.3008777"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","environmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","workloadProfileType":null,"outboundIpAddresses":["20.121.85.239"],"latestRevisionName":"containerapp000003--vm672yx","latestReadyRevisionName":"containerapp000003--vm672yx","latestRevisionFqdn":"","customDomainVerificationId":"A189264E60034F7C3E609ED4E5CC493CEEA6833044629E67A8D1AC75146808B3","configuration":{"secrets":null,"activeRevisionsMode":"Single","ingress":null,"registries":null,"dapr":null,"maxInactiveRevisions":null},"template":{"revisionSuffix":"","containers":[{"image":"mcr.microsoft.com/azuredocs/containerapps-helloworld:latest","name":"containerapp000003","resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":null,"maxReplicas":10,"rules":null},"volumes":null},"eventStreamEndpoint":"https://eastus.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/containerApps/containerapp000003/eventstream"},"identity":{"type":"None"}}'
     headers:
       api-supported-versions:
       - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
@@ -7430,11 +3233,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '1818'
+      - '1815'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:21:21 GMT
+      - Fri, 24 Mar 2023 21:38:17 GMT
       expires:
       - '-1'
       pragma:
@@ -7468,94 +3271,90 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.10.10 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.3 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App","namespace":"Microsoft.App","authorizations":[{"applicationId":"7e3bc4fd-85a3-4192-b177-5b8bfc87f42c","roleDefinitionId":"39a74f72-b40f-4bdc-b639-562fe2260bf0"},{"applicationId":"3734c1a4-2bed-4998-a37a-ff1a9e7bf019","roleDefinitionId":"5c779a4f-5cb2-4547-8c41-478d9be8ba90"},{"applicationId":"55ebbb62-3b9c-49fd-9b87-9595226dd4ac","roleDefinitionId":"e49ca620-7992-4561-a7df-4ed67dad77b5","managedByRoleDefinitionId":"9e3af657-a8ff-583c-a75c-2fe7c4bcb635"}],"resourceTypes":[{"resourceType":"operations","locations":["North
-        Central US (Stage)","Central US EUAP","East US 2 EUAP","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/connectedEnvironmentOperationResults","locations":["North
-        Central US (Stage)","North Central US","East US","East Asia","West Europe","Central
-        US EUAP","East US 2 EUAP"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"managedEnvironments","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/certificates","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/managedCertificates","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"containerApps","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App","namespace":"Microsoft.App","authorizations":[{"applicationId":"7e3bc4fd-85a3-4192-b177-5b8bfc87f42c","roleDefinitionId":"39a74f72-b40f-4bdc-b639-562fe2260bf0"},{"applicationId":"3734c1a4-2bed-4998-a37a-ff1a9e7bf019","roleDefinitionId":"5c779a4f-5cb2-4547-8c41-478d9be8ba90"},{"applicationId":"55ebbb62-3b9c-49fd-9b87-9595226dd4ac","roleDefinitionId":"e49ca620-7992-4561-a7df-4ed67dad77b5","managedByRoleDefinitionId":"9e3af657-a8ff-583c-a75c-2fe7c4bcb635"}],"resourceTypes":[{"resourceType":"managedEnvironments","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/certificates","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/managedCertificates","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"containerApps","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
-        SupportsLocation"},{"resourceType":"jobs","locations":["Central US EUAP","East
-        US 2 EUAP","North Central US (Stage)","Canada Central","West Europe","North
-        Europe","East US","East US 2","East Asia","Australia East","Germany West Central","Japan
+        SupportsLocation"},{"resourceType":"jobs","locations":["North Central US (Stage)","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationResults","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationStatuses","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"operations","locations":["North
+        Central US (Stage)","Central US EUAP","East US 2 EUAP","West US 2","Southeast
+        Asia","Sweden Central","Canada Central","West Europe","North Europe","East
+        US","East US 2","East Asia","Australia East","Germany West Central","Japan
         East","UK South","West US","Central US","North Central US","South Central
         US","Korea Central","Brazil South","West US 3","France Central","South Africa
-        North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
-        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationResults","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationStatuses","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationResults","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationStatuses","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"connectedEnvironments","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","North Central US","East
-        US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectedEnvironments/certificates","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","North Central US","East
-        US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectedEnvironmentOperationStatuses","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","North Central US","East
-        US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/billingMeters","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Australia East","North
-        Central US","East US 2","West Europe","Central US","East US","North Europe","South
-        Central US","UK South","West US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/availableManagedEnvironmentsWorkloadProfileTypes","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Australia East","North
-        Central US","East US 2","West Europe","Central US","East US","North Europe","South
-        Central US","UK South","West US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+        North","Norway East","Switzerland North","UAE North"],"apiVersions":["2023-02-01","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"connectedEnvironments","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectedEnvironments/certificates","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/connectedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/billingMeters","locations":["North
+        Central US (Stage)","Australia East","North Central US","East US 2","West
+        Europe","Central US","East US","North Europe","South Central US","UK South","West
+        US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/availableManagedEnvironmentsWorkloadProfileTypes","locations":["North
+        Central US (Stage)","Australia East","North Central US","East US 2","West
+        Europe","Central US","East US","North Europe","South Central US","UK South","West
+        US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '9060'
+      - '8594'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:21:22 GMT
+      - Fri, 24 Mar 2023 21:38:17 GMT
       expires:
       - '-1'
       pragma:
@@ -7583,13 +3382,13 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerApps/containerapp000003?api-version=2022-10-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerapps/containerapp000003","name":"containerapp000003","type":"Microsoft.App/containerApps","location":"East
-        US","systemData":{"createdBy":"xinyupang@microsoft.com","createdByType":"User","createdAt":"2023-03-14T07:20:52.432759","lastModifiedBy":"xinyupang@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-03-14T07:21:10.7949584"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","environmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","workloadProfileType":null,"outboundIpAddresses":["20.246.184.58"],"latestRevisionName":"containerapp000003--yu8mgc3","latestReadyRevisionName":"containerapp000003--yu8mgc3","latestRevisionFqdn":"","customDomainVerificationId":"D3F71C85EB6552E36A89A3E4A080C3CFB00181670B659B0003264FC673AA9B00","configuration":{"secrets":null,"activeRevisionsMode":"Single","ingress":null,"registries":null,"dapr":null,"maxInactiveRevisions":null},"template":{"revisionSuffix":"","containers":[{"image":"mcr.microsoft.com/azuredocs/containerapps-helloworld:latest","name":"containerapp000003","resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":null,"maxReplicas":10,"rules":null},"volumes":null},"eventStreamEndpoint":"https://eastus.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/containerApps/containerapp000003/eventstream"},"identity":{"type":"None"}}'
+        US","systemData":{"createdBy":"prvalav@microsoft.com","createdByType":"User","createdAt":"2023-03-24T21:37:35.3226001","lastModifiedBy":"prvalav@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-03-24T21:38:00.3008777"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","environmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","workloadProfileType":null,"outboundIpAddresses":["20.121.85.239"],"latestRevisionName":"containerapp000003--vm672yx","latestReadyRevisionName":"containerapp000003--vm672yx","latestRevisionFqdn":"","customDomainVerificationId":"A189264E60034F7C3E609ED4E5CC493CEEA6833044629E67A8D1AC75146808B3","configuration":{"secrets":null,"activeRevisionsMode":"Single","ingress":null,"registries":null,"dapr":null,"maxInactiveRevisions":null},"template":{"revisionSuffix":"","containers":[{"image":"mcr.microsoft.com/azuredocs/containerapps-helloworld:latest","name":"containerapp000003","resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":null,"maxReplicas":10,"rules":null},"volumes":null},"eventStreamEndpoint":"https://eastus.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/containerApps/containerapp000003/eventstream"},"identity":{"type":"None"}}'
     headers:
       api-supported-versions:
       - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
@@ -7597,11 +3396,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '1818'
+      - '1815'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:21:23 GMT
+      - Fri, 24 Mar 2023 21:38:18 GMT
       expires:
       - '-1'
       pragma:
@@ -7635,94 +3434,90 @@ interactions:
       ParameterSetName:
       - -g -n --type --target-port --allow-insecure --transport
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.10.10 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.3 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App","namespace":"Microsoft.App","authorizations":[{"applicationId":"7e3bc4fd-85a3-4192-b177-5b8bfc87f42c","roleDefinitionId":"39a74f72-b40f-4bdc-b639-562fe2260bf0"},{"applicationId":"3734c1a4-2bed-4998-a37a-ff1a9e7bf019","roleDefinitionId":"5c779a4f-5cb2-4547-8c41-478d9be8ba90"},{"applicationId":"55ebbb62-3b9c-49fd-9b87-9595226dd4ac","roleDefinitionId":"e49ca620-7992-4561-a7df-4ed67dad77b5","managedByRoleDefinitionId":"9e3af657-a8ff-583c-a75c-2fe7c4bcb635"}],"resourceTypes":[{"resourceType":"operations","locations":["North
-        Central US (Stage)","Central US EUAP","East US 2 EUAP","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/connectedEnvironmentOperationResults","locations":["North
-        Central US (Stage)","North Central US","East US","East Asia","West Europe","Central
-        US EUAP","East US 2 EUAP"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"managedEnvironments","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/certificates","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/managedCertificates","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"containerApps","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App","namespace":"Microsoft.App","authorizations":[{"applicationId":"7e3bc4fd-85a3-4192-b177-5b8bfc87f42c","roleDefinitionId":"39a74f72-b40f-4bdc-b639-562fe2260bf0"},{"applicationId":"3734c1a4-2bed-4998-a37a-ff1a9e7bf019","roleDefinitionId":"5c779a4f-5cb2-4547-8c41-478d9be8ba90"},{"applicationId":"55ebbb62-3b9c-49fd-9b87-9595226dd4ac","roleDefinitionId":"e49ca620-7992-4561-a7df-4ed67dad77b5","managedByRoleDefinitionId":"9e3af657-a8ff-583c-a75c-2fe7c4bcb635"}],"resourceTypes":[{"resourceType":"managedEnvironments","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/certificates","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/managedCertificates","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"containerApps","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
-        SupportsLocation"},{"resourceType":"jobs","locations":["Central US EUAP","East
-        US 2 EUAP","North Central US (Stage)","Canada Central","West Europe","North
-        Europe","East US","East US 2","East Asia","Australia East","Germany West Central","Japan
+        SupportsLocation"},{"resourceType":"jobs","locations":["North Central US (Stage)","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationResults","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationStatuses","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"operations","locations":["North
+        Central US (Stage)","Central US EUAP","East US 2 EUAP","West US 2","Southeast
+        Asia","Sweden Central","Canada Central","West Europe","North Europe","East
+        US","East US 2","East Asia","Australia East","Germany West Central","Japan
         East","UK South","West US","Central US","North Central US","South Central
         US","Korea Central","Brazil South","West US 3","France Central","South Africa
-        North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
-        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationResults","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationStatuses","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationResults","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationStatuses","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"connectedEnvironments","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","North Central US","East
-        US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectedEnvironments/certificates","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","North Central US","East
-        US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectedEnvironmentOperationStatuses","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","North Central US","East
-        US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/billingMeters","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Australia East","North
-        Central US","East US 2","West Europe","Central US","East US","North Europe","South
-        Central US","UK South","West US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/availableManagedEnvironmentsWorkloadProfileTypes","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Australia East","North
-        Central US","East US 2","West Europe","Central US","East US","North Europe","South
-        Central US","UK South","West US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+        North","Norway East","Switzerland North","UAE North"],"apiVersions":["2023-02-01","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"connectedEnvironments","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectedEnvironments/certificates","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/connectedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/billingMeters","locations":["North
+        Central US (Stage)","Australia East","North Central US","East US 2","West
+        Europe","Central US","East US","North Europe","South Central US","UK South","West
+        US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/availableManagedEnvironmentsWorkloadProfileTypes","locations":["North
+        Central US (Stage)","Australia East","North Central US","East US 2","West
+        Europe","Central US","East US","North Europe","South Central US","UK South","West
+        US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '9060'
+      - '8594'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:21:24 GMT
+      - Fri, 24 Mar 2023 21:38:19 GMT
       expires:
       - '-1'
       pragma:
@@ -7750,13 +3545,13 @@ interactions:
       ParameterSetName:
       - -g -n --type --target-port --allow-insecure --transport
       User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerApps/containerapp000003?api-version=2022-10-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerapps/containerapp000003","name":"containerapp000003","type":"Microsoft.App/containerApps","location":"East
-        US","systemData":{"createdBy":"xinyupang@microsoft.com","createdByType":"User","createdAt":"2023-03-14T07:20:52.432759","lastModifiedBy":"xinyupang@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-03-14T07:21:10.7949584"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","environmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","workloadProfileType":null,"outboundIpAddresses":["20.246.184.58"],"latestRevisionName":"containerapp000003--yu8mgc3","latestReadyRevisionName":"containerapp000003--yu8mgc3","latestRevisionFqdn":"","customDomainVerificationId":"D3F71C85EB6552E36A89A3E4A080C3CFB00181670B659B0003264FC673AA9B00","configuration":{"secrets":null,"activeRevisionsMode":"Single","ingress":null,"registries":null,"dapr":null,"maxInactiveRevisions":null},"template":{"revisionSuffix":"","containers":[{"image":"mcr.microsoft.com/azuredocs/containerapps-helloworld:latest","name":"containerapp000003","resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":null,"maxReplicas":10,"rules":null},"volumes":null},"eventStreamEndpoint":"https://eastus.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/containerApps/containerapp000003/eventstream"},"identity":{"type":"None"}}'
+        US","systemData":{"createdBy":"prvalav@microsoft.com","createdByType":"User","createdAt":"2023-03-24T21:37:35.3226001","lastModifiedBy":"prvalav@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-03-24T21:38:00.3008777"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","environmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","workloadProfileType":null,"outboundIpAddresses":["20.121.85.239"],"latestRevisionName":"containerapp000003--vm672yx","latestReadyRevisionName":"containerapp000003--vm672yx","latestRevisionFqdn":"","customDomainVerificationId":"A189264E60034F7C3E609ED4E5CC493CEEA6833044629E67A8D1AC75146808B3","configuration":{"secrets":null,"activeRevisionsMode":"Single","ingress":null,"registries":null,"dapr":null,"maxInactiveRevisions":null},"template":{"revisionSuffix":"","containers":[{"image":"mcr.microsoft.com/azuredocs/containerapps-helloworld:latest","name":"containerapp000003","resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":null,"maxReplicas":10,"rules":null},"volumes":null},"eventStreamEndpoint":"https://eastus.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/containerApps/containerapp000003/eventstream"},"identity":{"type":"None"}}'
     headers:
       api-supported-versions:
       - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
@@ -7764,11 +3559,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '1818'
+      - '1815'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:21:26 GMT
+      - Fri, 24 Mar 2023 21:38:19 GMT
       expires:
       - '-1'
       pragma:
@@ -7804,7 +3599,7 @@ interactions:
       ParameterSetName:
       - -g -n --type --target-port --allow-insecure --transport
       User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerApps/containerapp000003/listSecrets?api-version=2022-10-01
   response:
@@ -7821,7 +3616,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:21:27 GMT
+      - Fri, 24 Mar 2023 21:38:20 GMT
       expires:
       - '-1'
       pragma:
@@ -7830,14 +3625,12 @@ interactions:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
       vary:
-      - Accept-Encoding,Accept-Encoding
+      - Accept-Encoding
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
       x-powered-by:
       - ASP.NET
     status:
@@ -7846,14 +3639,14 @@ interactions:
 - request:
     body: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerapps/containerapp000003",
       "name": "containerapp000003", "type": "Microsoft.App/containerApps", "location":
-      "East US", "systemData": {"createdBy": "xinyupang@microsoft.com", "createdByType":
-      "User", "createdAt": "2023-03-14T07:20:52.432759", "lastModifiedBy": "xinyupang@microsoft.com",
-      "lastModifiedByType": "User", "lastModifiedAt": "2023-03-14T07:21:10.7949584"},
+      "East US", "systemData": {"createdBy": "prvalav@microsoft.com", "createdByType":
+      "User", "createdAt": "2023-03-24T21:37:35.3226001", "lastModifiedBy": "prvalav@microsoft.com",
+      "lastModifiedByType": "User", "lastModifiedAt": "2023-03-24T21:38:00.3008777"},
       "properties": {"provisioningState": "Succeeded", "managedEnvironmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002",
       "environmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002",
-      "workloadProfileType": null, "outboundIpAddresses": ["20.246.184.58"], "latestRevisionName":
-      "containerapp000003--yu8mgc3", "latestReadyRevisionName": "containerapp000003--yu8mgc3",
-      "latestRevisionFqdn": "", "customDomainVerificationId": "D3F71C85EB6552E36A89A3E4A080C3CFB00181670B659B0003264FC673AA9B00",
+      "workloadProfileType": null, "outboundIpAddresses": ["20.121.85.239"], "latestRevisionName":
+      "containerapp000003--vm672yx", "latestReadyRevisionName": "containerapp000003--vm672yx",
+      "latestRevisionFqdn": "", "customDomainVerificationId": "A189264E60034F7C3E609ED4E5CC493CEEA6833044629E67A8D1AC75146808B3",
       "configuration": {"secrets": [], "activeRevisionsMode": "Single", "ingress":
       {"fqdn": null, "external": false, "targetPort": 81, "transport": "http2", "exposedPort":
       null, "traffic": null, "customDomains": null, "ipSecurityRestrictions": null,
@@ -7873,33 +3666,33 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '2084'
+      - '2081'
       Content-Type:
       - application/json
       ParameterSetName:
       - -g -n --type --target-port --allow-insecure --transport
       User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerApps/containerapp000003?api-version=2022-10-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerapps/containerapp000003","name":"containerapp000003","type":"Microsoft.App/containerApps","location":"East
-        US","systemData":{"createdBy":"xinyupang@microsoft.com","createdByType":"User","createdAt":"2023-03-14T07:20:52.432759","lastModifiedBy":"xinyupang@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-03-14T07:21:29.5326037Z"},"properties":{"provisioningState":"InProgress","managedEnvironmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","environmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","workloadProfileType":null,"outboundIpAddresses":["20.246.184.58"],"latestRevisionName":"containerapp000003--yu8mgc3","latestReadyRevisionName":"containerapp000003--yu8mgc3","latestRevisionFqdn":"containerapp000003--yu8mgc3.internal.proudmushroom-29cefc29.eastus.azurecontainerapps.io","customDomainVerificationId":"D3F71C85EB6552E36A89A3E4A080C3CFB00181670B659B0003264FC673AA9B00","configuration":{"secrets":null,"activeRevisionsMode":"Single","ingress":{"fqdn":"containerapp000003.internal.proudmushroom-29cefc29.eastus.azurecontainerapps.io","external":false,"targetPort":81,"exposedPort":0,"transport":"Http2","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":true,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null},"registries":null,"dapr":null,"maxInactiveRevisions":null},"template":{"revisionSuffix":"","containers":[{"image":"mcr.microsoft.com/azuredocs/containerapps-helloworld:latest","name":"containerapp000003","resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":null,"maxReplicas":10,"rules":null},"volumes":null},"eventStreamEndpoint":"https://eastus.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/containerApps/containerapp000003/eventstream"},"identity":{"type":"None"}}'
+        US","systemData":{"createdBy":"prvalav@microsoft.com","createdByType":"User","createdAt":"2023-03-24T21:37:35.3226001","lastModifiedBy":"prvalav@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-03-24T21:38:21.004861Z"},"properties":{"provisioningState":"InProgress","managedEnvironmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","environmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","workloadProfileType":null,"outboundIpAddresses":["20.121.85.239"],"latestRevisionName":"containerapp000003--vm672yx","latestReadyRevisionName":"containerapp000003--vm672yx","latestRevisionFqdn":"containerapp000003--vm672yx.internal.victoriousflower-c5068f24.eastus.azurecontainerapps.io","customDomainVerificationId":"A189264E60034F7C3E609ED4E5CC493CEEA6833044629E67A8D1AC75146808B3","configuration":{"secrets":null,"activeRevisionsMode":"Single","ingress":{"fqdn":"containerapp000003.internal.victoriousflower-c5068f24.eastus.azurecontainerapps.io","external":false,"targetPort":81,"exposedPort":0,"transport":"Http2","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":true,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null},"registries":null,"dapr":null,"maxInactiveRevisions":null},"template":{"revisionSuffix":"","containers":[{"image":"mcr.microsoft.com/azuredocs/containerapps-helloworld:latest","name":"containerapp000003","resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":null,"maxReplicas":10,"rules":null},"volumes":null},"eventStreamEndpoint":"https://eastus.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/containerApps/containerapp000003/eventstream"},"identity":{"type":"None"}}'
     headers:
       api-supported-versions:
       - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
         2023-02-01
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/c9f420d5-a503-4ca8-bac5-8be28f4a0c26?api-version=2022-10-01&azureAsyncOperation=true
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/9dcc28ea-6524-4df3-8563-a4e53af98712?api-version=2022-10-01&azureAsyncOperation=true
       cache-control:
       - no-cache
       content-length:
-      - '2231'
+      - '2233'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:21:33 GMT
+      - Fri, 24 Mar 2023 21:38:21 GMT
       expires:
       - '-1'
       pragma:
@@ -7913,7 +3706,7 @@ interactions:
       x-ms-async-operation-timeout:
       - PT15M
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '499'
+      - '699'
       x-powered-by:
       - ASP.NET
     status:
@@ -7933,12 +3726,12 @@ interactions:
       ParameterSetName:
       - -g -n --type --target-port --allow-insecure --transport
       User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/c9f420d5-a503-4ca8-bac5-8be28f4a0c26?api-version=2022-10-01&azureAsyncOperation=true
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/9dcc28ea-6524-4df3-8563-a4e53af98712?api-version=2022-10-01&azureAsyncOperation=true
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/c9f420d5-a503-4ca8-bac5-8be28f4a0c26","name":"c9f420d5-a503-4ca8-bac5-8be28f4a0c26","status":"InProgress","startTime":"2023-03-14T07:21:31.0239615"}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/9dcc28ea-6524-4df3-8563-a4e53af98712","name":"9dcc28ea-6524-4df3-8563-a4e53af98712","status":"InProgress","startTime":"2023-03-24T21:38:21.0891323"}'
     headers:
       api-supported-versions:
       - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
@@ -7950,7 +3743,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:21:35 GMT
+      - Fri, 24 Mar 2023 21:38:21 GMT
       expires:
       - '-1'
       pragma:
@@ -7984,12 +3777,12 @@ interactions:
       ParameterSetName:
       - -g -n --type --target-port --allow-insecure --transport
       User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/c9f420d5-a503-4ca8-bac5-8be28f4a0c26?api-version=2022-10-01&azureAsyncOperation=true
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/9dcc28ea-6524-4df3-8563-a4e53af98712?api-version=2022-10-01&azureAsyncOperation=true
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/c9f420d5-a503-4ca8-bac5-8be28f4a0c26","name":"c9f420d5-a503-4ca8-bac5-8be28f4a0c26","status":"InProgress","startTime":"2023-03-14T07:21:31.0239615"}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/9dcc28ea-6524-4df3-8563-a4e53af98712","name":"9dcc28ea-6524-4df3-8563-a4e53af98712","status":"InProgress","startTime":"2023-03-24T21:38:21.0891323"}'
     headers:
       api-supported-versions:
       - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
@@ -8001,7 +3794,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:21:38 GMT
+      - Fri, 24 Mar 2023 21:38:23 GMT
       expires:
       - '-1'
       pragma:
@@ -8035,12 +3828,12 @@ interactions:
       ParameterSetName:
       - -g -n --type --target-port --allow-insecure --transport
       User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/c9f420d5-a503-4ca8-bac5-8be28f4a0c26?api-version=2022-10-01&azureAsyncOperation=true
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/9dcc28ea-6524-4df3-8563-a4e53af98712?api-version=2022-10-01&azureAsyncOperation=true
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/c9f420d5-a503-4ca8-bac5-8be28f4a0c26","name":"c9f420d5-a503-4ca8-bac5-8be28f4a0c26","status":"InProgress","startTime":"2023-03-14T07:21:31.0239615"}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/9dcc28ea-6524-4df3-8563-a4e53af98712","name":"9dcc28ea-6524-4df3-8563-a4e53af98712","status":"InProgress","startTime":"2023-03-24T21:38:21.0891323"}'
     headers:
       api-supported-versions:
       - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
@@ -8052,7 +3845,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:21:40 GMT
+      - Fri, 24 Mar 2023 21:38:26 GMT
       expires:
       - '-1'
       pragma:
@@ -8086,12 +3879,12 @@ interactions:
       ParameterSetName:
       - -g -n --type --target-port --allow-insecure --transport
       User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/c9f420d5-a503-4ca8-bac5-8be28f4a0c26?api-version=2022-10-01&azureAsyncOperation=true
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/9dcc28ea-6524-4df3-8563-a4e53af98712?api-version=2022-10-01&azureAsyncOperation=true
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/c9f420d5-a503-4ca8-bac5-8be28f4a0c26","name":"c9f420d5-a503-4ca8-bac5-8be28f4a0c26","status":"Succeeded","startTime":"2023-03-14T07:21:31.0239615"}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationStatuses/9dcc28ea-6524-4df3-8563-a4e53af98712","name":"9dcc28ea-6524-4df3-8563-a4e53af98712","status":"Succeeded","startTime":"2023-03-24T21:38:21.0891323"}'
     headers:
       api-supported-versions:
       - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
@@ -8103,7 +3896,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:21:43 GMT
+      - Fri, 24 Mar 2023 21:38:27 GMT
       expires:
       - '-1'
       pragma:
@@ -8137,13 +3930,13 @@ interactions:
       ParameterSetName:
       - -g -n --type --target-port --allow-insecure --transport
       User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerApps/containerapp000003?api-version=2022-10-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerapps/containerapp000003","name":"containerapp000003","type":"Microsoft.App/containerApps","location":"East
-        US","systemData":{"createdBy":"xinyupang@microsoft.com","createdByType":"User","createdAt":"2023-03-14T07:20:52.432759","lastModifiedBy":"xinyupang@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-03-14T07:21:29.5326037"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","environmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","workloadProfileType":null,"outboundIpAddresses":["20.246.184.58"],"latestRevisionName":"containerapp000003--yu8mgc3","latestReadyRevisionName":"containerapp000003--yu8mgc3","latestRevisionFqdn":"containerapp000003--yu8mgc3.internal.proudmushroom-29cefc29.eastus.azurecontainerapps.io","customDomainVerificationId":"D3F71C85EB6552E36A89A3E4A080C3CFB00181670B659B0003264FC673AA9B00","configuration":{"secrets":null,"activeRevisionsMode":"Single","ingress":{"fqdn":"containerapp000003.internal.proudmushroom-29cefc29.eastus.azurecontainerapps.io","external":false,"targetPort":81,"exposedPort":0,"transport":"Http2","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":true,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null},"registries":null,"dapr":null,"maxInactiveRevisions":null},"template":{"revisionSuffix":"","containers":[{"image":"mcr.microsoft.com/azuredocs/containerapps-helloworld:latest","name":"containerapp000003","resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":null,"maxReplicas":10,"rules":null},"volumes":null},"eventStreamEndpoint":"https://eastus.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/containerApps/containerapp000003/eventstream"},"identity":{"type":"None"}}'
+        US","systemData":{"createdBy":"prvalav@microsoft.com","createdByType":"User","createdAt":"2023-03-24T21:37:35.3226001","lastModifiedBy":"prvalav@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-03-24T21:38:21.004861"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","environmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","workloadProfileType":null,"outboundIpAddresses":["20.121.85.239"],"latestRevisionName":"containerapp000003--vm672yx","latestReadyRevisionName":"containerapp000003--vm672yx","latestRevisionFqdn":"containerapp000003--vm672yx.internal.victoriousflower-c5068f24.eastus.azurecontainerapps.io","customDomainVerificationId":"A189264E60034F7C3E609ED4E5CC493CEEA6833044629E67A8D1AC75146808B3","configuration":{"secrets":null,"activeRevisionsMode":"Single","ingress":{"fqdn":"containerapp000003.internal.victoriousflower-c5068f24.eastus.azurecontainerapps.io","external":false,"targetPort":81,"exposedPort":0,"transport":"Http2","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":true,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null},"registries":null,"dapr":null,"maxInactiveRevisions":null},"template":{"revisionSuffix":"","containers":[{"image":"mcr.microsoft.com/azuredocs/containerapps-helloworld:latest","name":"containerapp000003","resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":null,"maxReplicas":10,"rules":null},"volumes":null},"eventStreamEndpoint":"https://eastus.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/containerApps/containerapp000003/eventstream"},"identity":{"type":"None"}}'
     headers:
       api-supported-versions:
       - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
@@ -8151,11 +3944,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '2229'
+      - '2231'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:21:43 GMT
+      - Fri, 24 Mar 2023 21:38:28 GMT
       expires:
       - '-1'
       pragma:
@@ -8189,94 +3982,90 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.10.10 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.3 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App","namespace":"Microsoft.App","authorizations":[{"applicationId":"7e3bc4fd-85a3-4192-b177-5b8bfc87f42c","roleDefinitionId":"39a74f72-b40f-4bdc-b639-562fe2260bf0"},{"applicationId":"3734c1a4-2bed-4998-a37a-ff1a9e7bf019","roleDefinitionId":"5c779a4f-5cb2-4547-8c41-478d9be8ba90"},{"applicationId":"55ebbb62-3b9c-49fd-9b87-9595226dd4ac","roleDefinitionId":"e49ca620-7992-4561-a7df-4ed67dad77b5","managedByRoleDefinitionId":"9e3af657-a8ff-583c-a75c-2fe7c4bcb635"}],"resourceTypes":[{"resourceType":"operations","locations":["North
-        Central US (Stage)","Central US EUAP","East US 2 EUAP","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/connectedEnvironmentOperationResults","locations":["North
-        Central US (Stage)","North Central US","East US","East Asia","West Europe","Central
-        US EUAP","East US 2 EUAP"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"managedEnvironments","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/certificates","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/managedCertificates","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"containerApps","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App","namespace":"Microsoft.App","authorizations":[{"applicationId":"7e3bc4fd-85a3-4192-b177-5b8bfc87f42c","roleDefinitionId":"39a74f72-b40f-4bdc-b639-562fe2260bf0"},{"applicationId":"3734c1a4-2bed-4998-a37a-ff1a9e7bf019","roleDefinitionId":"5c779a4f-5cb2-4547-8c41-478d9be8ba90"},{"applicationId":"55ebbb62-3b9c-49fd-9b87-9595226dd4ac","roleDefinitionId":"e49ca620-7992-4561-a7df-4ed67dad77b5","managedByRoleDefinitionId":"9e3af657-a8ff-583c-a75c-2fe7c4bcb635"}],"resourceTypes":[{"resourceType":"managedEnvironments","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/certificates","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/managedCertificates","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"containerApps","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
-        SupportsLocation"},{"resourceType":"jobs","locations":["Central US EUAP","East
-        US 2 EUAP","North Central US (Stage)","Canada Central","West Europe","North
-        Europe","East US","East US 2","East Asia","Australia East","Germany West Central","Japan
+        SupportsLocation"},{"resourceType":"jobs","locations":["North Central US (Stage)","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationResults","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationStatuses","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"operations","locations":["North
+        Central US (Stage)","Central US EUAP","East US 2 EUAP","West US 2","Southeast
+        Asia","Sweden Central","Canada Central","West Europe","North Europe","East
+        US","East US 2","East Asia","Australia East","Germany West Central","Japan
         East","UK South","West US","Central US","North Central US","South Central
         US","Korea Central","Brazil South","West US 3","France Central","South Africa
-        North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
-        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationResults","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationStatuses","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationResults","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationStatuses","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"connectedEnvironments","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","North Central US","East
-        US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectedEnvironments/certificates","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","North Central US","East
-        US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectedEnvironmentOperationStatuses","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","North Central US","East
-        US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/billingMeters","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Australia East","North
-        Central US","East US 2","West Europe","Central US","East US","North Europe","South
-        Central US","UK South","West US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/availableManagedEnvironmentsWorkloadProfileTypes","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Australia East","North
-        Central US","East US 2","West Europe","Central US","East US","North Europe","South
-        Central US","UK South","West US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+        North","Norway East","Switzerland North","UAE North"],"apiVersions":["2023-02-01","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"connectedEnvironments","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectedEnvironments/certificates","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/connectedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/billingMeters","locations":["North
+        Central US (Stage)","Australia East","North Central US","East US 2","West
+        Europe","Central US","East US","North Europe","South Central US","UK South","West
+        US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/availableManagedEnvironmentsWorkloadProfileTypes","locations":["North
+        Central US (Stage)","Australia East","North Central US","East US 2","West
+        Europe","Central US","East US","North Europe","South Central US","UK South","West
+        US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '9060'
+      - '8594'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:21:44 GMT
+      - Fri, 24 Mar 2023 21:38:29 GMT
       expires:
       - '-1'
       pragma:
@@ -8304,13 +4093,13 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerApps/containerapp000003?api-version=2022-10-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerapps/containerapp000003","name":"containerapp000003","type":"Microsoft.App/containerApps","location":"East
-        US","systemData":{"createdBy":"xinyupang@microsoft.com","createdByType":"User","createdAt":"2023-03-14T07:20:52.432759","lastModifiedBy":"xinyupang@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-03-14T07:21:29.5326037"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","environmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","workloadProfileType":null,"outboundIpAddresses":["20.246.184.58"],"latestRevisionName":"containerapp000003--yu8mgc3","latestReadyRevisionName":"containerapp000003--yu8mgc3","latestRevisionFqdn":"containerapp000003--yu8mgc3.internal.proudmushroom-29cefc29.eastus.azurecontainerapps.io","customDomainVerificationId":"D3F71C85EB6552E36A89A3E4A080C3CFB00181670B659B0003264FC673AA9B00","configuration":{"secrets":null,"activeRevisionsMode":"Single","ingress":{"fqdn":"containerapp000003.internal.proudmushroom-29cefc29.eastus.azurecontainerapps.io","external":false,"targetPort":81,"exposedPort":0,"transport":"Http2","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":true,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null},"registries":null,"dapr":null,"maxInactiveRevisions":null},"template":{"revisionSuffix":"","containers":[{"image":"mcr.microsoft.com/azuredocs/containerapps-helloworld:latest","name":"containerapp000003","resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":null,"maxReplicas":10,"rules":null},"volumes":null},"eventStreamEndpoint":"https://eastus.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/containerApps/containerapp000003/eventstream"},"identity":{"type":"None"}}'
+        US","systemData":{"createdBy":"prvalav@microsoft.com","createdByType":"User","createdAt":"2023-03-24T21:37:35.3226001","lastModifiedBy":"prvalav@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-03-24T21:38:21.004861"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","environmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","workloadProfileType":null,"outboundIpAddresses":["20.121.85.239"],"latestRevisionName":"containerapp000003--vm672yx","latestReadyRevisionName":"containerapp000003--vm672yx","latestRevisionFqdn":"containerapp000003--vm672yx.internal.victoriousflower-c5068f24.eastus.azurecontainerapps.io","customDomainVerificationId":"A189264E60034F7C3E609ED4E5CC493CEEA6833044629E67A8D1AC75146808B3","configuration":{"secrets":null,"activeRevisionsMode":"Single","ingress":{"fqdn":"containerapp000003.internal.victoriousflower-c5068f24.eastus.azurecontainerapps.io","external":false,"targetPort":81,"exposedPort":0,"transport":"Http2","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":true,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null},"registries":null,"dapr":null,"maxInactiveRevisions":null},"template":{"revisionSuffix":"","containers":[{"image":"mcr.microsoft.com/azuredocs/containerapps-helloworld:latest","name":"containerapp000003","resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":null,"maxReplicas":10,"rules":null},"volumes":null},"eventStreamEndpoint":"https://eastus.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/containerApps/containerapp000003/eventstream"},"identity":{"type":"None"}}'
     headers:
       api-supported-versions:
       - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
@@ -8318,11 +4107,372 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '2229'
+      - '2231'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:21:46 GMT
+      - Fri, 24 Mar 2023 21:38:29 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp ingress update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --type --allow-insecure
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.3 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App?api-version=2022-09-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App","namespace":"Microsoft.App","authorizations":[{"applicationId":"7e3bc4fd-85a3-4192-b177-5b8bfc87f42c","roleDefinitionId":"39a74f72-b40f-4bdc-b639-562fe2260bf0"},{"applicationId":"3734c1a4-2bed-4998-a37a-ff1a9e7bf019","roleDefinitionId":"5c779a4f-5cb2-4547-8c41-478d9be8ba90"},{"applicationId":"55ebbb62-3b9c-49fd-9b87-9595226dd4ac","roleDefinitionId":"e49ca620-7992-4561-a7df-4ed67dad77b5","managedByRoleDefinitionId":"9e3af657-a8ff-583c-a75c-2fe7c4bcb635"}],"resourceTypes":[{"resourceType":"managedEnvironments","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/certificates","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/managedCertificates","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"containerApps","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"jobs","locations":["North Central US (Stage)","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationResults","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationStatuses","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"operations","locations":["North
+        Central US (Stage)","Central US EUAP","East US 2 EUAP","West US 2","Southeast
+        Asia","Sweden Central","Canada Central","West Europe","North Europe","East
+        US","East US 2","East Asia","Australia East","Germany West Central","Japan
+        East","UK South","West US","Central US","North Central US","South Central
+        US","Korea Central","Brazil South","West US 3","France Central","South Africa
+        North","Norway East","Switzerland North","UAE North"],"apiVersions":["2023-02-01","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"connectedEnvironments","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectedEnvironments/certificates","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/connectedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/billingMeters","locations":["North
+        Central US (Stage)","Australia East","North Central US","East US 2","West
+        Europe","Central US","East US","North Europe","South Central US","UK South","West
+        US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/availableManagedEnvironmentsWorkloadProfileTypes","locations":["North
+        Central US (Stage)","Australia East","North Central US","East US 2","West
+        Europe","Central US","East US","North Europe","South Central US","UK South","West
+        US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '8594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Mar 2023 21:38:29 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp ingress update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --type --allow-insecure
+      User-Agent:
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerApps/containerapp000003?api-version=2022-10-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerapps/containerapp000003","name":"containerapp000003","type":"Microsoft.App/containerApps","location":"East
+        US","systemData":{"createdBy":"prvalav@microsoft.com","createdByType":"User","createdAt":"2023-03-24T21:37:35.3226001","lastModifiedBy":"prvalav@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-03-24T21:38:21.004861"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","environmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","workloadProfileType":null,"outboundIpAddresses":["20.121.85.239"],"latestRevisionName":"containerapp000003--vm672yx","latestReadyRevisionName":"containerapp000003--vm672yx","latestRevisionFqdn":"containerapp000003--vm672yx.internal.victoriousflower-c5068f24.eastus.azurecontainerapps.io","customDomainVerificationId":"A189264E60034F7C3E609ED4E5CC493CEEA6833044629E67A8D1AC75146808B3","configuration":{"secrets":null,"activeRevisionsMode":"Single","ingress":{"fqdn":"containerapp000003.internal.victoriousflower-c5068f24.eastus.azurecontainerapps.io","external":false,"targetPort":81,"exposedPort":0,"transport":"Http2","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":true,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null},"registries":null,"dapr":null,"maxInactiveRevisions":null},"template":{"revisionSuffix":"","containers":[{"image":"mcr.microsoft.com/azuredocs/containerapps-helloworld:latest","name":"containerapp000003","resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":null,"maxReplicas":10,"rules":null},"volumes":null},"eventStreamEndpoint":"https://eastus.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/containerApps/containerapp000003/eventstream"},"identity":{"type":"None"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '2231'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Mar 2023 21:38:29 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"configuration": {"ingress": {"external": true, "allowInsecure":
+      false, "exposedPort": null}}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp ingress update
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '111'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -n --type --allow-insecure
+      User-Agent:
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+    method: PATCH
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerApps/containerapp000003?api-version=2022-10-01
+  response:
+    body:
+      string: ''
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Fri, 24 Mar 2023 21:38:30 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationResults/586dfe71-e342-4299-86b3-f05cd31a2a57?api-version=2022-10-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '699'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp ingress update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --type --allow-insecure
+      User-Agent:
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationResults/586dfe71-e342-4299-86b3-f05cd31a2a57?api-version=2022-10-01
+  response:
+    body:
+      string: ''
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Fri, 24 Mar 2023 21:38:31 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationResults/586dfe71-e342-4299-86b3-f05cd31a2a57?api-version=2022-10-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp ingress update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --type --allow-insecure
+      User-Agent:
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationResults/586dfe71-e342-4299-86b3-f05cd31a2a57?api-version=2022-10-01
+  response:
+    body:
+      string: ''
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Fri, 24 Mar 2023 21:38:36 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationResults/586dfe71-e342-4299-86b3-f05cd31a2a57?api-version=2022-10-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp ingress update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --type --allow-insecure
+      User-Agent:
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/containerappOperationResults/586dfe71-e342-4299-86b3-f05cd31a2a57?api-version=2022-10-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerapps/containerapp000003","name":"containerapp000003","type":"Microsoft.App/containerApps","location":"East
+        US","systemData":{"createdBy":"prvalav@microsoft.com","createdByType":"User","createdAt":"2023-03-24T21:37:35.3226001","lastModifiedBy":"prvalav@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-03-24T21:38:31.0988374"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","environmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","workloadProfileType":null,"outboundIpAddresses":["20.121.85.239"],"latestRevisionName":"containerapp000003--vm672yx","latestReadyRevisionName":"containerapp000003--vm672yx","latestRevisionFqdn":"containerapp000003--vm672yx.victoriousflower-c5068f24.eastus.azurecontainerapps.io","customDomainVerificationId":"A189264E60034F7C3E609ED4E5CC493CEEA6833044629E67A8D1AC75146808B3","configuration":{"secrets":null,"activeRevisionsMode":"Single","ingress":{"fqdn":"containerapp000003.victoriousflower-c5068f24.eastus.azurecontainerapps.io","external":true,"targetPort":81,"exposedPort":0,"transport":"Http2","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":false,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null},"registries":null,"dapr":null,"maxInactiveRevisions":null},"template":{"revisionSuffix":"","containers":[{"image":"mcr.microsoft.com/azuredocs/containerapps-helloworld:latest","name":"containerapp000003","resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":null,"maxReplicas":10,"rules":null},"volumes":null},"eventStreamEndpoint":"https://eastus.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/containerApps/containerapp000003/eventstream"},"identity":{"type":"None"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '2214'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Mar 2023 21:38:41 GMT
       expires:
       - '-1'
       pragma:
@@ -8356,94 +4506,90 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.10.10 (Windows-10-10.0.22621-SP0)
+      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.3 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App","namespace":"Microsoft.App","authorizations":[{"applicationId":"7e3bc4fd-85a3-4192-b177-5b8bfc87f42c","roleDefinitionId":"39a74f72-b40f-4bdc-b639-562fe2260bf0"},{"applicationId":"3734c1a4-2bed-4998-a37a-ff1a9e7bf019","roleDefinitionId":"5c779a4f-5cb2-4547-8c41-478d9be8ba90"},{"applicationId":"55ebbb62-3b9c-49fd-9b87-9595226dd4ac","roleDefinitionId":"e49ca620-7992-4561-a7df-4ed67dad77b5","managedByRoleDefinitionId":"9e3af657-a8ff-583c-a75c-2fe7c4bcb635"}],"resourceTypes":[{"resourceType":"operations","locations":["North
-        Central US (Stage)","Central US EUAP","East US 2 EUAP","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/connectedEnvironmentOperationResults","locations":["North
-        Central US (Stage)","North Central US","East US","East Asia","West Europe","Central
-        US EUAP","East US 2 EUAP"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"managedEnvironments","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/certificates","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/managedCertificates","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"containerApps","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App","namespace":"Microsoft.App","authorizations":[{"applicationId":"7e3bc4fd-85a3-4192-b177-5b8bfc87f42c","roleDefinitionId":"39a74f72-b40f-4bdc-b639-562fe2260bf0"},{"applicationId":"3734c1a4-2bed-4998-a37a-ff1a9e7bf019","roleDefinitionId":"5c779a4f-5cb2-4547-8c41-478d9be8ba90"},{"applicationId":"55ebbb62-3b9c-49fd-9b87-9595226dd4ac","roleDefinitionId":"e49ca620-7992-4561-a7df-4ed67dad77b5","managedByRoleDefinitionId":"9e3af657-a8ff-583c-a75c-2fe7c4bcb635"}],"resourceTypes":[{"resourceType":"managedEnvironments","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/certificates","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/managedCertificates","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"containerApps","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
-        SupportsLocation"},{"resourceType":"jobs","locations":["Central US EUAP","East
-        US 2 EUAP","North Central US (Stage)","Canada Central","West Europe","North
-        Europe","East US","East US 2","East Asia","Australia East","Germany West Central","Japan
+        SupportsLocation"},{"resourceType":"jobs","locations":["North Central US (Stage)","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationResults","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationStatuses","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"operations","locations":["North
+        Central US (Stage)","Central US EUAP","East US 2 EUAP","West US 2","Southeast
+        Asia","Sweden Central","Canada Central","West Europe","North Europe","East
+        US","East US 2","East Asia","Australia East","Germany West Central","Japan
         East","UK South","West US","Central US","North Central US","South Central
         US","Korea Central","Brazil South","West US 3","France Central","South Africa
-        North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
-        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationResults","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationStatuses","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationResults","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationStatuses","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Canada Central","West
-        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
-        West Central","Japan East","UK South","West US","Central US","North Central
-        US","South Central US","Korea Central","Brazil South","West US 3","France
-        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"connectedEnvironments","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","North Central US","East
-        US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectedEnvironments/certificates","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","North Central US","East
-        US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectedEnvironmentOperationStatuses","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","North Central US","East
-        US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/billingMeters","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Australia East","North
-        Central US","East US 2","West Europe","Central US","East US","North Europe","South
-        Central US","UK South","West US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/availableManagedEnvironmentsWorkloadProfileTypes","locations":["Central
-        US EUAP","East US 2 EUAP","North Central US (Stage)","Australia East","North
-        Central US","East US 2","West Europe","Central US","East US","North Europe","South
-        Central US","UK South","West US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+        North","Norway East","Switzerland North","UAE North"],"apiVersions":["2023-02-01","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"connectedEnvironments","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectedEnvironments/certificates","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/connectedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/billingMeters","locations":["North
+        Central US (Stage)","Australia East","North Central US","East US 2","West
+        Europe","Central US","East US","North Europe","South Central US","UK South","West
+        US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/availableManagedEnvironmentsWorkloadProfileTypes","locations":["North
+        Central US (Stage)","Australia East","North Central US","East US 2","West
+        Europe","Central US","East US","North Europe","South Central US","UK South","West
+        US 3"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '9060'
+      - '8594'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:21:47 GMT
+      - Fri, 24 Mar 2023 21:38:42 GMT
       expires:
       - '-1'
       pragma:
@@ -8471,13 +4617,13 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - python/3.10.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
+      - python/3.10.3 (Windows-10-10.0.22621-SP0) AZURECLI/2.46.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerApps/containerapp000003?api-version=2022-10-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerapps/containerapp000003","name":"containerapp000003","type":"Microsoft.App/containerApps","location":"East
-        US","systemData":{"createdBy":"xinyupang@microsoft.com","createdByType":"User","createdAt":"2023-03-14T07:20:52.432759","lastModifiedBy":"xinyupang@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-03-14T07:21:29.5326037"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","environmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","workloadProfileType":null,"outboundIpAddresses":["20.246.184.58"],"latestRevisionName":"containerapp000003--yu8mgc3","latestReadyRevisionName":"containerapp000003--yu8mgc3","latestRevisionFqdn":"containerapp000003--yu8mgc3.internal.proudmushroom-29cefc29.eastus.azurecontainerapps.io","customDomainVerificationId":"D3F71C85EB6552E36A89A3E4A080C3CFB00181670B659B0003264FC673AA9B00","configuration":{"secrets":null,"activeRevisionsMode":"Single","ingress":{"fqdn":"containerapp000003.internal.proudmushroom-29cefc29.eastus.azurecontainerapps.io","external":false,"targetPort":81,"exposedPort":0,"transport":"Http2","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":true,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null},"registries":null,"dapr":null,"maxInactiveRevisions":null},"template":{"revisionSuffix":"","containers":[{"image":"mcr.microsoft.com/azuredocs/containerapps-helloworld:latest","name":"containerapp000003","resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":null,"maxReplicas":10,"rules":null},"volumes":null},"eventStreamEndpoint":"https://eastus.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/containerApps/containerapp000003/eventstream"},"identity":{"type":"None"}}'
+        US","systemData":{"createdBy":"prvalav@microsoft.com","createdByType":"User","createdAt":"2023-03-24T21:37:35.3226001","lastModifiedBy":"prvalav@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-03-24T21:38:31.0988374"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","environmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerapp-env000002","workloadProfileType":null,"outboundIpAddresses":["20.121.85.239"],"latestRevisionName":"containerapp000003--vm672yx","latestReadyRevisionName":"containerapp000003--vm672yx","latestRevisionFqdn":"containerapp000003--vm672yx.victoriousflower-c5068f24.eastus.azurecontainerapps.io","customDomainVerificationId":"A189264E60034F7C3E609ED4E5CC493CEEA6833044629E67A8D1AC75146808B3","configuration":{"secrets":null,"activeRevisionsMode":"Single","ingress":{"fqdn":"containerapp000003.victoriousflower-c5068f24.eastus.azurecontainerapps.io","external":true,"targetPort":81,"exposedPort":0,"transport":"Http2","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":false,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null},"registries":null,"dapr":null,"maxInactiveRevisions":null},"template":{"revisionSuffix":"","containers":[{"image":"mcr.microsoft.com/azuredocs/containerapps-helloworld:latest","name":"containerapp000003","resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":null,"maxReplicas":10,"rules":null},"volumes":null},"eventStreamEndpoint":"https://eastus.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/containerApps/containerapp000003/eventstream"},"identity":{"type":"None"}}'
     headers:
       api-supported-versions:
       - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
@@ -8485,11 +4631,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '2229'
+      - '2214'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 14 Mar 2023 07:21:48 GMT
+      - Fri, 24 Mar 2023 21:38:42 GMT
       expires:
       - '-1'
       pragma:

--- a/src/containerapp/azext_containerapp/tests/latest/test_containerapp_commands.py
+++ b/src/containerapp/azext_containerapp/tests/latest/test_containerapp_commands.py
@@ -183,10 +183,12 @@ class ContainerappIngressTests(ScenarioTest):
             JMESPathCheck('transport', "Http2"),
         ])
 
+        self.cmd('containerapp ingress update -g {} -n {} --type external --allow-insecure=False'.format(resource_group, ca_name, env_name))
+
         self.cmd('containerapp ingress show -g {} -n {}'.format(resource_group, ca_name, env_name), checks=[
-            JMESPathCheck('external', False),
+            JMESPathCheck('external', True),
             JMESPathCheck('targetPort', 81),
-            JMESPathCheck('allowInsecure', True),
+            JMESPathCheck('allowInsecure', False),
             JMESPathCheck('transport', "Http2"),
         ])
 


### PR DESCRIPTION
### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
```
az containerapp ingress update
```

Today, the `az containerapp ingress enable` command is the same on that can be used to update an ingress as well. But this is not a patch operation which leads to unintended updates to the other properties of the ingress.

This command allows users to update single properties without affecting others. Also, the verb used here is more intuitive about it being to update an ingress.

resolves #6050

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?
