### PR TITLE
Skip onboarding prechecks for AKS-HCI

### DIFF
--- a/src/connectedk8s/HISTORY.rst
+++ b/src/connectedk8s/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+1.4.1
+++++++
+* Skip Onboarding prechecks for AKS-HCI.
+
 1.4.0
 ++++++
 * Added support for reading ARM metadata 2022-09-01.

--- a/src/connectedk8s/azext_connectedk8s/custom.py
+++ b/src/connectedk8s/azext_connectedk8s/custom.py
@@ -161,12 +161,11 @@ def create_connectedk8s(cmd, client, resource_group_name, cluster_name, correlat
     is_aks_hci = os.getenv('IS_AKS_HCI')    # returns bool
 
     # Pre onboarding checks
-   
     try:
         kubectl_client_location = install_kubectl_client()
         helm_client_location = install_helm_client()
 
-        if not is_aks_hci:                  # if not aks hci perform pre-check 
+        if not is_aks_hci:                  # if not aks hci perform pre-check
             kubectl_client_location = install_kubectl_client()
             helm_client_location = install_helm_client()
             diagnostic_checks = "Failed"
@@ -197,7 +196,7 @@ def create_connectedk8s(cmd, client, resource_group_name, cluster_name, correlat
 
             if storage_space_available is False:
                 logger.warning("There is no storage space available on your device and hence not saving cluster diagnostic check logs on your device")
-        
+
     except Exception as e:
         telemetry.set_exception(exception="An exception has occured while trying to execute pre-onboarding diagnostic checks : {}".format(str(e)),
                                 fault_type=consts.Pre_Onboarding_Diagnostic_Checks_Execution_Failed, summary="An exception has occured while trying to execute pre-onboarding diagnostic checks : {}".format(str(e)))
@@ -212,7 +211,7 @@ def create_connectedk8s(cmd, client, resource_group_name, cluster_name, correlat
         raise ManualInterrupt('Process terminated externally.')
 
     # If the checks didnt pass then stop the onboarding
-    if diagnostic_checks != consts.Diagnostic_Check_Passed and is_aks_hci == False:
+    if diagnostic_checks != consts.Diagnostic_Check_Passed and is_aks_hci is False:
         if storage_space_available:
                 logger.warning("The pre-check result logs logs have been saved at this path:" + filepath_with_timestamp + " .\nThese logs can be attached while filing a support ticket for further assistance.\n")
         if(diagnostic_checks == consts.Diagnostic_Check_Incomplete):
@@ -222,9 +221,9 @@ def create_connectedk8s(cmd, client, resource_group_name, cluster_name, correlat
             telemetry.set_exception(exception='Cluster Diagnostic Prechecks Failed', fault_type=consts.Cluster_Diagnostic_Prechecks_Failed, summary="Cluster Diagnostic Prechecks Failed in the cluster")
             raise ValidationError("One or more pre-onboarding diagnostic checks failed and hence not proceeding with cluster onboarding. Please resolve them and try onboarding again.")
 
-    if is_aks_hci == False:
+    if is_aks_hci is False:
         print("The required pre-checks for onboarding have succeeded.")
-    else: 
+    else:
         print("skipped onboarding pre-checks for AKS-HCI.")
 
     if not required_node_exists:

--- a/src/connectedk8s/azext_connectedk8s/custom.py
+++ b/src/connectedk8s/azext_connectedk8s/custom.py
@@ -158,7 +158,7 @@ def create_connectedk8s(cmd, client, resource_group_name, cluster_name, correlat
 
     # check if this is AKS_HCI
     aks_hci = False
-    if distribution =='aks_workload' and infrastructure == 'azure_stack_hci':
+    if distribution == 'aks_workload' and infrastructure == 'azure_stack_hci':
         aks_hci = True
 
     # Install kubectl and helm

--- a/src/connectedk8s/azext_connectedk8s/custom.py
+++ b/src/connectedk8s/azext_connectedk8s/custom.py
@@ -155,39 +155,49 @@ def create_connectedk8s(cmd, client, resource_group_name, cluster_name, correlat
     is_arm64_cluster = check_arm64_node(node_api_response)
 
     required_node_exists = check_linux_node(node_api_response)
+
+    # check if this is AKS_HCI
+    is_aks_hci = False
+    is_aks_hci = os.getenv('IS_AKS_HCI')    # returns bool
+
     # Pre onboarding checks
+   
     try:
         kubectl_client_location = install_kubectl_client()
         helm_client_location = install_helm_client()
-        diagnostic_checks = "Failed"
-        batchv1_api_instance = kube_client.BatchV1Api()
-        storage_space_available = True
 
-        current_time = time.ctime(time.time())
-        time_stamp = ""
-        for elements in current_time:
-            if(elements == ' '):
-                time_stamp += '-'
-                continue
-            elif(elements == ':'):
-                time_stamp += '.'
-                continue
-            time_stamp += elements
-        time_stamp = cluster_name + '-' + time_stamp
+        if not is_aks_hci:                  # if not aks hci perform pre-check 
+            kubectl_client_location = install_kubectl_client()
+            helm_client_location = install_helm_client()
+            diagnostic_checks = "Failed"
+            batchv1_api_instance = kube_client.BatchV1Api()
+            storage_space_available = True
 
-        # Generate the diagnostic folder in a given location
-        filepath_with_timestamp, diagnostic_folder_status = utils.create_folder_diagnosticlogs(time_stamp, consts.Pre_Onboarding_Check_Logs)
+            current_time = time.ctime(time.time())
+            time_stamp = ""
+            for elements in current_time:
+                if(elements == ' '):
+                    time_stamp += '-'
+                    continue
+                elif(elements == ':'):
+                    time_stamp += '.'
+                    continue
+                time_stamp += elements
+            time_stamp = cluster_name + '-' + time_stamp
 
-        if(diagnostic_folder_status is not True):
-            storage_space_available = False
+            # Generate the diagnostic folder in a given location
+            filepath_with_timestamp, diagnostic_folder_status = utils.create_folder_diagnosticlogs(time_stamp, consts.Pre_Onboarding_Check_Logs)
 
-        # Performing cluster-diagnostic-checks
-        diagnostic_checks, storage_space_available = precheckutils.fetch_diagnostic_checks_results(api_instance, batchv1_api_instance, helm_client_location, kubectl_client_location, kube_config, kube_context, location, http_proxy, https_proxy, no_proxy, proxy_cert, azure_cloud, filepath_with_timestamp, storage_space_available)
-        precheckutils.fetching_cli_output_logs(filepath_with_timestamp, storage_space_available, 1)
+            if(diagnostic_folder_status is not True):
+                storage_space_available = False
 
-        if storage_space_available is False:
-            logger.warning("There is no storage space available on your device and hence not saving cluster diagnostic check logs on your device")
+            # Performing cluster-diagnostic-checks
+            diagnostic_checks, storage_space_available = precheckutils.fetch_diagnostic_checks_results(api_instance, batchv1_api_instance, helm_client_location, kubectl_client_location, kube_config, kube_context, location, http_proxy, https_proxy, no_proxy, proxy_cert, azure_cloud, filepath_with_timestamp, storage_space_available)
+            precheckutils.fetching_cli_output_logs(filepath_with_timestamp, storage_space_available, 1)
 
+            if storage_space_available is False:
+                logger.warning("There is no storage space available on your device and hence not saving cluster diagnostic check logs on your device")
+        
     except Exception as e:
         telemetry.set_exception(exception="An exception has occured while trying to execute pre-onboarding diagnostic checks : {}".format(str(e)),
                                 fault_type=consts.Pre_Onboarding_Diagnostic_Checks_Execution_Failed, summary="An exception has occured while trying to execute pre-onboarding diagnostic checks : {}".format(str(e)))
@@ -202,7 +212,7 @@ def create_connectedk8s(cmd, client, resource_group_name, cluster_name, correlat
         raise ManualInterrupt('Process terminated externally.')
 
     # If the checks didnt pass then stop the onboarding
-    if diagnostic_checks != consts.Diagnostic_Check_Passed:
+    if diagnostic_checks != consts.Diagnostic_Check_Passed and is_aks_hci == False:
         if storage_space_available:
                 logger.warning("The pre-check result logs logs have been saved at this path:" + filepath_with_timestamp + " .\nThese logs can be attached while filing a support ticket for further assistance.\n")
         if(diagnostic_checks == consts.Diagnostic_Check_Incomplete):
@@ -212,7 +222,10 @@ def create_connectedk8s(cmd, client, resource_group_name, cluster_name, correlat
             telemetry.set_exception(exception='Cluster Diagnostic Prechecks Failed', fault_type=consts.Cluster_Diagnostic_Prechecks_Failed, summary="Cluster Diagnostic Prechecks Failed in the cluster")
             raise ValidationError("One or more pre-onboarding diagnostic checks failed and hence not proceeding with cluster onboarding. Please resolve them and try onboarding again.")
 
-    print("The required pre-checks for onboarding have succeeded.")
+    if is_aks_hci == False:
+        print("The required pre-checks for onboarding have succeeded.")
+    else: 
+        print("skipped onboarding pre-checks for AKS-HCI.")
 
     if not required_node_exists:
         telemetry.set_user_fault()

--- a/src/connectedk8s/azext_connectedk8s/custom.py
+++ b/src/connectedk8s/azext_connectedk8s/custom.py
@@ -174,7 +174,7 @@ def create_connectedk8s(cmd, client, resource_group_name, cluster_name, correlat
     # Pre onboarding checks
     try:
         # if aks_hci skip, otherwise continue to perform pre-onboarding check
-        if not aks_hci:                  
+        if not aks_hci:
             diagnostic_checks = "Failed"
             batchv1_api_instance = kube_client.BatchV1Api()
             storage_space_available = True

--- a/src/connectedk8s/setup.py
+++ b/src/connectedk8s/setup.py
@@ -17,7 +17,7 @@ except ImportError:
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
 
-VERSION = '1.4.0'
+VERSION = '1.4.1'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/src/index.json
+++ b/src/index.json
@@ -46432,6 +46432,49 @@
                     "version": "1.0.0b1"
                 },
                 "sha256Digest": "6c6856f9af7e57202a063c072e23b88bc6d337a5a7440c43cc9e01fa6833533e"
+            },
+            {
+                "downloadUrl": "https://azcliprod.blob.core.windows.net/cli-extensions/palo_alto_networks-1.1.0-py3-none-any.whl",
+                "filename": "palo_alto_networks-1.1.0-py3-none-any.whl",
+                "metadata": {
+                    "azext.isPreview": true,
+                    "azext.minCliCoreVersion": "2.51.0",
+                    "classifiers": [
+                        "Development Status :: 4 - Beta",
+                        "Intended Audience :: Developers",
+                        "Intended Audience :: System Administrators",
+                        "Programming Language :: Python",
+                        "Programming Language :: Python :: 3",
+                        "Programming Language :: Python :: 3.7",
+                        "Programming Language :: Python :: 3.8",
+                        "Programming Language :: Python :: 3.9",
+                        "License :: OSI Approved :: MIT License"
+                    ],
+                    "extensions": {
+                        "python.details": {
+                            "contacts": [
+                                {
+                                    "email": "azpycli@microsoft.com",
+                                    "name": "Microsoft Corporation",
+                                    "role": "author"
+                                }
+                            ],
+                            "document_names": {
+                                "description": "DESCRIPTION.rst"
+                            },
+                            "project_urls": {
+                                "Home": "https://github.com/Azure/azure-cli-extensions/tree/main/src/palo-alto-networks"
+                            }
+                        }
+                    },
+                    "generator": "bdist_wheel (0.30.0)",
+                    "license": "MIT",
+                    "metadata_version": "2.0",
+                    "name": "palo-alto-networks",
+                    "summary": "Microsoft Azure Command-Line Tools PaloAltoNetworks Extension.",
+                    "version": "1.1.0"
+                },
+                "sha256Digest": "1b6cab4a32956fd1a7ec4c50c41d0b8393d2e3371ac827b8aa3f4f2ad5616fe1"
             }
         ],
         "partnercenter": [


### PR DESCRIPTION
In this PR, I check if the infrastructure and distribution is AKS-HCI. If its AKS-HCI, I am skipping the Pre-onboarding checks to accommodate the low bandwidth networks they run on. This PR will be an immediate fix for multiple customer issues. We keep the pre-onboarding checks intact for all the other infra and distros. 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
az connectedk8s connect 

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- Performed the azdev style, test and lint locally. 
- Also performed the azdev build to build a local .whl file. 
