### PR TITLE
arcdata | Remove /en-us/ causing build warnings in azure-docs-cli

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -12736,7 +12736,7 @@
                                 "description": "DESCRIPTION.rst"
                             },
                             "project_urls": {
-                                "Home": "https://docs.microsoft.com/en-us/azure/azure-arc/data/"
+                                "Home": "https://docs.microsoft.com/azure/azure-arc/data/"
                             }
                         }
                     },
@@ -12794,7 +12794,7 @@
                                 "description": "DESCRIPTION.rst"
                             },
                             "project_urls": {
-                                "Home": "https://docs.microsoft.com/en-us/azure/azure-arc/data/"
+                                "Home": "https://docs.microsoft.com/azure/azure-arc/data/"
                             }
                         }
                     },
@@ -12852,7 +12852,7 @@
                                 "description": "DESCRIPTION.rst"
                             },
                             "project_urls": {
-                                "Home": "https://docs.microsoft.com/en-us/azure/azure-arc/data/"
+                                "Home": "https://docs.microsoft.com/azure/azure-arc/data/"
                             }
                         }
                     },
@@ -12910,7 +12910,7 @@
                                 "description": "DESCRIPTION.rst"
                             },
                             "project_urls": {
-                                "Home": "https://docs.microsoft.com/en-us/azure/azure-arc/data/"
+                                "Home": "https://docs.microsoft.com/azure/azure-arc/data/"
                             }
                         }
                     },
@@ -12968,7 +12968,7 @@
                                 "description": "DESCRIPTION.rst"
                             },
                             "project_urls": {
-                                "Home": "https://docs.microsoft.com/en-us/azure/azure-arc/data/"
+                                "Home": "https://docs.microsoft.com/azure/azure-arc/data/"
                             }
                         }
                     },
@@ -13026,7 +13026,7 @@
                                 "description": "DESCRIPTION.rst"
                             },
                             "project_urls": {
-                                "Home": "https://docs.microsoft.com/en-us/azure/azure-arc/data/"
+                                "Home": "https://docs.microsoft.com/azure/azure-arc/data/"
                             }
                         }
                     },
@@ -13084,7 +13084,7 @@
                                 "description": "DESCRIPTION.rst"
                             },
                             "project_urls": {
-                                "Home": "https://docs.microsoft.com/en-us/azure/azure-arc/data/"
+                                "Home": "https://docs.microsoft.com/azure/azure-arc/data/"
                             }
                         }
                     },
@@ -13142,7 +13142,7 @@
                                 "description": "DESCRIPTION.rst"
                             },
                             "project_urls": {
-                                "Home": "https://docs.microsoft.com/en-us/azure/azure-arc/data/"
+                                "Home": "https://docs.microsoft.com/azure/azure-arc/data/"
                             }
                         }
                     },
@@ -13200,7 +13200,7 @@
                                 "description": "DESCRIPTION.rst"
                             },
                             "project_urls": {
-                                "Home": "https://docs.microsoft.com/en-us/azure/azure-arc/data/"
+                                "Home": "https://docs.microsoft.com/azure/azure-arc/data/"
                             }
                         }
                     },
@@ -13258,7 +13258,7 @@
                                 "description": "DESCRIPTION.rst"
                             },
                             "project_urls": {
-                                "Home": "https://docs.microsoft.com/en-us/azure/azure-arc/data/"
+                                "Home": "https://docs.microsoft.com/azure/azure-arc/data/"
                             }
                         }
                     },
@@ -13316,7 +13316,7 @@
                                 "description": "DESCRIPTION.rst"
                             },
                             "project_urls": {
-                                "Home": "https://docs.microsoft.com/en-us/azure/azure-arc/data/"
+                                "Home": "https://docs.microsoft.com/azure/azure-arc/data/"
                             }
                         }
                     },
