### PR TITLE
{AzureAppService} Fixing the supported api-version for get_kube_client() function

### DIFF
--- a/src/appservice-kube/azext_appservice_kube/custom.py
+++ b/src/appservice-kube/azext_appservice_kube/custom.py
@@ -297,7 +297,7 @@ class WebAppClient:
 
 
 def _get_kube_client(cmd):
-    client = web_client_factory(cmd.cli_ctx, api_version="2021-01-01")
+    client = web_client_factory(cmd.cli_ctx, api_version="2022-03-01")
     return client.kube_environments
 
 


### PR DESCRIPTION
Fixes Azure/azure-cli-extensions#6155

We get the below error while running CLI command: `az appservice kube show`
```
Enviornment:
Windows-10-10.0.20348-SP0
Python 3.10.10
Installer: MSI

azure-cli 2.47.0

Extensions:
appservice-kube 0.1.7
```

**Error:**
```
  File "C:\Users\Administrator\.azure\cliextensions\appservice-kube\azext_appservice_kube\custom.py", line 305, in show_kube_environments
    client = _get_kube_client(cmd)
  File "C:\Users\Administrator\.azure\cliextensions\appservice-kube\azext_appservice_kube\custom.py", line 301, in _get_kube_client
    return client.kube_environments
  File "D:\a\_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/mgmt/web/_web_site_management_client.py", line 627, in kube_environments
ModuleNotFoundError: No module named 'azure.mgmt.web.v2021_01_01'
```
This error is because API version 2021-01-01 is trimmed from azure-mgmt-web SDK by scripts/trim_sdk.py to reduce MSI package size (#23946)

but appservice-kube extension hardcodes 2021-01-01:

https://github.com/Azure/azure-cli-extensions/blob/f4033ee2830c68668f340e12c39d76b6d2b7ee3f/src/appservice-kube/azext_appservice_kube/custom.py#L300

appservice-kube extension can use the latest API version api_version="2022-03-01" defined at:

https://github.com/Azure/azure-cli/blob/8c45b0feeaaa9a8ca3ed53c5cead1a8435b04fa6/src/azure-cli-core/azure/cli/core/profiles/_shared.py#L243

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
