### PR TITLE
removed az stack-hci-fm

### DIFF
--- a/src/service_name.json
+++ b/src/service_name.json
@@ -530,11 +530,6 @@
     "URL": "https://learn.microsoft.com/azure-stack/hci"
   },
   {
-    "Command": "az stack-hci-vm",
-    "AzureServiceName": "Stack HCI VM",
-    "URL": "https://learn.microsoft.com/en-us/azure-stack/hci/manage/azure-arc-vm-management-overview"
-  },
-  {
     "Command": "az staticwebapp",
     "AzureServiceName": "App Services",
     "URL": "https://learn.microsoft.com/azure/static-web-apps/"


### PR DESCRIPTION
`az stack-hci-vm` is in private preview and will not be published until end of October / early November.  Although this should never have been a top-level node, it was entered this way and therefore causes an empty node as seen here:

![image](https://github.com/Azure/azure-cli-extensions/assets/58762114/acfb84a3-679e-40c3-a24e-bec76ba7b732)
