### PR TITLE
[Spring] Use service fqdn to call logstream

### DIFF
--- a/src/spring/azext_spring/_log_stream.py
+++ b/src/spring/azext_spring/_log_stream.py
@@ -10,7 +10,10 @@ class LogStream:
     def __init__(self, client, resource_group, service):
         test_keys = client.services.list_test_keys(resource_group, service)
         self.primary_key = test_keys.primary_key
+        # non-legion arch:
         # https://primary:xxxx[key]@servicename.test.azuremicrosoervice.io -> servicename.azuremicroservice.io
+        # legion arch:
+        # https://primary:xxxx[key]@t.cert-name.region.azuremicrosoervice.io -> svc.cert-name.region.azuremicrosoervice.io
         test_url = test_keys.primary_test_endpoint
-        base_url = test_url.replace('.test.', '.')
+        base_url = test_url.replace('.test.', '.').replace('@t.', '@svc.')
         self.base_url = re.sub('https://.+?\@', '', base_url)

--- a/src/spring/azext_spring/_log_stream.py
+++ b/src/spring/azext_spring/_log_stream.py
@@ -3,17 +3,11 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-import re
-
 
 class LogStream:
     def __init__(self, client, resource_group, service):
         test_keys = client.services.list_test_keys(resource_group, service)
         self.primary_key = test_keys.primary_key
-        # non-legion arch:
-        # https://primary:xxxx[key]@servicename.test.azuremicrosoervice.io -> servicename.azuremicroservice.io
-        # legion arch:
-        # https://primary:xxxx[key]@t.cert-name.region.azuremicrosoervice.io -> svc.cert-name.region.azuremicrosoervice.io
-        test_url = test_keys.primary_test_endpoint
-        base_url = test_url.replace('.test.', '.').replace('@t.', '@svc.')
-        self.base_url = re.sub('https://.+?\@', '', base_url)
+
+        resource = client.services.get(resource_group, service)
+        self.base_url = resource.properties.fqdn


### PR DESCRIPTION
Previously, we get log stream url by modifying test endpoint. Just refactor it to use service fqdn directly in this PR.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
