### PR TITLE
Whitelist Version Check for Non-Stable Release Trains for connectedk8s

### DIFF
--- a/src/connectedk8s/HISTORY.rst
+++ b/src/connectedk8s/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+1.6.3
+++++++
+* Skip checking operation version support for non-stable release trains.
+
 1.6.2
 ++++++
 * Additional bugfixes.

--- a/src/connectedk8s/azext_connectedk8s/_utils.py
+++ b/src/connectedk8s/azext_connectedk8s/_utils.py
@@ -92,7 +92,7 @@ def validate_custom_token(cmd, resource_group_name, location):
     return False, location
 
 
-def get_chart_path(registry_path, kube_config, kube_context, helm_client_location, chart_folder_name='AzureArcCharts', chart_name='azure-arc-k8sagents', new_path=True, release_train='stable'):
+def get_chart_path(registry_path, kube_config, kube_context, helm_client_location, chart_folder_name='AzureArcCharts', chart_name='azure-arc-k8sagents', new_path=True):
     # Exporting Helm chart
     chart_export_path = os.path.join(os.path.expanduser('~'), '.azure', chart_folder_name)
     try:
@@ -101,7 +101,7 @@ def get_chart_path(registry_path, kube_config, kube_context, helm_client_locatio
     except:
         logger.warning("Unable to cleanup the {} already present on the machine. In case of failure, please cleanup the directory '{}' and try again.".format(chart_folder_name, chart_export_path))
 
-    pull_helm_chart(registry_path, chart_export_path, kube_config, kube_context, helm_client_location, new_path, release_train, chart_name)
+    pull_helm_chart(registry_path, chart_export_path, kube_config, kube_context, helm_client_location, new_path, chart_name)
 
     # Returning helm chart path
     helm_chart_path = os.path.join(chart_export_path, chart_name)
@@ -113,12 +113,12 @@ def get_chart_path(registry_path, kube_config, kube_context, helm_client_locatio
     return chart_path
 
 
-def pull_helm_chart(registry_path, chart_export_path, kube_config, kube_context, helm_client_location, new_path, release_train, chart_name='azure-arc-k8sagents', retry_count=5, retry_delay=3):
+def pull_helm_chart(registry_path, chart_export_path, kube_config, kube_context, helm_client_location, new_path, chart_name='azure-arc-k8sagents', retry_count=5, retry_delay=3):
     chart_url = registry_path.split(':')[0]
     chart_version = registry_path.split(':')[1]
 
     if new_path:
-        if release_train == 'stable' and (version.parse(chart_version) < version.parse("1.14.0")):
+        if '-' not in chart_version and (version.parse(chart_version) < version.parse("1.14.0")):
             error_summary = "This CLI version does not support upgrading to Agents versions older than v1.14"
             telemetry.set_exception(exception='Operation not supported on older Agents', fault_type=consts.Operation_Not_Supported_Fault_Type, summary=error_summary)
             raise ClientRequestError(error_summary, recommendation="Please select an agent-version >= v1.14 to upgrade to using 'az connectedk8s upgrade -g <rg_name> -n <cluster_name> --agent-version <at-least-1.14>'.")

--- a/src/connectedk8s/azext_connectedk8s/_utils.py
+++ b/src/connectedk8s/azext_connectedk8s/_utils.py
@@ -92,7 +92,7 @@ def validate_custom_token(cmd, resource_group_name, location):
     return False, location
 
 
-def get_chart_path(registry_path, kube_config, kube_context, helm_client_location, chart_folder_name='AzureArcCharts', chart_name='azure-arc-k8sagents', new_path=True):
+def get_chart_path(registry_path, kube_config, kube_context, helm_client_location, chart_folder_name='AzureArcCharts', chart_name='azure-arc-k8sagents', new_path=True, release_train='stable'):
     # Exporting Helm chart
     chart_export_path = os.path.join(os.path.expanduser('~'), '.azure', chart_folder_name)
     try:
@@ -101,7 +101,7 @@ def get_chart_path(registry_path, kube_config, kube_context, helm_client_locatio
     except:
         logger.warning("Unable to cleanup the {} already present on the machine. In case of failure, please cleanup the directory '{}' and try again.".format(chart_folder_name, chart_export_path))
 
-    pull_helm_chart(registry_path, chart_export_path, kube_config, kube_context, helm_client_location, new_path, chart_name)
+    pull_helm_chart(registry_path, chart_export_path, kube_config, kube_context, helm_client_location, new_path, release_train, chart_name)
 
     # Returning helm chart path
     helm_chart_path = os.path.join(chart_export_path, chart_name)
@@ -113,12 +113,12 @@ def get_chart_path(registry_path, kube_config, kube_context, helm_client_locatio
     return chart_path
 
 
-def pull_helm_chart(registry_path, chart_export_path, kube_config, kube_context, helm_client_location, new_path, chart_name='azure-arc-k8sagents', retry_count=5, retry_delay=3):
+def pull_helm_chart(registry_path, chart_export_path, kube_config, kube_context, helm_client_location, new_path, release_train, chart_name='azure-arc-k8sagents', retry_count=5, retry_delay=3):
     chart_url = registry_path.split(':')[0]
     chart_version = registry_path.split(':')[1]
 
     if new_path:
-        if (version.parse(chart_version) < version.parse("1.14.0")):
+        if release_train == 'stable' and (version.parse(chart_version) < version.parse("1.14.0")):
             error_summary = "This CLI version does not support upgrading to Agents versions older than v1.14"
             telemetry.set_exception(exception='Operation not supported on older Agents', fault_type=consts.Operation_Not_Supported_Fault_Type, summary=error_summary)
             raise ClientRequestError(error_summary, recommendation="Please select an agent-version >= v1.14 to upgrade to using 'az connectedk8s upgrade -g <rg_name> -n <cluster_name> --agent-version <at-least-1.14>'.")

--- a/src/connectedk8s/azext_connectedk8s/_utils.py
+++ b/src/connectedk8s/azext_connectedk8s/_utils.py
@@ -118,6 +118,7 @@ def pull_helm_chart(registry_path, chart_export_path, kube_config, kube_context,
     chart_version = registry_path.split(':')[1]
 
     if new_path:
+        # Version check for stable release train (chart_version will be in X.Y.Z format as opposed to X.Y.Z-NONSTABLE)
         if '-' not in chart_version and (version.parse(chart_version) < version.parse("1.14.0")):
             error_summary = "This CLI version does not support upgrading to Agents versions older than v1.14"
             telemetry.set_exception(exception='Operation not supported on older Agents', fault_type=consts.Operation_Not_Supported_Fault_Type, summary=error_summary)

--- a/src/connectedk8s/azext_connectedk8s/custom.py
+++ b/src/connectedk8s/azext_connectedk8s/custom.py
@@ -1122,7 +1122,7 @@ def update_connected_cluster(cmd, client, resource_group_name, cluster_name, htt
         agent_version = connected_cluster.agent_version
         registry_path = reg_path_array[0] + ":" + agent_version
 
-    check_operation_support("update (properties)", agent_version, release_train)
+    check_operation_support("update (properties)", agent_version)
 
     telemetry.add_extension_event('connectedk8s', {'Context.Default.AzureCLI.AgentVersion': agent_version})
 
@@ -1528,7 +1528,7 @@ def enable_features(cmd, client, resource_group_name, cluster_name, features, ku
         agent_version = connected_cluster.agent_version
         registry_path = reg_path_array[0] + ":" + agent_version
 
-    check_operation_support("enable-features", agent_version, release_train)
+    check_operation_support("enable-features", agent_version)
 
     telemetry.add_extension_event('connectedk8s', {'Context.Default.AzureCLI.AgentVersion': agent_version})
 
@@ -1662,7 +1662,7 @@ def get_chart_and_disable_features(cmd, connected_cluster, kube_config, kube_con
         agent_version = connected_cluster.agent_version
         registry_path = reg_path_array[0] + ":" + agent_version
 
-    check_operation_support("disable-features", agent_version, release_train)
+    check_operation_support("disable-features", agent_version)
 
     telemetry.add_extension_event('connectedk8s', {'Context.Default.AzureCLI.AgentVersion': agent_version})
 
@@ -2536,8 +2536,8 @@ def crd_cleanup_force_delete(kubectl_client_location, kube_config, kube_context)
                     _, error_helm_delete = output_patch_cmd.communicate()
 
 
-def check_operation_support(operation_name, agent_version, release_train):
+def check_operation_support(operation_name, agent_version):
     error_summary = 'This CLI version does not support {} for Agents older than v1.14'.format(operation_name)
-    if release_train == 'stable' and (version.parse(agent_version) < version.parse("1.14.0")):
+    if '-' not in agent_version and (version.parse(agent_version) < version.parse("1.14.0")):
         telemetry.set_exception(exception='Operation not supported on older Agents', fault_type=consts.Operation_Not_Supported_Fault_Type, summary=error_summary)
         raise ClientRequestError(error_summary, recommendation="Please upgrade to the latest version of the Agents using 'az connectedk8s upgrade -g <rg_name> -n <cluster_name>'.")

--- a/src/connectedk8s/azext_connectedk8s/custom.py
+++ b/src/connectedk8s/azext_connectedk8s/custom.py
@@ -2538,6 +2538,7 @@ def crd_cleanup_force_delete(kubectl_client_location, kube_config, kube_context)
 
 def check_operation_support(operation_name, agent_version):
     error_summary = 'This CLI version does not support {} for Agents older than v1.14'.format(operation_name)
+    # Version check for stable release train (agent_version will be in X.Y.Z format as opposed to X.Y.Z-NONSTABLE)
     if '-' not in agent_version and (version.parse(agent_version) < version.parse("1.14.0")):
         telemetry.set_exception(exception='Operation not supported on older Agents', fault_type=consts.Operation_Not_Supported_Fault_Type, summary=error_summary)
         raise ClientRequestError(error_summary, recommendation="Please upgrade to the latest version of the Agents using 'az connectedk8s upgrade -g <rg_name> -n <cluster_name>'.")

--- a/src/connectedk8s/azext_connectedk8s/custom.py
+++ b/src/connectedk8s/azext_connectedk8s/custom.py
@@ -1122,7 +1122,7 @@ def update_connected_cluster(cmd, client, resource_group_name, cluster_name, htt
         agent_version = connected_cluster.agent_version
         registry_path = reg_path_array[0] + ":" + agent_version
 
-    check_operation_support("update (properties)", agent_version)
+    check_operation_support("update (properties)", agent_version, release_train)
 
     telemetry.add_extension_event('connectedk8s', {'Context.Default.AzureCLI.AgentVersion': agent_version})
 
@@ -1528,7 +1528,7 @@ def enable_features(cmd, client, resource_group_name, cluster_name, features, ku
         agent_version = connected_cluster.agent_version
         registry_path = reg_path_array[0] + ":" + agent_version
 
-    check_operation_support("enable-features", agent_version)
+    check_operation_support("enable-features", agent_version, release_train)
 
     telemetry.add_extension_event('connectedk8s', {'Context.Default.AzureCLI.AgentVersion': agent_version})
 
@@ -1662,7 +1662,7 @@ def get_chart_and_disable_features(cmd, connected_cluster, kube_config, kube_con
         agent_version = connected_cluster.agent_version
         registry_path = reg_path_array[0] + ":" + agent_version
 
-    check_operation_support("disable-features", agent_version)
+    check_operation_support("disable-features", agent_version, release_train)
 
     telemetry.add_extension_event('connectedk8s', {'Context.Default.AzureCLI.AgentVersion': agent_version})
 
@@ -2536,8 +2536,8 @@ def crd_cleanup_force_delete(kubectl_client_location, kube_config, kube_context)
                     _, error_helm_delete = output_patch_cmd.communicate()
 
 
-def check_operation_support(operation_name, agent_version):
+def check_operation_support(operation_name, agent_version, release_train):
     error_summary = 'This CLI version does not support {} for Agents older than v1.14'.format(operation_name)
-    if (version.parse(agent_version) < version.parse("1.14.0")):
+    if release_train == 'stable' and (version.parse(agent_version) < version.parse("1.14.0")):
         telemetry.set_exception(exception='Operation not supported on older Agents', fault_type=consts.Operation_Not_Supported_Fault_Type, summary=error_summary)
         raise ClientRequestError(error_summary, recommendation="Please upgrade to the latest version of the Agents using 'az connectedk8s upgrade -g <rg_name> -n <cluster_name>'.")

--- a/src/connectedk8s/setup.py
+++ b/src/connectedk8s/setup.py
@@ -17,7 +17,7 @@ except ImportError:
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
 
-VERSION = '1.6.2'
+VERSION = '1.6.3'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Skip checking operation version support for non-stable release trains.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
az connectedk8s upgrade -g <rg_name> -n <cluster_name>
(should work for any version for dev/private/other-non-stable release trains, but only for v>1.1.14 for stable release train, the same applies for az connectedk8s update/enable-features/disable-features)

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)

For new extensions:

- [x] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
