### PR TITLE
Get Custom Locations RP app by object id

### DIFF
--- a/src/connectedk8s/HISTORY.rst
+++ b/src/connectedk8s/HISTORY.rst
@@ -3,6 +3,21 @@
 Release History
 ===============
 
+2.0.0
+++++++
+* Look up custom locations service principal application by object ID instead of display name.
+
+  Previous command
+    ``az connectedk8s enable-features -n <cluster name> -g <resource group name> --features custom-locations``
+  New command
+    ``az connectedk8s enable-features -n <cluster name> -g <resource group name> --features custom-locations --custom-locations-oid <custom locations object ID>``
+  Before
+    | Throws an error if it cannot retrieve the Custom Locations RP service principal application using the graph API.
+    | Error: ``Unable to fetch the Object ID of the Azure AD application used by Azure Arc service. Unable to enable the 'custom-locations' feature. Insufficient privileges to complete the operation.``
+  After
+    | Throws an error if the user didn't pass custom locations object ID.
+    | Error: ``Custom locations object ID was not passed. Please pass '--custom-locations-oid' to enable custom locations.``
+
 1.5.4
 ++++++
 * Log debug if 'arcConfigEndpoint' doesn't exist in 'dataplaneEndpoints' ARM metadata.

--- a/src/connectedk8s/azext_connectedk8s/_params.py
+++ b/src/connectedk8s/azext_connectedk8s/_params.py
@@ -83,7 +83,7 @@ def load_arguments(self, _):
         c.argument('azrbac_client_id', options_list=['--app-id'], arg_group='Azure RBAC', help='Application ID for enabling Azure RBAC. Specify when enabling azure-rbac.')
         c.argument('azrbac_client_secret', options_list=['--app-secret'], arg_group='Azure RBAC', help='Application secret for enabling Azure RBAC. Specify when enabling azure-rbac.')
         c.argument('azrbac_skip_authz_check', options_list=['--skip-azure-rbac-list'], arg_group='Azure RBAC', help='Comma separated list of names of usernames/email/oid. Azure RBAC will be skipped for these users. Specify when enabling azure-rbac.')
-        c.argument('cl_oid', options_list=['--custom-locations-oid'], help="OID of 'custom-locations' app")
+        c.argument('cl_oid', options_list=['--custom-locations-oid'], help="Object ID of 'custom-locations' app")
 
     with self.argument_context('connectedk8s disable-features') as c:
         c.argument('cluster_name', options_list=['--name', '-n'], id_part='name', help='The name of the connected cluster.')

