### PR TITLE
Partner Center Extension - v0.2.2-alpha

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -41961,6 +41961,60 @@
                     "version": "0.1.2"
                 },
                 "sha256Digest": "a2e4ef513b74c138c3c445c6c494eb9e4677338f53e1b5a634a280b57bd70fc5"
+            },
+            {
+                "downloadUrl": "https://github.com/Azure/partnercenter-cli-extension/releases/download/v0.2.2-alpha/partnercenter-0.2.2-py3-none-any.whl",
+                "filename": "partnercenter-0.2.2-py3-none-any.whl",
+                "metadata": {
+                    "azext.isPreview": true,
+                    "azext.minCliCoreVersion": "2.0.67",
+                    "classifiers": [
+                        "Development Status :: 4 - Beta",
+                        "Intended Audience :: Developers",
+                        "Intended Audience :: System Administrators",
+                        "Programming Language :: Python",
+                        "Programming Language :: Python :: 3",
+                        "Programming Language :: Python :: 3.6",
+                        "Programming Language :: Python :: 3.7",
+                        "Programming Language :: Python :: 3.8",
+                        "License :: OSI Approved :: MIT License"
+                    ],
+                    "extensions": {
+                        "python.details": {
+                            "contacts": [
+                                {
+                                    "email": "azpycli@microsoft.com",
+                                    "name": "Microsoft Corporation",
+                                    "role": "author"
+                                }
+                            ],
+                            "document_names": {
+                                "description": "DESCRIPTION.rst"
+                            },
+                            "project_urls": {
+                                "Home": "https://github.com/Azure/partnercenter-cli-extension/tree/main/partnercenter"
+                            }
+                        }
+                    },
+                    "extras": [],
+                    "generator": "bdist_wheel (0.30.0)",
+                    "license": "MIT",
+                    "metadata_version": "2.0",
+                    "name": "partnercenter",
+                    "run_requires": [
+                        {
+                            "requires": [
+                                "azure-storage-blob",
+                                "docker",
+                                "pydantic",
+                                "requests"
+                            ]
+                        }
+                    ],
+                    "summary": "Microsoft Azure CLI Extension for Partner Center",
+                    "version": "0.2.2"
+                },
+                "sha256Digest": "583323a6ed8c1a304aa965c6696aeb1454507ccf81dc312109f15fc52b12d4b1"
             }
         ],
         "peering": [


### PR DESCRIPTION
CLI extension for the Partner Center, v0.2.2-alpha

Currently, experimentally supporting Marketplace management commands, commissioned by Global Partner Services US division.

### Maintainers
- @kevinhillinger 
- @bobjac 

### Source
- Type: External repository
- URL: https://github.com/Azure/partnercenter-cli-extension
