### PR TITLE
[quantum] Assign "Storage account contributor" role to workspace for linked StorageAccount

### DIFF
--- a/src/quantum/HISTORY.rst
+++ b/src/quantum/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+1.0.0b3
+++++++
+* [2024-04-11] Version intended to work with QDK version 0.29.0
+* Change role assignment for new Workspaces to linked Storage Accounts from Contributor to Storage Account Contributor.
+
 1.0.0b2
 ++++++
 * [2024-02-14] Version intended to work with QDK version 0.29.0

--- a/src/quantum/azext_quantum/__init__.py
+++ b/src/quantum/azext_quantum/__init__.py
@@ -13,7 +13,7 @@ import azext_quantum._help  # pylint: disable=unused-import
 # This is the version reported by the CLI to the service when submitting requests.
 # This should be in sync with the extension version in 'setup.py', unless we need to
 # submit using a different version.
-CLI_REPORTED_VERSION = "1.0.0b2"
+CLI_REPORTED_VERSION = "1.0.0b3"
 
 
 class QuantumCommandsLoader(AzCommandsLoader):

--- a/src/quantum/azext_quantum/operations/templates/create-workspace-and-assign-role.json
+++ b/src/quantum/azext_quantum/operations/templates/create-workspace-and-assign-role.json
@@ -145,7 +145,7 @@
                             "type": "Microsoft.Storage/storageAccounts/providers/roleAssignments",
                             "location": "[parameters('storageAccountLocation')]",
                             "properties": {
-                                "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+                                "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', '17d1049b-9a84-46fb-8f53-869881c3d3ab')]",
                                 "principalId": "[reference(concat('Microsoft.Quantum/Workspaces/', parameters('quantumWorkspaceName')), '2019-11-04-preview', 'Full').identity.principalId]",
                                 "principalType": "ServicePrincipal"
                             },

--- a/src/quantum/setup.py
+++ b/src/quantum/setup.py
@@ -17,7 +17,7 @@ except ImportError:
 # This version should match the latest entry in HISTORY.rst
 # Also, when updating this, please review the version used by the extension to
 # submit requests, which can be found at './azext_quantum/__init__.py'
-VERSION = '1.0.0b2'
+VERSION = '1.0.0b3'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Previously, we assigned a contributor role to the storage account for the workspace. This PR changes it to the "storage account contributor" role. This is done in order to be compatible with the new "Quantum Workspace Owner" built-in role that allows constrained role assignment of storage account contributor.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [x] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
