### PR TITLE
Change default ACS generation to Gen2

### DIFF
--- a/src/spring/HISTORY.md
+++ b/src/spring/HISTORY.md
@@ -1,6 +1,6 @@
 Release History
 ===============
-1.19.5
+1.20.0
 ---
 * Change default Application Configuration Service generation value to Gen2.
 

--- a/src/spring/HISTORY.md
+++ b/src/spring/HISTORY.md
@@ -1,5 +1,9 @@
 Release History
 ===============
+1.19.5
+---
+* Change default Application Configuration Service generation value to Gen2.
+
 1.19.4
 ---
 * Enhance managed component log streaming when `-i/--instance` and `--all-instances` parameters are not specified.

--- a/src/spring/azext_spring/_tanzu_component.py
+++ b/src/spring/azext_spring/_tanzu_component.py
@@ -41,8 +41,8 @@ def create_application_configuration_service(cmd, client, resource_group, servic
             acs_resource.properties.generation = application_configuration_service_generation
             logger.warning("Create with generation {}".format(application_configuration_service_generation))
         else:
-            acs_resource.properties.generation = ConfigurationServiceGeneration.GEN1
-            logger.warning("Default generation will be Gen1")
+            acs_resource.properties.generation = ConfigurationServiceGeneration.GEN2
+            logger.warning("Default generation will be Gen2")
 
         return client.configuration_services.begin_create_or_update(resource_group, service, DEFAULT_NAME, acs_resource)
 

--- a/src/spring/azext_spring/tests/latest/test_asa_create.py
+++ b/src/spring/azext_spring/tests/latest/test_asa_create.py
@@ -141,6 +141,29 @@ class TestSpringAppsCreateWithApplicationLiveView(BasicTest):
         self.assertIsNone(self.dev_tool)
 
 
+class TestSpringAppsCreateWithApplicationConfigurationService(BasicTest):
+    def __init__(self, methodName: str = ...):
+        super().__init__(methodName=methodName)
+        self.acs_resource = None
+        self.acs_request = None
+
+    def _execute(self, resource_group, name, **kwargs):
+        client = kwargs.pop('client', None) or _get_basic_mock_client()
+        super()._execute(resource_group, name, client=client, **kwargs)
+        self.acs_request = client.configuration_services.begin_create_or_update.call_args_list
+        self.acs_resource = self.acs_request[0][0][3] if self.acs_request else None
+
+    def test_asa_enterprise_with_acs(self):
+        self._execute('rg', 'asa', sku=self._get_sku('Enterprise'),
+                      enable_application_configuration_service=True)
+        self.assertIsNotNone(self.acs_resource)
+        self.assertEqual('rg', self.acs_request[0][0][0])
+        self.assertEqual('asa', self.acs_request[0][0][1])
+        self.assertEqual('default', self.acs_request[0][0][2])
+        self.assertIsNotNone(self.acs_resource)
+        self.assertEqual(models.ConfigurationServiceGeneration.GEN2, self.acs_resource.properties.generation)
+
+
 class TestSpringAppsCreateWithApplicationAccelerator(BasicTest):
     def __init__(self, methodName: str = ...):
         super().__init__(methodName=methodName)

--- a/src/spring/setup.py
+++ b/src/spring/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
-VERSION = '1.19.5'
+VERSION = '1.20.0'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/src/spring/setup.py
+++ b/src/spring/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
-VERSION = '1.19.4'
+VERSION = '1.19.5'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
Change the ACS generation to Gen2 when enabling ACS, `spring create enable_application_configuration_service`


### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
