### PR TITLE
Prepare for new azdev

### DIFF
--- a/.azure-pipelines/templates/azdev_setup.yml
+++ b/.azure-pipelines/templates/azdev_setup.yml
@@ -14,7 +14,7 @@ steps:
       # clone azure-cli
       git clone -q --single-branch -b dev https://github.com/Azure/azure-cli.git ../azure-cli
       python -m pip install -U pip
-      pip install azdev
+      pip install git+https://github.com/dciborow/azure-cli-dev-tools.git@dciborow/pylint
       azdev --version
       azdev setup -c $CLI_REPO_PATH -r $CLI_EXT_REPO_PATH --debug
       pip list -v

--- a/.flake8
+++ b/.flake8
@@ -14,6 +14,8 @@ ignore =
     C901
     # line break after binary operator effect on readability is subjective
     W504
+    # line break occurred before a binary operator
+    W503
 exclude =
     */vendored_sdks
     docs

--- a/.flake8
+++ b/.flake8
@@ -2,13 +2,18 @@
 max-line-length = 120
 max-complexity = 10
 ignore =
-    E501,  # line too long, it is covered by pylint
-    E722,  # bare except, bad practice, to be removed in the future
-    F401,  # imported but unused, too many violations, to be removed in the future
-    F811,  # redefinition of unused, to be removed in the future
-    C901   # code flow is too complex, too many violations, to be removed in the future
-    W503   # line break before binary operator effect on readability is subjective
-    W504   # line break after binary operator effect on readability is subjective
+    # line too long, it is covered by pylint
+    E501
+    # bare except, bad practice, to be removed in the future
+    E722
+    # imported but unused, too many violations, to be removed in the future
+    F401
+    # redefinition of unused, to be removed in the future
+    F811
+    # code flow is too complex, too many violations, to be removed in the future
+    C901
+    # line break after binary operator effect on readability is subjective
+    W504
 exclude =
     */vendored_sdks
     docs

--- a/pylintrc
+++ b/pylintrc
@@ -51,13 +51,13 @@ min-similarity-lines=10
 # The invalid-name checker must be **enabled** for these hints to be used.
 include-naming-hint=yes
 
-module-name-hint=lowercase (keep short; underscores are discouraged)
-const-name-hint=UPPER_CASE_WITH_UNDERSCORES
-class-name-hint=CapitalizedWords
-class-attribute-name-hint=lower_case_with_underscores
-attr-name-hint=lower_case_with_underscores
-method-name-hint=lower_case_with_underscores
-function-name-hint=lower_case_with_underscores
-argument-name-hint=lower_case_with_underscores
-variable-name-hint=lower_case_with_underscores
-inlinevar-name-hint=lower_case_with_underscores (short is OK)
+module-naming-style=snake_case
+const-naming-style=UPPER_CASE
+class-naming-style=PascalCase
+class-attribute-naming-style=snake_case
+attr-naming-style=snake_case
+method-naming-style=snake_case
+function-naming-style=snake_case
+argument-naming-style=snake_case
+variable-naming-style=snake_case
+inlinevar-naming-style=snake_case

--- a/pylintrc
+++ b/pylintrc
@@ -17,7 +17,12 @@ disable=
     invalid-name,
     duplicate-code,
     import-outside-toplevel,
-    too-many-lines
+    too-many-lines,
+    # These rules were added in Pylint >= 2.12, disable them to avoid making retroactive change
+    missing-timeout,
+    superfluous-parens,
+    implicit-str-concat,
+    unnecessary-dunder-call,
 
 [TYPECHECK]
 # For Azure CLI extensions, we ignore some import errors as they'll be available in the environment of the CLI


### PR DESCRIPTION
Check if CI works in new azdev https://github.com/Azure/azure-cli-dev-tools/pull/359

As pylint version bumps to 2.17, many new rules are added. I guess the service team may need to fix their code style when PR is submitted.