### PR TITLE
Adding space to connected k8s error 

### DIFF
--- a/src/connectedk8s/azext_connectedk8s/custom.py
+++ b/src/connectedk8s/azext_connectedk8s/custom.py
@@ -734,7 +734,7 @@ def load_kube_config(kube_config, kube_context, skip_ssl_verification):
     except Exception as e:
         telemetry.set_exception(exception=e, fault_type=consts.Load_Kubeconfig_Fault_Type,
                                 summary='Problem loading the kubeconfig file')
-        raise FileOperationError("Problem loading the kubeconfig file." + str(e))
+        raise FileOperationError("Problem loading the kubeconfig file. " + str(e))
 
 
 def get_private_key(key_pair):


### PR DESCRIPTION
#### Summary
This pull request addresses a minor formatting issue in an error message within the project.

#### Description
- **Issue**: The error message `Problem loading the kubeconfig file.Invalid kube-config. /root/.kube/config file is empty` lacks a space after the period in `file.`
- **Fix**: Added a space to correct the formatting. The updated error message now reads: `Problem loading the kubeconfig file. Invalid kube-config. /root/.kube/config file is empty`

#### Impact

This change improves the readability and clarity of the error message displayed to users, ensuring better user experience and understanding of the issue.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

`az connectedk8s connect`

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
