### PR TITLE
[k8s-runtime] Use `preview` release train to install storage class extension when enabling storage class service

### DIFF
--- a/src/k8s-runtime/HISTORY.rst
+++ b/src/k8s-runtime/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+1.0.2
+++++++
+* Use `preview` release train storage class extension when enabling storage class service
+
 1.0.1
 ++++++
 * Add RP registration check to networking resources

--- a/src/k8s-runtime/azext_k8s_runtime/custom_commands/storage_class.py
+++ b/src/k8s-runtime/azext_k8s_runtime/custom_commands/storage_class.py
@@ -65,7 +65,7 @@ def enable_storage_class(cmd: AzCliCommand, resource_uri: str):
                 type="SystemAssigned"
             ),
             extension_type=STORAGE_CLASS_EXTENSION_TYPE,
-            release_train="dev",
+            release_train="preview",
             configuration_settings={
                 "k8sRuntimeFpaObjectId": object_id,
             },

--- a/src/k8s-runtime/setup.py
+++ b/src/k8s-runtime/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 
 
 # HISTORY.rst entry.
-VERSION = '1.0.1'
+VERSION = '1.0.2'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

`az k8s-runtime storage-class enable`.

 Use `preview` release train to install storage class extension when enabling storage class service

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
