### PR TITLE
{interactive} Fix bugs of CTRL+C to cease the whole interactive mode

### DIFF
--- a/src/interactive/HISTORY.rst
+++ b/src/interactive/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+0.5.1
++++++
+* Fix bugs to prevent users from exiting the entire az interactive by using Ctrl+C during command execution
+* Fix confusing error message caused by uncompleted command loading and param update
+
 0.5.0
 +++++
 * Support command recommendations that predicts the next commands users might need.

--- a/src/interactive/azext_interactive/azclishell/__init__.py
+++ b/src/interactive/azext_interactive/azclishell/__init__.py
@@ -3,4 +3,4 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-VERSION = '0.5.0'
+VERSION = '0.5.1'


### PR DESCRIPTION
---

Prevent users from exiting the entire az interactive by using Ctrl+C during command execution

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
az interactive

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
