### PR TITLE
[AKS] Filter out NoSchedule initialization taints when targettting a system pool in request

### DIFF
--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -18,6 +18,10 @@ Pending
 * Add option `--azure-container-storage-perf-tier` to `az aks create` and `az aks update` to define resource tiers for Azure Container Storage performance.
 * Vendor new SDK and bump API version to 2024-04-02-preview.
 
+5.0.1b1
+++++++++
+* Only send soft initialization taints in request body when initialization taints are being added to a system node pool
+
 5.0.0b1
 ++++++++
 * [BREAKING CHANGE]: Remove --enable-network-observability and --disable-network-observability from aks create and update commands.

--- a/src/aks-preview/azext_aks_preview/agentpool_decorator.py
+++ b/src/aks-preview/azext_aks_preview/agentpool_decorator.py
@@ -417,7 +417,7 @@ class AKSPreviewAgentPoolContext(AKSAgentPoolContext):
 
         # if this is for a system agent pool, we remove hard taints as they cannot be installed on system pools,
         # but we still want them on user pools
-        if self.agentpool and self.agentpool.mode == CONST_NODEPOOL_MODE_SYSTEM:
+        if self.agentpool and self.agentpool.mode == CONST_NODEPOOL_MODE_SYSTEM and node_init_taints:
             soft_taints_for_system_pool = []
             for init_taint in node_init_taints:
                 if ":noschedule" not in init_taint.lower():

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -14233,9 +14233,9 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             "taint1=value1:PreferNoSchedule,taint2=value2:PreferNoSchedule"
         )
         nodepool_init_taints = (
-            "initTaint1=value1:PreferNoSchedule,initTaint2=value2:PreferNoSchedule"
+            "initTaint1=value1:NoSchedule,initTaint2=value3:PreferNoSchedule"
         )
-        nodepool_taints2 = "taint1=value2:PreferNoSchedule"
+        nodepool_taints2 = "taint1=value2:NoSchedule,taint2=value3:PreferNoSchedule"
         nodepool_init_taints2 = "initTaint1=value2:PreferNoSchedule"
         self.kwargs.update(
             {
@@ -14280,10 +14280,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
                 ),
                 self.check(
                     "agentPoolProfiles[0].nodeInitializationTaints[0]",
-                    "initTaint1=value1:PreferNoSchedule",
-                ),
-                self.check(
-                    "agentPoolProfiles[0].nodeInitializationTaints[1]",
                     "initTaint2=value2:PreferNoSchedule",
                 ),
             ],
@@ -14306,7 +14302,7 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
                 ),
                 self.check(
                     "agentPoolProfiles[0].nodeInitializationTaints[0]",
-                    "initTaint1=value2:PreferNoSchedule",
+                    "initTaint2=value3:PreferNoSchedule",
                 ),
             ],
         )


### PR DESCRIPTION
…tem pool

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
- az aks create
- az aks update

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
