### PR TITLE
Add CLI v2.20.0 to index

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -44567,6 +44567,94 @@
                     "version": "2.19.1"
                 },
                 "sha256Digest": "808df1eda155eb202579e88f8cd97ff2bdea8585a5562d84a7819e6d928dea9f"
+            },
+            {
+                "downloadUrl": "https://azuremlsdktestpypi.blob.core.windows.net/wheels/sdk-cli-v2-public/ml-2.20.0-py3-none-any.whl",
+                "filename": "ml-2.20.0-py3-none-any.whl",
+                "metadata": {
+                    "azext.minCliCoreVersion": "2.15.0",
+                    "classifiers": [
+                        "Development Status :: 5 - Production/Stable",
+                        "Intended Audience :: Developers",
+                        "Intended Audience :: System Administrators",
+                        "Environment :: Console",
+                        "Programming Language :: Python",
+                        "Programming Language :: Python :: 3",
+                        "Programming Language :: Python :: 3.7",
+                        "Programming Language :: Python :: 3.8",
+                        "Programming Language :: Python :: 3.9",
+                        "Programming Language :: Python :: 3.10",
+                        "License :: OSI Approved :: MIT License"
+                    ],
+                    "description_content_type": "text/x-rst",
+                    "extensions": {
+                        "python.details": {
+                            "contacts": [
+                                {
+                                    "email": "azuremlsdk@microsoft.com",
+                                    "name": "Microsoft Corporation",
+                                    "role": "author"
+                                }
+                            ],
+                            "document_names": {
+                                "description": "DESCRIPTION.rst"
+                            },
+                            "project_urls": {
+                                "Home": "https://github.com/Azure/azureml-examples"
+                            }
+                        }
+                    },
+                    "extras": [],
+                    "generator": "bdist_wheel (0.30.0)",
+                    "license": "MIT",
+                    "metadata_version": "2.0",
+                    "name": "ml",
+                    "run_requires": [
+                        {
+                            "requires": [
+                                "azure-common (<2.0.0,>=1.1)",
+                                "azure-common<2.0.0,>=1.1",
+                                "azure-mgmt-resource (<23.0.0,>=3.0.0)",
+                                "azure-mgmt-resource<23.0.0,>=3.0.0",
+                                "azure-mgmt-resourcegraph (<9.0.0,>=2.0.0)",
+                                "azure-mgmt-resourcegraph<9.0.0,>=2.0.0",
+                                "azure-storage-blob (<13.0.0,>=12.10.0)",
+                                "azure-storage-blob<13.0.0,>=12.10.0",
+                                "azure-storage-file-datalake (<13.0.0)",
+                                "azure-storage-file-datalake<13.0.0",
+                                "azure-storage-file-share (<13.0.0)",
+                                "azure-storage-file-share<13.0.0",
+                                "colorama (<0.5.0)",
+                                "colorama<0.5.0",
+                                "cryptography",
+                                "cryptography",
+                                "docker",
+                                "docker",
+                                "isodate",
+                                "isodate",
+                                "jsonschema (<5.0.0,>=4.0.0)",
+                                "jsonschema<5.0.0,>=4.0.0",
+                                "marshmallow (<4.0.0,>=3.5)",
+                                "marshmallow<4.0.0,>=3.5",
+                                "opencensus-ext-azure (<2.0.0)",
+                                "opencensus-ext-azure<2.0.0",
+                                "pydash (<6.0.0)",
+                                "pydash<6.0.0",
+                                "pyjwt (<3.0.0)",
+                                "pyjwt<3.0.0",
+                                "strictyaml (<2.0.0)",
+                                "strictyaml<2.0.0",
+                                "tqdm (<5.0.0)",
+                                "tqdm<5.0.0",
+                                "typing-extensions (<5.0.0)",
+                                "typing-extensions<5.0.0"
+                            ]
+                        }
+                    ],
+                    "summary": "Microsoft Azure Command-Line Tools AzureMachineLearningWorkspaces Extension",
+                    "version": "2.20.0"
+                },
+                "sha256Digest": "dab4fa8889574743328aafd4cccf06eb22ec21ca7407c8397238ce75c00b39c4"
             }
         ],
         "mobile-network": [


### PR DESCRIPTION
The result of running ` azdev extension update-index https://azuremlsdktestpypi.blob.core.windows.net/wheels/sdk-cli-v2-public/ml-2.20.0-py3-none-any.whl`

Adds a reference to the 2.20.0 whl to the extensions index.