### PR TITLE
Add sqlServerSchema command in data migration

### DIFF
--- a/src/datamigration/HISTORY.rst
+++ b/src/datamigration/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.5.0
+++++++
+* [NEW COMMAND] `az datamigration sql-server-schema` : Migrate database schema objects to the target Azure Sql Servers.
+
 0.4.1
 ++++++
 * Bug fix for list-logins parameter in command "az datamigration login-migration".

--- a/src/datamigration/README.md
+++ b/src/datamigration/README.md
@@ -34,6 +34,11 @@ az datamigration get-sku-recommendation --output-folder "C:\\PerfCollectionOutpu
 az datamigration login-migration --src-sql-connection-str  "data source=servername;user id=userid;password=;initial catalog=master;TrustServerCertificate=True" --tgt-sql-connection-str  "data source=servername;user id=userid;password=;initial catalog=master;TrustServerCertificate=True" --csv-file-path "C:\\CSVFile" --list-of-login "loginname1" "loginname2" --output-folder "C:\\OutputFolder" --aad-domain-name "AADDomainName" --display-result --overwrite
 ```
 
+##### Sql-server-schema #####
+```
+az datamigration sql-server-schema --action "MigrateSchema" --src-sql-connection-str  "Server=;Initial Catalog=;User ID=;Password=" --tgt-sql-connection-str  "Server=;Initial Catalog=;User ID=;Password=" --input-script-file-path "C:\inputFile" --output-folder "C:\OutputFolder" --display-result --overwrite
+```
+
 #### datamigration sql-managed-instance ####
 ##### Create (Backup source Fileshare) #####
 ```

--- a/src/datamigration/azext_datamigration/manual/_help.py
+++ b/src/datamigration/azext_datamigration/manual/_help.py
@@ -69,6 +69,24 @@ helps['datamigration login-migration'] = """
                az datamigration login-migration --config-file-path "C:\\Users\\user\\document\\config.json"
 """
 
