### PR TITLE
Change Login Migration Console App source to NuGet.org and Versioning…

### DIFF
--- a/src/datamigration/HISTORY.rst
+++ b/src/datamigration/HISTORY.rst
@@ -4,7 +4,7 @@ Release History
 ===============
 
 =======
-0.6.2
+1.0.0b1
 ++++++
 * Added support for version update in command `az datamigration login-migration`.
 

--- a/src/datamigration/HISTORY.rst
+++ b/src/datamigration/HISTORY.rst
@@ -4,6 +4,10 @@ Release History
 ===============
 
 =======
+0.6.2
+++++++
+* Added support for version update in command `az datamigration login-migration`.
+
 0.6.1
 ++++++
 * Added parameter to help gather telemetry in command `az datamigration tde-migration`.

--- a/src/datamigration/azext_datamigration/azext_metadata.json
+++ b/src/datamigration/azext_datamigration/azext_metadata.json
@@ -1,4 +1,4 @@
 {
-    "azext.isExperimental": true,
+    "azext.isPreview": true,
     "azext.minCliCoreVersion": "2.15.0"
 }

--- a/src/datamigration/azext_datamigration/manual/custom.py
+++ b/src/datamigration/azext_datamigration/manual/custom.py
@@ -281,12 +281,14 @@ def datamigration_login_migration(src_sql_connection_str=None,
                 elif param.__contains__("list") and parameterList[param] is not None:
                     parameterList[param] = " ".join(f"\"{i}\"" for i in parameterList[param])
                     cmd += f' {param} {parameterList[param]}'
+            print("Starting execution...")
             subprocess.call(cmd, shell=False)
 
         # When Config file.
         elif config_file_path is not None:
             helper.test_path_exist(config_file_path)
             cmd = f'{exePath} --configFile "{config_file_path}"'
+            print("Starting execution...")
             subprocess.call(cmd, shell=False)
 
         else:

--- a/src/datamigration/azext_datamigration/manual/helper.py
+++ b/src/datamigration/azext_datamigration/manual/helper.py
@@ -32,7 +32,7 @@ from azure.cli.core.azclierror import InvalidArgumentValueError
 # -----------------------------------------------------------------------------------------------------------------
 def validate_os_env():
 
-    if not platform.system().__contains__('Windows'):
+    if 'Windows' not in platform.system():
         raise CLIInternalError("This command cannot be run in non-windows environment. Please run this command in Windows environment")
 
 
@@ -100,11 +100,11 @@ def loginMigration_console_app_setup():
     login_migration_console_csproj = os.path.join(downloads_folder, "Logins.Console.csproj")
     login_migration_version_file = os.path.join(downloads_folder, "loginconsoleappversion.json")
     if os.path.exists(login_migration_console_zip):
-	    os.remove(login_migration_console_zip)
+        os.remove(login_migration_console_zip)
     if os.path.exists(login_migration_console_csproj):
-	    shutil.rmtree(login_migration_console_csproj)
+        shutil.rmtree(login_migration_console_csproj)
     if os.path.exists(login_migration_version_file):
-	    os.remove(login_migration_version_file)
+        os.remove(login_migration_version_file)
 
     # check and download console app
     console_app_version = check_and_download_loginMigration_console_app(downloads_folder)
@@ -117,6 +117,7 @@ def loginMigration_console_app_setup():
     exePath = os.path.join(console_app_location, "tools", "Microsoft.SqlServer.Migration.Logins.ConsoleApp.exe")
 
     return default_output_folder, exePath
+
 
 # -----------------------------------------------------------------------------------------------------------------
 # TdeMigration helper function to do console app setup (mkdir, download and extract)
@@ -170,9 +171,9 @@ def get_default_output_folder():
 
     osPlatform = platform.system()
 
-    if osPlatform.__contains__('Linux'):
+    if 'Linux' in osPlatform:
         defaultOutputPath = os.path.join(os.getenv('USERPROFILE'), ".config", "Microsoft", "SqlAssessment")
-    elif osPlatform.__contains__('Darwin'):
+    elif 'Darwin' in osPlatform:
         defaultOutputPath = os.path.join(os.getenv('USERPROFILE'), "Library", "Application Support", "Microsoft", "SqlAssessment")
     else:
         defaultOutputPath = os.path.join(os.getenv('LOCALAPPDATA'), "Microsoft", "SqlAssessment")
@@ -187,9 +188,9 @@ def get_loginMigration_default_output_folder():
 
     osPlatform = platform.system()
 
-    if osPlatform.__contains__('Linux'):
+    if 'Linux' in osPlatform:
         defaultOutputPath = os.path.join(os.getenv('USERPROFILE'), ".config", "Microsoft", "SqlLoginMigrations")
-    elif osPlatform.__contains__('Darwin'):
+    elif 'Darwin' in osPlatform:
         defaultOutputPath = os.path.join(os.getenv('USERPROFILE'), "Library", "Application Support", "Microsoft", "SqlLoginMigrations")
     else:
         defaultOutputPath = os.path.join(os.getenv('LOCALAPPDATA'), "Microsoft", "SqlLoginMigrations")
@@ -204,9 +205,9 @@ def get_tdeMigration_default_output_folder():
 
     osPlatform = platform.system()
 
-    if osPlatform.__contains__('Linux'):
+    if 'Linux' in osPlatform:
         defaultOutputPath = os.path.join(os.getenv('USERPROFILE'), ".config", "Microsoft", "SqlTdeMigrations")
-    elif osPlatform.__contains__('Darwin'):
+    elif 'Darwin' in osPlatform:
         defaultOutputPath = os.path.join(os.getenv('USERPROFILE'), "Library", "Application Support", "Microsoft", "SqlTdeMigrations")
     else:
         defaultOutputPath = os.path.join(os.getenv('LOCALAPPDATA'), "Microsoft", "SqlTdeMigrations")
@@ -221,9 +222,9 @@ def get_sqlServerSchema_default_output_folder():
 
     osPlatform = platform.system()
 
-    if osPlatform.__contains__('Linux'):
+    if 'Linux' in osPlatform:
         defaultOutputPath = os.path.join(os.getenv('USERPROFILE'), ".config", "Microsoft", "SqlSchemaMigration")
-    elif osPlatform.__contains__('Darwin'):
+    elif 'Darwin' in osPlatform:
         defaultOutputPath = os.path.join(os.getenv('USERPROFILE'), "Library", "Application Support", "Microsoft", "SqlSchemaMigration")
     else:
         defaultOutputPath = os.path.join(os.getenv('LOCALAPPDATA'), "Microsoft", "SqlSchemaMigration")
@@ -247,6 +248,7 @@ def check_and_download_console_app(exePath, baseFolder):
         with ZipFile(zipDestination, 'r') as zipFile:
             zipFile.extractall(path=baseFolder)
 
+
 # -----------------------------------------------------------------------------------------------------------------
 # LoginMigration helper function to check if console app exists, if not download it.
 # -----------------------------------------------------------------------------------------------------------------
@@ -268,7 +270,7 @@ def check_and_download_loginMigration_console_app(downloads_folder):
         print(f"Installed Login migration console app nupkg version: {latest_local_name_and_version}")
         return latest_local_name_and_version
 
-    #if cx has no consent return local version
+    # if cx has no consent return local version
     if latest_local_name_and_version is not None:
         print(f"Installed Login migration console app nupkg version: {latest_local_name_and_version}")
         while True:
@@ -336,7 +338,7 @@ def get_latest_nuget_org_version(package_id):
     except Exception:
         print("Unable to connect to NuGet.org to check for updates.")
 
-    if(service_index_response is None or
+    if (service_index_response is None or
        service_index_response.status_code != 200 or
        len(service_index_response.content) > 999999):
         return None
@@ -357,7 +359,7 @@ def get_latest_nuget_org_version(package_id):
 
     package_versions_response = None
     package_versions_response = requests.get(f"{package_base_address_url}{package_id.lower()}/index.json")
-    if(package_versions_response.status_code != 200 or len(package_versions_response.content) > 999999):
+    if (package_versions_response.status_code != 200 or len(package_versions_response.content) > 999999):
         return None
 
     package_versions_json = json.loads(package_versions_response.content)

--- a/src/datamigration/setup.py
+++ b/src/datamigration/setup.py
@@ -10,7 +10,7 @@ from codecs import open
 from setuptools import setup, find_packages
 
 # HISTORY.rst entry.
-VERSION = '0.6.1'
+VERSION = '0.6.2'
 try:
     from azext_datamigration.manual.version import VERSION
 except ImportError:

--- a/src/datamigration/setup.py
+++ b/src/datamigration/setup.py
@@ -10,7 +10,7 @@ from codecs import open
 from setuptools import setup, find_packages
 
 # HISTORY.rst entry.
-VERSION = '0.6.2'
+VERSION = '1.0.0b1'
 try:
     from azext_datamigration.manual.version import VERSION
 except ImportError:


### PR DESCRIPTION
### Description
SQL Login migration CLI backend uses SqlLoginMigration console app, which is stored in SQLVM storage account blob which is not the recommended source to get the console App.
We need to maintain the version files as part of console app and also in the storage account to support upgrades. Want to do away with this approach as this is error prone.

### Fix
This PR fixes the following

- Moves the SQL Login migration console app source from Storage account to recommended Nuget.org. https://www.nuget.org/packages/Microsoft.SqlServer.Migration.LoginsConsoleApp
- It also adds the support for versioning for aiding in upgrading to latest version when available.
- Renames the console app from Logins.Console to Microsoft.SqlServer.Migration.Logins.ConsoleApp.exe to keep the naming convention consistent with all the other NuGet packages.

### Local Testing

1. First time running the cli command

![image](https://github.com/Azure/azure-cli-extensions/assets/126583651/3ae0f943-228f-42fd-859e-e375468951c0)

2. Running the script with the environment containing the old Login.console app.

![image](https://github.com/Azure/azure-cli-extensions/assets/126583651/3ae0f943-228f-42fd-859e-e375468951c0)

3. When local has a version lower than the latest version uploaded in Nuget.org. But the cx doesn't want to upgrade.

![image](https://github.com/Azure/azure-cli-extensions/assets/126583651/982d6935-7907-4266-8b23-7a57680551ca)

4. When local has a version lower than the latest version uploaded in Nuget.org and cx opts to upgrade.

![image](https://github.com/Azure/azure-cli-extensions/assets/126583651/679cbc65-16d5-42f8-ab65-af2547935768)

5. When local and latest version is the same.

![image](https://github.com/Azure/azure-cli-extensions/assets/126583651/f5efd29c-eaa5-4677-bc42-26210bd505de)

### Related command
az datamigration login-migration


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
