### PR TITLE
{Containerapp} Fix cannot import name 'CloudNameEnum'

### DIFF
--- a/src/containerapp/azext_containerapp/_utils.py
+++ b/src/containerapp/azext_containerapp/_utils.py
@@ -729,11 +729,6 @@ def parse_build_env_vars(env_list):
 
 
 def is_cloud_supported_by_connected_env(cli_ctx):
-    try:
-        from azure.cli.core.cloud import CloudNameEnum
-        if cli_ctx.cloud.name == CloudNameEnum.AzureCloud:
-            return True
-    except:  # pylint: disable=bare-except
-        # CloudNameEnum is supported from azure-cli version 2.54.0
+    if cli_ctx.cloud.name == 'AzureCloud':
         return True
     return False

--- a/src/containerapp/azext_containerapp/_utils.py
+++ b/src/containerapp/azext_containerapp/_utils.py
@@ -729,8 +729,11 @@ def parse_build_env_vars(env_list):
 
 
 def is_cloud_supported_by_connected_env(cli_ctx):
-    from azure.cli.core.cloud import CloudNameEnum
-    if cli_ctx.cloud.name == CloudNameEnum.AzureCloud:
+    try:
+        from azure.cli.core.cloud import CloudNameEnum
+        if cli_ctx.cloud.name == CloudNameEnum.AzureCloud:
+            return True
+    except:  # pylint: disable=bare-except
+        # CloudNameEnum is supported from azure-cli version 2.54.0
         return True
-
     return False


### PR DESCRIPTION

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
Currently the `"azext.minCliCoreVersion": "2.53.0"`, but azure-cli version is 2.53.0, with a upcoming PR: https://github.com/Azure/azure-cli-extensions/pull/7551, it will throw: Unable to load extension 'containerapp: cannot import name 'CloudNameEnum' from 'azure.cli.core.cloud'


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
