### PR TITLE
{CI} Fix command tree broken issue

### DIFF
--- a/scripts/ci/build_ext_cmd_tree.sh
+++ b/scripts/ci/build_ext_cmd_tree.sh
@@ -20,7 +20,15 @@ export AZURE_EXTENSION_INDEX_URL=https://raw.githubusercontent.com/Azure/azure-c
 output=$(az extension list-available --query [].name -otsv)
 # azure-cli-ml is replaced by ml
 # disable alias which relies on Jinja2 2.10
-blocklist=("azure-cli-ml" "alias")
+# -----------------------------------------------
+# When two extensions have the same command, the following error will be reported:
+# `Exception: Key: show already exists in containerapp. 2 extensions cannot have the same command!`
+# Temporarily skip the containerapp-preview extension,
+# Which will cause the containerapp-preview extension to be unable to use the dynamic load function.
+# That is, when using the unique command of containerapp-preview, the extension cannot be automatically prompted to install.
+# TODO: remove this after support for building dependencies in command index between extensions
+# -----------------------------------------------
+blocklist=("azure-cli-ml" "alias" "containerapp-preview")
 
 rm -f ~/.azure/extCmdTreeToUpload.json
 

--- a/scripts/ci/update_ext_cmd_tree.py
+++ b/scripts/ci/update_ext_cmd_tree.py
@@ -96,13 +96,6 @@ def upload_cmd_tree():
 
 if __name__ == '__main__':
     for ext in sys.argv[1:]:
-        # When two extensions have the same command, the following error will be reported:
-        # `Exception: Key: show already exists in containerapp. 2 extensions cannot have the same command!`
-        # Temporarily skip the containerapp-preview extension,
-        # Which will cause the containerapp-preview extension to be unable to use the dynamic load function.
-        # That is, when using the unique command of containerapp-preview, the extension cannot be automatically prompted to install.
-        # TODO: remove this after support for building dependencies in command index between extensions
-        if ext != 'containerapp-preview':
-            update_cmd_tree(ext)
-            print()
+        update_cmd_tree(ext)
+        print()
     upload_cmd_tree()

--- a/scripts/ci/update_ext_cmd_tree.py
+++ b/scripts/ci/update_ext_cmd_tree.py
@@ -96,6 +96,8 @@ def upload_cmd_tree():
 
 if __name__ == '__main__':
     for ext in sys.argv[1:]:
-        update_cmd_tree(ext)
-        print()
+        # Exception: Key: show already exists in containerapp. 2 extensions cannot have the same command!
+        if ext != 'containerapp-preview':
+            update_cmd_tree(ext)
+            print()
     upload_cmd_tree()

--- a/scripts/ci/update_ext_cmd_tree.py
+++ b/scripts/ci/update_ext_cmd_tree.py
@@ -96,7 +96,12 @@ def upload_cmd_tree():
 
 if __name__ == '__main__':
     for ext in sys.argv[1:]:
-        # Exception: Key: show already exists in containerapp. 2 extensions cannot have the same command!
+        # When two extensions have the same command, the following error will be reported:
+        # `Exception: Key: show already exists in containerapp. 2 extensions cannot have the same command!`
+        # Temporarily skip the containerapp-preview extension,
+        # Which will cause the containerapp-preview extension to be unable to use the dynamic load function.
+        # That is, when using the unique command of containerapp-preview, the extension cannot be automatically prompted to install.
+        # TODO: remove this after support for building dependencies in command index between extensions
         if ext != 'containerapp-preview':
             update_cmd_tree(ext)
             print()


### PR DESCRIPTION
---
When two extensions have the same command, the following error will be reported:
`Exception: Key: show already exists in containerapp. 2 extensions cannot have the same command!`
Temporarily skip the containerapp-preview extension to aviod this error.
Which will cause the containerapp-preview extension to be unable to use the dynamic load function.
That is, when using the unique command of containerapp-preview, the extension cannot be automatically prompted to install.


This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
