### PR TITLE
fix: quantum extension - obfuscating E2E test recordings

### DIFF
--- a/src/quantum/tests.live/Run.ps1
+++ b/src/quantum/tests.live/Run.ps1
@@ -9,7 +9,7 @@ param (
 
 $RecordingsFolderPath = "src\quantum\azext_quantum\tests\latest\recordings"
 
-function Obfuscate-SASTokens {
+function Invoke-SASTokenObfuscation {
     param (
         [Parameter(mandatory=$true)]
         $RecordingsFolderPath
@@ -17,7 +17,8 @@ function Obfuscate-SASTokens {
     
     Get-ChildItem "$RecordingsFolderPath" -Filter *.yaml | 
     Foreach-Object {
-        $PathToRecording = "$RecordingsFolderPath/$_"
+        $RecordingFileName = $_.Name
+        $PathToRecording = "$RecordingsFolderPath\$RecordingFileName"
         Write-Verbose -Message "Searching for SAS Tokens in ""$PathToRecording"" and obfuscating it..."
         # Signature "sig=" query parameter consists of URL-encoded Base64 characters, so [\w%] should suffice
         (Get-Content $PathToRecording) -replace 'sig=[\w%]+(&|$)','sig=REDACTED$1' | Set-Content $PathToRecording
@@ -42,7 +43,7 @@ az account set -s $Env:AZURE_QUANTUM_SUBSCRIPTION_ID
 azdev test quantum --live --verbose --xml-path $RecordingsFolderPath
 
 # Make sure we don't check-in SAS-tokens
-Obfuscate-SASTokens -RecordingsFolderPath $RecordingsFolderPath
+Invoke-SASTokenObfuscation -RecordingsFolderPath $RecordingsFolderPath
 
 # Restoring to initial folder location
 Pop-Location


### PR DESCRIPTION
HOTFIX FOR E2E TESTS - RELEASE OF "AZ QUANTUM" EXTENSION IS NOT NEEDED
---
Fixing an issue with e2e tests for `quantum` extension where test recording obfuscation fails in PowerShell 7

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
N/A


### General Guidelines

- [X] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [X] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)

For new extensions:

- [X] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
