### PR TITLE
[k8s-extension] Roll back k8s-extension to 1.4.3

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -39300,48 +39300,6 @@
                     "version": "1.4.3"
                 },
                 "sha256Digest": "a388796ad467016b71b0020ddc5a2ee1e9ebe51a41d6394dda5402e19b58abbd"
-            },
-            {
-                "downloadUrl": "https://azcliprod.blob.core.windows.net/cli-extensions/k8s_extension-1.4.4-py3-none-any.whl",
-                "filename": "k8s_extension-1.4.4-py3-none-any.whl",
-                "metadata": {
-                    "azext.minCliCoreVersion": "2.50.0",
-                    "classifiers": [
-                        "Development Status :: 4 - Beta",
-                        "Intended Audience :: Developers",
-                        "Intended Audience :: System Administrators",
-                        "Programming Language :: Python",
-                        "Programming Language :: Python :: 3",
-                        "Programming Language :: Python :: 3.6",
-                        "Programming Language :: Python :: 3.7",
-                        "Programming Language :: Python :: 3.8",
-                        "License :: OSI Approved :: MIT License"
-                    ],
-                    "extensions": {
-                        "python.details": {
-                            "contacts": [
-                                {
-                                    "email": "azpycli@microsoft.com",
-                                    "name": "Microsoft Corporation",
-                                    "role": "author"
-                                }
-                            ],
-                            "document_names": {
-                                "description": "DESCRIPTION.rst"
-                            },
-                            "project_urls": {
-                                "Home": "https://github.com/Azure/azure-cli-extensions/tree/main/src/k8s-extension"
-                            }
-                        }
-                    },
-                    "generator": "bdist_wheel (0.30.0)",
-                    "license": "MIT",
-                    "metadata_version": "2.0",
-                    "name": "k8s-extension",
-                    "summary": "Microsoft Azure Command-Line Tools K8s-extension Extension",
-                    "version": "1.4.4"
-                },
-                "sha256Digest": "f3b0e604ddb3d59323bceeecbc7cabe241e642a4ce20132e146306d15087ac93"
             }
         ],
         "k8sconfiguration": [


### PR DESCRIPTION
Rolling back k8s_extension extension to 1.4.3 [k8s_extension]

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
