### PR TITLE
{AKS} `az aks nodepool add/update`: Add option `--enable-artifact-streaming` to support artifact streaming

### DIFF
--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -13,6 +13,7 @@ Pending
 +++++++
 * Add `--node-provisioning-mode` to the `az aks update` command.
 * Add `--node-provisioning-mode` to the `az aks create` command.
+* Add Artifact Streaming enablement option to node pool property in `az aks nodepool add` and `az aks nodepool update`.
 
 0.5.169
 +++++++

--- a/src/aks-preview/azcli_aks_live_test/configs/ext_matrix_default.json
+++ b/src/aks-preview/azcli_aks_live_test/configs/ext_matrix_default.json
@@ -39,6 +39,11 @@
         ],
         "workload runtime, missing feature registration": [
             "test_aks_nodepool_add_with_workload_runtime"
+        ],
+        "artifact streaming, missing feature registration": [
+            "test_aks_nodepool_add_with_artifact_streaming",
+            "test_aks_nodepool_update_with_artifact_streaming"
+        ],
         ]
     }
 }

--- a/src/aks-preview/azcli_aks_live_test/configs/ext_matrix_default.json
+++ b/src/aks-preview/azcli_aks_live_test/configs/ext_matrix_default.json
@@ -40,10 +40,9 @@
         "workload runtime, missing feature registration": [
             "test_aks_nodepool_add_with_workload_runtime"
         ],
-        "artifact streaming, missing feature registration": [
+        "artifact streaming, missing feature registration & toggle": [
             "test_aks_nodepool_add_with_artifact_streaming",
             "test_aks_nodepool_update_with_artifact_streaming"
-        ],
         ]
     }
 }

--- a/src/aks-preview/azext_aks_preview/_help.py
+++ b/src/aks-preview/azext_aks_preview/_help.py
@@ -1614,9 +1614,6 @@ helps['aks nodepool add'] = """
         - name: --mode
           type: string
           short-summary: The mode for a node pool which defines a node pool's primary function. If set as "System", AKS prefers system pods scheduling to node pools with mode `System`. Learn more at https://aka.ms/aks/nodepool/mode.
-        - name: --enable-artifact-streaming
-          type: bool
-          short-summary: Enable artifact streaming for VirtualMachineScaleSets managed by a node pool, to speed up the cold-start of containers on a node through on-demand image loading. To use this feature, container images must also enable artifact streaming on ACR. If not specified, the default is false.
         - name: --vm-set-type
           type: string
           short-summary: Agent pool vm set type. VirtualMachineScaleSets, AvailabilitySet or VirtualMachines(Preview).
@@ -1677,6 +1674,9 @@ helps['aks nodepool add'] = """
         - name: --node-public-ip-tags
           type: string
           short-summary: The ipTags of the node public IPs. Must use VMSS agent pool type.
+        - name: --enable-artifact-streaming
+          type: bool
+          short-summary: Enable artifact streaming for VirtualMachineScaleSets managed by a node pool, to speed up the cold-start of containers on a node through on-demand image loading. To use this feature, container images must also enable artifact streaming on ACR. If not specified, the default is false.
     examples:
         - name: Create a nodepool in an existing AKS cluster with ephemeral os enabled.
           text: az aks nodepool add -g MyResourceGroup -n nodepool1 --cluster-name MyManagedCluster --node-osdisk-type Ephemeral --node-osdisk-size 48
