### PR TITLE
Cast "certificate_validity" as an int before calling ListCredentials

### DIFF
--- a/src/ssh/azext_ssh/connectivity_utils.py
+++ b/src/ssh/azext_ssh/connectivity_utils.py
@@ -178,7 +178,7 @@ def _list_credentials(cmd, resource_uri, certificate_validity_in_seconds):
     list_cred_args = {
         'endpoint_name': 'default',
         'resource_uri': resource_uri,
-        'expiresin': certificate_validity_in_seconds,
+        'expiresin': int(certificate_validity_in_seconds),
         'service_name': "SSH"
     }
 


### PR DESCRIPTION
This has never been a problem before, but a customer suddenly started having issues because ListCredentials was being called with a float instead of an int.
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)

For new extensions:

- [x] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
