### PR TITLE
{all services] TOC | fixed incorrect plural product names

### DIFF
--- a/src/service_name.json
+++ b/src/service_name.json
@@ -156,7 +156,7 @@
   },
   {
     "Command": "az datamigration",
-    "AzureServiceName": "Database Migration Services",
+    "AzureServiceName": "Data Migration",
     "URL": "https://learn.microsoft.com/azure/dms"
   },
   {

--- a/src/service_name.json
+++ b/src/service_name.json
@@ -1,7 +1,7 @@
 [
   {
     "Command": "az account",
-    "AzureServiceName": "Account",
+    "AzureServiceName": "Accounts",
     "URL": ""
   },
   {
@@ -36,7 +36,7 @@
   },
   {
     "Command": "az appservice",
-    "AzureServiceName": "App Services",
+    "AzureServiceName": "App Service",
     "URL": "https://learn.microsoft.com/azure/app-service"
   },
   {
@@ -511,7 +511,7 @@
   },
   {
     "Command": "az staticwebapp",
-    "AzureServiceName": "App Services",
+    "AzureServiceName": "App Service",
     "URL": "https://learn.microsoft.com/azure/static-web-apps/"
   },
   {
@@ -551,7 +551,7 @@
   },
   {
     "Command": "az webapp",
-    "AzureServiceName": "App Services",
+    "AzureServiceName": "App Service",
     "URL": "https://learn.microsoft.com/azure/app-service"
   },
   {

--- a/src/service_name.json
+++ b/src/service_name.json
@@ -36,7 +36,7 @@
   },
   {
     "Command": "az appservice",
-    "AzureServiceName": "App Service",
+    "AzureServiceName": "App Services",
     "URL": "https://learn.microsoft.com/azure/app-service"
   },
   {
@@ -511,7 +511,7 @@
   },
   {
     "Command": "az staticwebapp",
-    "AzureServiceName": "App Service",
+    "AzureServiceName": "App Services",
     "URL": "https://learn.microsoft.com/azure/static-web-apps/"
   },
   {
@@ -551,7 +551,7 @@
   },
   {
     "Command": "az webapp",
-    "AzureServiceName": "App Service",
+    "AzureServiceName": "App Services",
     "URL": "https://learn.microsoft.com/azure/app-service"
   },
   {


### PR DESCRIPTION
In aligning with the Azure PowerShell reference TOC, _Account_ should be plural _Accounts_, and _App Services_ should be singular _App Service_.