--- a/src/connectedk8s/azext_connectedk8s/_utils.py
+++ b/src/connectedk8s/azext_connectedk8s/_utils.py
@@ -569,8 +569,8 @@ def cleanup_release_install_namespace_if_exists():
 # DO NOT use this method for re-put scenarios. This method involves new NS creation for helm release. For re-put scenarios, brownfield scenario needs to be handled where helm release still stays in default NS
 def helm_install_release(resource_manager, chart_path, subscription_id, kubernetes_distro, kubernetes_infra, resource_group_name,
                          cluster_name, location, onboarding_tenant_id, http_proxy, https_proxy, no_proxy, proxy_cert, private_key_pem,
-                         kube_config, kube_context, no_wait, values_file, cloud_name, disable_auto_upgrade, enable_custom_locations,
-                         custom_locations_oid, helm_client_location, enable_private_link, arm_metadata, onboarding_timeout="600",
+                         kube_config, kube_context, no_wait, values_file, cloud_name, disable_auto_upgrade, custom_locations_oid,
+                         helm_client_location, enable_private_link, arm_metadata, onboarding_timeout="600",
                          container_log_path=None):
 
     cmd_helm_install = [helm_client_location, "upgrade", "--install", "azure-arc", chart_path,
@@ -614,7 +614,7 @@ def helm_install_release(resource_manager, chart_path, subscription_id, kubernet
             logger.debug("'arcConfigEndpoint' doesn't exist under 'dataplaneEndpoints' in the ARM metadata.")
 
     # Add custom-locations related params
-    if enable_custom_locations and not enable_private_link:
+    if custom_locations_oid is not None and not enable_private_link:
         cmd_helm_install.extend(["--set", "systemDefaultValues.customLocations.enabled=true"])
         cmd_helm_install.extend(["--set", "systemDefaultValues.customLocations.oid={}".format(custom_locations_oid)])
     # Disable cluster connect if private link is enabled

--- a/src/connectedk8s/azext_connectedk8s/custom.py
+++ b/src/connectedk8s/azext_connectedk8s/custom.py
@@ -34,6 +34,7 @@ from azure.cli.core._profile import Profile
 from azure.cli.core.util import sdk_no_wait
 from azure.cli.core import telemetry
 from azure.cli.core.azclierror import ManualInterrupt, InvalidArgumentValueError, UnclassifiedUserFault, CLIInternalError, FileOperationError, ClientRequestError, DeploymentError, ValidationError, ArgumentUsageError, MutuallyExclusiveArgumentError, RequiredArgumentMissingError, ResourceNotFoundError
+from azure.graphrbac.models import GraphErrorException
 from azure.core.exceptions import HttpResponseError
 from kubernetes import client as kube_client, config
 from Crypto.IO import PEM
@@ -406,15 +407,15 @@ def create_connectedk8s(cmd, client, resource_group_name, cluster_name, correlat
     put_cc_response = create_cc_resource(client, resource_group_name, cluster_name, cc, no_wait)
     put_cc_response = LongRunningOperation(cmd.cli_ctx)(put_cc_response)
     print("Azure resource provisioning has finished.")
-    # Checking if custom locations rp is registered and fetching oid if it is registered
-    enable_custom_locations, custom_locations_oid = check_cl_registration_and_get_oid(cmd, cl_oid, subscription_id)
+    # Check if the custom locations RP is registered and attempt to verify passed-in cl_oid.
+    test_custom_location_requirements(cmd, cl_oid, subscription_id)
 
     print("Starting to install Azure arc agents on the Kubernetes cluster.")
     # Install azure-arc agents
     utils.helm_install_release(cmd.cli_ctx.cloud.endpoints.resource_manager, chart_path, subscription_id, kubernetes_distro, kubernetes_infra, resource_group_name, cluster_name,
                                location, onboarding_tenant_id, http_proxy, https_proxy, no_proxy, proxy_cert, private_key_pem, kube_config,
-                               kube_context, no_wait, values_file, azure_cloud, disable_auto_upgrade, enable_custom_locations,
-                               custom_locations_oid, helm_client_location, enable_private_link, arm_metadata, onboarding_timeout, container_log_path)
+                               kube_context, no_wait, values_file, azure_cloud, disable_auto_upgrade, cl_oid, helm_client_location,
+                               enable_private_link, arm_metadata, onboarding_timeout, container_log_path)
     return put_cc_response
 
 
@@ -1398,22 +1399,21 @@ def enable_features(cmd, client, resource_group_name, cluster_name, features, ku
     if enable_azure_rbac:
         if (azrbac_client_id is None) or (azrbac_client_secret is None):
             telemetry.set_exception(exception='Application ID or secret is not provided for Azure RBAC', fault_type=consts.Application_Details_Not_Provided_For_Azure_RBAC_Fault,
-                                    summary='Application id, application secret is required to enable/update Azure RBAC feature')
-            raise RequiredArgumentMissingError("Please provide Application id, application secret to enable/update Azure RBAC feature")
+                                    summary='Application ID, application secret is required to enable/update Azure RBAC feature')
+            raise RequiredArgumentMissingError("Please provide Application ID, application secret to enable/update Azure RBAC feature")
         if azrbac_skip_authz_check is None:
             azrbac_skip_authz_check = ""
         azrbac_skip_authz_check = escape_proxy_settings(azrbac_skip_authz_check)
 
     if enable_cl:
+        if cl_oid is None:
+            raise RequiredArgumentMissingError("Custom locations object ID was not passed. Please pass '--custom-locations-oid' to enable custom locations.")
         subscription_id = os.getenv('AZURE_SUBSCRIPTION_ID') if custom_token_passed is True else get_subscription_id(cmd.cli_ctx)
-        enable_cl, custom_locations_oid = check_cl_registration_and_get_oid(cmd, cl_oid, subscription_id)
-        if not enable_cluster_connect and enable_cl:
+        # The following throws an error if custom location requirements are not met since user expects to use custom locations.
+        test_custom_location_requirements(cmd, cl_oid, subscription_id)
+        if not enable_cluster_connect:
             enable_cluster_connect = True
             logger.warning("Enabling 'custom-locations' feature will enable 'cluster-connect' feature too.")
-        if not enable_cl:
-            features.remove("custom-locations")
-            if len(features) == 0:
-                raise ClientRequestError("Failed to enable 'custom-locations' feature.")
 
     # Send cloud information to telemetry
     send_cloud_telemetry(cmd)
@@ -1494,7 +1494,7 @@ def enable_features(cmd, client, resource_group_name, cluster_name, features, ku
         cmd_helm_upgrade.extend(["--set", "systemDefaultValues.clusterconnect-agent.enabled=true"])
     if enable_cl:
         cmd_helm_upgrade.extend(["--set", "systemDefaultValues.customLocations.enabled=true"])
-        cmd_helm_upgrade.extend(["--set", "systemDefaultValues.customLocations.oid={}".format(custom_locations_oid)])
+        cmd_helm_upgrade.extend(["--set", "systemDefaultValues.customLocations.oid={}".format(cl_oid)])
 
     response_helm_upgrade = Popen(cmd_helm_upgrade, stdout=PIPE, stderr=PIPE)
     _, error_helm_upgrade = response_helm_upgrade.communicate()
@@ -2169,62 +2169,57 @@ def client_side_proxy(cmd,
     return expiry, clientproxy_process
 
 
-def check_cl_registration_and_get_oid(cmd, cl_oid, subscription_id):
-    enable_custom_locations = True
-    custom_locations_oid = ""
+def test_custom_location_requirements(cmd, cl_oid, subscription_id):
+    # Checking if custom locations rp is registered and verify passed-in cl_oid.
+    if cl_oid is not None:
+        if not extended_location_registered(cmd, subscription_id):
+            raise ResourceNotFoundError("Custom locations object ID was passed, but Microsoft.ExtendedLocation is not registered. Please register it and run again.")
+        custom_locations_oid_valid(cmd, cl_oid)
+    else:
+        logger.warning("Won't enable custom locations feature as parameter '--custom-locations-oid' wasn't passed. Learn more at https://aka.ms/CustomLocationsObjectID")
+
+
+def extended_location_registered(cmd, subscription_id):
     try:
         rp_client = resource_providers_client(cmd.cli_ctx, subscription_id)
         cl_registration_state = rp_client.get(consts.Custom_Locations_Provider_Namespace).registration_state
-        if cl_registration_state != "Registered":
-            enable_custom_locations = False
-            logger.warning("'Custom-locations' feature couldn't be enabled on this cluster as the pre-requisite registration of 'Microsoft.ExtendedLocation' was not met. More details for enabling this feature later on this cluster can be found here - https://aka.ms/EnableCustomLocations")
-        else:
-            custom_locations_oid = get_custom_locations_oid(cmd, cl_oid)
-            if custom_locations_oid == "":
-                enable_custom_locations = False
     except Exception as e:
-        enable_custom_locations = False
-        logger.warning("Unable to fetch registration state of 'Microsoft.ExtendedLocation'. Failed to enable 'custom-locations' feature. This is fine if not required. Proceeding with helm install.")
+        logger.warning("Unable to fetch registration state of 'Microsoft.ExtendedLocation'. Failed to enable 'custom-locations' feature.")
         telemetry.set_exception(exception=e, fault_type=consts.Custom_Locations_Registration_Check_Fault_Type,
                                 summary='Unable to fetch status of Custom Locations RP registration.')
-    return enable_custom_locations, custom_locations_oid
+        raise
+    if cl_registration_state != "Registered":
+        logger.warning("Custom locations couldn't be enabled on this cluster as 'Microsoft.ExtendedLocation' is not registered. More details for enabling this feature can be found here: https://aka.ms/EnableCustomLocations")
+        return False
+    return True
 
 
-def get_custom_locations_oid(cmd, cl_oid):
+def custom_locations_oid_valid(cmd, cl_oid):
+    if cl_oid is None:
+        raise RequiredArgumentMissingError("The passed in custom locations object ID is None. Please pass in the custom locations object ID to verify.")
     try:
+        # WARNING: Graph requires new permissions for users. Users currently don't expect to need graph permission to use connectedk8s.
+        # If there is an error, warn users and continue execution. Therefore, users' passed-in object ID are verifiable only if
+        # the current Azure CLI user also has graph permission to read applications from the graph directory. So, verification of application
+        # object ID will be a courtesy and not required for continuing execution.
         sp_graph_client = get_graph_client_service_principals(cmd.cli_ctx)
-        sub_filters = []
-        sub_filters.append("displayName eq '{}'".format("Custom Locations RP"))
-        result = list(sp_graph_client.list(filter=(' and '.join(sub_filters))))
-        if len(result) != 0:
-            if cl_oid is not None and cl_oid != result[0].object_id:
-                logger.debug("The 'Custom-locations' OID passed is different from the actual OID({}) of the Custom Locations RP app. Proceeding with the correct one...".format(result[0].object_id))
-            return result[0].object_id  # Using the fetched OID
-
-        if cl_oid is None:
-            logger.warning("Failed to enable Custom Locations feature on the cluster. Unable to fetch Object ID of Azure AD application used by Azure Arc service. Try enabling the feature by passing the --custom-locations-oid parameter directly. Learn more at https://aka.ms/CustomLocationsObjectID")
-            telemetry.set_exception(exception='Unable to fetch oid of custom locations app.', fault_type=consts.Custom_Locations_OID_Fetch_Fault_Type,
-                                    summary='Unable to fetch oid for custom locations app.')
-            return ""
-        else:
-            return cl_oid
-    except Exception as e:
-        log_string = "Unable to fetch the Object ID of the Azure AD application used by Azure Arc service. "
+        # Do not use display names for look-up as display names are not unique.
+        result = sp_graph_client.get(cl_oid)
+        logger.debug("Retrieved SP app named '%s' for object ID %s.", result.display_name, cl_oid)
+    except GraphErrorException as e:
+        warning = (
+            f"Failed to validate custom locations service principal application with object ID {cl_oid}. Reason:\n{str(e)}\n"
+            "This could be because your admin didn't grant you the graph API permission to read applications from the graph directory.\n"
+            "If there are any future custom location errors, verify that the Custom Locations RP application object ID is valid."
+        )
+        logger.warning("%s", warning)
+        logger.warning("Continuing execution using the provided object ID '%s' to enable custom locations feature.", cl_oid)
         telemetry.set_exception(exception=e, fault_type=consts.Custom_Locations_OID_Fetch_Fault_Type,
-                                summary='Unable to fetch oid for custom locations app.')
-        if cl_oid:
-            log_string += "Proceeding with the Object ID provided to enable the 'custom-locations' feature."
-            logger.warning(log_string)
-            return cl_oid
-        log_string += "Unable to enable the 'custom-locations' feature. " + str(e)
-        logger.warning(log_string)
-        return ""
+                                summary=warning)
 
 
 def troubleshoot(cmd, client, resource_group_name, cluster_name, kube_config=None, kube_context=None, no_wait=False, tags=None):
-
     try:
-
         logger.warning("Diagnoser running. This may take a while ...\n")
         absolute_path = os.path.abspath(os.path.dirname(__file__))
 

--- a/src/connectedk8s/azext_connectedk8s/tests/latest/README.md
+++ b/src/connectedk8s/azext_connectedk8s/tests/latest/README.md
@@ -5,6 +5,18 @@ Tests need to be configured before running.
 1. Fill in the details of the newly created `config.json` file:
     - Note that the code doesn't verify that you have a valid RBAC service principal application, so a fake one can be used for testing.
     - `customLocationsOid`: The custom locations RP service principal object ID for enabling the custom locations feature.
+        - Getting an object ID: Search for required application details via AAD graph with the following `$filter` query in az rest in PowerShell (make sure to fill in the tenant id):
+        - Filter by starts with:
+            ```powershell
+            az rest --method get --url "https://graph.windows.net/<tenant id>/servicePrincipals?`$filter=startswith(displayName,'Custom Locations')&api-version=1.6"
+            ```
+        - Filter by exact value:
+            ```powershell
+            az rest --method get --url "https://graph.windows.net/<tenant id>/servicePrincipals?`$filter=appId eq '<app id>'&api-version=1.6"
+            ```
+        - For more information about AAD graph queries:
+            - https://learn.microsoft.com/en-us/graph/filter-query-parameter?tabs=http
+            - https://learn.microsoft.com/en-us/graph/migrate-azure-ad-graph-request-differences
     - `rbacAppId`: The RBAC service principal app ID for testing RBAC feature.
     - `rbacAppSecret`: The RBAC service principal secret for testing RBAC feature.
 1. Please make sure to test using a service principal with minimal privileges to replicate customer scenarios.

--- a/src/connectedk8s/setup.py
+++ b/src/connectedk8s/setup.py
@@ -17,7 +17,7 @@ except ImportError:
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
 
-VERSION = '1.5.4'
+VERSION = '2.0.0'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
ignore error if cannot get custom locations app by object id
update to major version 2.0.0 for enabled-features security update breaking change

---

### Related command
az connectedk8s

### General Guidelines

- [X] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?
Can't run it, seems to be a bug with the script as I get the below error:
```
Traceback (most recent call last):
  File "C:\tasks\TheOnlyWei\azure-cli-extensions\scripts\ci\test_index.py", line 23, in <module>
    from wheel.install import WHEEL_INFO_RE
ModuleNotFoundError: No module named 'wheel.install'
```

### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
