### PR TITLE
[dataprotection] Support for AKS Vaulted Backups

### DIFF
--- a/src/dataprotection/HISTORY.rst
+++ b/src/dataprotection/HISTORY.rst
@@ -6,7 +6,7 @@ Release History
 +++++
 * Support for vaulted backup for AKS
 * `az dataprotection backup-policy get-default-policy-template`: For AzureKubernetesService, default policy now adds vaulted backup rules.
-* `az dataprotection backup-vault initialize-restoreconfig:` Three new parameters - `staging_resource_group_id`, `staging_storage_account_id`, `resource_modifier_reference`.
+* `az dataprotection backup-vault initialize-restoreconfig:` Three new parameters - `--staging-resource-group-id`, `--staging-storage-account-id`, `--resource-modifier-reference`.
 
 
 1.4.0

--- a/src/dataprotection/HISTORY.rst
+++ b/src/dataprotection/HISTORY.rst
@@ -2,6 +2,13 @@
 
 Release History
 ===============
+1.5.0
++++++
+* Support for vaulted backup for AKS
+* `az dataprotection backup-policy get-default-policy-template`: For AzureKubernetesService, default policy now adds vaulted backup rules.
+* `az dataprotection backup-vault initialize-restoreconfig:` Three new parameters - `staging_resource_group_id`, `staging_storage_account_id`, `resource_modifier_reference`.
+
+
 1.4.0
 +++++
 * Added support for cmk encryption on backup vault

--- a/src/dataprotection/azext_dataprotection/manual/Manifests/AzureKubernetesService.py
+++ b/src/dataprotection/azext_dataprotection/manual/Manifests/AzureKubernetesService.py
@@ -52,7 +52,7 @@ manifest = '''
   ],
   "policySettings": {
     "supportedRetentionTags": [ "Daily", "Weekly" ],
-    "supportedDatastoreTypes": [ "OperationalStore" ],
+    "supportedDatastoreTypes": [ "OperationalStore", "VaultStore" ],
     "disableAddRetentionRule": false,
     "disableCustomRetentionTag": true,
     "backupScheduleSupported": true,
@@ -71,6 +71,22 @@ manifest = '''
               ]
             },
             "taggingCriteria": [
+              {
+                "tagInfo": {
+                  "tagName": "Daily",
+                  "id": "Daily_"
+                },
+                "taggingPriority": 25,
+                "isDefault": false,
+                "criteria": [
+                  {
+                    "absoluteCriteria": [
+                      "FirstOfDay"
+                    ],
+                    "objectType": "ScheduleBasedBackupCriteria"
+                  }
+                ]
+              },
               {
                 "tagInfo": {
                   "tagName": "Default",
@@ -105,7 +121,46 @@ manifest = '''
           "isDefault": true,
           "name": "Default",
           "objectType": "AzureRetentionRule"
-        }
+        },
+        {
+          "lifecycles": [
+            {
+              "deleteAfter": {
+                "objectType": "AbsoluteDeleteOption",
+                "duration": "P7D"
+              },
+              "targetDataStoreCopySettings": [
+                {
+                  "dataStore": {
+                    "dataStoreType": "VaultStore",
+                    "objectType": "DataStoreInfoBase"
+                  },
+                  "copyAfter": {
+                    "objectType": "ImmediateCopyOption"
+                  }
+                }
+              ],
+              "sourceDataStore": {
+                  "dataStoreType": "OperationalStore",
+                  "objectType": "DataStoreInfoBase"
+              }
+            },
+            {
+              "deleteAfter": {
+                "objectType": "AbsoluteDeleteOption",
+                "duration": "P84D"
+              },
+              "targetDataStoreCopySettings": [],
+              "sourceDataStore": {
+                "dataStoreType": "VaultStore",
+                "objectType": "DataStoreInfoBase"
+              }
+            }
+          ],
+          "isDefault": false,
+          "name": "Daily",
+          "objectType": "AzureRetentionRule"
+        },
       ],
       "name": "AKSPolicy1",
       "datasourceTypes": [

--- a/src/dataprotection/azext_dataprotection/manual/Manifests/AzureKubernetesService.py
+++ b/src/dataprotection/azext_dataprotection/manual/Manifests/AzureKubernetesService.py
@@ -160,7 +160,7 @@ manifest = '''
           "isDefault": false,
           "name": "Daily",
           "objectType": "AzureRetentionRule"
-        },
+        }
       ],
       "name": "AKSPolicy1",
       "datasourceTypes": [

--- a/src/dataprotection/azext_dataprotection/manual/_params.py
+++ b/src/dataprotection/azext_dataprotection/manual/_params.py
@@ -255,6 +255,14 @@ def load_arguments(self, _):
                    type=namespaced_name_resource_type,
                    options_list=['--restore-hook-references', '--restore-hook-refs'],
                    help='Property sets the hook reference to be executed during restore.')
