### PR TITLE
{AzureContainerApp} az containerapp create --bind "my-app" throws error when service has dashes in the name "-" 

### DIFF
--- a/src/containerapp/HISTORY.rst
+++ b/src/containerapp/HISTORY.rst
@@ -2,7 +2,7 @@
 
 Release History
 ===============
-0.3.37
+upcoming
 ++++++
 * 'az containerapp create': fix `InvalidArgumentValueError` exception when binding has `-` dash in its name.
 

--- a/src/containerapp/HISTORY.rst
+++ b/src/containerapp/HISTORY.rst
@@ -2,6 +2,10 @@
 
 Release History
 ===============
+0.3.37
+++++++
+* 'az containerapp create': fix `InvalidArgumentValueError` exception when binding has `-` dash in its name.
+
 0.3.36
 ++++++
 * 'az containerapp hostname bind': fix exception when not bringing --validation-method inputs

--- a/src/containerapp/azext_containerapp/_utils.py
+++ b/src/containerapp/azext_containerapp/_utils.py
@@ -467,7 +467,7 @@ def process_service(cmd, resource_list, service_name, arg_dict, subscription_id,
 
 
 def validate_binding_name(binding_name):
-    pattern = r'^(?=.{1,60}$)[a-zA-Z0-9._]+$'
+    pattern = r'^(?=.{1,60}$)[a-zA-Z0-9._-]+$'
     return bool(re.match(pattern, binding_name))
 
 

--- a/src/containerapp/setup.py
+++ b/src/containerapp/setup.py
@@ -28,7 +28,7 @@ except ImportError:
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
 
-VERSION = '0.3.37'
+VERSION = '0.3.36'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/src/containerapp/setup.py
+++ b/src/containerapp/setup.py
@@ -28,7 +28,7 @@ except ImportError:
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
 
-VERSION = '0.3.36'
+VERSION = '0.3.37'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
fixes Azure/azure-cli-extensions#6524

Container Apps lets me create a container with dashes ("-") in the name, but then I can't reference that container in the --bind parameter. so I expect the command to accept the service with a dash in the name because I was allowed to create it in the first place.



```
cli.azure.cli.core.azclierror: Traceback (most recent call last):
  File "D:\a\_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\knack/cli.py", line 233, in invoke
  File "D:\a\_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/commands/__init__.py", line 663, in execute
  File "D:\a\_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/commands/__init__.py", line 726, in _run_jobs_serially
  File "D:\a\_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/commands/__init__.py", line 718, in _run_job
  File "C:\Users\charris\.azure\cliextensions\containerapp\azext_containerapp\_client_factory.py", line 28, in _polish_bad_errors
    raise ex
  File "D:\a\_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/commands/__init__.py", line 697, in _run_job
  File "D:\a\_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/commands/__init__.py", line 333, in __call__
  File "D:\a\_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/commands/command_operation.py", line 121, in handler
  File "C:\Users\charris\.azure\cliextensions\containerapp\azext_containerapp\custom.py", line 627, in create_containerapp
    service_connectors_def_list, service_bindings_def_list = parse_service_bindings(cmd, service_bindings,
  File "C:\Users\charris\.azure\cliextensions\containerapp\azext_containerapp\_utils.py", line 542, in parse_service_bindings
    raise InvalidArgumentValueError("The Binding Name can only contain letters, numbers (0-9), periods ('.'), "
azure.cli.core.azclierror.InvalidArgumentValueError: The Binding Name can only contain letters, numbers (0-9), periods ('.'), and underscores ('_'). The length must not be more than 60 characters.

cli.azure.cli.core.azclierror: The Binding Name can only contain letters, numbers (0-9), periods ('.'), and underscores ('_'). The length must not be more than 60 characters.
az_command_data_logger: The Binding Name can only contain letters, numbers (0-9), periods ('.'), and underscores ('_'). The length must not be more than 60 characters.
cli.knack.cli: Event: Cli.PostExecute [<function AzCliLogging.deinit_cmd_metadata_logging at 0x048C0580>]

```



---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
