### PR TITLE
Use default_factory when dataclass defaults are hashable

### DIFF
--- a/src/aosm/HISTORY.rst
+++ b/src/aosm/HISTORY.rst
@@ -8,3 +8,7 @@ Release History
 * Initial release - beta quality
     * `az aosm nfd|nsd generate-config` to generate an example config file to fill in for an NFD or NSD
     * `az aosm nfd|nsd build|publish|delete` to prepare files for, publish or delete an NFD or NSD
+
+1.0.0b2
+++++++++
+* Fixed: Use default_factory when a dataclass default is hashable (Python 3.11 compatibility)

--- a/src/aosm/azext_aosm/_configuration.py
+++ b/src/aosm/azext_aosm/_configuration.py
@@ -268,8 +268,8 @@ class NFConfiguration(Configuration):
 class VNFConfiguration(NFConfiguration):
     blob_artifact_store_name: str = ""
     image_name_parameter: str = ""
-    arm_template: Union[Dict[str, str], ArtifactConfig] = ArtifactConfig()
-    vhd: Union[Dict[str, str], VhdArtifactConfig] = VhdArtifactConfig()
+    arm_template: Union[Dict[str, str], ArtifactConfig] = field(default_factory=ArtifactConfig)
+    vhd: Union[Dict[str, str], VhdArtifactConfig] = field(default_factory=VhdArtifactConfig)
 
     @classmethod
     def helptext(cls) -> "VNFConfiguration":
@@ -465,7 +465,7 @@ class CNFImageConfig:
 
 @dataclass
 class CNFConfiguration(NFConfiguration):
-    images: Union[Dict[str, str], CNFImageConfig] = CNFImageConfig()
+    images: Union[Dict[str, str], CNFImageConfig] = field(default_factory=CNFImageConfig)
     helm_packages: List[Union[Dict[str, Any], HelmPackageConfig]] = field(
         default_factory=lambda: []
     )

--- a/src/aosm/setup.py
+++ b/src/aosm/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 # Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
-VERSION = "1.0.0b1"
+VERSION = "1.0.0b2"
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Python 3.11 dataclasses require hashable defaults to use a default_factory.

This PR implements that for the az aosm extension.

Fixes https://github.com/Azure/azure-cli-extensions/pull/6426#discussion_r1371209404

Testing that this resolves all instance of the `mutable default is not allowed` error **to be completed by @yanzhudd**, as agreed offline. 

Function testing of the extension has been completed using the test suite with live tests.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
az aosm nfd generate-config --definition-type cnf


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
