### PR TITLE
{AKS} `az aks update`: force `--network-policy=cilium` whenever `--network-dataplane=cilium`

### DIFF
--- a/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
@@ -68,6 +68,7 @@ from azext_aks_preview._consts import (
     CONST_NETWORK_PLUGIN_AZURE,
     CONST_NETWORK_PLUGIN_MODE_OVERLAY,
     CONST_NETWORK_DATAPLANE_CILIUM,
+    CONST_NETWORK_POLICY_CILIUM,
     CONST_PRIVATE_DNS_ZONE_NONE,
     CONST_PRIVATE_DNS_ZONE_SYSTEM,
     CONST_AZURE_KEYVAULT_SECRETS_PROVIDER_ADDON_NAME,
@@ -3436,6 +3437,9 @@ class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):
         network_policy = self.context.get_network_policy()
         if network_policy:
             mc.network_profile.network_policy = network_policy
+
+        if network_dataplane == CONST_NETWORK_DATAPLANE_CILIUM:
+            mc.network_profile.network_policy = CONST_NETWORK_POLICY_CILIUM
 
         return mc
 

--- a/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
@@ -3437,8 +3437,10 @@ class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):
         network_policy = self.context.get_network_policy()
         if network_policy:
             mc.network_profile.network_policy = network_policy
-
-        if network_dataplane == CONST_NETWORK_DATAPLANE_CILIUM:
+        elif network_dataplane == CONST_NETWORK_DATAPLANE_CILIUM:
+            # force network_policy to "cilium" when network_dataplane is "cilium" to pass validation in aks rp
+            # this was needed because api version 2023-08-02preview introduced --network-policy=none
+            # without forcing network_policy to "cilium" here, when upgrading to cilium without specifying --network-policy, it will be set to none by default and validation in aks rp will fail.
             mc.network_profile.network_policy = CONST_NETWORK_POLICY_CILIUM
 
         return mc

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
@@ -5104,6 +5104,7 @@ class AKSPreviewManagedClusterUpdateDecoratorTestCase(unittest.TestCase):
                 network_plugin="azure",
                 network_plugin_mode="overlay",
                 network_dataplane="cilium",
+                network_policy="",
                 pod_cidr="100.64.0.0/16",
                 service_cidr="192.168.0.0/16"
             ),
@@ -5121,6 +5122,7 @@ class AKSPreviewManagedClusterUpdateDecoratorTestCase(unittest.TestCase):
                 network_plugin="azure",
                 network_plugin_mode="overlay",
                 network_dataplane="cilium",
+                network_policy="cilium",
                 pod_cidr="100.64.0.0/16",
                 service_cidr="192.168.0.0/16",
             ),


### PR DESCRIPTION
Recent versions of the aks-preview Azure CLI extension use an AKS preview API (2023-08-02preview) that introduced networkPolicy=none. This causes the command to upgrade to Cilium dataplane to fail with a validation error when --network-policy isn't set explicitly to "cilium".

1. Azure CLI retrieves the current cluster, which defaults to networkPolicy=none.
2. Azure CLI modifies the cluster object, leaving networkPolicy=none if not explicitly overridden by a CLI flag.
3. Azure CLI sends the modified cluster object to AKS, which fails on validation that networkPolicy=cilium when networkDataplane=cilium.

Update Azure Preview CLI to force `--network-policy=cilium` when it is not specified and when `--network-dataplane=cilium` allows the validation to succeed. 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
`az aks update --network-dataplane=cilium`


### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