@@ -13374,7 +13374,7 @@
                                 "description": "DESCRIPTION.rst"
                             },
                             "project_urls": {
-                                "Home": "https://docs.microsoft.com/en-us/azure/azure-arc/data/"
+                                "Home": "https://docs.microsoft.com/azure/azure-arc/data/"
                             }
                         }
                     },
@@ -13432,7 +13432,7 @@
                                 "description": "DESCRIPTION.rst"
                             },
                             "project_urls": {
-                                "Home": "https://docs.microsoft.com/en-us/azure/azure-arc/data/"
+                                "Home": "https://docs.microsoft.com/azure/azure-arc/data/"
                             }
                         }
                     },
@@ -13490,7 +13490,7 @@
                                 "description": "DESCRIPTION.rst"
                             },
                             "project_urls": {
-                                "Home": "https://docs.microsoft.com/en-us/azure/azure-arc/data/"
+                                "Home": "https://docs.microsoft.com/azure/azure-arc/data/"
                             }
                         }
                     },
@@ -13548,7 +13548,7 @@
                                 "description": "DESCRIPTION.rst"
                             },
                             "project_urls": {
-                                "Home": "https://docs.microsoft.com/en-us/azure/azure-arc/data/"
+                                "Home": "https://docs.microsoft.com/azure/azure-arc/data/"
                             }
                         }
                     },
@@ -13606,7 +13606,7 @@
                                 "description": "DESCRIPTION.rst"
                             },
                             "project_urls": {
-                                "Home": "https://docs.microsoft.com/en-us/azure/azure-arc/data/"
+                                "Home": "https://docs.microsoft.com/azure/azure-arc/data/"
                             }
                         }
                     },
@@ -13664,7 +13664,7 @@
                                 "description": "DESCRIPTION.rst"
                             },
                             "project_urls": {
-                                "Home": "https://docs.microsoft.com/en-us/azure/azure-arc/data/"
+                                "Home": "https://docs.microsoft.com/azure/azure-arc/data/"
                             }
                         }
                     },
@@ -13722,7 +13722,7 @@
                                 "description": "DESCRIPTION.rst"
                             },
                             "project_urls": {
-                                "Home": "https://docs.microsoft.com/en-us/azure/azure-arc/data/"
+                                "Home": "https://docs.microsoft.com/azure/azure-arc/data/"
                             }
                         }
                     },
@@ -13780,7 +13780,7 @@
                                 "description": "DESCRIPTION.rst"
                             },
                             "project_urls": {
-                                "Home": "https://docs.microsoft.com/en-us/azure/azure-arc/data/"
+                                "Home": "https://docs.microsoft.com/azure/azure-arc/data/"
                             }
                         }
                     },
@@ -13838,7 +13838,7 @@
                                 "description": "DESCRIPTION.rst"
                             },
                             "project_urls": {
-                                "Home": "https://docs.microsoft.com/en-us/azure/azure-arc/data/"
+                                "Home": "https://docs.microsoft.com/azure/azure-arc/data/"
                             }
                         }
                     },
@@ -13896,7 +13896,7 @@
                                 "description": "DESCRIPTION.rst"
                             },
                             "project_urls": {
-                                "Home": "https://docs.microsoft.com/en-us/azure/azure-arc/data/"
+                                "Home": "https://docs.microsoft.com/azure/azure-arc/data/"
                             }
                         }
                     },
@@ -13954,7 +13954,7 @@
                                 "description": "DESCRIPTION.rst"
                             },
                             "project_urls": {
-                                "Home": "https://docs.microsoft.com/en-us/azure/azure-arc/data/"
+                                "Home": "https://docs.microsoft.com/azure/azure-arc/data/"
                             }
                         }
                     },
@@ -14012,7 +14012,7 @@
                                 "description": "DESCRIPTION.rst"
                             },
                             "project_urls": {
-                                "Home": "https://docs.microsoft.com/en-us/azure/azure-arc/data/"
+                                "Home": "https://docs.microsoft.com/azure/azure-arc/data/"
                             }
                         }
                     },
