### PR TITLE
{AKS} Replace Workload Identity related functions in aks-preview with azure-cli

### DIFF
--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -11,8 +11,12 @@ To release a new version, please select a new version number (usually plus 1 to 
 
 Pending
 +++++++
+
+0.5.174
++++++++
 * Fix the response format for `az aks mesh get-revisions` and `az aks mesh get-upgrades`.
 * Fix for `az aks approuting update` command failing on granting keyvault permissions to managed identity.
+* Replace Workload Identity related functions with stable version.
 
 0.5.173
 +++++++

--- a/src/aks-preview/azext_aks_preview/_params.py
+++ b/src/aks-preview/azext_aks_preview/_params.py
@@ -465,7 +465,7 @@ def load_arguments(self, _):
         c.argument('enable_pod_security_policy', action='store_true', deprecate_info=c.deprecate(target='--enable-pod-security-policy', hide=True))
         c.argument('enable_pod_identity', action='store_true')
         c.argument('enable_pod_identity_with_kubenet', action='store_true')
-        c.argument('enable_workload_identity', action='store_true', is_preview=True)
+        c.argument('enable_workload_identity', action='store_true')
         c.argument('enable_image_cleaner', action='store_true')
         c.argument('enable_azure_service_mesh',
                    options_list=["--enable-azure-service-mesh", "--enable-asm"],
@@ -614,8 +614,8 @@ def load_arguments(self, _):
         c.argument('enable_pod_identity', action='store_true')
         c.argument('enable_pod_identity_with_kubenet', action='store_true')
         c.argument('disable_pod_identity', action='store_true')
-        c.argument('enable_workload_identity', action='store_true', is_preview=True)
-        c.argument('disable_workload_identity', action='store_true', is_preview=True)
+        c.argument('enable_workload_identity', action='store_true')
+        c.argument('disable_workload_identity', action='store_true')
         c.argument('enable_image_cleaner', action='store_true')
         c.argument('disable_image_cleaner', action='store_true', validator=validate_image_cleaner_enable_disable_mutually_exclusive)
         c.argument('image_cleaner_interval_hours', type=int)

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
@@ -5924,7 +5924,7 @@ class AKSPreviewManagedClusterUpdateDecoratorTestCase(unittest.TestCase):
         )
         dec.context.attach_mc(mc)
         updated_mc = dec.update_workload_identity_profile(mc)
-        self.assertIsNone(updated_mc.security_profile.workload_identity)
+        self.assertIsNotNone(updated_mc.security_profile.workload_identity)
 
     def test_update_workload_identity_profile__enabled(self):
         dec = AKSPreviewManagedClusterUpdateDecorator(

--- a/src/aks-preview/setup.py
+++ b/src/aks-preview/setup.py
@@ -9,7 +9,7 @@ from codecs import open as open1
 
 from setuptools import setup, find_packages
 
-VERSION = "0.5.173"
+VERSION = "0.5.174"
 
 CLASSIFIERS = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
```bash
az aks create --subscription $SUB_ID \
  -n $CLUSTER_NAME \
  -g $RG_NAME \
  --enable-workload-identity

az aks update --subscription $SUB_ID \
  -n $CLUSTER_NAME \
  -g $RG_NAME \
  --disable-workload-identity
```


### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)

For new extensions:

- [x] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
