### PR TITLE
{CI} Cancel serial release

### DIFF
--- a/.github/workflows/TriggerExtensionRelease.yml
+++ b/.github/workflows/TriggerExtensionRelease.yml
@@ -10,12 +10,6 @@ on:
 permissions:
   contents: read
 
-# This is the only solution to trigger OneBranch pipeline from a GitHub commit。
-# But it lacks batch CI support, we have to use concurrency to prevent earlier commits task overwriting index.json from later ones。
-# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
-concurrency:
-  group: trigger-extension-release
-
 jobs:
     build:
         name: Trigger Extension Release Pipeline
@@ -34,6 +28,3 @@ jobs:
             # expire on 2024/9/21
             azure-devops-token: ${{ secrets.ONE_BRANCH_TOKEN }}
             azure-pipeline-variables:  '{"commit_id": "${{ github.sha }}"}'
-        - name: Wait for Extension Release
-          # azure-cli-extensions-release.yml + azure-cli-extensions-sync-after-release.yml ~= 20 minutes
-          run: sleep 1200


### PR DESCRIPTION
---
There can be at most one running and one pending job in a concurrency group at any time.
![image](https://github.com/Azure/azure-cli-extensions/assets/18628534/c3ba58fb-9bee-4a9e-beef-f8387635d3fc)
https://github.com/orgs/community/discussions/41518
https://github.com/orgs/community/discussions/12835
If extension A and extension B are released at the same time, B's pengding release workflow will be canceled because of extension A's automatically update index.json commit.
![image](https://github.com/Azure/azure-cli-extensions/assets/18628534/6cd4c293-d014-4b7e-8182-cc6c5afc415f)

So we still keep concurrent release for CLI extensions.
But after each release, we will ensure that pull the latest index.json from main branch and overwrite the index.json in blob.(The last task in OneBranch extension release pipeline)

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
