### PR TITLE
{CI} Use GitHub Actions to trigger the ADO OneBranch Extension Release Pipeline

### DIFF
--- a/.github/workflows/TriggerExtensionRelease.yml
+++ b/.github/workflows/TriggerExtensionRelease.yml
@@ -35,4 +35,5 @@ jobs:
             azure-devops-token: ${{ secrets.ONE_BRANCH_TOKEN }}
             azure-pipeline-variables:  '{"commit_id": "${{ github.sha }}"}'
         - name: Wait for Extension Release
-          run: sleep 600
+          # azure-cli-extensions-release.yml + azure-cli-extensions-sync-after-release.yml ~= 20 minutes
+          run: sleep 1200

--- a/.github/workflows/TriggerExtensionRelease.yml
+++ b/.github/workflows/TriggerExtensionRelease.yml
@@ -1,0 +1,31 @@
+name: Trigger ADO OneBranch Extension Release Pipeline
+
+# Run this workflow every time a commit gets pushed to main
+# This triggers the ADO OneBranch Extension Release Pipeline
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+    build:
+        name: Trigger Extension Release Pipeline
+        runs-on: ubuntu-latest
+        steps:
+        - name: Harden Runner
+          uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+          with:
+            egress-policy: audit
+
+        - name: Azure Pipelines Action
+          uses: Azure/pipelines@v1.2
+          with:
+            azure-devops-project-url: https://dev.azure.com/azclitools/release
+            azure-pipeline-name: 'azure-cli-extensions-release'
+            # https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=Windows
+            # expire on 2024/9/21
+            azure-devops-token: ${{ secrets.ONE_BRANCH_TOKEN }}
+            azure-pipeline-variables:  '{"commit_id": "${{ github.sha }}"}'

--- a/.github/workflows/TriggerExtensionRelease.yml
+++ b/.github/workflows/TriggerExtensionRelease.yml
@@ -10,6 +10,12 @@ on:
 permissions:
   contents: read
 
+# This is the only solution to trigger OneBranch pipeline from a GitHub commit。
+# But it lacks batch CI support, we have to use concurrency to prevent earlier commits task overwriting index.json from later ones。
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
+concurrency:
+  group: trigger-extension-release
+
 jobs:
     build:
         name: Trigger Extension Release Pipeline
@@ -19,7 +25,6 @@ jobs:
           uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
           with:
             egress-policy: audit
-
         - name: Azure Pipelines Action
           uses: Azure/pipelines@v1.2
           with:
@@ -29,3 +34,5 @@ jobs:
             # expire on 2024/9/21
             azure-devops-token: ${{ secrets.ONE_BRANCH_TOKEN }}
             azure-pipeline-variables:  '{"commit_id": "${{ github.sha }}"}'
+        - name: Wait for Extension Release
+          run: sleep 600


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