@@ -1789,6 +1789,9 @@ helps['aks nodepool update'] = """
         - name: --asg-ids
           type: string
           short-summary: The IDs of the application security groups to which the node pool's network interface should belong. When specified, format should be a comma-separated list of IDs. Must use VMSS agent pool type.
+        - name: --enable-artifact-streaming
+          type: bool
+          short-summary: Enable artifact streaming for VirtualMachineScaleSets managed by a node pool, to speed up the cold-start of containers on a node through on-demand image loading. To use this feature, container images must also enable artifact streaming on ACR. If not specified, the default is false.
     examples:
       - name: Reconcile the nodepool back to its current state.
         text: az aks nodepool update -g MyResourceGroup -n nodepool1 --cluster-name MyManagedCluster

--- a/src/aks-preview/azext_aks_preview/_help.py
+++ b/src/aks-preview/azext_aks_preview/_help.py
@@ -1614,6 +1614,9 @@ helps['aks nodepool add'] = """
         - name: --mode
           type: string
           short-summary: The mode for a node pool which defines a node pool's primary function. If set as "System", AKS prefers system pods scheduling to node pools with mode `System`. Learn more at https://aka.ms/aks/nodepool/mode.
+        - name: --enable-artifact-streaming
+          type: bool
+          short-summary: Enable artifact streaming for VirtualMachineScaleSets managed by a node pool, to speed up the cold-start of containers on a node through on-demand image loading. To use this feature, container images must also enable artifact streaming on ACR. If not specified, the default is false.
         - name: --vm-set-type
           type: string
           short-summary: Agent pool vm set type. VirtualMachineScaleSets, AvailabilitySet or VirtualMachines(Preview).

--- a/src/aks-preview/azext_aks_preview/_params.py
+++ b/src/aks-preview/azext_aks_preview/_params.py
@@ -726,7 +726,7 @@ def load_arguments(self, _):
         c.argument('disable_windows_outbound_nat', action='store_true', validator=validate_disable_windows_outbound_nat)
         c.argument('allowed_host_ports', validator=validate_allowed_host_ports, is_preview=True)
         c.argument('asg_ids', validator=validate_application_security_groups, is_preview=True)
-        c.argument('enable_artifact_streaming', validator=validate_artifact_streaming, is_preview=True)
+        c.argument('enable_artifact_streaming', action='store_true', validator=validate_artifact_streaming, is_preview=True)
         c.argument('node_public_ip_tags', arg_type=tags_type, validator=validate_node_public_ip_tags,
                    help='space-separated tags: key[=value] [key[=value] ...].')
 
@@ -752,7 +752,7 @@ def load_arguments(self, _):
         c.argument('disable_custom_ca_trust', options_list=['--disable-custom-ca-trust', '--dcat'], action='store_true')
         c.argument('allowed_host_ports', validator=validate_allowed_host_ports, is_preview=True)
         c.argument('asg_ids', validator=validate_application_security_groups, is_preview=True)
-        c.argument('enable_artifact_streaming', validator=validate_artifact_streaming, is_preview=True)
+        c.argument('enable_artifact_streaming', action='store_true', validator=validate_artifact_streaming, is_preview=True)
 
     with self.argument_context('aks nodepool upgrade') as c:
         c.argument('max_surge', validator=validate_max_surge)

