### PR TITLE
Update baremetalinstance version

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -19832,10 +19832,10 @@
         ],
         "baremetal-infrastructure": [
             {
-                "downloadUrl": "https://github.com/Azure/azure-baremetalinfrastructure-cli-extension/releases/download/1.0.0/baremetal_infrastructure-1.0.0-py2.py3-none-any.whl",
-                "filename": "baremetal_infrastructure-1.0.0-py2.py3-none-any.whl",
+                "downloadUrl": "https://github.com/Azure/azure-baremetalinfrastructure-cli-extension/releases/download/2.0.0/baremetal_infrastructure-2.0.0-py2.py3-none-any.whl",
+                "filename": "baremetal_infrastructure-2.0.0-py2.py3-none-any.whl",
                 "metadata": {
-                    "azext.minCliCoreVersion": "2.12.0",
+                    "azext.minCliCoreVersion": "2.53.0",
                     "classifiers": [
                         "Development Status :: 4 - Beta",
                         "Intended Audience :: Developers",
@@ -19871,9 +19871,9 @@
                     "metadata_version": "2.0",
                     "name": "baremetal-infrastructure",
                     "summary": "Additional commands for working with BareMetal instances.",
-                    "version": "1.0.0"
+                    "version": "2.0.0"
                 },
-                "sha256Digest": "9e0bd5e66debbb9a4a810dad44f710eba43f0249b2f8a630539b68e21a849d6f"
+                "sha256Digest": "394b11563e087a7838b977b50ec10a84d54cbea59c198ccc043287b604c85607"
             }
         ],
         "bastion": [

--- a/src/index.json
+++ b/src/index.json
@@ -19832,6 +19832,50 @@
         ],
         "baremetal-infrastructure": [
             {
+                "downloadUrl": "https://github.com/Azure/azure-baremetalinfrastructure-cli-extension/releases/download/1.0.0/baremetal_infrastructure-1.0.0-py2.py3-none-any.whl",
+                "filename": "baremetal_infrastructure-1.0.0-py2.py3-none-any.whl",
+                "metadata": {
+                    "azext.minCliCoreVersion": "2.12.0",
+                    "classifiers": [
+                        "Development Status :: 4 - Beta",
+                        "Intended Audience :: Developers",
+                        "Intended Audience :: System Administrators",
+                        "Programming Language :: Python",
+                        "Programming Language :: Python :: 2",
+                        "Programming Language :: Python :: 2.7",
+                        "Programming Language :: Python :: 3",
+                        "Programming Language :: Python :: 3.4",
+                        "Programming Language :: Python :: 3.5",
+                        "Programming Language :: Python :: 3.6",
+                        "License :: OSI Approved :: MIT License"
+                    ],
+                    "extensions": {
+                        "python.details": {
+                            "contacts": [
+                                {
+                                    "email": "azpycli@microsoft.com",
+                                    "name": "Microsoft Corporation",
+                                    "role": "author"
+                                }
+                            ],
+                            "document_names": {
+                                "description": "DESCRIPTION.rst"
+                            },
+                            "project_urls": {
+                                "Home": "https://github.com/Azure/azure-baremetalinfrastructure-cli-extension"
+                            }
+                        }
+                    },
+                    "generator": "bdist_wheel (0.30.0)",
+                    "license": "MIT",
+                    "metadata_version": "2.0",
+                    "name": "baremetal-infrastructure",
+                    "summary": "Additional commands for working with BareMetal instances.",
+                    "version": "1.0.0"
+                },
+                "sha256Digest": "9e0bd5e66debbb9a4a810dad44f710eba43f0249b2f8a630539b68e21a849d6f"
+            },
+            {
                 "downloadUrl": "https://github.com/Azure/azure-baremetalinfrastructure-cli-extension/releases/download/2.0.0/baremetal_infrastructure-2.0.0-py2.py3-none-any.whl",
                 "filename": "baremetal_infrastructure-2.0.0-py2.py3-none-any.whl",
                 "metadata": {
@@ -19873,7 +19917,7 @@
                     "summary": "Additional commands for working with BareMetal instances.",
                     "version": "2.0.0"
                 },
-                "sha256Digest": "394b11563e087a7838b977b50ec10a84d54cbea59c198ccc043287b604c85607"
+                "sha256Digest": "8672d29ce35b01141c2acfb9d2be5fedc78a9937d2abc9813e95ec061343264b"
             }
         ],
         "bastion": [


### PR DESCRIPTION
Introducing a new 2.0.0 version of the bare metal infrastructure extension. This update includes a powerful new force power management command specifically designed for SuperDome Flex Servers.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
`az extension add --name baremetal-infrastructure` should install the new 2.0.0 version instead of old 1.0.0 version.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [X] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)

For new extensions:

- [X] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
