### PR TITLE
[connectedvmware] Search for BIOS IDs with both Big Endian and Middle Endian

### DIFF
--- a/src/connectedvmware/HISTORY.rst
+++ b/src/connectedvmware/HISTORY.rst
@@ -4,7 +4,7 @@ Release History
 ===============
 1.1.1
 ++++++
-* `create-from-machines` : Search for BIOS IDs with both Little Endian and Big Endian format.
+* `create-from-machines` : Search for BIOS IDs with both Little Endian and Middle Endian format.
 
 1.1.0
 ++++++

--- a/src/connectedvmware/HISTORY.rst
+++ b/src/connectedvmware/HISTORY.rst
@@ -2,6 +2,10 @@
 
 Release History
 ===============
+1.1.1
+++++++
+* `create-from-machines` : Search for BIOS IDs with both Little Endian and Big Endian format.
+
 1.1.0
 ++++++
 * Prompt credentials if not provided for Guest Agent.

--- a/src/connectedvmware/azext_connectedvmware/custom.py
+++ b/src/connectedvmware/azext_connectedvmware/custom.py
@@ -842,7 +842,10 @@ Resources
     substring(u, 11, 2), substring(u, 9, 2), '-',
     substring(u, 16, 2), substring(u, 14, 2), '-',
     substring(u, 19))
-| project machineId=id, name, resourceGroup, vmUuidRev, kind
+| extend vmUuid=pack_array(u, vmUuidRev)
+| mv-expand vmUuid
+| extend vmUuid=tostring(vmUuid)
+| project machineId=id, name, resourceGroup, vmUuid, kind
 | join kind=inner (
 ConnectedVMwareVsphereResources
 | where type =~ 'Microsoft.ConnectedVMwareVsphere/VCenters/InventoryItems'
@@ -852,8 +855,8 @@ ConnectedVMwareVsphereResources
 | extend biosId = tolower(tostring(p['smbiosUuid']))
 | extend managedResourceId=tolower(tostring(p['managedResourceId']))
 | project inventoryId=id, biosId, managedResourceId
-) on $left.vmUuidRev == $right.biosId
-| project-away vmUuidRev
+) on $left.vmUuid == $right.biosId
+| project-away vmUuid
 """
     query = " ".join(query.splitlines())
 

--- a/src/connectedvmware/setup.py
+++ b/src/connectedvmware/setup.py
@@ -19,7 +19,7 @@ except ImportError:
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
 
-VERSION = '1.1.0'
+VERSION = '1.1.1'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
`az connectedvmware create-from-machines` : Check for BIOS UUIDs in both Big Endian and Middle Endian format.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

`az connectedvmware`

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