@@ -14071,7 +14071,7 @@
                                 "description": "DESCRIPTION.rst"
                             },
                             "project_urls": {
-                                "Home": "https://docs.microsoft.com/en-us/azure/azure-arc/data/"
+                                "Home": "https://docs.microsoft.com/azure/azure-arc/data/"
                             }
                         }
                     },
@@ -14130,7 +14130,7 @@
                                 "description": "DESCRIPTION.rst"
                             },
                             "project_urls": {
-                                "Home": "https://docs.microsoft.com/en-us/azure/azure-arc/data/"
+                                "Home": "https://docs.microsoft.com/azure/azure-arc/data/"
                             }
                         }
                     },
@@ -14189,7 +14189,7 @@
                                 "description": "DESCRIPTION.rst"
                             },
                             "project_urls": {
-                                "Home": "https://docs.microsoft.com/en-us/azure/azure-arc/data/"
+                                "Home": "https://docs.microsoft.com/azure/azure-arc/data/"
                             }
                         }
                     },
@@ -14248,7 +14248,7 @@
                                 "description": "DESCRIPTION.rst"
                             },
                             "project_urls": {
-                                "Home": "https://docs.microsoft.com/en-us/azure/azure-arc/data/"
+                                "Home": "https://docs.microsoft.com/azure/azure-arc/data/"
                             }
                         }
                     },
@@ -14307,7 +14307,7 @@
                                 "description": "DESCRIPTION.rst"
                             },
                             "project_urls": {
-                                "Home": "https://docs.microsoft.com/en-us/azure/azure-arc/data/"
+                                "Home": "https://docs.microsoft.com/azure/azure-arc/data/"
                             }
                         }
                     },
@@ -14366,7 +14366,7 @@
                                 "description": "DESCRIPTION.rst"
                             },
                             "project_urls": {
-                                "Home": "https://docs.microsoft.com/en-us/azure/azure-arc/data/"
+                                "Home": "https://docs.microsoft.com/azure/azure-arc/data/"
                             }
                         }
                     },
@@ -14425,7 +14425,7 @@
                                 "description": "DESCRIPTION.rst"
                             },
                             "project_urls": {
-                                "Home": "https://docs.microsoft.com/en-us/azure/azure-arc/data/"
+                                "Home": "https://docs.microsoft.com/azure/azure-arc/data/"
                             }
                         }
                     },
@@ -14485,7 +14485,7 @@
                                 "description": "DESCRIPTION.rst"
                             },
                             "project_urls": {
-                                "Home": "https://docs.microsoft.com/en-us/azure/azure-arc/data/"
+                                "Home": "https://docs.microsoft.com/azure/azure-arc/data/"
                             }
                         }
                     },
@@ -14544,7 +14544,7 @@
                                 "description": "DESCRIPTION.rst"
                             },
                             "project_urls": {
-                                "Home": "https://docs.microsoft.com/en-us/azure/azure-arc/data/"
+                                "Home": "https://docs.microsoft.com/azure/azure-arc/data/"
                             }
                         }
                     },
@@ -14603,7 +14603,7 @@
                                 "description": "DESCRIPTION.rst"
                             },
                             "project_urls": {
-                                "Home": "https://docs.microsoft.com/en-us/sql/sql-server/azure-arc/overview?view=sql-server-ver15"
+                                "Home": "https://docs.microsoft.com/sql/sql-server/azure-arc/overview?view=sql-server-ver15"
                             }
                         }
                     },
@@ -14660,7 +14660,7 @@
                                 "description": "DESCRIPTION.rst"
                             },
                             "project_urls": {
-                                "Home": "https://docs.microsoft.com/en-us/sql/sql-server/azure-arc/overview?view=sql-server-ver15"
+                                "Home": "https://docs.microsoft.com/sql/sql-server/azure-arc/overview?view=sql-server-ver15"
                             }
                         }
                     },


### PR DESCRIPTION
The purpose of this PR is to remove `/en-us/` in URLs causing build warnings in azure-docs-cli `azure-cli-extensions-list.md`.