### PR TITLE
{CI} Fix extension name mismatch in metadata error

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -50752,7 +50752,7 @@
                     "generator": "bdist_wheel (0.30.0)",
                     "license": "MIT",
                     "metadata_version": "2.0",
-                    "name": "monitor_control_service",
+                    "name": "monitor-control-service",
                     "summary": "Microsoft Azure Command-Line Tools MonitorClient Extension",
                     "version": "1.0.0"
                 },

--- a/src/monitor-control-service/setup.py
+++ b/src/monitor-control-service/setup.py
@@ -34,7 +34,7 @@ with open('HISTORY.rst', 'r', encoding='utf-8') as f:
     HISTORY = f.read()
 
 setup(
-    name='monitor_control_service',
+    name='monitor-control-service',
     version=VERSION,
     description='Microsoft Azure Command-Line Tools MonitorClient Extension',
     author='Microsoft Corporation',


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
https://github.com/Azure/azure-cli-extensions/blob/f5caab7a6063e94971b4a7ff0f08a94730ed605a/scripts/ci/test_index.py#L84
ext_name comes from the key of index.json.
item['metadata']['name'] comes from name in setup.py.
These two should be consistent.

![image](https://github.com/Azure/azure-cli-extensions/assets/18628534/a778b411-028e-4057-af67-1e14550e021b)


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
