### PR TITLE
{CI} Regenerating breaking change report with only_break=True to control length within 65535.

### DIFF
--- a/scripts/ci/breaking_change_test.py
+++ b/scripts/ci/breaking_change_test.py
@@ -96,11 +96,13 @@ def get_base_meta_files(diff_ref):
     subprocess.run(cmd)
 
 
-def meta_diff():
+def meta_diff(only_break=False):
     if os.path.exists(diff_meta_path):
         for file in os.listdir(diff_meta_path):
             if file.endswith('.json'):
                 cmd = ['azdev', 'command-change', 'meta-diff', '--base-meta-file', os.path.join(base_meta_path, file), '--diff-meta-file', os.path.join(diff_meta_path, file), '--output-file', os.path.join(output_path, file)]
+                if only_break:
+                    cmd.append('--only-break')
                 print(cmd)
                 subprocess.run(cmd)
         cmd = ['ls', '-al', output_path]
@@ -108,7 +110,7 @@ def meta_diff():
         subprocess.run(cmd)
 
 
-def get_pipeline_result():
+def get_pipeline_result(only_break=False):
     pipeline_result = {
         "breaking_change_test": {
             "Details": [
@@ -148,7 +150,18 @@ def get_pipeline_result():
             "Status": "Succeeded",
             "Content": ""
         })
-    print(json.dumps(pipeline_result, indent=4))
+
+    result_length = len(json.dumps(pipeline_result, indent=4))
+    if result_length > 65535:
+        if only_break:
+            logger.error("Breaking change report exceeds 65535 characters even with only_break=True.")
+            return pipeline_result
+
+        logger.info("Regenerating breaking change report with only_break=True to control length within 65535.")
+        meta_diff(only_break=True)
+        pipeline_result = get_pipeline_result(only_break=True)
+        return pipeline_result
+
     return pipeline_result
 
 


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

![image](https://github.com/Azure/azure-cli-extensions/assets/18628534/91b8da09-fbb3-4128-8ede-c4b1ba635db5)


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
