### PR TITLE
{CI} Pin setuptools version to 70.0.0.

### DIFF
--- a/.azure-pipelines/templates/azdev_setup.yml
+++ b/.azure-pipelines/templates/azdev_setup.yml
@@ -17,6 +17,8 @@ steps:
       pip install azdev
       azdev --version
       azdev setup -c $CLI_REPO_PATH -r $CLI_EXT_REPO_PATH --debug
+      # Installing setuptools with a version higher than 70.0.0 will not generate metadata.json
+      pip install setuptools==70.0.0
       pip list -v
       az --version
     displayName: 'azdev setup'


### PR DESCRIPTION
---

Setuptools 70.1.0 was released on Jun 19.
The latest setuptools adds a vendored wheel 0.4.3 to generate wheel and it does not generate metadata.json.
Related PR:
[Adopted the bdist_wheel command from "wheel" by agronholm · Pull Request #4369 · pypa/setuptools (github.com)](https://github.com/pypa/setuptools/pull/4369)
Installing setuptools with a version higher than 70.0.0 will not generate metadata.json.
Pin setuptools version to 70.0.0 to unblock extension release.
![image](https://github.com/Azure/azure-cli-extensions/assets/18628534/4f449eb4-f0da-45f5-87c5-cfc688b79b30)


This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
