### PR TITLE
update connectedk8s for ARM metadata 2022-09-01

### DIFF
--- a/src/connectedk8s/HISTORY.rst
+++ b/src/connectedk8s/HISTORY.rst
@@ -1,6 +1,11 @@
 .. :changelog:
 
 Release History
+===============
+
+1.4.0
+++++++
+* Added support for reading ARM metadata 2022-09-01.
 
 1.3.20
 ++++++
@@ -9,19 +14,16 @@ Release History
 
 1.3.19
 ++++++
-
 * Adding outbound network connectivity check for Cluster Connect (OBO endpoint)
 
 1.3.18
 ++++++
-
 * Cleaning up stale CRDs if present during onboarding (even in absence of azure-arc release)
 * Adding retries in Helm client download
 * Added some failures to be classified as userfaults
 
 1.3.17
 ++++++
-
 * Added a spinner which runs while ARM resource is being provisioned
 * Added additional logging to indicate which step is running
 
@@ -34,26 +36,22 @@ Release History
 
 1.3.15
 ++++++
-
 * Diagnoser Enhancements - storing metadata and KAP CR snapshots , azure-arc helm values , azure-arc ns secret list
 * Removing circular imports of 1. custom from precheckutils and 2.(precheckutils and troubleshootutils) from utils
 * Adding back heuristics detection in connect command
 
 1.3.14
 ++++++
-
 * Changing telemetry push interval to 1 hr
 * Adding two new supported infra values - Windows 10 IoT Enterprise, LTSCWindows 10 Enterprise LTSC
 * Saving cluster diagnostic checks pod and job logs
 
 1.3.13
 ++++++
-
 * Bumping up the cluster diagnostic checks helm chart version - Nodeselector addition
 
 1.3.12
 ++++++
-
 * Added retries for helm chart pull and config DP POST call
 * Fix parameterizing for kid in csp method
 * Bug fix in delete_arc_agents for arm64 parameter
@@ -61,7 +59,6 @@ Release History
 
 1.3.11
 ++++++
-
 * Added support for custom AAD token
 * Removed ARM64 unsupported warning
 * Increased helm delete timeout for ARM64 clusters
@@ -69,121 +66,98 @@ Release History
 
 1.3.10
 ++++++
-
 * Added CLI heuristics change
 * Added AKS IOT infra support 
 * Bug Fix in precheckutils
 
 1.3.9
 ++++++
-
 * Added DNS and outbound connectivity prechecks in connect command
 
 1.3.8
 ++++++
-
 * Added connectedk8s proxy support for fairfax
 
 1.3.7
 ++++++
-
 * Install new helm release in azure-arc-release NS
 
 1.3.6
 ++++++
-
 * Updated patch behaviour for Azure Hybrid Benefit property
 
 1.3.5
 ++++++
-
 * Added software assurance related changes for AKS HCI
 * Added parameter for overriding container log path
 * Updated kubernetes package dependency to 24.2.0
 
 1.3.4
 ++++++
-
 * Fixed a proxy related bug in connectedk8s upgrade
 
 1.3.3
 ++++++
-
 * Added a timeout in force delete's CRD deletion command
 
 1.3.2
 ++++++
-
 * Added force delete command which is an added functionality in connectedk8s delete function
 
 1.3.1
 ++++++
-
 * Updated min cli core version to 2.30.0
 
 1.3.0
 ++++++
-
 * Added private link support
 
 1.2.11
 ++++++
-
 * Increased the timeout of diagnoser job completion to 180 seconds
 
 1.2.10
 ++++++
-
 * Added troubleshoot command which can be used to diagnose Arc enabled K8s clusters
 
 1.2.9
 ++++++
-
 * Add correlation-id parameter to internally track onboarding sources
 
 1.2.8
 ++++++
-
 * Bump up CSP version to 1.3.019103, bump up `pycryptodome` to 3.14.1 to support Python 3.10
 
 1.2.7
 ++++++
-
 * Avoid using packaging module and revert minCliCoreVersion to 2.16.0
 
 1.2.6
 ++++++
-
 * Update minCliCoreVersion to 2.23.0
 
 1.2.5
 ++++++
-
 * Using MSAL based auth for CLI version >= 2.30.0
 
 1.2.4
 ++++++
-
 * Custom cert changes, using "userValues.txt" for existing values in update command instead of --reuse-values, fix to wait for LRO to complete before starting agent installation/deletion
 
 1.2.3
 ++++++
-
 * Fetching the tenantID from subscription object instead of graphclient
 
 1.2.2
 ++++++
-
 * Updated connectedk8s proxy to support mooncake
 
 1.2.1
 ++++++
-
 * Add maxCliCoreVersion as 2.29.0
 
 1.2.0
 ++++++
-
 * Updated CSP version to 1.3.017131
 * Updated GA SDK to 2021-10-01
 * Updated CSP endpoint to CDN
@@ -191,17 +165,14 @@ Release History
 
 1.1.11
 ++++++
-
 * Installing helm binary as part of CLI commands
 
 1.1.10
 ++++++
-
 * Fixed ARM exception telemetry
 
 1.1.9
 ++++++
-
 * Increase onboarding and upgrade timeout
 
 1.1.8

--- a/src/connectedk8s/setup.py
+++ b/src/connectedk8s/setup.py
@@ -17,7 +17,7 @@ except ImportError:
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
 
-VERSION = '1.3.20'
+VERSION = '1.4.0'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
This PR adds ability to fetch new properties from 2022-09-01 ARM metadata in an on-premises environment that is currently in preview.

### Related command
az connectedk8s

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

**IMPORTANT:** I ran "azdev style azext_connectedk8s", but there are preexisting formatting errors unrelated to my change. I assumption is the project never followed the style guides to begin with. If the style guide should be followed, I am not going to fix those issues in this PR as there are many of them and likely not related to my changes.

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
