### PR TITLE
{CI} Use OIDC to trigger extension release pipeline

### DIFF
--- a/.github/workflows/TriggerExtensionRelease.yml
+++ b/.github/workflows/TriggerExtensionRelease.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
     build:
@@ -19,12 +20,19 @@ jobs:
           uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
           with:
             egress-policy: audit
-        - name: Azure Pipelines Action
-          uses: Azure/pipelines@v1.2
+        - name: Azure login
+          uses: azure/login@v2
           with:
-            azure-devops-project-url: https://dev.azure.com/azclitools/release
-            azure-pipeline-name: 'azure-cli-extensions-release'
-            # https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=Windows
-            # expire on 2024/9/21
-            azure-devops-token: ${{ secrets.ONE_BRANCH_TOKEN }}
-            azure-pipeline-variables:  '{"commit_id": "${{ github.sha }}"}'
+            client-id: ${{ secrets.ADO_SP_ClientID }}
+            tenant-id: ${{ secrets.ADO_SP_TenantID }}
+            allow-no-subscriptions: true
+        - name: Azure CLI
+          uses: azure/cli@v2
+          env:
+            ado-org: ${{secrets.ADO_ORGANIZATION}}
+            ado-project: ${{secrets.ADO_PROJECT}}
+            ado-pipeline-id: ${{secrets.ADO_PIPELINE_ID}}
+            commit-id: ${{ github.sha }}
+          with:
+            inlineScript: |
+              az pipelines build queue --definition-id ${{ env.ado-pipeline-id }} --organization ${{ env.ado-org }}  --project ${{ env.ado-project }} --variables commit_id=${{ env.commit-id }}


### PR DESCRIPTION
---
If we continue to use ADO PAT, we have to replace the PAT token every seven days.
So I must migrate to OIDC to login to Azure and trigger onebranch pipeline.

![image](https://github.com/Azure/azure-cli-extensions/assets/18628534/6286067b-5d4b-47f5-89ba-8726ea7ae099)
![image](https://github.com/Azure/azure-cli-extensions/assets/18628534/022440e2-8f13-4c53-b0f2-52d309c6c3a5)


This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