+        c.argument('staging_resource_group_id', type=str, options_list=['--staging-resource-group-id', '--staging-rg-id'],
+                   help='Resource group of the staging storage account for AKS vaulted backups')
+        c.argument('staging_storage_account_id', type=str, options_list=['--staging-storage-account-id', '--staging-storage-id'],
+                   help='Storage Account ID for AKS vaulted backups')
+        c.argument('resource_modifier_reference', type=validate_file_or_dict,
+                   options_list=['--resource-modifier-reference', '--resource-modifier'],
+                   help='Key value mapping for resource modifier reference')
+
 
     with self.argument_context('dataprotection backup-instance restore initialize-for-data-recovery') as c:
         c.argument('target_resource_id', type=str, help="specify the resource ID to which the data will be restored.")

--- a/src/dataprotection/azext_dataprotection/manual/_params.py
+++ b/src/dataprotection/azext_dataprotection/manual/_params.py
@@ -263,7 +263,6 @@ def load_arguments(self, _):
                    options_list=['--resource-modifier-reference', '--resource-modifier'],
                    help='Key value mapping for resource modifier reference')
 
-
     with self.argument_context('dataprotection backup-instance restore initialize-for-data-recovery') as c:
         c.argument('target_resource_id', type=str, help="specify the resource ID to which the data will be restored.")
         c.argument('backup_instance_id', type=str, help="specify the backup instance ID.")

--- a/src/dataprotection/azext_dataprotection/manual/custom.py
+++ b/src/dataprotection/azext_dataprotection/manual/custom.py
@@ -859,7 +859,8 @@ def dataprotection_backup_instance_initialize_restoreconfig(datasource_type, exc
                                                             persistent_volume_restore_mode=None,
                                                             include_cluster_scope_resources=None,
                                                             namespace_mappings=None, conflict_policy=None,
-                                                            restore_hook_references=None):
+                                                            restore_hook_references=None,  staging_resource_group_id=None,
+                                                            staging_storage_account_id=None, resource_modifier_reference=None):
     if datasource_type != "AzureKubernetesService":
         raise InvalidArgumentValueError("This command is currently not supported for datasource types other than AzureKubernetesService")
 
@@ -883,7 +884,10 @@ def dataprotection_backup_instance_initialize_restoreconfig(datasource_type, exc
         "include_cluster_scope_resources": include_cluster_scope_resources,
         "conflict_policy": conflict_policy,
         "namespace_mappings": namespace_mappings,
-        "restore_hook_references": restore_hook_references
+        "restore_hook_references": restore_hook_references,
+        "staging_resource_group_id":staging_resource_group_id,
+        "staging_storage_account_id":staging_storage_account_id,
+        "resource_modifier_reference": resource_modifier_reference
     }
 
 

--- a/src/dataprotection/azext_dataprotection/manual/custom.py
+++ b/src/dataprotection/azext_dataprotection/manual/custom.py
@@ -859,7 +859,7 @@ def dataprotection_backup_instance_initialize_restoreconfig(datasource_type, exc
                                                             persistent_volume_restore_mode=None,
                                                             include_cluster_scope_resources=None,
                                                             namespace_mappings=None, conflict_policy=None,
-                                                            restore_hook_references=None,  staging_resource_group_id=None,
+                                                            restore_hook_references=None, staging_resource_group_id=None,
                                                             staging_storage_account_id=None, resource_modifier_reference=None):
     if datasource_type != "AzureKubernetesService":
         raise InvalidArgumentValueError("This command is currently not supported for datasource types other than AzureKubernetesService")
