### PR TITLE
{AKS} Fix #27461 `az aks create`: Update help information for option `--node-osdisk-size`

### DIFF
--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -11,11 +11,6 @@ To release a new version, please select a new version number (usually plus 1 to 
 
 Pending
 +++++++
-* Vendor new SDK and bump API version to 2023-08-02-preview.
-* Update the operation/method used in following commands as the put/delete operations have been changed to long running operations
-    * `az aks trustedaccess rolebinding create`
-    * `az aks trustedaccess rolebinding update`
-    * `az aks trustedaccess rolebinding delete`
 
 0.5.163
 +++++++
@@ -25,6 +20,11 @@ Pending
 0.5.162
 +++++++
 * Replace Image Cleaner related functions with stable version.
+* Vendor new SDK and bump API version to 2023-08-02-preview.
+* Update the operation/method used in following commands as the put/delete operations have been changed to long running operations
+    * `az aks trustedaccess rolebinding create`
+    * `az aks trustedaccess rolebinding update`
+    * `az aks trustedaccess rolebinding delete`
 
 0.5.161
 +++++++

--- a/src/aks-preview/azext_aks_preview/_help.py
+++ b/src/aks-preview/azext_aks_preview/_help.py
@@ -50,7 +50,7 @@ helps['aks create'] = """
                          size of its node pool with `az aks scale`.
         - name: --node-osdisk-size
           type: int
-          short-summary: Size in GB of the OS disk for each node in the node pool. Minimum 30 GB.
+          short-summary: Size in GiB of the OS disk for each node in the node pool. Minimum 30 GiB.
         - name: --node-osdisk-type
           type: string
           short-summary: OS disk type to be used for machines in a given agent pool. Defaults to 'Managed'. May not be changed for this pool after creation.
@@ -1524,7 +1524,7 @@ helps['aks nodepool add'] = """
           - "`az aks get-versions`"
         - name: --node-osdisk-size
           type: int
-          short-summary: Size in GB of the OS disk for each node in the agent pool. Minimum 30 GB.
+          short-summary: Size in GiB of the OS disk for each node in the agent pool. Minimum 30 GiB.
         - name: --node-osdisk-type
           type: string
           short-summary: OS disk type to be used for machines in a given agent pool. Defaults to 'Managed'. May not be changed for this pool after creation.


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

Update help information for option `--node-osdisk-size`. The disk size specified by this option is actually in GiB (instead of GB). Fix issue [#27461](https://github.com/Azure/azure-cli/issues/27461)

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
- az aks create
- az aks nodepool add


### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
