### PR TITLE
[Azure Load Testing] Fix for 'az load test update' command failing due to accessing undefined object

### DIFF
--- a/src/load/HISTORY.rst
+++ b/src/load/HISTORY.rst
@@ -2,6 +2,10 @@
 
 Release History
 ===============
+0.3.3
+++++++
+* Fix for 'az load test update' command when using --load-test-config-file option failing due to accessing undefined object.
+
 0.3.2
 ++++++
 * Added null support for argument --certificate and --subnet in commands "az load update" and "az load create" to remove those properties from test.

--- a/src/load/azext_load/data_plane/utils/utils.py
+++ b/src/load/azext_load/data_plane/utils/utils.py
@@ -423,6 +423,7 @@ def create_or_update_test_with_config(
     new_body["loadTestConfiguration"]["quickStartTest"] = False
 
     new_body["passFailCriteria"] = {}
+    
     for key in body.get("passFailCriteria", {}):
         new_body["passFailCriteria"][key] = None
     if yaml_test_body.get("passFailCriteria") is not None:

--- a/src/load/azext_load/data_plane/utils/utils.py
+++ b/src/load/azext_load/data_plane/utils/utils.py
@@ -422,6 +422,7 @@ def create_or_update_test_with_config(
     # quick test is not supported in CLI
     new_body["loadTestConfiguration"]["quickStartTest"] = False
 
+    new_body["passFailCriteria"] = {}
     for key in body.get("passFailCriteria", {}):
         new_body["passFailCriteria"][key] = None
     if yaml_test_body.get("passFailCriteria") is not None:

--- a/src/load/azext_load/data_plane/utils/utils.py
+++ b/src/load/azext_load/data_plane/utils/utils.py
@@ -423,7 +423,6 @@ def create_or_update_test_with_config(
     new_body["loadTestConfiguration"]["quickStartTest"] = False
 
     new_body["passFailCriteria"] = {}
-    
     for key in body.get("passFailCriteria", {}):
         new_body["passFailCriteria"][key] = None
     if yaml_test_body.get("passFailCriteria") is not None:

--- a/src/load/azext_load/tests/latest/test_load.py
+++ b/src/load/azext_load/tests/latest/test_load.py
@@ -88,7 +88,7 @@ class LoadScenario(ScenarioTest):
 
         # Create a new Key for CMK encryption
         key = self.cmd('az keyvault key create -n {cmk_key1_name} '
-                '-p software '
+                '--protection software '
                 '--vault-name {kv}').get_output_in_json()
 
         self.kwargs['cmk_key1'] = key['key']['kid']

--- a/src/load/setup.py
+++ b/src/load/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 
 
 # HISTORY.rst entry.
-VERSION = '0.3.2'
+VERSION = '0.3.3'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
---
This PR is for a bug fix in our existing extension for Azure Load Testing service under "load" extension.
Change in this PR:
1. Fix for 'az load test update' command when using --load-test-config-file option failing due to accessing undefined object.

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
Changes will be reflected for "az load test update" command.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