@@ -885,8 +885,8 @@ def dataprotection_backup_instance_initialize_restoreconfig(datasource_type, exc
         "conflict_policy": conflict_policy,
         "namespace_mappings": namespace_mappings,
         "restore_hook_references": restore_hook_references,
-        "staging_resource_group_id":staging_resource_group_id,
-        "staging_storage_account_id":staging_storage_account_id,
+        "staging_resource_group_id": staging_resource_group_id,
+        "staging_storage_account_id": staging_storage_account_id,
         "resource_modifier_reference": resource_modifier_reference
     }
 

--- a/src/dataprotection/azext_dataprotection/tests/latest/test_dataprotection_configs.py
+++ b/src/dataprotection/azext_dataprotection/tests/latest/test_dataprotection_configs.py
@@ -19,21 +19,10 @@ class ConfigScenarioTest(ScenarioTest):
     @unittest.skip("Tests are passing in local but not getting recorded and failing on cloud. Finding a fix.")
     def test_dataprotection_aks_backup_and_restore_initialize_configs(test):
         test.kwargs.update({
-            # 'location': 'eastus2euap',
-            # 'restoreLocation': 'eastus2euap',
-            # 'rg': 'clitest-dpp-rg',
-            # 'rgId': '/subscriptions/38304e13-357e-405e-9e9a-220351dcce8c/resourceGroups/oss-clitest-rg',
-            # 'vaultName': "clitest-bkp-vault-aks-donotdelete",
-            # 'policyId': '/subscriptions/38304e13-357e-405e-9e9a-220351dcce8c/resourceGroups/clitest-dpp-rg/providers/Microsoft.DataProtection/backupVaults/clitest-bkp-vault-aks-donotdelete/backupPolicies/akspolicy',
             'dataSourceType': 'AzureKubernetesService',
-            # 'sourceDataStore': 'OperationalStore',
-            # 'aksClusterName': 'clitest-cluster1-donotdelete',
-            # 'aksClusterId': '/subscriptions/38304e13-357e-405e-9e9a-220351dcce8c/resourceGroups/oss-clitest-rg/providers/Microsoft.ContainerService/managedClusters/clitest-cluster1-donotdelete',
-            # 'friendlyName': "clitest-friendly-aks",
-            # 'permissionsScope': "ResourceGroup",
-            # 'policyRuleName': 'BackupHourly',
             'payloadBackupHooks': "[{ \'name\':\'name1\',\'namespace\':\'ns1\' },{ \'name\':\'name2\',\'namespace\':\'ns2\'}]",
             'payloadRestoreHooks': "[{'name':'restorehookname','namespace':'default'},{'name':'restorehookname1','namespace':'hrweb'}]",
+            'payloadResourceModifier': "{'CustomerResourceName': 'targetNamespace'}",
         })
 
         # backup_instance_guid = "faec6818-0720-11ec-bd1b-c8f750f92764"
@@ -54,4 +43,10 @@ class ConfigScenarioTest(ScenarioTest):
                      test.check("include_cluster_scope_resources", True),
                      test.check('length(restore_hook_references)', 2),
                      test.check('restore_hook_references[0].name', 'restorehookname')
+                 ])
+
+        test.cmd('az dataprotection backup-instance initialize-restoreconfig --datasource-type "{dataSourceType}" '
+                 '--resource-modifier "{payloadResourceModifier}"',
+                 checks=[
+                     test.check("resource_modifier_reference.CustomerResourceName", 'targetNamespace')
                  ])

--- a/src/dataprotection/setup.py
+++ b/src/dataprotection/setup.py
@@ -10,7 +10,7 @@ from codecs import open
 from setuptools import setup, find_packages
 
 # HISTORY.rst entry.
-VERSION = '1.4.0'
+VERSION = '1.5.0'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

* Support for vaulted backup for AKS
* `az dataprotection backup-policy get-default-policy-template`: For AzureKubernetesService, default policy now adds vaulted backup rules.
* `az dataprotection backup-vault initialize-restoreconfig:` Three new parameters - `staging_resource_group_id`, `staging_storage_account_id`, `resource_modifier_reference`.

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