--- a/src/aks-preview/azext_aks_preview/_params.py
+++ b/src/aks-preview/azext_aks_preview/_params.py
@@ -164,7 +164,8 @@ from azext_aks_preview._validators import (
     validate_vm_set_type,
     validate_vnet_subnet_id,
     validate_force_upgrade_disable_and_enable_parameters,
-    validate_azure_service_mesh_revision
+    validate_azure_service_mesh_revision,
+    validate_artifact_streaming
 )
 from azure.cli.core.commands.parameters import (
     edge_zone_type,
@@ -725,6 +726,7 @@ def load_arguments(self, _):
         c.argument('disable_windows_outbound_nat', action='store_true', validator=validate_disable_windows_outbound_nat)
         c.argument('allowed_host_ports', validator=validate_allowed_host_ports, is_preview=True)
         c.argument('asg_ids', validator=validate_application_security_groups, is_preview=True)
+        c.argument('enable_artifact_streaming', validator=validate_artifact_streaming, is_preview=True)
         c.argument('node_public_ip_tags', arg_type=tags_type, validator=validate_node_public_ip_tags,
                    help='space-separated tags: key[=value] [key[=value] ...].')
 
@@ -750,6 +752,7 @@ def load_arguments(self, _):
         c.argument('disable_custom_ca_trust', options_list=['--disable-custom-ca-trust', '--dcat'], action='store_true')
         c.argument('allowed_host_ports', validator=validate_allowed_host_ports, is_preview=True)
         c.argument('asg_ids', validator=validate_application_security_groups, is_preview=True)
+        c.argument('enable_artifact_streaming', validator=validate_artifact_streaming, is_preview=True)
 
     with self.argument_context('aks nodepool upgrade') as c:
         c.argument('max_surge', validator=validate_max_surge)

--- a/src/aks-preview/azext_aks_preview/_validators.py
+++ b/src/aks-preview/azext_aks_preview/_validators.py
@@ -793,3 +793,9 @@ def validate_azure_service_mesh_revision(namespace):
     found = asm_revision_regex.findall(revision)
     if not found:
         raise InvalidArgumentValueError(f"Revision {revision} is not supported by the service mesh add-on.")
+
+def validate_artifact_streaming(namespace):
+    """Validates that artifact streaming enablement can only be used on Linux."""
+    if namespace.enable_artifact_streaming:
+        if hasattr(namespace, 'os_type') and str(namespace.os_type).lower() == "windows":
+            raise ArgumentUsageError('--enable-artifact-streaming can only be set for Linux nodepools')

--- a/src/aks-preview/azext_aks_preview/_validators.py
+++ b/src/aks-preview/azext_aks_preview/_validators.py
@@ -794,6 +794,7 @@ def validate_azure_service_mesh_revision(namespace):
     if not found:
         raise InvalidArgumentValueError(f"Revision {revision} is not supported by the service mesh add-on.")
 
+
 def validate_artifact_streaming(namespace):
     """Validates that artifact streaming enablement can only be used on Linux."""
     if namespace.enable_artifact_streaming:

--- a/src/aks-preview/azext_aks_preview/agentpool_decorator.py
+++ b/src/aks-preview/azext_aks_preview/agentpool_decorator.py
@@ -367,6 +367,19 @@ class AKSPreviewAgentPoolContext(AKSAgentPoolContext):
         # this parameter does not need validation
         return node_soak_duration
 
+    def get_enable_artifact_streaming(self) -> bool:
+        """Obtain the value of enable_artifact_streaming.
+
+        :return: bool
+        """
+
+        # read the original value passed by the command
+        enable_artifact_streaming = self.raw_param.get("enable_artifact_streaming")
+        # In create mode, try to read the property value corresponding to the parameter from the `agentpool` object
+        if self.decorator_mode == DecoratorMode.CREATE:
+            if self.agentpool and self.agentpool.enable_artifact_streaming is not None:
+                enable_artifact_streaming = self.agentpool.enable_artifact_streaming
+        return enable_artifact_streaming
 
 class AKSPreviewAgentPoolAddDecorator(AKSAgentPoolAddDecorator):
     def __init__(
@@ -512,6 +525,15 @@ class AKSPreviewAgentPoolAddDecorator(AKSAgentPoolAddDecorator):
         agentpool = self._restore_defaults_in_agentpool(agentpool)
         return agentpool
 
+    def set_up_artifact_streaming(self, agentpool: AgentPool) -> AgentPool:
+        """Set up artifact streaming property for the AgentPool object.
+
+        :return: the AgentPool object
+        """
+
+        agentpool.enable_artifact_streaming = self.context.get_enable_artifact_streaming()
+        return agentpool
+
     def set_up_upgrade_settings(self, agentpool: AgentPool) -> AgentPool:
         """Set up upgrade settings for the AgentPool object.
 
@@ -642,4 +664,15 @@ class AKSPreviewAgentPoolUpdateDecorator(AKSAgentPoolUpdateDecorator):
             upgrade_settings.node_soak_duration_in_minutes = node_soak_duration
             agentpool.upgrade_settings = upgrade_settings
 
+        return agentpool
+
+    def update_artifact_streaming(self, agentpool: AgentPool) -> AgentPool:
+        """Update artifact streaming property for the AgentPool object.
+
+        :return: the AgentPool object
+        """
+        self._ensure_agentpool(agentpool)
+
+        if self.context.get_enable_artifact_streaming():
+            agentpool.enable_artifact_streaming = True
         return agentpool

--- a/src/aks-preview/azext_aks_preview/agentpool_decorator.py
+++ b/src/aks-preview/azext_aks_preview/agentpool_decorator.py
@@ -377,8 +377,8 @@ class AKSPreviewAgentPoolContext(AKSAgentPoolContext):
         enable_artifact_streaming = self.raw_param.get("enable_artifact_streaming")
         # In create mode, try to read the property value corresponding to the parameter from the `agentpool` object
         if self.decorator_mode == DecoratorMode.CREATE:
-            if self.agentpool and self.agentpool.enable_artifact_streaming is not None:
-                enable_artifact_streaming = self.agentpool.enable_artifact_streaming
+            if self.agentpool and self.agentpool.artifact_streaming_profile.enabled is not None:
+                enable_artifact_streaming = self.agentpool.artifact_streaming_profile.enabled
         return enable_artifact_streaming
 
 class AKSPreviewAgentPoolAddDecorator(AKSAgentPoolAddDecorator):
@@ -674,5 +674,5 @@ class AKSPreviewAgentPoolUpdateDecorator(AKSAgentPoolUpdateDecorator):
         self._ensure_agentpool(agentpool)
 
         if self.context.get_enable_artifact_streaming():
-            agentpool.enable_artifact_streaming = True
+            agentpool.artifact_streaming_profile.enabled = True
         return agentpool

--- a/src/aks-preview/azext_aks_preview/agentpool_decorator.py
+++ b/src/aks-preview/azext_aks_preview/agentpool_decorator.py
@@ -654,7 +654,7 @@ class AKSPreviewAgentPoolUpdateDecorator(AKSAgentPoolUpdateDecorator):
         # update network profile
         agentpool = self.update_network_profile(agentpool)
 
-        # update artifact streaming 
+        # update artifact streaming
         agentpool = self.update_artifact_streaming(agentpool)
         return agentpool
 

--- a/src/aks-preview/azext_aks_preview/custom.py
+++ b/src/aks-preview/azext_aks_preview/custom.py
@@ -1127,6 +1127,7 @@ def aks_agentpool_add(
     allowed_host_ports=None,
     asg_ids=None,
     node_public_ip_tags=None,
+    enable_artifact_streaming=False,
 ):
     # DO NOT MOVE: get all the original parameters and save them as a dictionary
     raw_parameters = locals()
@@ -1178,6 +1179,7 @@ def aks_agentpool_update(
     disable_custom_ca_trust=False,
     allowed_host_ports=None,
     asg_ids=None,
+    enable_artifact_streaming=False,
 ):
     # DO NOT MOVE: get all the original parameters and save them as a dictionary
     raw_parameters = locals()

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -2739,7 +2739,7 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         ])
 
         # nodepool add
-        self.cmd('aks nodepool add --resource-group={resource_group} --cluster-name={name} --name={nodepool2_name} --enable-artifact-streaming --aks-custom-headers=AKSHTTPCustomFeatures=Microsoft.ContainerService/ArtifactStreamingPreview', checks=[
+        self.cmd('aks nodepool add --resource-group={resource_group} --cluster-name={name} --name={nodepool2_name} --enable-artifact-streaming true --aks-custom-headers=AKSHTTPCustomFeatures=Microsoft.ContainerService/ArtifactStreamingPreview', checks=[
             self.check('provisioningState', 'Succeeded'),
             self.check('agentpoolProfiles[0].ArtifactStreamingProfile.enabled', True)
         ])
@@ -7347,7 +7347,7 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             '--cluster-name={name} '
             '--name={node_pool_name} '
             '--allowed-host-ports={allowed_host_ports} '
-            '--enable-artifact-streaming '
+            '--enable-artifact-streaming true'
             '--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/ArtifactStreamingPreview',
             checks=[
                 self.check('provisioningState', 'Succeeded'),

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -2739,10 +2739,16 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         ])
 
         # nodepool add
-        self.cmd('aks nodepool add --resource-group={resource_group} --cluster-name={name} --name={nodepool2_name} --enable-artifact-streaming true --aks-custom-headers=AKSHTTPCustomFeatures=Microsoft.ContainerService/ArtifactStreamingPreview', checks=[
-            self.check('provisioningState', 'Succeeded'),
-            self.check('agentpoolProfiles[1].ArtifactStreamingProfile.enabled', True)
-        ])
+        self.cmd(
+            "aks nodepool add --resource-group={resource_group} --cluster-name={name} --name={nodepool2_name} "
+            "--enable-artifact-streaming --aks-custom-headers=AKSHTTPCustomFeatures=Microsoft.ContainerService/ArtifactStreamingPreview",
+            checks=[
+                self.check("provisioningState", "Succeeded"),
+                self.check(
+                    "agentpoolProfiles[1].ArtifactStreamingProfile.enabled", True
+                ),
+            ],
+        )
 
         # delete
         self.cmd(
@@ -7346,12 +7352,11 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             '--resource-group={resource_group} '
             '--cluster-name={name} '
             '--name={node_pool_name} '
-            '--allowed-host-ports={allowed_host_ports} '
-            '--enable-artifact-streaming true'
+            '--enable-artifact-streaming '
             '--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/ArtifactStreamingPreview',
             checks=[
                 self.check('provisioningState', 'Succeeded'),
-                self.check('agentPoolProfiles[1].ArtifactStreamingProfile.enabled'),
+                self.check('agentPoolProfiles[1].ArtifactStreamingProfile.enabled', True),
             ],
         )
 

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -2739,7 +2739,7 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         ])
 
         # nodepool add
-        self.cmd('aks nodepool add --resource-group={resource_group} --cluster-name={name} --name={nodepool2_name} --enable-artifact-streaming', checks=[
+        self.cmd('aks nodepool add --resource-group={resource_group} --cluster-name={name} --name={nodepool2_name} --enable-artifact-streaming --aks-custom-headers=AKSHTTPCustomFeatures=Microsoft.ContainerService/ArtifactStreamingPreview', checks=[
             self.check('provisioningState', 'Succeeded'),
             self.check('agentpoolProfiles[0].ArtifactStreamingProfile.enabled', True)
         ])

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -2712,6 +2712,9 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         self.cmd(
             'aks delete -g {resource_group} -n {name} --yes --no-wait', checks=[self.is_empty()])
 
+    # the availability of features is controlled by a toggle and cannot be fully tested yet,
+    # however, existing test results show that the client side works as expected, so exclude it at this moment
+    @live_only()
     @AllowLargeResponse()
     @AKSCustomResourceGroupPreparer(random_name_length=17, name_prefix='clitest', location='eastus')
     def test_aks_nodepool_add_with_artifact_streaming(self, resource_group, resource_group_location):
@@ -7317,6 +7320,9 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             self.is_empty(),
         ])
 
+    # the availability of features is controlled by a toggle and cannot be fully tested yet,
+    # however, existing test results show that the client side works as expected, so exclude it at this moment
+    @live_only()
     @AllowLargeResponse()
     @AKSCustomResourceGroupPreparer(random_name_length=17, name_prefix='clitest', location='eastus')
     def test_aks_nodepool_update_with_artifact_streaming(self, resource_group, resource_group_location):

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -2731,8 +2731,9 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
 
         # create
         create_cmd = 'aks create --resource-group={resource_group} --name={name} ' \
-                     '--ssh-key-value={ssh_key_value}'
+                     '--ssh-key-value={ssh_key_value} '
                      '--aks-custom-headers=AKSHTTPCustomFeatures=Microsoft.ContainerService/ArtifactStreamingPreview '
+
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
         ])

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -2741,7 +2741,7 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         # nodepool add
         self.cmd('aks nodepool add --resource-group={resource_group} --cluster-name={name} --name={nodepool2_name} --enable-artifact-streaming true --aks-custom-headers=AKSHTTPCustomFeatures=Microsoft.ContainerService/ArtifactStreamingPreview', checks=[
             self.check('provisioningState', 'Succeeded'),
-            self.check('agentpoolProfiles[0].ArtifactStreamingProfile.enabled', True)
+            self.check('agentpoolProfiles[1].ArtifactStreamingProfile.enabled', True)
         ])
 
         # delete
@@ -7351,7 +7351,7 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             '--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/ArtifactStreamingPreview',
             checks=[
                 self.check('provisioningState', 'Succeeded'),
-                self.check('agentPoolProfiles[0].ArtifactStreamingProfile.enabled'),
+                self.check('agentPoolProfiles[1].ArtifactStreamingProfile.enabled'),
             ],
         )
 

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -2732,6 +2732,7 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         # create
         create_cmd = 'aks create --resource-group={resource_group} --name={name} ' \
                      '--ssh-key-value={ssh_key_value}'
+                     '--aks-custom-headers=AKSHTTPCustomFeatures=Microsoft.ContainerService/ArtifactStreamingPreview '
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),
         ])
@@ -7300,6 +7301,56 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
                 self.check('provisioningState', 'Succeeded'),
                 self.check('networkProfile.applicationSecurityGroups', self.kwargs['asg_ids'].split(',')),
                 self.check('networkProfile.allowedHostPorts[] | length(@)', len(self.kwargs['allowed_host_ports'].split(','))),
+            ],
+        )
+
+        # delete
+        cmd = 'aks delete --resource-group={resource_group} --name={name} --yes --no-wait'
+        self.cmd(cmd, checks=[
+            self.is_empty(),
+        ])
+
+    @AllowLargeResponse()
+    @AKSCustomResourceGroupPreparer(random_name_length=17, name_prefix='clitest', location='eastus')
+    def test_aks_nodepool_update_with_artifact_streaming(self, resource_group, resource_group_location):
+        aks_name = self.create_random_name('cliakstest', 16)
+        nodepool_name = self.create_random_name('n', 6)
+
+        self.kwargs.update({
+            'resource_group': resource_group,
+            'name': aks_name,
+            'location': resource_group_location,
+            'ssh_key_value': self.generate_ssh_keys(),
+            'node_pool_name': nodepool_name,
+            'node_vm_size': 'standard_d2s_v3',
+        })
+
+        self.cmd(
+            'aks create '
+            '--resource-group={resource_group} '
+            '--name={name} '
+            '--location={location} '
+            '--ssh-key-value={ssh_key_value} '
+            '--nodepool-name={node_pool_name} '
+            '--node-count=1 '
+            '--node-vm-size={node_vm_size} '
+            '--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/ArtifactStreamingPreview',
+            checks=[
+                self.check('provisioningState', 'Succeeded'),
+            ],
+        )
+
+        self.cmd(
+            'aks nodepool update '
+            '--resource-group={resource_group} '
+            '--cluster-name={name} '
+            '--name={node_pool_name} '
+            '--allowed-host-ports={allowed_host_ports} '
+            '--enable-artifact-streaming'
+            '--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/ArtifactStreamingPreview',
+            checks=[
+                self.check('provisioningState', 'Succeeded'),
+                self.check('agentPoolProfiles[0].ArtifactStreamingProfile.enabled'),
             ],
         )
 

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -2713,6 +2713,40 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             'aks delete -g {resource_group} -n {name} --yes --no-wait', checks=[self.is_empty()])
 
     @AllowLargeResponse()
+    @AKSCustomResourceGroupPreparer(random_name_length=17, name_prefix='clitest', location='eastus')
+    def test_aks_nodepool_add_with_artifact_streaming(self, resource_group, resource_group_location):
+        # reset the count so in replay mode the random names will start with 0
+        self.test_resources_count = 0
+        # kwargs for string formatting
+        aks_name = self.create_random_name('cliakstest', 16)
+        self.kwargs.update({
+            'resource_group': resource_group,
+            'name': aks_name,
+            'dns_name_prefix': self.create_random_name('cliaksdns', 16),
+            'location': resource_group_location,
+            'resource_type': 'Microsoft.ContainerService/ManagedClusters',
+            'nodepool2_name': 'np2',
+            'ssh_key_value': self.generate_ssh_keys()
+        })
+
+        # create
+        create_cmd = 'aks create --resource-group={resource_group} --name={name} ' \
+                     '--ssh-key-value={ssh_key_value}'
+        self.cmd(create_cmd, checks=[
+            self.check('provisioningState', 'Succeeded'),
+        ])
+
+        # nodepool add
+        self.cmd('aks nodepool add --resource-group={resource_group} --cluster-name={name} --name={nodepool2_name} --enable-artifact-streaming', checks=[
+            self.check('provisioningState', 'Succeeded'),
+            self.check('agentpoolProfiles[0].ArtifactStreamingProfile.enabled', True)
+        ])
+
+        # delete
+        self.cmd(
+            'aks delete -g {resource_group} -n {name} --yes --no-wait', checks=[self.is_empty()])
+
+    @AllowLargeResponse()
     @AKSCustomResourceGroupPreparer(random_name_length=17, name_prefix='clitest', location='westus2')
     def test_aks_create_with_ahub(self, resource_group, resource_group_location):
         # reset the count so in replay mode the random names will start with 0

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -2731,7 +2731,7 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
 
         # create
         create_cmd = 'aks create --resource-group={resource_group} --name={name} ' \
-                     '--ssh-key-value={ssh_key_value} '
+                     '--ssh-key-value={ssh_key_value} ' \
                      '--aks-custom-headers=AKSHTTPCustomFeatures=Microsoft.ContainerService/ArtifactStreamingPreview '
 
         self.cmd(create_cmd, checks=[
@@ -7347,7 +7347,7 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             '--cluster-name={name} '
             '--name={node_pool_name} '
             '--allowed-host-ports={allowed_host_ports} '
-            '--enable-artifact-streaming'
+            '--enable-artifact-streaming '
             '--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/ArtifactStreamingPreview',
             checks=[
                 self.check('provisioningState', 'Succeeded'),

--- a/src/aks-preview/linter_exclusions.yml
+++ b/src/aks-preview/linter_exclusions.yml
@@ -214,6 +214,7 @@ aks nodepool add:
       rule_exclusions:
         - option_length_too_long
 aks nodepool update:
+  parameters:
     enable_artifact_streaming:
       rule_exclusions:
         - option_length_too_long

--- a/src/aks-preview/linter_exclusions.yml
+++ b/src/aks-preview/linter_exclusions.yml
@@ -210,6 +210,13 @@ aks nodepool add:
     node_public_ip_tags:
       rule_exclusions:
         - option_length_too_long
+    enable_artifact_streaming:
+      rule_exclusions:
+        - option_length_too_long
+aks nodepool update:
+    enable_artifact_streaming:
+      rule_exclusions:
+        - option_length_too_long
 aks nodepool delete:
   parameters:
     ignore_pod_disruption_budget:


### PR DESCRIPTION
---

- {AKS} `az aks nodepool add/update`: Add option `--enable-artifact-streaming` to support artifact streaming.
- PR forked from #6950.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

- `az aks nodepool add`
- `az aks nodepool update`

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
