### PR TITLE
configures survey messages and telemetry

### DIFF
--- a/src/init/HISTORY.rst
+++ b/src/init/HISTORY.rst
@@ -3,6 +3,12 @@
 Release History
 ===============
 
+0.2.0
+++++++
+* Adds support for core.survey_message
+* Adds support for core.collect_telemetry
+* Adds support for auto-upgrade.enable=false for automation
+
 0.1.0
 ++++++
 * Initial release.

--- a/src/init/azext_init/_bundles.py
+++ b/src/init/azext_init/_bundles.py
@@ -33,6 +33,11 @@ BUILD_IN_INTERACTION_BUNDLES = [
         "brief": "Enable the survey prompts",
         "configuration": "core.survey_message",
         "value": "true",
+    },
+    {
+        "brief": "Collect telemetry",
+        "configuration": "core.collect_telemetry",
+        "value": "true",
     }
 ]
 
@@ -66,5 +71,10 @@ BUILD_IN_AUTOMATION_BUNDLES = [
         "brief": "Disable the survey prompts",
         "configuration": "core.survey_message",
         "value": "falso",
+    },
+    {
+        "brief": "Do not collect telemetry",
+        "configuration": "core.collect_telemetry",
+        "value": "false",
     }
 ]

--- a/src/init/azext_init/_bundles.py
+++ b/src/init/azext_init/_bundles.py
@@ -70,7 +70,7 @@ BUILD_IN_AUTOMATION_BUNDLES = [
     {
         "brief": "Disable the survey prompts",
         "configuration": "core.survey_message",
-        "value": "falso",
+        "value": "false",
     },
     {
         "brief": "Do not collect telemetry",

--- a/src/init/azext_init/_bundles.py
+++ b/src/init/azext_init/_bundles.py
@@ -28,6 +28,11 @@ BUILD_IN_INTERACTION_BUNDLES = [
         "brief": "Display a progress bar for long running commands",
         "configuration": "core.disable_progress_bar",
         "value": "false",
+    },
+    {
+        "brief": "Enable the survey prompts",
+        "configuration": "core.survey_message",
+        "value": "true",
     }
 ]
 
@@ -56,5 +61,10 @@ BUILD_IN_AUTOMATION_BUNDLES = [
         "brief": "Display progress bar for long running commands",
         "configuration": "core.disable_progress_bar",
         "value": "true",
+    },
+    {
+        "brief": "Disable the survey prompts",
+        "configuration": "core.survey_message",
+        "value": "falso",
     }
 ]

--- a/src/init/azext_init/_bundles.py
+++ b/src/init/azext_init/_bundles.py
@@ -38,6 +38,11 @@ BUILD_IN_INTERACTION_BUNDLES = [
         "brief": "Collect telemetry",
         "configuration": "core.collect_telemetry",
         "value": "true",
+    },
+    {
+        "brief": "Enable auto-upgrade",
+        "configuration": "auto-upgrade.enable",
+        "value": "true",
     }
 ]
 
@@ -75,6 +80,11 @@ BUILD_IN_AUTOMATION_BUNDLES = [
     {
         "brief": "Do not collect telemetry",
         "configuration": "core.collect_telemetry",
+        "value": "false",
+    },
+    {
+        "brief": "Disable auto-upgrade",
+        "configuration": "auto-upgrade.enable",
         "value": "false",
     }
 ]

--- a/src/init/azext_init/_configs.py
+++ b/src/init/azext_init/_configs.py
@@ -138,5 +138,23 @@ WALK_THROUGH_CONFIG_LIST = [
                 "desc": "Survey links will never be shown"
             }
         ]
+    },
+    {
+        "configuration": "core.collect_telemetry",
+        "brief": "Collect Telemetry",
+        "description": "This option is used to enable/disable telemetry",
+        "options": [
+            {
+                "option": "On",
+                "value": "true",
+                "desc": "Telemetry will be colected",
+                "tag": "default"
+            },
+            {
+                "option": "Off",
+                "value": "false",
+                "desc": "Telemetry will not be collected"
+            }
+        ]
     }
 ]

--- a/src/init/azext_init/_configs.py
+++ b/src/init/azext_init/_configs.py
@@ -120,5 +120,23 @@ WALK_THROUGH_CONFIG_LIST = [
                 "desc": "Disable the progress bar during long running commands"
             }
         ]
+    },
+    {
+        "configuration": "core.survey_message",
+        "brief": "PSurvey Message",
+        "description": "This option is used to enable/disable the survey message",
+        "options": [
+            {
+                "option": "On",
+                "value": "true",
+                "desc": "The survey link will be shown",
+                "tag": "default"
+            },
+            {
+                "option": "Off",
+                "value": "false",
+                "desc": "Survey links will never be shown"
+            }
+        ]
     }
 ]

--- a/src/init/azext_init/_configs.py
+++ b/src/init/azext_init/_configs.py
@@ -123,7 +123,7 @@ WALK_THROUGH_CONFIG_LIST = [
     },
     {
         "configuration": "core.survey_message",
-        "brief": "PSurvey Message",
+        "brief": "Survey Message",
         "description": "This option is used to enable/disable the survey message",
         "options": [
             {

--- a/src/init/azext_init/_configs.py
+++ b/src/init/azext_init/_configs.py
@@ -156,5 +156,23 @@ WALK_THROUGH_CONFIG_LIST = [
                 "desc": "Telemetry will not be collected"
             }
         ]
+    },
+    {
+        "configuration": "auto-upgrade.enable",
+        "brief": "Automaticaly upgrade",
+        "description": "This option is used to enable/disable auto-upgrade",
+        "options": [
+            {
+                "option": "enable",
+                "value": "true",
+                "desc": "Auto-upgrade enabled",
+                "tag": "default"
+            },
+            {
+                "option": "disable",
+                "value": "false",
+                "desc": "Auto-upgrade disabled"
+            }
+        ]
     }
 ]

--- a/src/init/setup.py
+++ b/src/init/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
-VERSION = '0.1.0'
+VERSION = '0.2.0'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
Adds settings for `[core.survey_message](https://github.com/Azure/azure-cli/issues/25242)` and `core.collect_telemetry` to `az init`.
Adds the following defaults:

 * Manual Mode
   * Survey=on
   * Telemetry=on
   * Auto-update=on
 * Automation Mode
   * Survey=off
   * Telemetry=off 
   * Auto-update=off


### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [x] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
