### PR TITLE
package HISTORY.rst

### DIFF
--- a/src/connectedk8s/MANIFEST.in
+++ b/src/connectedk8s/MANIFEST.in
@@ -1,0 +1,1 @@
+include HISTORY.rst


### PR DESCRIPTION
A pedantic packaging fix: probably not making a meaningful difference today but likely saving trouble in the future

packaging `connectedk8s` using the tooling recommended in current python packaging reveals that `HISTORY.rst` is not included in the sdist, and therefore not available for use by `setup.py` when building the wheel.

```
$ pip install build ; python -m build
<snipped output>
* Getting build dependencies for wheel...
Wheel is not available, disabling bdist_wheel hook
Traceback (most recent call last):
  File "/home/dch/.virtualenvs/foo/lib/python3.12/site-packages/pyproject_hooks/_in_process/_in_process.py", line 373, in <module>
    main()
  File "/home/dch/.virtualenvs/foo/lib/python3.12/site-packages/pyproject_hooks/_in_process/_in_process.py", line 357, in main
    json_out["return_val"] = hook(**hook_input["kwargs"])
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dch/.virtualenvs/foo/lib/python3.12/site-packages/pyproject_hooks/_in_process/_in_process.py", line 134, in get_requires_for_build_wheel
    return hook(config_settings)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/build-env-4bdqbk0w/lib/python3.12/site-packages/setuptools/build_meta.py", line 327, in get_requires_for_build_wheel
    return self._get_build_requires(config_settings, requirements=[])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/build-env-4bdqbk0w/lib/python3.12/site-packages/setuptools/build_meta.py", line 297, in _get_build_requires
    self.run_setup()
  File "/tmp/build-env-4bdqbk0w/lib/python3.12/site-packages/setuptools/build_meta.py", line 497, in run_setup
    super().run_setup(setup_script=setup_script)
  File "/tmp/build-env-4bdqbk0w/lib/python3.12/site-packages/setuptools/build_meta.py", line 313, in run_setup
    exec(code, locals())
  File "<string>", line 45, in <module>
  File "<frozen codecs>", line 918, in open
FileNotFoundError: [Errno 2] No such file or directory: 'HISTORY.rst'
```

per https://github.com/pypa/setuptools/blob/08bd31115732ece3cca50bd93f338e1b90dead34/docs/userguide/miscellaneous.rst#controlling-files-in-the-distribution, setuptools includes certain files by default - eg `README.md` - and `HISTORY.rst` is not among them.

Therefore explicitly package `HISTORY.rst`, after which this works fine.

