### PR TITLE
{AKS} az aks create/update: ignore invalid ip error in ip_ranges validator

### DIFF
--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -12,6 +12,10 @@ To release a new version, please select a new version number (usually plus 1 to 
 Pending
 +++++++
 
+3.0.0b8
++++++++
+* Ignore invalid ip error for `--api-server-authorized-ip-ranges`.
+
 3.0.0b7
 +++++++
 * Support `--yes` for `az aks mesh upgrade rollback` and `az aks mesh upgrade complete` commands.

--- a/src/aks-preview/azext_aks_preview/_validators.py
+++ b/src/aks-preview/azext_aks_preview/_validators.py
@@ -160,10 +160,7 @@ def validate_ip_ranges(namespace):
                 raise CLIError(
                     "--api-server-authorized-ip-ranges cannot be IPv6 addresses")
         except ValueError:
-            # pylint: disable=raise-missing-from
-            raise CLIError(
-                "--api-server-authorized-ip-ranges should be a list of IPv4 addresses or CIDRs"
-            )
+            pass
 
 
 def _validate_nodepool_name(nodepool_name):

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_validators.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_validators.py
@@ -55,14 +55,10 @@ class TestValidateIPRanges(unittest.TestCase):
             validators.validate_ip_ranges(namespace)
         self.assertEqual(str(cm.exception), err)
 
-    def test_invalid_ip(self):
+    def test_invalid_ip_no_err_raised(self):
         api_server_authorized_ip_ranges = "193.168.0"
         namespace = Namespace(api_server_authorized_ip_ranges)
-        err = "--api-server-authorized-ip-ranges should be a list of IPv4 addresses or CIDRs"
-
-        with self.assertRaises(CLIError) as cm:
-            validators.validate_ip_ranges(namespace)
-        self.assertEqual(str(cm.exception), err)
+        validators.validate_ip_ranges(namespace)
 
     def test_IPv6(self):
         api_server_authorized_ip_ranges = "3ffe:1900:4545:3:200:f8ff:fe21:67cf"

--- a/src/aks-preview/setup.py
+++ b/src/aks-preview/setup.py
@@ -9,7 +9,7 @@ from codecs import open as open1
 
 from setuptools import setup, find_packages
 
-VERSION = "3.0.0b7"
+VERSION = "3.0.0b8"
 
 CLASSIFIERS = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
---

ignore invalid ip error in validator since we would support service tag input with the same api.
We would rely on AKS RP validator.

### Related command
az aks create/update --api-server-authorized-ip-ranges


### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
