### PR TITLE
Bug fix for get-resource-id

### DIFF
--- a/src/connectedvmware/HISTORY.rst
+++ b/src/connectedvmware/HISTORY.rst
@@ -2,6 +2,9 @@
 
 Release History
 ===============
+0.2.1
+++++++
+* Bug fix for `get-resource-id` internal function, which was not honoring resource-group override.
 
 0.2.0
 ++++++

--- a/src/connectedvmware/azext_connectedvmware/vmware_utils.py
+++ b/src/connectedvmware/azext_connectedvmware/vmware_utils.py
@@ -99,9 +99,8 @@ def get_resource_id(
             )
         rid_parts.update(child_rid_parts)
 
-    rid_parts: dict[str, str] = {}
+    rid_parts: Dict[str, str] = {}
     rid_parts.update(
-        resource_group=resource_group,
         namespace=namespace,
         type=_type,
     )
@@ -169,6 +168,8 @@ def get_resource_id(
 
     if "subscription" not in rid_parts:
         rid_parts["subscription"] = get_subscription_id(cmd.cli_ctx)
+    if "resource_group" not in rid_parts:
+        rid_parts["resource_group"] = resource_group
 
     return resource_id(**rid_parts)
 

--- a/src/connectedvmware/azext_connectedvmware/vmware_utils_test.py
+++ b/src/connectedvmware/azext_connectedvmware/vmware_utils_test.py
@@ -43,7 +43,7 @@ class TestGetResourceId(unittest.TestCase):
                 "invalid/resource",
             )
 
-    def test_get_resource_id_with_child1_id(self):
+    def test_get_resource_id_with_child1_id_and_diff_rg(self):
         cmd = self._get_test_cmd()
 
         res_id = (
@@ -53,7 +53,7 @@ class TestGetResourceId(unittest.TestCase):
         )
         result = get_resource_id(
             cmd,
-            "contoso-rg",
+            "contoso-parent-rg",
             "Microsoft.HybridCompute",
             "Machines",
             None,

--- a/src/connectedvmware/setup.py
+++ b/src/connectedvmware/setup.py
@@ -19,7 +19,7 @@ except ImportError:
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
 
-VERSION = '0.2.0'
+VERSION = '0.2.1'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
There was a bug that was introduced in 0.2.0. The resource-group override was not getting honoured.
We are honouring it now.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
