### PR TITLE
{Interactive} Pass the cli_ctx when it calls `handle_exception`

### DIFF
--- a/src/interactive/HISTORY.rst
+++ b/src/interactive/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+<future release version placeholder>
++++++
+* Show suggestions from LLM when a command returns an error.
++++++
+
 0.5.3
 +++++
 * Optimize the visualization of help text when the window is reduced horizontally

--- a/src/interactive/azext_interactive/azclishell/app.py
+++ b/src/interactive/azext_interactive/azclishell/app.py
@@ -927,7 +927,7 @@ class AzInteractiveShell(object):
                     self.last = result
 
         except Exception as ex:  # pylint: disable=broad-except
-            self.last_exit_code = handle_exception(ex, self.cli_ctx, cmd)
+            self.last_exit_code = handle_exception(ex, self.cli_ctx)
         except SystemExit as ex:
             self.last_exit_code = int(ex.code)
 

--- a/src/interactive/azext_interactive/azclishell/app.py
+++ b/src/interactive/azext_interactive/azclishell/app.py
@@ -927,7 +927,7 @@ class AzInteractiveShell(object):
                     self.last = result
 
         except Exception as ex:  # pylint: disable=broad-except
-            self.last_exit_code = handle_exception(ex, self.cli_ctx)
+            self.last_exit_code = handle_exception(ex, self.cli_ctx, f"az {cmd}")
         except SystemExit as ex:
             self.last_exit_code = int(ex.code)
 

--- a/src/interactive/azext_interactive/azclishell/app.py
+++ b/src/interactive/azext_interactive/azclishell/app.py
@@ -927,7 +927,7 @@ class AzInteractiveShell(object):
                     self.last = result
 
         except Exception as ex:  # pylint: disable=broad-except
-            self.last_exit_code = handle_exception(ex)
+            self.last_exit_code = handle_exception(ex, self.cli_ctx)
         except SystemExit as ex:
             self.last_exit_code = int(ex.code)
 

--- a/src/interactive/azext_interactive/azclishell/app.py
+++ b/src/interactive/azext_interactive/azclishell/app.py
@@ -927,7 +927,7 @@ class AzInteractiveShell(object):
                     self.last = result
 
         except Exception as ex:  # pylint: disable=broad-except
-            self.last_exit_code = handle_exception(ex, self.cli_ctx)
+            self.last_exit_code = handle_exception(ex, self.cli_ctx, cmd)
         except SystemExit as ex:
             self.last_exit_code = int(ex.code)
 


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

When an exception is thrown and handled, it may also ask for the LLM for the suggestion to fix the error. To make that work, we need to pass the `cli_ctx` when we call `handle_exception` directly in the interactive mode. The feature is enabled/disabled separately by a configuration though. See this PR for what is done to show the suggestion when an error occurs. https://github.com/Azure/azure-cli/pull/27801


### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
