### PR TITLE
{CI} Modify the extension's azdev test to use the `azext_xxx` directory

### DIFF
--- a/scripts/ci/test_source.py
+++ b/scripts/ci/test_source.py
@@ -70,6 +70,7 @@ def test_extension():
         logger.info(f'installing extension: {ext_name}')
         cmd = ['azdev', 'extension', 'add', ext_name]
         run_command(cmd, check_return_code=True)
+        # python -m azdev test --no-exitfirst --discover --verbose azext_containerapp
         test_args = [sys.executable, '-m', 'azdev', 'test', '--no-exitfirst', '--discover', '--verbose', tname]
         logger.warning(f'test_args: {test_args}')
         run_command(test_args, check_return_code=True)

--- a/scripts/ci/test_source.py
+++ b/scripts/ci/test_source.py
@@ -70,7 +70,7 @@ def test_extension():
         logger.info(f'installing extension: {ext_name}')
         cmd = ['azdev', 'extension', 'add', ext_name]
         run_command(cmd, check_return_code=True)
-        test_args = [sys.executable, '-m', 'azdev', 'test', '--no-exitfirst', '--discover', '--verbose', ext_name]
+        test_args = [sys.executable, '-m', 'azdev', 'test', '--no-exitfirst', '--discover', '--verbose', tname]
         logger.warning(f'test_args: {test_args}')
         run_command(test_args, check_return_code=True)
         logger.info(f'uninstalling extension: {ext_name}')


### PR DESCRIPTION
Modify the extension's azdev test to use the azext_xxx directory to avoid the issue of being unable to detect the test when it has the same name as the main module.
The containerapp module exists in both the main repo and the extension repo.
After installing the extension, running `azdev test containerapp` will not run any tests. The log is as follows:
![image](https://github.com/Azure/azure-cli-extensions/assets/18628534/2d42b7c7-5a0a-4fdc-9323-32e569ac1767)
To avoid this problem, modify the `azdev test $extension` command to the `azdev test azext_$extension` command.

Test screenshot:
![image](https://github.com/Azure/azure-cli-extensions/assets/18628534/df5651fa-0f7b-44ec-8078-3665896fd7e7)
![image](https://github.com/Azure/azure-cli-extensions/assets/18628534/2dcb5763-4677-47f7-86be-22bfd021577c)


---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
