### PR TITLE
fix lookup for custom locations rp sp to use appId instead of displayName

### DIFF
--- a/src/connectedk8s/HISTORY.rst
+++ b/src/connectedk8s/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+1.5.5
+++++++
+* Lookup Custom Locations objectId using appId instead of displayName
+
 1.5.4
 ++++++
 * Log debug if 'arcConfigEndpoint' doesn't exist in 'dataplaneEndpoints' ARM metadata.

--- a/src/connectedk8s/azext_connectedk8s/custom.py
+++ b/src/connectedk8s/azext_connectedk8s/custom.py
@@ -2194,7 +2194,7 @@ def get_custom_locations_oid(cmd, cl_oid):
     try:
         sp_graph_client = get_graph_client_service_principals(cmd.cli_ctx)
         sub_filters = []
-        sub_filters.append("appId eq '{}'".format("bc313c14-388c-4e7d-a58e-70017303ee3b")) # lookup using well-known first-party application id
+        sub_filters.append("appId eq '{}'".format("bc313c14-388c-4e7d-a58e-70017303ee3b"))  # Lookup using well-known first-party application id
         result = list(sp_graph_client.list(filter=(' and '.join(sub_filters))))
         if len(result) != 0:
             if cl_oid is not None and cl_oid != result[0].object_id:

--- a/src/connectedk8s/azext_connectedk8s/custom.py
+++ b/src/connectedk8s/azext_connectedk8s/custom.py
@@ -2194,7 +2194,7 @@ def get_custom_locations_oid(cmd, cl_oid):
     try:
         sp_graph_client = get_graph_client_service_principals(cmd.cli_ctx)
         sub_filters = []
-        sub_filters.append("displayName eq '{}'".format("Custom Locations RP"))
+        sub_filters.append("appId eq '{}'".format("bc313c14-388c-4e7d-a58e-70017303ee3b")) # lookup using well-known first-party application id
         result = list(sp_graph_client.list(filter=(' and '.join(sub_filters))))
         if len(result) != 0:
             if cl_oid is not None and cl_oid != result[0].object_id:

--- a/src/connectedk8s/setup.py
+++ b/src/connectedk8s/setup.py
@@ -17,7 +17,7 @@ except ImportError:
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
 
-VERSION = '1.5.4'
+VERSION = '1.5.5'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Fixes an interaction that was previously looking-up an identity object using a weak filter that could be exploited to return multiple entities. The code would just take the first one in the results and grant it access. This change modifies that lookup to use a stronger filter that cannot have multiple objects returned, plugging the security hole.