### PR TITLE
revert connectedk8s 1.6.4

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -28087,62 +28087,6 @@
                     "version": "1.6.3"
                 },
                 "sha256Digest": "04609310d99babb5b07bb6159a6f5c2c6ea58f758505af95a206f88ae33f7701"
-            },
-            {
-                "downloadUrl": "https://azcliprod.blob.core.windows.net/cli-extensions/connectedk8s-1.6.4-py2.py3-none-any.whl",
-                "filename": "connectedk8s-1.6.4-py2.py3-none-any.whl",
-                "metadata": {
-                    "azext.minCliCoreVersion": "2.38.0",
-                    "classifiers": [
-                        "Development Status :: 4 - Beta",
-                        "Intended Audience :: Developers",
-                        "Intended Audience :: System Administrators",
-                        "Programming Language :: Python",
-                        "Programming Language :: Python :: 3",
-                        "Programming Language :: Python :: 3.6",
-                        "Programming Language :: Python :: 3.7",
-                        "Programming Language :: Python :: 3.8",
-                        "License :: OSI Approved :: MIT License"
-                    ],
-                    "description_content_type": "text/markdown",
-                    "extensions": {
-                        "python.details": {
-                            "contacts": [
-                                {
-                                    "email": "k8connect@microsoft.com",
-                                    "name": "Microsoft Corporation",
-                                    "role": "author"
-                                }
-                            ],
-                            "document_names": {
-                                "description": "DESCRIPTION.rst"
-                            },
-                            "project_urls": {
-                                "Home": "https://github.com/Azure/azure-cli-extensions/tree/main/src/connectedk8s"
-                            }
-                        }
-                    },
-                    "extras": [],
-                    "generator": "bdist_wheel (0.30.0)",
-                    "license": "MIT",
-                    "metadata_version": "2.0",
-                    "name": "connectedk8s",
-                    "run_requires": [
-                        {
-                            "requires": [
-                                "azure-mgmt-hybridcompute (==7.0.0)",
-                                "azure-mgmt-hybridcompute==7.0.0",
-                                "kubernetes (==24.2.0)",
-                                "kubernetes==24.2.0",
-                                "pycryptodome (==3.14.1)",
-                                "pycryptodome==3.14.1"
-                            ]
-                        }
-                    ],
-                    "summary": "Microsoft Azure Command-Line Tools Connectedk8s Extension",
-                    "version": "1.6.4"
-                },
-                "sha256Digest": "fba619dc3cbf0d08abfc172e128e8c87ce6e13856a278ed462e74f0337e0d67c"
             }
         ],
         "connectedmachine": [


### PR DESCRIPTION
### Related command
az connectedk8s

Revert connectedk8s 1.6.4 which has broken the `az connectedk8s proxy` command. The fix is in this PR:
https://github.com/Azure/azure-cli-extensions/pull/7250

### General Guidelines

- [X] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [X] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [X] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