+helps['datamigration sql-server-schema'] = """
+    type: command
+    short-summary: Migrate schema from the source Sql Servers to the target Azure Sql Servers.
+    examples:
+      - name: Run Migrate database objects from the source SQL Server to the target Azure SQL Database using Parameters.
+        text: |-
+               az datamigration sql-server-schema --action "MigrateSchema" --src-sql-connection-str "Server=;Initial Catalog=;User ID=;Password=" --tgt-sql-connection-str "Server=;Initial Catalog=;User ID=;Password="
+      - name: Run Generate TSQL schema script from the source SQL Server using Parameters.
+        text: |-
+               az datamigration sql-server-schema --action "GenerateScript" --src-sql-connection-str "Server=;Initial Catalog=;User ID=;Password=" --tgt-sql-connection-str "Server=;Initial Catalog=;User ID=;Password="  --output-folder "C:\OutputFolder"
+      - name: Run Deploy TSQL script to the target Azure SQL Database using Parameters.
+        text: |-
+               az datamigration sql-server-schema --action "GenerateScript" --src-sql-connection-str "Server=;Initial Catalog=;User ID=;Password=" --tgt-sql-connection-str "Server=;Initial Catalog=;User ID=;Password="  --input-script-file-path "C:\OutputFolder\script.sql"
+      - name: Run Migrate database objects from the source SQL Server to the target Azure SQL Database using ConfigFile.
+        text: |-
+               az datamigration sql-server-schema --config-file-path "C:\configfile.json" configfile.json example: { "Action": "GenerateScript", "sourceConnectionString": "Server=;Initial Catalog=;User ID=;Password=", "targetConnectionString": "Server=;Initial Catalog=;User ID=;Password=", "targetConnectionString": "Server=;Initial Catalog=;User ID=;Password=", "inputScriptFilePath": "C:\OutputFolder\script.sql", "outputFolder": "C:\OutputFolder\script.sql"}             
+"""
+
 helps['datamigration register-integration-runtime'] = """
     type: command
     short-summary: Register Database Migration Service on Integration Runtime

--- a/src/datamigration/azext_datamigration/manual/_params.py
+++ b/src/datamigration/azext_datamigration/manual/_params.py
@@ -62,6 +62,14 @@ def load_arguments(self, _):
         c.argument('output_folder', type=str, help='Default: %LocalAppData%/Microsoft/SqlLoginMigrations) Folder where logs will be written.')
         c.argument('aad_domain_name', type=str, help='Required if Windows logins are included in the list of logins to be migrated.')
         c.argument('config_file_path', type=file_type, completer=FilesCompleter(), help='Path of the ConfigFile')
+    
+    with self.argument_context('datamigration sql-server-schema') as c:
+        c.argument('action', type=str, help='Select one schema migration action. The valid values are: MigrateSchema, GenerateScript, DeploySchema. MigrateSchema is to migrate the database objects to Azure SQL Database target. GenerateScript is to generate an editable TSQL schema script that can be used to run on the target to deploy the objects. DeploySchema is to run the TSQL script generated from -GenerateScript action on the target to deploy the objects.')
+        c.argument('src_sql_connection_str', type=str, help='Connection string for the source SQL instance, using the formal connection string format.')
+        c.argument('tgt_sql_connection_str', type=str, help='Connection string for the target SQL instance, using the formal connection string format.')
+        c.argument('input_script_file_path', type=file_type, completer=FilesCompleter(), help='Location of an editable TSQL schema script. Use this parameter only with DeploySchema Action.')
+        c.argument('output_folder', type=str, help='Default: %LocalAppData%/Microsoft/SqlSchemaMigration) Folder where logs will be written and the generated TSQL schema script by GenerateScript Action.')
+        c.argument('config_file_path', type=file_type, completer=FilesCompleter(), help='Path of the ConfigFile. Accepted parameter names in configfile.json is Action, sourceConnectionString, targetConnectionString, inputScriptFilePath and outputFolder.')
 
     with self.argument_context('datamigration register-integration-runtime') as c:
         c.argument('auth_key', type=str, help='AuthKey of SQL Migration Service')

--- a/src/datamigration/azext_datamigration/manual/commands.py
+++ b/src/datamigration/azext_datamigration/manual/commands.py
@@ -20,3 +20,4 @@ def load_command_table(self, _):
         g.custom_command('get-sku-recommendation', 'datamigration_get_sku_recommendation')
         g.custom_command('register-integration-runtime', 'datamigration_register_ir')
         g.custom_command('login-migration', 'datamigration_login_migration')
+        g.custom_command('sql-server-schema', 'datamigration_sql_server_schema')

--- a/src/datamigration/azext_datamigration/manual/custom.py
+++ b/src/datamigration/azext_datamigration/manual/custom.py
@@ -299,3 +299,82 @@ def datamigration_login_migration(src_sql_connection_str=None,
 
     except Exception as e:
         raise e
+
+
+# -----------------------------------------------------------------------------------------------------------------
+#  Migrate schema from the source Sql Servers to the target Azure Sql Servers.
+# -----------------------------------------------------------------------------------------------------------------
+def datamigration_sql_server_schema(action=None,
+                                  src_sql_connection_str=None,
+                                  tgt_sql_connection_str=None,
+                                  input_script_file_path=None,
+                                  output_folder=None,
+                                  config_file_path=None):
+    # Error message strings
+    actionError = "Please provide valid action value. The valid values are: MigrateSchema, GenerateScript, DeploySchema."
+    srcConnectionError = "Please provide src_sql_connection_str value."
+    tgtConnectionError = "Please provide tgt_sql_connection_str value."
+    inputFilePathError = "Please provide input_script_file_path value for the action of DeploySchema."
+
+    # The accepted actions
+    actionList = ["MigrateSchema", "GenerateScript", "DeploySchema"]
+
+    try:
+        # Setup the console app
+        defaultOutputFolder, exePath = helper.sqlServerSchema_console_app_setup()
+
+        if config_file_path is not None:
+            helper.test_path_exist(config_file_path)
+            print(f"Run through the provided config file:")
+            cmd = f'{exePath} --configFile "{config_file_path}"'
+            subprocess.call(cmd, shell=False)
+        else:
+            if action is None:
+                raise RequiredArgumentMissingError(actionError)
+
+            actionPassed = str(); 
+
+            for allowedAction in actionList:
+                if allowedAction.lower() == action.lower():
+                    actionPassed = allowedAction
+            
+            if actionPassed == str():
+                raise RequiredArgumentMissingError(actionError)
+
+            if src_sql_connection_str is None:
+                raise RequiredArgumentMissingError(srcConnectionError)
+            
+            if tgt_sql_connection_str is None:
+                raise RequiredArgumentMissingError(tgtConnectionError)
+
+            if actionPassed == "DeploySchema":
+                if input_script_file_path == None:
+                    raise RequiredArgumentMissingError(inputFilePathError)
+                else:
+                    helper.test_path_exist(input_script_file_path)
+
+            # parameter set for Perfornace data collection
+            parameterList = {
+                "--sourceConnectionString": src_sql_connection_str,
+                "--targetConnectionString": tgt_sql_connection_str,
+                "--inputScriptFilePath": input_script_file_path,
+                "--outputFolder": output_folder
+            }
+
+            # joining paramaters together in a string
+            cmd = f'{exePath} {actionPassed}'
+
+            # formating the parameter list into a string
+            for param in parameterList:
+                if parameterList[param] is not None and not param.__contains__("list"):
+                    cmd += f' {param} "{parameterList[param]}"'
+
+                # in case the parameter input is list format it accordingly
+                elif param.__contains__("list") and parameterList[param] is not None:
+                    parameterList[param] = " ".join(f"\"{i}\"" for i in parameterList[param])
+                    cmd += f' {param} {parameterList[param]}'
+            
+            subprocess.call(cmd, shell=False)
+
+    except Exception as e:
+        raise e

--- a/src/datamigration/azext_datamigration/manual/helper.py
+++ b/src/datamigration/azext_datamigration/manual/helper.py
@@ -103,6 +103,27 @@ def loginMigration_console_app_setup():
 
 
 # -----------------------------------------------------------------------------------------------------------------
+# SqlServerSchema helper function to do console app setup (mkdir, download and extract)
+# -----------------------------------------------------------------------------------------------------------------
+def sqlServerSchema_console_app_setup():
+
+    validate_os_env()
+
+    defaultOutputFolder = get_sqlServerSchema_default_output_folder()
+
+    # Assigning base folder path
+    baseFolder = os.path.join(defaultOutputFolder, "Downloads")
+    exePath = os.path.join(baseFolder, "SchemaMigration.Console.csproj", "SqlSchemaMigration.exe")
+
+    # Creating base folder structure
+    create_dir_path(baseFolder)
+    # check and download console app
+    check_and_download_sqlServerSchema_console_app(exePath, baseFolder)
+
+    return defaultOutputFolder, exePath
+
+
+# -----------------------------------------------------------------------------------------------------------------
 # Assessment helper function to return the default output folder path depending on OS environment.
 # -----------------------------------------------------------------------------------------------------------------
 def get_default_output_folder():
@@ -137,6 +158,23 @@ def get_loginMigration_default_output_folder():
 
 
 # -----------------------------------------------------------------------------------------------------------------
+# SqlServerSchema helper function to return the default output folder path depending on OS environment.
+# -----------------------------------------------------------------------------------------------------------------
+def get_sqlServerSchema_default_output_folder():
+
+    osPlatform = platform.system()
+
+    if osPlatform.__contains__('Linux'):
+        defaultOutputPath = os.path.join(os.getenv('USERPROFILE'), ".config", "Microsoft", "SqlSchemaMigration")
+    elif osPlatform.__contains__('Darwin'):
+        defaultOutputPath = os.path.join(os.getenv('USERPROFILE'), "Library", "Application Support", "Microsoft", "SqlSchemaMigration")
+    else:
+        defaultOutputPath = os.path.join(os.getenv('LOCALAPPDATA'), "Microsoft", "SqlSchemaMigration")
+
+    return defaultOutputPath
+
+
+# -----------------------------------------------------------------------------------------------------------------
 # Assessment helper function to check if console app exists, if not download it.
 # -----------------------------------------------------------------------------------------------------------------
 def check_and_download_console_app(exePath, baseFolder):
@@ -164,6 +202,23 @@ def check_and_download_loginMigration_console_app(exePath, baseFolder):
     if not testPath:
         zipSource = "https://sqlassess.blob.core.windows.net/app/LoginsMigration.zip"
         zipDestination = os.path.join(baseFolder, "LoginsMigration.zip")
+
+        urllib.request.urlretrieve(zipSource, filename=zipDestination)
+        with ZipFile(zipDestination, 'r') as zipFile:
+            zipFile.extractall(path=baseFolder)
+
+
+# -----------------------------------------------------------------------------------------------------------------
+# SqlServerSchema helper function to check if console app exists, if not download it.
+# -----------------------------------------------------------------------------------------------------------------
+def check_and_download_sqlServerSchema_console_app(exePath, baseFolder):
+
+    testPath = os.path.exists(exePath)
+
+    # Downloading console app zip and extracting it
+    if not testPath:
+        zipSource = "https://migrationapps.blob.core.windows.net/schemamigration/SqlSchemaMigration.zip"
+        zipDestination = os.path.join(baseFolder, "SqlSchemaMigration.zip")
 
         urllib.request.urlretrieve(zipSource, filename=zipDestination)
         with ZipFile(zipDestination, 'r') as zipFile:

--- a/src/datamigration/setup.py
+++ b/src/datamigration/setup.py
@@ -10,7 +10,7 @@ from codecs import open
 from setuptools import setup, find_packages
 
 # HISTORY.rst entry.
-VERSION = '0.4.1'
+VERSION = '0.5.0'
 try:
     from azext_datamigration.manual.version import VERSION
 except ImportError:


### PR DESCRIPTION
The PR is to add new CLI commands "az datamigration sql-server-schema". The same command for Powershell has been published. The new CLI commands has passed local tests.

The local test commands: 
az datamigration sql-server-schema --action "MigrateSchema" --src-sql-connection-str "Server=;Initial Catalog=;User ID=;Password=" --tgt-sql-connection-str "Server=;Initial Catalog=;User ID=;Password="
az datamigration sql-server-schema --action "GenerateScript" --src-sql-connection-str "Server=;Initial Catalog=;User ID=;Password=" --tgt-sql-connection-str "Server=;Initial Catalog=;User ID=;Password="  --output-folder "C:\OutputFolder"
az datamigration sql-server-schema --action "GenerateScript" --src-sql-connection-str "Server=;Initial Catalog=;User ID=;Password=" --tgt-sql-connection-str "Server=;Initial Catalog=;User ID=;Password="  --input-script-file-path "C:\OutputFolder\script.sql"
az datamigration sql-server-schema --config-file-path "C:\configfile.json"

I am from the service team.




