### PR TITLE
{CI} Disable ref doc testing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -167,23 +167,23 @@ jobs:
         ADO_PULL_REQUEST_LATEST_COMMIT: HEAD
         ADO_PULL_REQUEST_TARGET_BRANCH: $(System.PullRequest.TargetBranch)
 
-- job: IndexRefDocVerify
-  displayName: "Verify Ref Docs"
-  continueOnError: true
-  pool:
-    name: 'pool-ubuntu-2004'
-  steps:
-  - task: UsePythonVersion@0
-    displayName: 'Use Python 3.11'
-    inputs:
-      versionSpec: 3.11
-  - bash: pip install wheel==0.30.0
-    displayName: 'Install wheel==0.30.0'
-  - task: Bash@3
-    displayName: "Verify Extension Ref Docs"
-    inputs:
-      targetType: 'filePath'
-      filePath: scripts/ci/test_index_ref_doc.sh
+#- job: IndexRefDocVerify
+#  displayName: "Verify Ref Docs"
+#  continueOnError: true
+#  pool:
+#    name: 'pool-ubuntu-2004'
+#  steps:
+#  - task: UsePythonVersion@0
+#    displayName: 'Use Python 3.11'
+#    inputs:
+#      versionSpec: 3.11
+#  - bash: pip install wheel==0.30.0
+#    displayName: 'Install wheel==0.30.0'
+#  - task: Bash@3
+#    displayName: "Verify Extension Ref Docs"
+#    inputs:
+#      targetType: 'filePath'
+#      filePath: scripts/ci/test_index_ref_doc.sh
 
 - job: CheckInit
   displayName: "Check Init Files"


### PR DESCRIPTION
Alabaster dropped the old sphinx on 1/8/2024, causing ref doc related tests to fail. 
![image](https://github.com/Azure/azure-cli/assets/18628534/d5a66cd7-2248-4d1f-bf24-50fdb8334443)
This task is a pre-test task of Build Microsoft Docs, but the Microsoft Docs team has refactored this task and no longer uses sphinx, so we decided to disable this test task.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
