### PR TITLE
{AKS} `az aks addon update`: Fix unexpected error 'Addon "web_application_routing" is not enabled in this cluster'

### DIFF
--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -12,6 +12,10 @@ To release a new version, please select a new version number (usually plus 1 to 
 Pending
 ++++++
 
+0.5.149
++++++++
+* `aks addon update`: Fix unexpected error 'Addon "web_application_routing" is not enabled in this cluster' when trying to update the web app routing addon for an managed cluster that already has it enabled.
+
 0.5.148
 +++++++
 * Add support for option --nodepool-taints to some aks commands

--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -14,7 +14,7 @@ Pending
 
 0.5.149
 +++++++
-* `aks addon update`: Fix unexpected error 'Addon "web_application_routing" is not enabled in this cluster' when trying to update the web app routing addon for an managed cluster that already has it enabled.
+* `az aks addon update`: Fix unexpected error 'Addon "web_application_routing" is not enabled in this cluster' when trying to update the web app routing addon for an managed cluster that already has it enabled.
 
 0.5.148
 +++++++

--- a/src/aks-preview/azext_aks_preview/custom.py
+++ b/src/aks-preview/azext_aks_preview/custom.py
@@ -1521,7 +1521,7 @@ def aks_addon_update(cmd, client, resource_group_name, name, addon, workspace_re
         if (instance.ingress_profile is None) or (instance.ingress_profile.web_app_routing is None) or not instance.ingress_profile.web_app_routing.enabled:
             raise InvalidArgumentValueError(f'Addon "{addon}" is not enabled in this cluster.')
 
-    if addon == "monitoring" and enable_msi_auth_for_monitoring is None:
+    elif addon == "monitoring" and enable_msi_auth_for_monitoring is None:
         enable_msi_auth_for_monitoring = True
 
     else:

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -6091,6 +6091,43 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
 
     @AllowLargeResponse()
     @AKSCustomResourceGroupPreparer(random_name_length=17, name_prefix='clitest', location='westus2')
+    def test_aks_create_and_update_web_application_routing_dns_zone(self, resource_group, resource_group_location):
+        aks_name = self.create_random_name('cliakstest', 16)
+        dns_zone_name = self.create_random_name('cliakstest', 16)
+        self.kwargs.update({
+            'resource_group': resource_group,
+            'name': aks_name,
+            'dns_zone_name': dns_zone_name,
+            'ssh_key_value': self.generate_ssh_keys()
+        })
+
+        create_cmd = 'aks create --resource-group={resource_group} --name={name} ' \
+                     '-a web_application_routing --ssh-key-value={ssh_key_value} -o json'
+        mc = self.cmd(create_cmd, checks=[
+            self.check('provisioningState', 'Succeeded'),
+            self.check('ingressProfile.webAppRouting.enabled', True),
+        ]).get_output_in_json()
+        web_app_routing_identity_obj_id = mc["ingressProfile"]["webAppRouting"]["identity"]["objectId"]
+
+        create_dns_zone_cmd = 'network dns zone create -g {resource_group} -n {dns_zone_name}'
+        dns_zone = self.cmd(create_dns_zone_cmd,checks=[
+            self.check('provisioningState', 'Succeeded'),
+        ]).get_output_in_json()
+        assert dns_zone['provisioningState'] == 'Succeeded'
+        dns_zone_id = dns_zone['id']
+
+        self.kwargs.update({ 'web_app_routing_identity_obj_id': web_app_routing_identity_obj_id, 'dns_zone_id': dns_zone_id })
+
+        role_assignment_cmd = 'role assignment create --role "DNS Zone Contributor" --assignee {web_app_routing_identity_obj_id} --scope {dns_zone_id}'
+        self.cmd(role_assignment_cmd)
+
+        addon_update_cmd = 'aks addon update -g {resource_group} -n {name} --addon web_application_routing --dns-zone-resource-id={dns_zone_id}'
+        self.cmd(addon_update_cmd, checks=[
+            self.check('provisioningState', 'Succeeded')
+        ])
+
+    @AllowLargeResponse()
+    @AKSCustomResourceGroupPreparer(random_name_length=17, name_prefix='clitest', location='westus2')
     def test_aks_create_with_keda(self, resource_group, resource_group_location):
         aks_name = self.create_random_name('cliakstest', 16)
         self.kwargs.update({

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -6089,6 +6089,7 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             # self.check('ingressProfile.webAppRouting.enabled', False)
         ])
 
+    @live_only()
     @AllowLargeResponse()
     @AKSCustomResourceGroupPreparer(random_name_length=17, name_prefix='clitest', location='westus2')
     def test_aks_create_and_update_web_application_routing_dns_zone(self, resource_group, resource_group_location):

--- a/src/aks-preview/setup.py
+++ b/src/aks-preview/setup.py
@@ -9,7 +9,7 @@ from codecs import open as open1
 
 from setuptools import setup, find_packages
 
-VERSION = "0.5.148"
+VERSION = "0.5.149"
 
 CLASSIFIERS = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

Fix unexpected error 'Addon "web_application_routing" is not enabled in this cluster' when trying to update the web app routing addon for an managed cluster that already has it enabled. PR forked from #6429, thanks to the contribution by @tg123. Fix issue [#3761](https://github.com/Azure/AKS/issues/3761).

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

`az aks addon update`

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
