### PR TITLE
{all services} service name mapping updates

### DIFF
--- a/src/service_name.json
+++ b/src/service_name.json
@@ -186,7 +186,7 @@
   },
   {
     "Command": "az dms",
-    "AzureServiceName": "Database Migration Services",
+    "AzureServiceName": "Data Migration",
     "URL": "https://learn.microsoft.com/azure/dms"
   },
   {
@@ -741,12 +741,12 @@
   },
   {
     "Command": "az amlfs",
-    "AzureServiceName": "Microsoft.StorageCache",
-    "URL": "https://learn.microsoft.com/en-us/azure/templates/microsoft.storagecache/amlfilesystems"
+    "AzureServiceName": "Storage Cache - AML file systems",
+    "URL": "https://learn.microsoft.com/en-us/azure/templates/microsoft.storagecache/amlfilesystems and https://learn.microsoft.com/en-us/rest/api/storagecache/aml-filesystems"
   },
   {
     "Command": "az graph-services",
-    "AzureServiceName": "Microsoft.GraphServices",
+    "AzureServiceName": "Graph Services",
     "URL": "https://learn.microsoft.com/en-us/rest/api/graphservices/"
   }
 ]


### PR DESCRIPTION
We have dropped "Azure" and "Microsoft" prefixes from our reference TOC.  This PR changes ....
**az dms**
**az amlfs**
- https://learn.microsoft.com/en-us/azure/templates/microsoft.storagecache/amlfilesystems
- https://learn.microsoft.com/en-us/rest/api/storagecache/aml-filesystems

**az graph-services**
- https://learn.microsoft.com/en-us/rest/api/graphservices/

**Reference TOC guidelines**
1.	Placement in the reference TOC should reflect customer search terms and patterns.  
2.	The reference TOC is organized by Azure service or product without the “Azure” or “Microsoft” prefix.
3.	The reference TOC organization is intended to help our customers answer the question: “What Azure CLI commands are available to me when working with [an Azure product]?”
