### PR TITLE
[SSH][Bug Fix] Error when user tries to download proxy for unsupported arm64 and not attempt to update service conf when user has no permission

### DIFF
--- a/src/ssh/HISTORY.md
+++ b/src/ssh/HISTORY.md
@@ -1,5 +1,10 @@
 Release History
 ===============
+2.0.1
+-----
+* [Bug fix] For connections to arc resources, stop attempting to create new service configuration if user has no permission to read service configuration.
+
+
 2.0.0
 -----
 * [BREAKING CHANGE] Update Microsoft.HybridConnectivity SDK to stable version, which adds functionality to enable SSH connections on specified ports in your Arc Server using an API, instead of enabling ports for connection locally in the Arc Agent running in the target machine. New connections might fail after updating the extension, since the port for connection will need to be enabled at the HybridConnectivity Resource Provider at the first connection attempt. This change doesn't affect those who use this extension to connect to Azure Virtual Machines.

--- a/src/ssh/azext_ssh/connectivity_utils.py
+++ b/src/ssh/azext_ssh/connectivity_utils.py
@@ -89,7 +89,7 @@ def _check_service_configuration(cmd, resource_uri, port):
         # is not setup correctly, the connection will fail.
         # The more likely scenario is that the request failed with a "Authorization Error",
         # in case the user isn't an owner/contributor.
-        return None
+        return True
     if port:
         return serviceConfig['port'] == int(port)
 

--- a/src/ssh/setup.py
+++ b/src/ssh/setup.py
@@ -7,7 +7,7 @@
 
 from setuptools import setup, find_packages
 
-VERSION = "2.0.0"
+VERSION = "2.0.1"
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',


### PR DESCRIPTION
- Small bug fix. Function that checked that target port matched allowed port for arc connections now returns true if user has no permission to read service config.
- Error when user tries to connect to arc from arm64 machine
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
