### PR TITLE
[containerapp] Fix telemetry collection when using local builder

### DIFF
--- a/src/containerapp/HISTORY.rst
+++ b/src/containerapp/HISTORY.rst
@@ -4,6 +4,7 @@ Release History
 ===============
 upcoming
 ++++++
+* 'az containerapp create/update/up': Propagate telemetry collection configuration to builder when building provided source locally
 
 0.3.46
 ++++++


### PR DESCRIPTION
Currently, when `containerapp create/update/up` are called and the provided source is built locally using the builder, the previously set value for `collect_telemetry` within the Azure CLI is not respected when running the builder. This PR will set the `ORYX_DISABLE_TELEMETRY` environment variable on the builder if it's found that the user previously disabled telemetry collection.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

az containerapp create
az containerapp update
az containerapp up

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)

For new extensions:

~- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).~


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
