### PR TITLE
Use case-insensitive comparison in dashboard sync logic

### DIFF
--- a/src/amg/HISTORY.rst
+++ b/src/amg/HISTORY.rst
@@ -9,7 +9,7 @@ Release History
 
 0.1.1
 ++++++
-* `az grafana delete`: now automatically removes the default role assignment created for the managed identity
+* `az grafana delete`: automatically remove the default role assignment created for the managed identity
 
 0.1.2
 ++++++
@@ -29,12 +29,12 @@ Release History
 
 1.1
 ++++++
-* `az grafana update`: support email through new SMTP configuration arguments
+* `az grafana update`: support email contact point through new SMTP configuration arguments
 
 1.2
 ++++++
-* `az grafana backup`: backup a grafana workspace
-* `az grafana restore`: restore a grafana workspace
+* `az grafana backup`: backup a Grafana workspace
+* `az grafana restore`: restore a Grafana workspace
 * `az grafana dashboard sync`: sync dashboard between 2 grafana workspaces
 
 1.2.8

--- a/src/amg/HISTORY.rst
+++ b/src/amg/HISTORY.rst
@@ -35,7 +35,7 @@ Release History
 ++++++
 * `az grafana backup`: backup a Grafana workspace
 * `az grafana restore`: restore a Grafana workspace
-* `az grafana dashboard sync`: sync dashboard between 2 grafana workspaces
+* `az grafana dashboard sync`: sync dashboard between 2 Grafana workspaces
 
 1.2.8
 ++++++

--- a/src/amg/HISTORY.rst
+++ b/src/amg/HISTORY.rst
@@ -9,7 +9,7 @@ Release History
 
 0.1.1
 ++++++
-* update 'az grafana delete' to automatically remove the default role assignment created for the managed identity
+* `az grafana delete`: now automatically removes the default role assignment created for the managed identity
 
 0.1.2
 ++++++
@@ -61,3 +61,7 @@ Release History
 ++++++
 * `az grafana dashboard sync`: support library panel sync
 * `az grafana dashboard create`: use unique id instead of generic id for folder creation
+
+1.3.4
+++++++
+* `az grafana dashboard sync`: use case-insensitive comparison for library panel folders

--- a/src/amg/azext_amg/sync.py
+++ b/src/amg/azext_amg/sync.py
@@ -147,9 +147,12 @@ def sync(cmd, source, destination, folders_to_include=None, folders_to_exclude=N
             panel_folder_name = content["result"]["meta"]["folderName"]
 
             # user error case where library panel in dashboard is not in an excluded folder
-            included = folders_to_include
-            excluded = folders_to_exclude
-            if (included and panel_folder_name not in included) or (excluded and panel_folder_name in excluded):
+            if folders_to_include and panel_folder_name.lower() not in [f.lower() for f in folders_to_include]:
+                logger.warning("Skipping library panel from excluded folder: %s",
+                               panel_folder_name + "/" + panel_name)
+                library_panel_skipped = True
+                continue
+            if folders_to_exclude and panel_folder_name.lower() in [f.lower() for f in folders_to_exclude]:
                 logger.warning("Skipping library panel from excluded folder: %s",
                                panel_folder_name + "/" + panel_name)
                 library_panel_skipped = True
@@ -179,7 +182,7 @@ def sync(cmd, source, destination, folders_to_include=None, folders_to_exclude=N
 
         dashboard_path = folder_title + "/" + dashboard_title
         if library_panel_skipped:
-            logger.warning("Skipping dashboard due to missing library panel: %s", dashboard_path)
+            logger.warning("Skipping dashboard due to missing library panel(s): %s", dashboard_path)
             if folder_title not in dashboards_skipped_summary:
                 dashboards_skipped_summary[folder_title] = []
             dashboards_skipped_summary[folder_title].append(dashboard_title)

--- a/src/amg/setup.py
+++ b/src/amg/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
-VERSION = '1.3.3'
+VERSION = '1.3.4'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
### Related command
az grafana dashboard sync

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)