### PR TITLE
{AKS} `az aks update`: refactor pod_cidr and network_plugin_mode getters to check decorator mode

### DIFF
--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -11,6 +11,7 @@ To release a new version, please select a new version number (usually plus 1 to 
 
 Pending
 +++++++
+* Refactor: use decorator mode in pod_cidr and network_plugin_mode getters to read from mc only during CREATE
 
 0.5.135
 +++++++

--- a/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
@@ -3240,7 +3240,7 @@ class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):
             if override_until is not None:
                 try:
                     mc.upgrade_settings.override_settings.until = parse(override_until)
-                except Exception as ex:  # pylint: disable=broad-except # noqa: F841
+                except Exception:  # pylint: disable=broad-except
                     raise InvalidArgumentValueError(
                         f"{override_until} is not a valid datatime format."
                     )

--- a/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
@@ -510,7 +510,6 @@ class AKSPreviewManagedClusterContext(AKSManagedClusterContext):
             ):
                 network_plugin_mode = self.mc.network_profile.network_plugin_mode
 
-
         # this parameter does not need dynamic completion
         # this parameter does not need validation
         return network_plugin_mode
@@ -3241,7 +3240,7 @@ class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):
             if override_until is not None:
                 try:
                     mc.upgrade_settings.override_settings.until = parse(override_until)
-                except Exception as ex:  # pylint: disable=broad-except
+                except Exception as ex:  # pylint: disable=broad-except # noqa: F841
                     raise InvalidArgumentValueError(
                         f"{override_until} is not a valid datatime format."
                     )

--- a/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
@@ -477,18 +477,16 @@ class AKSPreviewManagedClusterContext(AKSManagedClusterContext):
         :return: str or None
         """
         # try to read the property value corresponding to the parameter from the `mc` object
-        pod_cidr = None
+        # only read on CREATE as this property can be updated
+        pod_cidr = self.raw_param.get("pod_cidr")
 
-        if (
-            self.mc and
-            self.mc.network_profile and
-            self.mc.network_profile.pod_cidr is not None
-        ):
-            pod_cidr = self.mc.network_profile.pod_cidr
-
-        # overwrite if provided by user
-        if self.raw_param.get("pod_cidr") is not None:
-            pod_cidr = self.raw_param.get("pod_cidr")
+        if self.decorator_mode == DecoratorMode.CREATE:
+            if (
+                self.mc and
+                self.mc.network_profile and
+                self.mc.network_profile.pod_cidr is not None
+            ):
+                pod_cidr = self.mc.network_profile.pod_cidr
 
         # this parameter does not need dynamic completion
         # this parameter does not need validation
@@ -499,18 +497,19 @@ class AKSPreviewManagedClusterContext(AKSManagedClusterContext):
 
         :return: str or None
         """
-        network_plugin_mode = None
-        # try to read the property value corresponding to the parameter from the `mc` object
-        if (
-            self.mc and
-            self.mc.network_profile and
-            self.mc.network_profile.network_plugin_mode is not None
-        ):
-            network_plugin_mode = self.mc.network_profile.network_plugin_mode
-
         # overwrite if provided by user
-        if self.raw_param.get("network_plugin_mode") is not None:
-            network_plugin_mode = self.raw_param.get("network_plugin_mode")
+        network_plugin_mode = self.raw_param.get("network_plugin_mode")
+
+        # try to read the property value corresponding to the parameter from the `mc` object
+        # only read on CREATE as this property can be updated
+        if self.decorator_mode == DecoratorMode.CREATE:
+            if (
+                self.mc and
+                self.mc.network_profile and
+                self.mc.network_profile.network_plugin_mode is not None
+            ):
+                network_plugin_mode = self.mc.network_profile.network_plugin_mode
+
 
         # this parameter does not need dynamic completion
         # this parameter does not need validation

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
@@ -4825,6 +4825,78 @@ class AKSPreviewManagedClusterUpdateDecoratorTestCase(unittest.TestCase):
 
         self.assertEqual(dec_mc_2, ground_truth_mc_2)
 
+        # test no updates made with same network plugin mode
+        dec_3 = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "network_plugin_mode": "overlay",
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        mc_3 = self.models.ManagedCluster(
+            location="test_location",
+            network_profile=self.models.ContainerServiceNetworkProfile(
+                network_plugin="azure",
+                network_plugin_mode="overlay",
+                pod_cidr="100.64.0.0/16",
+                service_cidr="192.168.0.0/16"
+            ),
+        )
+
+        dec_3.context.attach_mc(mc_3)
+        # fail on passing the wrong mc object
+        with self.assertRaises(CLIInternalError):
+            dec_3.update_network_plugin_settings(None)
+        dec_mc_3 = dec_3.update_network_plugin_settings(mc_3)
+
+        ground_truth_mc_3 = self.models.ManagedCluster(
+            location="test_location",
+            network_profile=self.models.ContainerServiceNetworkProfile(
+                network_plugin="azure",
+                network_plugin_mode="overlay",
+                pod_cidr="100.64.0.0/16",
+                service_cidr="192.168.0.0/16",
+            ),
+        )
+
+        self.assertEqual(dec_mc_3, ground_truth_mc_3)
+
+        # test no updates made with empty network plugin settings
+        dec_4 = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {},
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        mc_4 = self.models.ManagedCluster(
+            location="test_location",
+            network_profile=self.models.ContainerServiceNetworkProfile(
+                network_plugin="azure",
+                network_plugin_mode="overlay",
+                pod_cidr="100.64.0.0/16",
+                service_cidr="192.168.0.0/16"
+            ),
+        )
+
+        dec_4.context.attach_mc(mc_4)
+        # fail on passing the wrong mc object
+        with self.assertRaises(CLIInternalError):
+            dec_4.update_network_plugin_settings(None)
+        dec_mc_4 = dec_4.update_network_plugin_settings(mc_4)
+
+        ground_truth_mc_4 = self.models.ManagedCluster(
+            location="test_location",
+            network_profile=self.models.ContainerServiceNetworkProfile(
+                network_plugin="azure",
+                network_plugin_mode="overlay",
+                pod_cidr="100.64.0.0/16",
+                service_cidr="192.168.0.0/16",
+            ),
+        )
+
+        self.assertEqual(dec_mc_4, ground_truth_mc_4)
+
     def test_update_api_server_access_profile(self):
         dec_1 = AKSPreviewManagedClusterUpdateDecorator(
             self.cmd,


### PR DESCRIPTION
add checks for decorator mode to better match the
logic in the acs (GA CLI) and avoid reading any values from mc unless doing CREATE

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

`az aks update`

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [x] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
