### PR TITLE
[confcom] adding warning if users are going to print to the command line

### DIFF
--- a/src/confcom/azext_confcom/custom.py
+++ b/src/confcom/azext_confcom/custom.py
@@ -52,6 +52,16 @@ def acipolicygen_confcom(
     elif save_to_file and arm_template and not (print_policy_to_terminal or outraw or outraw_pretty_print):
         error_out("Must print policy to terminal when saving to file")
 
+    if print_existing_policy or outraw or outraw_pretty_print:
+        logger.warning(
+            "%s %s %s %s %s",
+            "Secrets that are included in the provided arm template or configuration files ",
+            "in the container env or cmd sections will be printed out with this flag.",
+            "These are outputed secrets that you must protect. Be sure that you do not include these secrets in your",
+            "source control. Also verify that no secrets are present in the logs of your command or script.",
+            "For additional information, see http://aka.ms/clisecrets. \n",
+        )
+
     if print_existing_policy:
         print_existing_policy_from_arm_template(arm_template, arm_template_parameters)
         sys.exit(0)


### PR DESCRIPTION
Needed for compliance with best practices in warning users when secrets may be printed to the command line
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
confcom


### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
