### PR TITLE
Bump minCliCoreVersion to 2.56.0 for Spring

### DIFF
--- a/src/spring/azext_spring/azext_metadata.json
+++ b/src/spring/azext_spring/azext_metadata.json
@@ -1,4 +1,4 @@
 {
     "azext.isPreview": false,
-    "azext.minCliCoreVersion": "2.45.0"
+    "azext.minCliCoreVersion": "2.56.0"
 }


### PR DESCRIPTION
Description

After this PR merged: https://github.com/Azure/azure-cli-extensions/pull/7462
We find there are error with latest code against Azure CLI Core <= 2.55.0
After testing, we find it need at least `2.56.0`, so bump version here.

We don't need to update CLI extension version here, since above PRs didn't update the CLI extension version

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
