### PR TITLE
{CI} Mark ref doc test as continueOnError

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -155,6 +155,7 @@ jobs:
 
 - job: IndexRefDocVerify
   displayName: "Verify Ref Docs"
+  continueOnError: true
   pool:
     name: 'pool-ubuntu-2004'
   steps:


### PR DESCRIPTION
---
[Change Verify Ref Docs from full test to incremental test](https://github.com/Azure/azure-cli-extensions/pull/6581) is not a good solution.
Because if the extension is not in the azure-cli-extensions repo, it will never be tested.
But all extensions are independent of each other, we should not let an issue with one extension block other extensions.
So mark ref doc test as continueOnError so it will not block pull request from being merged.

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
