### PR TITLE
[AKS] Remove support for az aks get-os-options command

### DIFF
--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -12,6 +12,10 @@ To release a new version, please select a new version number (usually plus 1 to 
 Pending
 +++++++
 
+6.0.0b2
+++++++++
+* Remove support for `az aks get-os-options` command.
+
 6.0.0b1
 ++++++++
 * Remove support for `az aks mesh` egress gateway commands.

--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -18,7 +18,7 @@ Pending
 
 6.0.0b1
 ++++++++
-* Remove support for `az aks mesh` egress gateway commands.
+* [BREAKING CHANGE]: Remove support for `az aks mesh` egress gateway commands.
 * Add validation to `az aks create` and `az aks update` while modifying the `--ephemeral-disk-volume-type` and `--ephemeral-disk-nvme-perf-tier` values.
 
 5.0.0b4

--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -12,9 +12,9 @@ To release a new version, please select a new version number (usually plus 1 to 
 Pending
 +++++++
 
-6.0.0b2
+7.0.0b1
 ++++++++
-* Remove support for `az aks get-os-options` command.
+* [Breaking Change]: Remove support for `az aks get-os-options` command.
 
 6.0.0b1
 ++++++++

--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -14,7 +14,7 @@ Pending
 
 7.0.0b1
 ++++++++
-* [Breaking Change]: Remove support for `az aks get-os-options` command.
+* [BREAKING CHANGE]: Remove support for `az aks get-os-options` command.
 
 6.0.0b1
 ++++++++

--- a/src/aks-preview/azext_aks_preview/_help.py
+++ b/src/aks-preview/azext_aks_preview/_help.py
@@ -2519,15 +2519,6 @@ examples:
     crafted: true
 """
 
-helps['aks get-os-options'] = """
-type: command
-short-summary: Get the OS options available for creating a managed Kubernetes cluster.
-examples:
-  - name: Get the OS options available for creating a managed Kubernetes cluster
-    text: az aks get-os-options --location westus2
-    crafted: true
-"""
-
 helps['aks get-credentials'] = """
 type: command
 short-summary: Get access credentials for a managed Kubernetes cluster.

--- a/src/aks-preview/azext_aks_preview/commands.py
+++ b/src/aks-preview/azext_aks_preview/commands.py
@@ -180,7 +180,6 @@ def load_command_table(self, _):
         # aks-preview only
         g.custom_command("kollect", "aks_kollect")
         g.custom_command("kanalyze", "aks_kanalyze")
-        g.custom_command("get-os-options", "aks_get_os_options")
         g.custom_command(
             "operation-abort", "aks_operation_abort", supports_no_wait=True
         )

--- a/src/aks-preview/azext_aks_preview/custom.py
+++ b/src/aks-preview/azext_aks_preview/custom.py
@@ -2524,10 +2524,6 @@ def aks_get_versions(cmd, client, location):    # pylint: disable=unused-argumen
     return client.list_kubernetes_versions(location)
 
 
-def aks_get_os_options(cmd, client, location):    # pylint: disable=unused-argument
-    return client.get_os_options(location, resource_type='managedClusters')
-
-
 def get_aks_custom_headers(aks_custom_headers=None):
     headers = {}
     if aks_custom_headers is not None:

--- a/src/aks-preview/setup.py
+++ b/src/aks-preview/setup.py
@@ -9,7 +9,7 @@ from codecs import open as open1
 
 from setuptools import setup, find_packages
 
-VERSION = "6.0.0b2"
+VERSION = "7.0.0b1"
 
 CLASSIFIERS = [
     "Development Status :: 4 - Beta",

--- a/src/aks-preview/setup.py
+++ b/src/aks-preview/setup.py
@@ -9,7 +9,7 @@ from codecs import open as open1
 
 from setuptools import setup, find_packages
 
-VERSION = "6.0.0b1"
+VERSION = "6.0.0b2"
 
 CLASSIFIERS = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
Remove support for 'az aks get-os-options' command. 
The API required by this command was removed from AKS API 2024-05-01, 2024-05-02-preview or later. So remove this command before aks-preview extension starts to use 2024-05-02-preview API.

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
