### PR TITLE
[ConnectedK8s] Add support for multiple proxy instances running on the same machine using different ports

### DIFF
--- a/src/connectedk8s/HISTORY.rst
+++ b/src/connectedk8s/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+1.6.8
+++++++
+* Add support for running multiple proxy instances on the same machine using different ports.
+
 1.6.7
 ++++++
 * Improve Error logs during Arc Onboarding scenarios, Style fixes.

--- a/src/connectedk8s/azext_connectedk8s/custom.py
+++ b/src/connectedk8s/azext_connectedk8s/custom.py
@@ -1968,7 +1968,7 @@ def client_side_proxy_wrapper(cmd,
     telemetry.set_debug_info('OS is ', operating_system)
 
     if (clientproxyutils.check_process(proc_name)) and clientproxyutils.check_if_port_is_open(api_server_port):
-        raise ClientRequestError('The proxy port is already in use, potentialy by another proxy instance.', recommendation='Please stop the existing proxy instance or pass a different port through --port option.')
+        raise ClientRequestError('The proxy port is already in use, potentially by another proxy instance.', recommendation='Please stop the existing proxy instance or pass a different port through --port option.')
 
     port_error_string = ""
     if clientproxyutils.check_if_port_is_open(api_server_port):

--- a/src/connectedk8s/azext_connectedk8s/custom.py
+++ b/src/connectedk8s/azext_connectedk8s/custom.py
@@ -1951,8 +1951,14 @@ def client_side_proxy_wrapper(cmd,
     tenant_id = profile.get_subscription()['tenantId']
 
     client_proxy_port = consts.CLIENT_PROXY_PORT
+
+    # Check if the internal port is already open. If so and the user has specified a port,
+    # try using the port before the user specified port instead.
+    if clientproxyutils.check_if_port_is_open(client_proxy_port) and api_server_port != consts.API_SERVER_PORT:
+        client_proxy_port = int(api_server_port) - 1
+
     if int(client_proxy_port) == int(api_server_port):
-        raise ClientRequestError('Proxy uses port 47010 internally.', recommendation='Please pass some other unused port through --port option.')
+        raise ClientRequestError(f'Proxy uses port {client_proxy_port} internally.', recommendation='Please pass some other unused port through --port option.')
 
     args = []
     operating_system = platform.system()
@@ -1961,8 +1967,8 @@ def client_side_proxy_wrapper(cmd,
     telemetry.set_debug_info('CSP Version is ', consts.CLIENT_PROXY_VERSION)
     telemetry.set_debug_info('OS is ', operating_system)
 
-    if (clientproxyutils.check_process(proc_name)):
-        raise ClientRequestError('Another instance of proxy already running')
+    if (clientproxyutils.check_process(proc_name)) and clientproxyutils.check_if_port_is_open(api_server_port):
+        raise ClientRequestError('The proxy port is already in use, potentialy by another proxy instance.', recommendation='Please stop the existing proxy instance or pass a different port through --port option.')
 
     port_error_string = ""
     if clientproxyutils.check_if_port_is_open(api_server_port):

--- a/src/connectedk8s/setup.py
+++ b/src/connectedk8s/setup.py
@@ -17,7 +17,7 @@ except ImportError:
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
 
-VERSION = '1.6.7'
+VERSION = '1.6.8'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
This PR addresses https://github.com/Azure/azure-cli-extensions/issues/6366

For our use case, it would be very helpful for the connectedk8s proxy to support multiple instances running on the same machine. This enables interactions/ control over multiple Arc connected Kubernetes clusters from the same machine by simply switching your kube context. 

I've tested the change locally and been able to run multiple proxies on different ports and use kubectl to target multiple clusters by switching kube context.


---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
az connectedk8s proxy

### General Guidelines

- [X] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [X] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [X] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
