### PR TITLE
adding partnercenter

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -28162,6 +28162,128 @@
                 "sha256Digest": "1918817070ae9e0ceef57b93366d18b6e8bf577fd632e7da999e1e2abbb53656"
             }
         ],
+        "partnercenter": [
+            {
+                "downloadUrl": "https://github.com/Azure/partnercenter-cli-extension/releases/download/v0.2.6-alpha/partnercenter-0.2.6-py3-none-any.whl",
+                "filename": "partnercenter-0.2.6-py3-none-any.whl",
+                "metadata": {
+                    "azext.isPreview": true,
+                    "azext.minCliCoreVersion": "2.0.67",
+                    "classifiers": [
+                        "Development Status :: 4 - Beta",
+                        "Intended Audience :: Developers",
+                        "Intended Audience :: System Administrators",
+                        "Programming Language :: Python",
+                        "Programming Language :: Python :: 3",
+                        "Programming Language :: Python :: 3.6",
+                        "Programming Language :: Python :: 3.7",
+                        "Programming Language :: Python :: 3.8",
+                        "License :: OSI Approved :: MIT License"
+                    ],
+                    "extensions": {
+                        "python.details": {
+                            "contacts": [
+                                {
+                                    "email": "azpycli@microsoft.com",
+                                    "name": "Microsoft Corporation",
+                                    "role": "author"
+                                }
+                            ],
+                            "document_names": {
+                                "description": "DESCRIPTION.rst"
+                            },
+                            "project_urls": {
+                                "Home": "https://github.com/Azure/partnercenter-cli-extension/tree/main/partnercenter"
+                            }
+                        }
+                    },
+                    "extras": [],
+                    "generator": "bdist_wheel (0.30.0)",
+                    "license": "MIT",
+                    "metadata_version": "2.0",
+                    "name": "partnercenter",
+                    "run_requires": [
+                        {
+                            "requires": [
+                                "azure-storage-blob",
+                                "azure-storage-blob",
+                                "commercial-marketplace-offer-deploy",
+                                "commercial-marketplace-offer-deploy",
+                                "docker",
+                                "docker",
+                                "pydantic (~=2.5.3)",
+                                "pydantic~=2.5.3",
+                                "requests",
+                                "requests"
+                            ]
+                        }
+                    ],
+                    "summary": "Microsoft Azure CLI Extension for Partner Center",
+                    "version": "0.2.6"
+                },
+                "sha256Digest": "915751ce95893afd64593842767a8f4f780764291de3854716562eb90f12797b"
+            },
+            {
+                "downloadUrl": "https://github.com/Azure/partnercenter-cli-extension/releases/download/v0.2.6-alpha/partnercenter-0.2.6-py3-none-any.whl",
+                "filename": "partnercenter-0.2.6-py3-none-any.whl",
+                "metadata": {
+                    "azext.isPreview": true,
+                    "azext.minCliCoreVersion": "2.0.67",
+                    "classifiers": [
+                        "Development Status :: 4 - Beta",
+                        "Intended Audience :: Developers",
+                        "Intended Audience :: System Administrators",
+                        "Programming Language :: Python",
+                        "Programming Language :: Python :: 3",
+                        "Programming Language :: Python :: 3.6",
+                        "Programming Language :: Python :: 3.7",
+                        "Programming Language :: Python :: 3.8",
+                        "License :: OSI Approved :: MIT License"
+                    ],
+                    "extensions": {
+                        "python.details": {
+                            "contacts": [
+                                {
+                                    "email": "azpycli@microsoft.com",
+                                    "name": "Microsoft Corporation",
+                                    "role": "author"
+                                }
+                            ],
+                            "document_names": {
+                                "description": "DESCRIPTION.rst"
+                            },
+                            "project_urls": {
+                                "Home": "https://github.com/Azure/partnercenter-cli-extension/tree/main/partnercenter"
+                            }
+                        }
+                    },
+                    "extras": [],
+                    "generator": "bdist_wheel (0.30.0)",
+                    "license": "MIT",
+                    "metadata_version": "2.0",
+                    "name": "partnercenter",
+                    "run_requires": [
+                        {
+                            "requires": [
+                                "azure-storage-blob",
+                                "azure-storage-blob",
+                                "commercial-marketplace-offer-deploy",
+                                "commercial-marketplace-offer-deploy",
+                                "docker",
+                                "docker",
+                                "pydantic (~=2.5.3)",
+                                "pydantic~=2.5.3",
+                                "requests",
+                                "requests"
+                            ]
+                        }
+                    ],
+                    "summary": "Microsoft Azure CLI Extension for Partner Center",
+                    "version": "0.2.6"
+                },
+                "sha256Digest": "915751ce95893afd64593842767a8f4f780764291de3854716562eb90f12797b"
+            }
+        ],
         "peering": [
             {
                 "downloadUrl": "https://azurecliprod.blob.core.windows.net/cli-extensions/peering-0.1.0rc2-py2.py3-none-any.whl",


### PR DESCRIPTION
CLI extension for the Partner Center, v0.2.6-alpha

Currently, experimentally supporting Marketplace management commands, commissioned by Global Partner Services US division.

Maintainers
@kevinhillinger
@bobjac
Source
Type: External repository
URL: https://github.com/Azure/partnercenter-cli-extension