### PR TITLE
{Pipeline} Exclude `azure-iot-ops` from build command tree

### DIFF
--- a/scripts/ci/build_ext_cmd_tree.sh
+++ b/scripts/ci/build_ext_cmd_tree.sh
@@ -20,7 +20,8 @@ export AZURE_EXTENSION_INDEX_URL=https://raw.githubusercontent.com/Azure/azure-c
 output=$(az extension list-available --query [].name -otsv)
 # azure-cli-ml is replaced by ml
 # disable alias which relies on Jinja2 2.10
-blocklist=("azure-cli-ml" "alias")
+# disable azure-iot-ops temporarily which requires kubernetes >= 27.2
+blocklist=("azure-cli-ml" "alias" "azure-iot-ops")
 
 rm -f ~/.azure/extCmdTreeToUpload.json
 


### PR DESCRIPTION
### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

It raises this error when build command tree:
```
2023-11-10T03:08:15.5413703Z Processing azure-iot-ops
2023-11-10T03:08:15.5414095Z Traceback (most recent call last):
2023-11-10T03:08:15.5414786Z   File "/mnt/vss/_work/1/s/scripts/ci/update_ext_cmd_tree.py", line 99, in <module>
2023-11-10T03:08:15.5415577Z     update_cmd_tree(ext)
2023-11-10T03:08:15.5416253Z   File "/mnt/vss/_work/1/s/scripts/ci/update_ext_cmd_tree.py", line 47, in update_cmd_tree
2023-11-10T03:08:15.5417369Z     extension_command_table, _ = _load_extension_command_loader(invoker.commands_loader, None, ext_mod)
2023-11-10T03:08:15.5419421Z   File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/azure/cli/core/commands/__init__.py", line 1081, in _load_extension_command_loader
2023-11-10T03:08:15.5421025Z     return _load_command_loader(loader, args, ext, '')
2023-11-10T03:08:15.5422963Z   File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/azure/cli/core/commands/__init__.py", line 1067, in _load_command_loader
2023-11-10T03:08:15.5424454Z     command_table = command_loader.load_command_table(args)
2023-11-10T03:08:15.5425700Z   File "/opt/az/azcliextensions/azure-iot-ops/azext_edge/__init__.py", line 16, in load_command_table
2023-11-10T03:08:15.5426790Z     from azext_edge.edge.command_map import load_iotops_commands
2023-11-10T03:08:15.5428002Z   File "/opt/az/azcliextensions/azure-iot-ops/azext_edge/edge/__init__.py", line 7, in <module>
2023-11-10T03:08:15.5428911Z     from ._help import load_iotops_help
2023-11-10T03:08:15.5429926Z   File "/opt/az/azcliextensions/azure-iot-ops/azext_edge/edge/_help.py", line 11, in <module>
2023-11-10T03:08:15.5431083Z     from .providers.edge_api import MQ_ACTIVE_API
2023-11-10T03:08:15.5432413Z   File "/opt/az/azcliextensions/azure-iot-ops/azext_edge/edge/providers/edge_api/__init__.py", line 7, in <module>
2023-11-10T03:08:15.5433851Z     from .base import EdgeResourceApi, EdgeApiManager
2023-11-10T03:08:15.5435186Z   File "/opt/az/azcliextensions/azure-iot-ops/azext_edge/edge/providers/edge_api/base.py", line 10, in <module>
2023-11-10T03:08:15.5436464Z     from ...providers.base import get_cluster_custom_api, get_custom_objects
2023-11-10T03:08:15.5437830Z   File "/opt/az/azcliextensions/azure-iot-ops/azext_edge/edge/providers/base.py", line 15, in <module>
2023-11-10T03:08:15.5438877Z     from kubernetes.client.exceptions import ApiException
2023-11-10T03:08:15.5439766Z ModuleNotFoundError: No module named 'kubernetes.client.exceptions'
2023-11-10T03:08:15.7089667Z ##[error]Script failed with exit code: 1
```


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
