### PR TITLE
[confcom] Updating katapolicygen to support new node image

### DIFF
--- a/src/confcom/HISTORY.rst
+++ b/src/confcom/HISTORY.rst
@@ -2,6 +2,13 @@
 
 Release History
 ===============
+0.3.6
+++++++
+* updating genpolicy version up through 3.2.0.azl1.genpolicy0. Please note that this is a breaking change for deploying older policies. With the new node image, 0.3.6 or newer will be required.
+* changing genpolicy flags to give full path to config files instead of path as a flag
+* adding genpolicy flags for --containerd-pull, --containerd-socket-path, --rules-file-name, and --print-version
+* `-c` flag for katapolicygen now supports persistent volume claims
+
 0.3.5
 ++++++
 * making diff mode more robust

--- a/src/confcom/azext_confcom/_help.py
+++ b/src/confcom/azext_confcom/_help.py
@@ -127,6 +127,23 @@ helps[
           type: bool
           short-summary: 'Path to custom settings file'
 
+        - name: --rules-file-name -p
+          type: bool
+          short-summary: 'Path to custom rules file'
+
+        - name: --print-version -v
+          type: bool
+          short-summary: 'Print the version of genpolicy tooling'
+
+        - name: --containerd-pull -d
+          type: string
+          short-summary: 'Use containerd to pull the image. This option is only supported on Linux'
+
+        - name: --containerd-socket-path
+          type: string
+          short-summary: 'Path to the containerd socket. This option is only supported on Linux'
+
+
     examples:
         - name: Input a Kubernetes YAML file to inject a base64 encoded Confidential Container Security Policy into the YAML file
           text: az confcom katapolicygen --yaml "./pod.json"
@@ -136,4 +153,8 @@ helps[
           text: az confcom katapolicygen --yaml "./pod.json" -j "./settings.json"
         - name: Input a Kubernetes YAML file and external config map file
           text: az confcom katapolicygen --yaml "./pod.json" --config-map-file "./configmap.json"
+        - name: Input a Kubernetes YAML file and custom rules file
+          text: az confcom katapolicygen --yaml "./pod.json" -p "./rules.rego"
+        - name: Input a Kubernetes YAML file with a custom containerd socket path
+          text: az confcom katapolicygen --yaml "./pod.json" --containerd-pull --containerd-socket-path "/my/custom/containerd.sock"
 """

--- a/src/confcom/azext_confcom/_params.py
+++ b/src/confcom/azext_confcom/_params.py
@@ -132,7 +132,7 @@ def load_arguments(self, _):
         c.argument(
             "yaml_path",
             options_list=("--yaml", "-y"),
-            required=True,
+            required=False,
             help="Input YAML config file",
         )
         c.argument(
@@ -164,4 +164,28 @@ def load_arguments(self, _):
             options_list=("--settings-file-name", "-j"),
             required=False,
             help="Path for custom settings file",
+        )
+        c.argument(
+            "rules_file_name",
+            options_list=("--rules-file-name", "-p"),
+            required=False,
+            help="Path for custom rules file",
+        )
+        c.argument(
+            "print_version",
+            options_list=("--print-version", "-v"),
+            required=False,
+            help="Print the version of the genpolicy tool",
+        )
+        c.argument(
+            "containerd_pull",
+            options_list=("--containerd-pull", "-d"),
+            required=False,
+            help="Use containerd to pull the image",
+        )
+        c.argument(
+            "containerd_socket_path",
+            options_list=("--containerd-socket-path"),
+            required=False,
+            help="Path to containerd socket if not using the default",
         )

--- a/src/confcom/azext_confcom/custom.py
+++ b/src/confcom/azext_confcom/custom.py
@@ -8,7 +8,7 @@ import sys
 
 from pkg_resources import parse_version
 from knack.log import get_logger
-from azext_confcom.config import DEFAULT_REGO_FRAGMENTS, DATA_FOLDER
+from azext_confcom.config import DEFAULT_REGO_FRAGMENTS
 from azext_confcom import os_util
 from azext_confcom.template_util import (
     pretty_print_func,
@@ -164,14 +164,15 @@ def katapolicygen_confcom(
     print_policy: bool = False,
     use_cached_files: bool = False,
     settings_file_name: str = None,
+    rules_file_name: str = None,
+    print_version: bool = False,
+    containerd_pull: str = False,
+    containerd_socket_path: str = None,
 ):
-
-    if settings_file_name:
-        if "genpolicy-settings.json" in settings_file_name:
-            error_out("Cannot use default settings file names")
-        os_util.copy_file(settings_file_name, DATA_FOLDER)
-
     kata_proxy = KataPolicyGenProxy()
+
+    if not (yaml_path or print_version):
+        error_out("Either --yaml-path or --print-version is required")
 
     output = kata_proxy.kata_genpolicy(
         yaml_path,
@@ -180,6 +181,10 @@ def katapolicygen_confcom(
         print_policy=print_policy,
         use_cached_files=use_cached_files,
         settings_file_name=settings_file_name,
+        rules_file_name=rules_file_name,
+        print_version=print_version,
+        containerd_pull=containerd_pull,
+        containerd_socket_path=containerd_socket_path,
     )
     print(output)
     sys.exit(0)

--- a/src/confcom/azext_confcom/data/internal_config.json
+++ b/src/confcom/azext_confcom/data/internal_config.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.3.5",
+    "version": "0.3.6",
     "hcsshim_config": {
         "maxVersion": "1.0.0",
         "minVersion": "0.0.1"

--- a/src/confcom/azext_confcom/init_checks.py
+++ b/src/confcom/azext_confcom/init_checks.py
@@ -18,10 +18,6 @@ def is_linux():
     return sys.platform in ("linux", "linux2")
 
 
-if is_linux():
-    import grp  # pylint: disable=import-error
-
-
 def is_admin() -> bool:
     admin = False
     try:
@@ -53,6 +49,7 @@ def docker_permissions() -> str:
     if is_linux() and not is_admin():
         client = None
         try:
+            import grp  # pylint: disable=import-error
             docker_group = grp.getgrnam("docker")
             client = docker.from_env()
             # need any command that will show the docker daemon is

--- a/src/confcom/azext_confcom/kata_proxy.py
+++ b/src/confcom/azext_confcom/kata_proxy.py
@@ -109,10 +109,18 @@ class KataPolicyGenProxy:  # pylint: disable=too-few-public-methods
         print_policy=False,
         use_cached_files=False,
         settings_file_name=None,
+        rules_file_name=None,
+        print_version=False,
+        containerd_pull=False,
+        containerd_socket_path=None
     ) -> List[str]:
         policy_bin_str = str(self.policy_bin)
         # get path to data and rules folder
-        arg_list = [policy_bin_str, "-y", yaml_path, "-i", DATA_FOLDER]
+        arg_list = [policy_bin_str]
+
+        if yaml_path:
+            arg_list.append("-y")
+            arg_list.append(yaml_path)
 
         if config_map_file is not None:
             arg_list.append("-c")
@@ -127,16 +135,31 @@ class KataPolicyGenProxy:  # pylint: disable=too-few-public-methods
         if use_cached_files:
             arg_list.append("-u")
 
+        arg_list.append("-j")
         if settings_file_name:
-            arg_list.append("-j")
-            # only take the last part of the path for the settings file
-            settings_file_name = os.path.basename(settings_file_name)
             arg_list.append(settings_file_name)
+        else:
+            arg_list.append(os.path.join(DATA_FOLDER, "genpolicy-settings.json"))
+
+        arg_list.append("-p")
+        if rules_file_name:
+            arg_list.append(rules_file_name)
+        else:
+            arg_list.append(os.path.join(DATA_FOLDER, "rules.rego"))
+
+        if print_version:
+            arg_list.append("-v")
+
+        if containerd_pull:
+            item_to_append = "-d"
+            # -d by itself will use default path: /var/run/containerd/containerd.sock
+            # -d=my/path/my_containerd.sock will use the specified path
+            if containerd_socket_path:
+                item_to_append += f"={containerd_socket_path}"
+            arg_list.append(item_to_append)
 
         item = subprocess.run(
             arg_list,
-            # stdout=sys.stdout,
-            # stderr=sys.stderr,
             check=False,
         )
 

--- a/src/confcom/azext_confcom/kata_proxy.py
+++ b/src/confcom/azext_confcom/kata_proxy.py
@@ -103,7 +103,8 @@ class KataPolicyGenProxy:  # pylint: disable=too-few-public-methods
             os.chmod(self.policy_bin, st.st_mode | stat.S_IXUSR)
 
     def kata_genpolicy(
-        self, yaml_path,
+        self,
+        yaml_path,
         config_map_file=None,
         outraw=False,
         print_policy=False,

--- a/src/confcom/azext_confcom/security_policy.py
+++ b/src/confcom/azext_confcom/security_policy.py
@@ -737,8 +737,6 @@ def load_policy_from_image_name(
         {
             config.ACI_FIELD_VERSION: "1.0",
             config.ACI_FIELD_CONTAINERS: containers,
-            # fallback to default fragments if the policy is not present
-            config.POLICY_FIELD_CONTAINERS_ELEMENTS_REGO_FRAGMENTS: config.DEFAULT_REGO_FRAGMENTS,
         },
         debug_mode=debug_mode,
         disable_stdio=disable_stdio,

--- a/src/confcom/azext_confcom/template_util.py
+++ b/src/confcom/azext_confcom/template_util.py
@@ -188,7 +188,10 @@ def process_env_vars_from_template(params: dict,
     if template_env_vars:
         for env_var in template_env_vars:
             name = case_insensitive_dict_get(env_var, "name")
-            value = case_insensitive_dict_get(env_var, "value") or case_insensitive_dict_get(env_var, "secureValue")
+            value = case_insensitive_dict_get(env_var, "value")
+            # "value" is allowed to be empty string
+            if value is None:
+                value = case_insensitive_dict_get(env_var, "secureValue")
 
             if not name:
                 eprint(

--- a/src/confcom/azext_confcom/tests/latest/README.md
+++ b/src/confcom/azext_confcom/tests/latest/README.md
@@ -132,4 +132,5 @@ Test Name | Image Used | Purpose
 ---|---|---
 test_invalid_input_path | mcr.microsoft.com/aks/e2e/library-busybox:master.220314.1-linux-amd64 | Input a path that does not exist for the pod.yaml file
 test_invalid_config_map_path | mcr.microsoft.com/aks/e2e/library-busybox:master.220314.1-linux-amd64 | Input a path that does not exist for the config-map.yaml file
-test_invalid_settings | mcr.microsoft.com/aks/e2e/library-busybox:master.220314.1-linux-amd64 | Input an invalid name for a custom settings file
+test_valid_settings | mcr.microsoft.com/aks/e2e/library-busybox:master.220314.1-linux-amd64 | Input a valid path for the pod.yaml with the default config file
+test_print_version | N/A | Print the version of the extension

--- a/src/confcom/azext_confcom/tests/latest/README.md
+++ b/src/confcom/azext_confcom/tests/latest/README.md
@@ -19,29 +19,29 @@ It uses the ARM template used to deploy a ACI Container Group while taking into 
 
 Test Name | Image Used | Purpose
 ---|---|---
-test_arm_template_policy | python:3.6.14-slim-buster | Generate an ARM Template policy and policy.json policy and see if their outputs match
-test_default_infrastructure_svn | python:3.6.14-slim-buster | See the default value of the minimum SVN for the infrastructure fragment
-test_default_pause_container | python:3.6.14-slim-buster | See if the default pause containers match the config
+test_arm_template_policy | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot | Generate an ARM Template policy and policy.json policy and see if their outputs match
+test_default_infrastructure_svn | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot | See the default value of the minimum SVN for the infrastructure fragment
+test_default_pause_container | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot | See if the default pause containers match the config
 test_arm_template_missing_image_name | N/A | Error condition if an image isn't specified
 test_arm_template_missing_resources | N/A | Error condition where no resources are specified to deploy
 test_arm_template_missing_aci | N/A | Error condition where ACI is not specified in resources
 test_arm_template_missing_containers | N/A | Error condition where there are no containers in the ACI resource
-test_arm_template_missing_definition | python:3.6.14-slim-buster | Error condition where image is specified in template.parameters.json but not in template.json
+test_arm_template_missing_definition | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot | Error condition where image is specified in template.parameters.json but not in template.json
 test_arm_template_with_parameter_file | mcr.microsoft.com/azure-functions/python:4-python3.8 | Condition where image in template.parameters.json overwrites image name in template.json
 test_arm_template_with_parameter_file_injected_env_vars | mcr.microsoft.com/azure-functions/python:4-python3.8 | See if env vars from the image are injected into the policy. Also make sure the `concat` function in ARM template won't break the CLI if it's not in a required spot like image name
 test_arm_template_with_parameter_file_arm_config | mcr.microsoft.com/azure-functions/python:4-python3.8 | Test valid case of using a parameter file with JSON output instead of Rego
 test_arm_template_with_parameter_file_clean_room | mcr.microsoft.com/azure-functions/node:4 | Test clean room case where image specified does not exist remotely but does locally
-test_policy_diff | alpine:3.16 | See if the diff functionality outputs `True` when diffs match completely
-test_incorrect_policy_diff | alpine:3.16 | Check output formatting and functionality of diff command
-test_update_infrastructure_svn | python:3.6.14-slim-buster | Change the minimum SVN for the insfrastructure fragment
-test_multiple_policies | python:3.6.14-slim-buster & alpine:3.16 | See if two unique policies are generated from a single ARM Template container multiple container groups. Also have an extra resource that is untouched. Also has a secureValue for an environment variable.
-test_arm_template_with_init_container | python:3.6.14-slim-buster & alpine:3.16 | See if having an initContainer is picked up and added to the list of valid containers
-test_arm_template_without_stdio_access | alpine:3.16 | See if disabling container stdio access gets passed down to individual containers
-test_arm_template_allow_elevated_false | alpine:3.16 | Disabling allow_elevated via securityContext
-test_arm_template_policy_regex | python:3.6.14-slim-buster | Make sure the regex generated from the ARM Template workflow matches that of the policy.json workflow
-test_wildcard_env_var | python:3.6.14-slim-buster | Check that an "allow all" regex is created when a value for env var is not provided via a parameter value
+test_policy_diff | mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 | See if the diff functionality outputs `True` when diffs match completely
+test_incorrect_policy_diff | mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 | Check output formatting and functionality of diff command
+test_update_infrastructure_svn | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot | Change the minimum SVN for the insfrastructure fragment
+test_multiple_policies | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot & mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 | See if two unique policies are generated from a single ARM Template container multiple container groups. Also have an extra resource that is untouched. Also has a secureValue for an environment variable.
+test_arm_template_with_init_container | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot & mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 | See if having an initContainer is picked up and added to the list of valid containers
+test_arm_template_without_stdio_access | mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 | See if disabling container stdio access gets passed down to individual containers
+test_arm_template_allow_elevated_false | mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 | Disabling allow_elevated via securityContext
+test_arm_template_policy_regex | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot | Make sure the regex generated from the ARM Template workflow matches that of the policy.json workflow
+test_wildcard_env_var | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot | Check that an "allow all" regex is created when a value for env var is not provided via a parameter value
 test_wildcard_env_var_invalid | N/A | Make sure the process errors out if a value is not given for an env var or an undefined parameter is used for the name of an env var
-test_arm_template_with_env_var | alpine:3.16 | Make sure that a value that looks similar to but is not an ARM parameter is treated as a string
+test_arm_template_with_env_var | mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 | Make sure that a value that looks similar to but is not an ARM parameter is treated as a string
 test_arm_template_security_context_defaults | N/A | Make sure default values for securityContext are correct
 test_arm_template_security_context_allow_privilege_escalation | N/A | See if changing the allowPrivilegeEscalation flag is working
 test_arm_template_security_context_user | N/A | Set the user field manually to make sure it is reflected in the policy
@@ -64,27 +64,26 @@ It is still used for generating sidecar CCE Policies.
 
 Test Name | Image Used | Purpose
 ---|---|---
-test_user_container_customized_mounts | alpine:3.16 | See if mounts are translated correctly to the appropriate source and destination locations
-test_user_container_mount_injected_dns | python:3.6.14-slim-buster | See if the resolvconf mount works properly
+test_user_container_customized_mounts | mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 | See if mounts are translated correctly to the appropriate source and destination locations
+test_user_container_mount_injected_dns | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot | See if the resolvconf mount works properly
 test_injected_sidecar_container_msi | mcr.microsoft.com/aci/msi-atlas-adapter:master_20201203.1 | Make sure User mounts and env vars aren't added to sidecar containers, using JSON output format
-test_debug_flags | python:3.6.14-slim-buster | Enable flags set via debug_mode
+test_debug_flags | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot | Enable flags set via debug_mode
 test_sidecar | mcr.microsoft.com/aci/msi-atlas-adapter:master_20201210.1 | See if sidecar validation would pass policy created by given policy.json
-test_sidecar_stdio_access_default | Check that sidecar containers have std I/O access by default
+test_sidecar_stdio_access_default | mcr.microsoft.com/aci/msi-atlas-adapter:master_20201210.1 | Check that sidecar containers have std I/O access by default
 test_incorrect_sidecar | mcr.microsoft.com/aci/msi-atlas-adapter:master_20201210.1 | See what output format for failing sidecar validation would be
-test_customized_workingdir | python:3.6.14-slim-buster | Using different working dir than specified in image metadata
-test_allow_elevated | python:3.6.14-slim-buster | Using allow_elevated in container
-test_image_layers_python | python:3.6.14-slim-buster | Make sure image layers are as expected
-test_image_layers_nginx | nginx:1.22 | Make sure image layers are as expected with different image
-test_docker_pull | alpine:3.16 | Test pulling an image from docker client
-test_infrastructure_svn | alpine:3.16 | make sure the correct infrastructure_svn is present in the policy
-test_stdio_access_default | python:3.6.14-slim-buster | Checking the default value for std I/O access
-test_stdio_access_updated | python:3.6.14-slim-buster | Checking the value for std I/O when it's set
+test_customized_workingdir | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot | Using different working dir than specified in image metadata
+test_allow_elevated | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot | Using allow_elevated in container
+test_image_layers_python | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot | Make sure image layers are as expected
+test_docker_pull | mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 | Test pulling an image from docker client
+test_infrastructure_svn | mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 | make sure the correct infrastructure_svn is present in the policy
+test_stdio_access_default | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot | Checking the default value for std I/O access
+test_stdio_access_updated | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot | Checking the value for std I/O when it's set
 test_environment_variables_parsing | mcr.microsoft.com/azuredocs/aci-dataprocessing-cc:v1 | Make sure env vars are output in the right format
 test_get_layers_from_not_exists_image | notexists:1.0.0 | Fail out grabbing layers if image doesn't exist
-test_incorrect_allow_elevated_data_type | alpine:3.16 | Making allow_elevated fail out if it's not a boolean
-test_incorrect_workingdir_path | alpine:3.16 | Fail if working dir isn't an absolute path string
-test_incorrect_workingdir_data_type | alpine:3.16 | Fail if working dir is an array
-test_incorrect_command_data_type | alpine:3.16 | Fail if command is not array of strings
+test_incorrect_allow_elevated_data_type | mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 | Making allow_elevated fail out if it's not a boolean
+test_incorrect_workingdir_path | mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 | Fail if working dir isn't an absolute path string
+test_incorrect_workingdir_data_type | mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 | Fail if working dir is an array
+test_incorrect_command_data_type | mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 | Fail if command is not array of strings
 test_json_missing_containers | N/A | Fail if containers are not specified
 test_json_missing_version | mcr.microsoft.com/azuredocs/aci-dataprocessing-cc:v1 | Fail if version is not included in policy.json
 test_json_missing_containerImage | N/A | Fail if container doesn't have an image specified
@@ -98,7 +97,7 @@ It accepts a string of the image name and tag and outputs a CCE Policy using the
 
 Test Name | Image Used | Purpose
 ---|---|---
-test_image_policy | python:3.6.14-slim-buster | Create a policy based on only an image name
+test_image_policy | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot | Create a policy based on only an image name
 test_sidecar_image_policy |mcr.microsoft.com/aci/atlas-mount-azure-file-volume:master_20201210.2| Create a policy based on a sidecar so no env vars are injected
 test_invalid_image_policy | mcr.microsoft.com/aci/fake-image:master_20201210.2 | Fail out if the image doesn't exist locally or remotely
 test_clean_room_policy | mcr.microsoft.com/aci/atlas-mount-azure-file-volume:master_20201210.2 | create a new tag of a sidecar locally and make sure it matches the original
@@ -120,8 +119,8 @@ This is a way to generate a CCE policy without the use of the docker daemon. The
 
 Test Name | Image Used | Purpose
 ---|---|---
-test_arm_template_with_parameter_file_clean_room_tar | nginx:1.23 | Create a policy from a tar file and compare it to a policy generated from an ARM template
-test_arm_template_mixed_mode_tar | python:3.9 & nginx:1.22 | Create a policy with one image from a tar file and one image that must be downloaded or used locally from the daemon
+test_arm_template_with_parameter_file_clean_room_tar | mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 | Create a policy from a tar file and compare it to a policy generated from an ARM template
+test_arm_template_mixed_mode_tar | mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot & mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 | Create a policy with one image from a tar file and one image that must be downloaded or used locally from the daemon
 test_arm_template_with_parameter_file_clean_room_tar_invalid | N/A | Fail out if searching for an image in a tar file that does not include it
 test_clean_room_fake_tar_invalid | N/A | Fail out if the path to the tar file doesn't exist
 

--- a/src/confcom/azext_confcom/tests/latest/test_confcom_arm.py
+++ b/src/confcom/azext_confcom/tests/latest/test_confcom_arm.py
@@ -29,41 +29,11 @@ class PolicyGeneratingArm(unittest.TestCase):
             "containers": [
                 {
                     "name": "simple-container",
-                    "containerImage": "python:3.6.14-slim-buster",
+                    "containerImage": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot",
                     "environmentVariables": [
                         {
                             "name":"PATH",
-                            "value":"/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-                            "strategy":"string"
-                        },
-                        {
-                            "name":"LANG",
-                            "value":"C.UTF-8",
-                            "strategy":"string"
-                        },
-                        {
-                            "name":"GPG_KEY",
-                            "value":"0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D",
-                            "strategy":"string"
-                        },
-                        {
-                            "name":"PYTHON_VERSION",
-                            "value":"3.6.14",
-                            "strategy":"string"
-                        },
-                        {
-                            "name":"PYTHON_PIP_VERSION",
-                            "value":"21.2.4",
-                            "strategy":"string"
-                        },
-                        {
-                            "name":"PYTHON_GET_PIP_URL",
-                            "value":"https://github.com/pypa/get-pip/raw/c20b0cfd643cd4a19246ccf204e2997af70f6b21/public/get-pip.py",
-                            "strategy":"string"
-                        },
-                        {
-                            "name":"PYTHON_GET_PIP_SHA256",
-                            "value":"fa6f3fb93cce234cd4e8dd2beb54a51ab9c247653b52855a48dd44e6b21ff28b",
+                            "value":"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
                             "strategy":"string"
                         }
                     ],
@@ -91,7 +61,7 @@ class PolicyGeneratingArm(unittest.TestCase):
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
         "contentVersion": "1.0.0.0",
         "variables": {
-            "image": "python:3.6.14-slim-buster"
+            "image": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
         },
 
 
@@ -253,7 +223,6 @@ class PolicyGeneratingArm(unittest.TestCase):
 
         normalized_aci_policy[0].pop(config.POLICY_FIELD_CONTAINERS_ID)
         normalized_aci_arm_policy[0].pop(config.POLICY_FIELD_CONTAINERS_ID)
-
         self.assertEqual(
             deepdiff.DeepDiff(
                 normalized_aci_policy, normalized_aci_arm_policy, ignore_order=True
@@ -724,7 +693,7 @@ class PolicyGeneratingArmParametersIncorrect(unittest.TestCase):
         "contentVersion": "1.0.0.0",
         "parameters": {
             "image": {
-            "value": "python:3.6.14-slim-buster"
+            "value": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
             },
             "containername": {
             "value": "simple-container"
@@ -785,7 +754,7 @@ class PolicyGeneratingArmParameters(unittest.TestCase):
                 "metadata": {
                     "description": "Name for the image"
                 },
-                "defaultValue": "python:3.6.14-slim-buster"
+                "defaultValue": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
             },
 
             "port": {
@@ -925,7 +894,7 @@ class PolicyGeneratingArmParameters2(unittest.TestCase):
             "metadata": {
                 "description": "Name for the container group"
             },
-            "defaultValue":"python:3.6.14-slim-buster"
+            "defaultValue":"mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
             },
              "imagebase": {
             "type": "string",
@@ -1094,7 +1063,7 @@ class PolicyGeneratingArmContainerConfig(unittest.TestCase):
             "metadata": {
                 "description": "Name for the container group"
             },
-            "defaultValue":"python:3.6.14-slim-buster"
+            "defaultValue":"mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
             },
              "imagebase": {
             "type": "string",
@@ -1281,7 +1250,7 @@ class PolicyGeneratingArmParametersCleanRoom(unittest.TestCase):
                 "metadata": {
                     "description": "Name for the container group"
                 },
-                "defaultValue":"alpine:3.16"
+                "defaultValue":"mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0"
             },
             "containername": {
                 "type": "string",
@@ -1387,7 +1356,7 @@ class PolicyGeneratingArmParametersCleanRoom(unittest.TestCase):
     """
         with DockerClient() as client:
             # client = docker.from_env()
-            original_image = "alpine:3.16"
+            original_image = "mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0"
             try:
                 client.images.remove(original_image)
             except:
@@ -1442,7 +1411,7 @@ class PolicyDiff(unittest.TestCase):
     "contentVersion": "1.0.0.0",
     "variables": {
         "container1name": "aci-test",
-        "container1image": "alpine:3.16"
+        "container1image": "mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0"
     },
     "resources": [
         {
@@ -1521,7 +1490,7 @@ class PolicyDiff(unittest.TestCase):
     "contentVersion": "1.0.0.0",
     "variables": {
         "container1name": "aci-test",
-        "container1image": "alpine:3.16"
+        "container1image": "mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0"
     },
     "resources": [
         {
@@ -1653,7 +1622,7 @@ class PolicyGeneratingArmInfrastructureSvn(unittest.TestCase):
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
         "contentVersion": "1.0.0.0",
         "variables": {
-            "image": "python:3.6.14-slim-buster"
+            "image": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
         },
 
 
@@ -1821,9 +1790,9 @@ class MultiplePolicyTemplate(unittest.TestCase):
     "contentVersion": "1.0.0.0",
     "variables": {
         "container1name": "aci-test",
-        "container1image": "alpine:3.16",
+        "container1image": "mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0",
         "container2name": "aci-test2",
-        "container2image": "python:3.6.14-slim-buster"
+        "container2image": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
     },
     "resources": [
         {
@@ -2081,7 +2050,7 @@ class MultiplePolicyTemplate(unittest.TestCase):
         is_valid, diff = self.aci_policy.validate_cce_policy()
         self.assertFalse(is_valid)
         # just check to make sure the containers in both policies are different
-        expected_diff = {"aci-test": "alpine:3.16 not found in policy"}
+        expected_diff = {"aci-test": "mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 not found in policy"}
         self.assertEqual(diff, expected_diff)
 
     def test_multiple_diffs(self):
@@ -2118,7 +2087,7 @@ class PolicyGeneratingArmInitContainer(unittest.TestCase):
                 "metadata": {
                     "description": "Name for the container group"
                 },
-                "defaultValue":"alpine:3.16"
+                "defaultValue":"mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0"
             },
             "containername": {
                 "type": "string",
@@ -2200,7 +2169,7 @@ class PolicyGeneratingArmInitContainer(unittest.TestCase):
                     {
                         "name": "init-container-python",
                         "properties": {
-                            "image": "python:3.6.14-slim-buster",
+                            "image": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot",
                             "environmentVariables": [
                                 {
                                     "name":"PATH",
@@ -2303,7 +2272,7 @@ class PolicyGeneratingDisableStdioAccess(unittest.TestCase):
                 "metadata": {
                     "description": "Name for the container group"
                 },
-                "defaultValue":"alpine:3.16"
+                "defaultValue":"mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0"
             },
             "containername": {
                 "type": "string",
@@ -2449,7 +2418,7 @@ class PolicyGeneratingAllowElevated(unittest.TestCase):
                 "metadata": {
                     "description": "Name for the container group"
                 },
-                "defaultValue":"alpine:3.16"
+                "defaultValue":"mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0"
             },
             "containername": {
                 "type": "string",
@@ -2584,7 +2553,7 @@ class PrintExistingPolicy(unittest.TestCase):
             "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
             "contentVersion": "1.0.0.0",
             "variables": {
-                "image": "python:3.6.14-slim-buster"
+                "image": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
             },
 
 
@@ -2724,7 +2693,7 @@ class PrintExistingPolicy(unittest.TestCase):
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "variables": {
-    "image": "python:3.6.14-slim-buster"
+    "image": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
   },
   "parameters": {
     "containergroupname": {
@@ -2883,41 +2852,11 @@ class PolicyGeneratingArmWildcardEnvs(unittest.TestCase):
             "containers": [
                 {
                     "name": "simple-container",
-                    "containerImage": "python:3.6.14-slim-buster",
+                    "containerImage": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot",
                     "environmentVariables": [
                         {
                             "name":"PATH",
                             "value":"/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-                            "strategy":"string"
-                        },
-                        {
-                            "name":"LANG",
-                            "value":"C.UTF-8",
-                            "strategy":"string"
-                        },
-                        {
-                            "name":"GPG_KEY",
-                            "value":"0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D",
-                            "strategy":"string"
-                        },
-                        {
-                            "name":"PYTHON_VERSION",
-                            "value":"3.6.14",
-                            "strategy":"string"
-                        },
-                        {
-                            "name":"PYTHON_PIP_VERSION",
-                            "value":"21.2.4",
-                            "strategy":"string"
-                        },
-                        {
-                            "name":"PYTHON_GET_PIP_URL",
-                            "value":"https://github.com/pypa/get-pip/raw/c20b0cfd643cd4a19246ccf204e2997af70f6b21/public/get-pip.py",
-                            "strategy":"string"
-                        },
-                        {
-                            "name":"PYTHON_GET_PIP_SHA256",
-                            "value":"fa6f3fb93cce234cd4e8dd2beb54a51ab9c247653b52855a48dd44e6b21ff28b",
                             "strategy":"string"
                         },
                         {
@@ -2939,7 +2878,7 @@ class PolicyGeneratingArmWildcardEnvs(unittest.TestCase):
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
         "contentVersion": "1.0.0.0",
         "variables": {
-            "image": "python:3.6.14-slim-buster"
+            "image": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
         },
 
 
@@ -3057,7 +2996,7 @@ class PolicyGeneratingArmWildcardEnvs(unittest.TestCase):
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
         "contentVersion": "1.0.0.0",
         "variables": {
-            "image": "python:3.6.14-slim-buster"
+            "image": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
         },
 
 
@@ -3173,7 +3112,7 @@ class PolicyGeneratingArmWildcardEnvs(unittest.TestCase):
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
         "contentVersion": "1.0.0.0",
         "variables": {
-            "image": "python:3.6.14-slim-buster"
+            "image": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
         },
 
 
@@ -3307,7 +3246,7 @@ class PolicyGeneratingArmWildcardEnvs(unittest.TestCase):
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
         "contentVersion": "1.0.0.0",
         "variables": {
-            "image": "python:3.6.14-slim-buster"
+            "image": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
         },
 
 
@@ -3483,7 +3422,6 @@ class PolicyGeneratingArmWildcardEnvs(unittest.TestCase):
         normalized_aci_policy[0].pop(config.POLICY_FIELD_CONTAINERS_ID)
 
         normalized_aci_arm_policy[0].pop(config.POLICY_FIELD_CONTAINERS_ID)
-
         self.assertEqual(
             deepdiff.DeepDiff(
                 normalized_aci_policy, normalized_aci_arm_policy, ignore_order=True
@@ -3563,7 +3501,7 @@ class PolicyGeneratingEdgeCases(unittest.TestCase):
                 "metadata": {
                     "description": "Name for the container group"
                 },
-                "defaultValue":"alpine:3.16"
+                "defaultValue":"mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0"
             },
             "containername": {
                 "type": "string",
@@ -3691,7 +3629,7 @@ class PolicyGeneratingEdgeCases(unittest.TestCase):
 
         # see if the remote image and the local one produce the same output
         self.assertEqual(env_var, "PORT=parameters('abc')")
-        self.assertEqual(regular_image_json[0][config.POLICY_FIELD_CONTAINERS_ID], "alpine:3.16")
+        self.assertEqual(regular_image_json[0][config.POLICY_FIELD_CONTAINERS_ID], "mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0")
 
     def test_arm_template_config_map_sidecar(self):
         regular_image_json = json.loads(
@@ -3711,7 +3649,7 @@ class PolicyGeneratingSecurityContext(unittest.TestCase):
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
         "contentVersion": "1.0.0.0",
         "variables": {
-            "image": "python:3.6.14-slim-buster"
+            "image": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
         },
 
 
@@ -3852,7 +3790,7 @@ class PolicyGeneratingSecurityContext(unittest.TestCase):
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
         "contentVersion": "1.0.0.0",
         "variables": {
-            "image": "python:3.6.14-slim-buster"
+            "image": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
         },
 
 
@@ -4003,7 +3941,7 @@ class PolicyGeneratingSecurityContext(unittest.TestCase):
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
         "contentVersion": "1.0.0.0",
         "variables": {
-            "image": "python:3.6.14-slim-buster"
+            "image": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
         },
 
 
@@ -4150,7 +4088,7 @@ class PolicyGeneratingSecurityContext(unittest.TestCase):
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
         "contentVersion": "1.0.0.0",
         "variables": {
-            "image": "python:3.6.14-slim-buster"
+            "image": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
         },
 
 
@@ -4322,8 +4260,8 @@ class PolicyGeneratingSecurityContext(unittest.TestCase):
         expected_user_json = json.loads("""{
             "user_idname":
             {
-                "pattern": "",
-                "strategy": "any"
+                "pattern": "nonroot",
+                "strategy": "name"
             },
             "group_idnames": [
                 {
@@ -4438,7 +4376,7 @@ class PolicyGeneratingSecurityContextUserEdgeCases(unittest.TestCase):
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
         "contentVersion": "1.0.0.0",
         "variables": {
-            "image": "python:3.6.14-slim-buster"
+            "image": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
         },
 
 
@@ -4588,7 +4526,7 @@ class PolicyGeneratingSecurityContextUserEdgeCases(unittest.TestCase):
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
         "contentVersion": "1.0.0.0",
         "variables": {
-            "image": "python:3.6.14-slim-buster"
+            "image": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
         },
 
 
@@ -5196,7 +5134,7 @@ class PolicyGeneratingSecurityContextSeccompProfileEdgeCases(unittest.TestCase):
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
         "contentVersion": "1.0.0.0",
         "variables": {
-            "image": "python:3.6.14-slim-buster"
+            "image": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
         },
 
 

--- a/src/confcom/azext_confcom/tests/latest/test_confcom_image.py
+++ b/src/confcom/azext_confcom/tests/latest/test_confcom_image.py
@@ -29,9 +29,7 @@ class PolicyGeneratingImage(unittest.TestCase):
                     "environmentVariables": [
 
                     ],
-                    "command": [
-                        "python3"
-                    ],
+                    "command": [],
                     "workingDir": ""
                 }
             ]

--- a/src/confcom/azext_confcom/tests/latest/test_confcom_image.py
+++ b/src/confcom/azext_confcom/tests/latest/test_confcom_image.py
@@ -25,7 +25,7 @@ class PolicyGeneratingImage(unittest.TestCase):
             "version": "1.0",
             "containers": [
                 {
-                    "containerImage": "python:3.6.14-slim-buster",
+                    "containerImage": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot",
                     "environmentVariables": [
 
                     ],
@@ -40,7 +40,7 @@ class PolicyGeneratingImage(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        with load_policy_from_image_name("python:3.6.14-slim-buster") as aci_policy:
+        with load_policy_from_image_name("mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot") as aci_policy:
             aci_policy.populate_policy_content_for_all_images(individual_image=True)
             cls.aci_policy = aci_policy
         with load_policy_from_str(cls.custom_json) as custom_policy:

--- a/src/confcom/azext_confcom/tests/latest/test_confcom_scenario.py
+++ b/src/confcom/azext_confcom/tests/latest/test_confcom_scenario.py
@@ -25,7 +25,7 @@ class MountEnforcement(unittest.TestCase):
         "version": "1.0",
         "containers": [
             {
-                "containerImage": "alpine:3.16",
+                "containerImage": "mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0",
                 "environmentVariables": [
                     {
                         "name": "PATH",
@@ -48,7 +48,7 @@ class MountEnforcement(unittest.TestCase):
                 ]
             },
             {
-                "containerImage": "nginx:1.24",
+                "containerImage": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot",
                 "environmentVariables": [],
                 "command": ["echo", "hello"],
                 "workingDir": "/customized/absolute/path",
@@ -73,7 +73,7 @@ class MountEnforcement(unittest.TestCase):
             (
                 img
                 for img in self.aci_policy.get_images()
-                if isinstance(img, UserContainerImage) and img.base == "alpine"
+                if isinstance(img, UserContainerImage) and img.base == "mcr.microsoft.com/cbl-mariner/distroless/minimal"
             ),
             None,
         )
@@ -112,7 +112,7 @@ class MountEnforcement(unittest.TestCase):
             (
                 img
                 for img in self.aci_policy.get_images()
-                if isinstance(img, UserContainerImage) and img.base == "nginx"
+                if isinstance(img, UserContainerImage) and img.base == "mcr.microsoft.com/cbl-mariner/distroless/python"
             ),
             None,
         )
@@ -365,7 +365,7 @@ class PolicyGeneratingDebugMode(unittest.TestCase):
         "version": "1.0",
         "containers": [
             {
-                "containerImage": "python:3.6.14-slim-buster",
+                "containerImage": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot",
             "environmentVariables": [
 
             ],
@@ -505,7 +505,7 @@ class CustomJsonParsing(unittest.TestCase):
             "version": "1.0",
             "containers": [
                 {
-                    "containerImage": "python:3.6.14-slim-buster",
+                    "containerImage": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot",
                     "environmentVariables": [],
                     "command": ["echo", "hello"],
                     "workingDir": "/customized/absolute/path"
@@ -533,7 +533,7 @@ class CustomJsonParsing(unittest.TestCase):
             "version": "1.0",
             "containers": [
                 {
-                    "containerImage": "python:3.6.14-slim-buster",
+                    "containerImage": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot",
                     "environmentVariables": [],
                     "command": ["echo", "hello"],
                     "workingDir": "/customized/absolute/path",
@@ -562,7 +562,7 @@ class CustomJsonParsing(unittest.TestCase):
             "version": "1.0",
             "containers": [
                 {
-                    "containerImage": "python:3.6.14-slim-buster",
+                    "containerImage": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot",
                     "environmentVariables": [],
                     "command": ["echo", "hello"]
                 }
@@ -575,42 +575,8 @@ class CustomJsonParsing(unittest.TestCase):
             aci_policy.populate_policy_content_for_all_images()
             layers = aci_policy.get_images()[0]._layers
             expected_layers = [
-                "254cc853da6081905c9109c8b9d99c9fb0987ba1d88f729088903cffb80f55f1",
-                "a568f1900bed60a0641b76b991ad431446d9c3a344d7b261f10de8d8e73763ac",
-                "c70c530e842f66215b0bd955877157ba24c3799303567c3f5673c45663ea4d15",
-                "3e86c3ccf1642bf584de33b49c7248f87eecd0f6d8c08353daa36cc7ad0a7b6a",
-                "1e4684d8c7caa74c6524172b4d5a159a10887613ed70f18d0a55d05b2af61acd",
-            ]
-            self.assertEqual(len(layers), len(expected_layers))
-            for i in range(len(expected_layers)):
-                self.assertEqual(layers[i], expected_layers[i])
-
-    def test_image_layers_nginx(self):
-        custom_json = """
-        {
-            "version": "1.0",
-            "containers": [
-                {
-                    "containerImage": "nginx:1.22",
-                    "environmentVariables": [],
-                    "command": ["echo", "hello"]
-                }
-            ]
-        }
-        """
-        with load_policy_from_str(custom_json) as aci_policy:
-            # pull actual image to local for next step
-            aci_policy.pull_image(aci_policy.get_images()[0])
-            aci_policy.populate_policy_content_for_all_images()
-            layers = aci_policy.get_images()[0]._layers
-
-            expected_layers = [
-                "5250e7d2517bcae4d264c84d8e7c6da14607ce867e29a81bf4327ee6896218a3",
-                "b6d54ad6a7223dd687d308c8562aaa7dfef2f5a88ec701fb3f89e49312832b82",
-                "8608c5be3af25ed58b2291999fe76cc021ced0ea70b6387c4373c6551f4d6ddb",
-                "1e0878890d701c494c8aeade31d15eaaf9b9c382c27e2519727cb5d1e91df764",
-                "233b6e2f8931a4d67930ac602688acc16c930926fcadc9e31195440db0737791",
-                "1053a7714644b99537bc0e8058a7e4771d2fe679ef54097e128a813f3c80a9cf",
+                "7b1ae25401fd6ca6c47b8b40aea586716a5097f61319e56fe362b3fc75e23d4b",
+                "458d929fa0c010516795d30c506ba603c4e8a784e8b79ff8f299bab214484232"
             ]
             self.assertEqual(len(layers), len(expected_layers))
             for i in range(len(expected_layers)):
@@ -622,7 +588,7 @@ class CustomJsonParsing(unittest.TestCase):
             "version": "1.0",
             "containers": [
                 {
-                    "containerImage": "alpine:3.16",
+                    "containerImage": "mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0",
                     "environmentVariables": [],
                     "command": ["echo", "hello"]
                 }
@@ -635,7 +601,7 @@ class CustomJsonParsing(unittest.TestCase):
 
             self.assertEqual(
                 image.id,
-                "sha256:d49a5025be10344cce77d178103a225cb5d7316861e5d8f106e7ff278ae51b62",
+                "sha256:c86070f98acd42b18ef21eefac32fead5d5b0291e0f0fc554e6c3eb9acc0cb60",
             )
 
     def test_infrastructure_svn(self):
@@ -644,7 +610,7 @@ class CustomJsonParsing(unittest.TestCase):
             "version": "1.0",
             "containers": [
                 {
-                    "containerImage": "alpine:3.16",
+                    "containerImage": "mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0",
                     "environmentVariables": [],
                     "command": ["echo", "hello"]
                 }
@@ -720,7 +686,7 @@ class CustomJsonParsing(unittest.TestCase):
             "version": "1.0",
             "containers": [
                 {
-                    "containerImage": "python:3.6.14-slim-buster",
+                    "containerImage": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot",
                     "environmentVariables": [],
                     "command": ["echo", "hello"]
                 }
@@ -743,7 +709,7 @@ class CustomJsonParsing(unittest.TestCase):
             "version": "1.0",
             "containers": [
                 {
-                    "containerImage": "python:3.6.14-slim-buster",
+                    "containerImage": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot",
                     "environmentVariables": [],
                     "command": ["echo", "hello"],
                     "allowStdioAccess": false
@@ -790,7 +756,7 @@ class CustomJsonParsingIncorrect(unittest.TestCase):
             "version": "1.0",
             "containers": [
                 {
-                    "containerImage": "alpine:3.16",
+                    "containerImage": "mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0",
                     "environmentVariables": [],
                     "command": "echo hello",
                     "workingDir": "relative/string/path",
@@ -810,7 +776,7 @@ class CustomJsonParsingIncorrect(unittest.TestCase):
             "version": "1.0",
             "containers": [
                 {
-                    "containerImage": "alpine:3.16",
+                    "containerImage": "mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0",
                     "environmentVariables": [],
                     "command": "echo hello",
                     "workingDir": "relative/string/path"
@@ -829,7 +795,7 @@ class CustomJsonParsingIncorrect(unittest.TestCase):
             "version": "1.0",
             "containers": [
                 {
-                    "containerImage": "alpine:3.16",
+                    "containerImage": "mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0",
                     "environmentVariables": [],
                     "command": "echo hello",
                     "workingDir": ["hello"]
@@ -848,7 +814,7 @@ class CustomJsonParsingIncorrect(unittest.TestCase):
             "version": "1.0",
             "containers": [
                 {
-                    "containerImage": "alpine:3.16",
+                    "containerImage": "mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0",
                     "environmentVariables": [],
                     "command": "echo hello"
                 }

--- a/src/confcom/azext_confcom/tests/latest/test_confcom_scenario.py
+++ b/src/confcom/azext_confcom/tests/latest/test_confcom_scenario.py
@@ -575,8 +575,8 @@ class CustomJsonParsing(unittest.TestCase):
             aci_policy.populate_policy_content_for_all_images()
             layers = aci_policy.get_images()[0]._layers
             expected_layers = [
-                "0b69f91b136ad63a510c03b03e16ca56696868643918549e0271473f39f104f1",
-                "13e566df4074c2107b765d3d16aede04a79281a99839a05fa693d679e6e33413"
+                "5e7ea0fd847ed540d08972f79a6db00784ad6e8bdd46376e8b06d91487dae543",
+                "6aa20e05a8d57ef7b0cb2f8e6aa06745a83646c448c8955bce3cf3a077ae9219"
             ]
             self.assertEqual(len(layers), len(expected_layers))
             for i in range(len(expected_layers)):
@@ -601,7 +601,7 @@ class CustomJsonParsing(unittest.TestCase):
 
             self.assertEqual(
                 image.id,
-                "sha256:378a3707f10cca088b84a8d6d550ee2636053761d4e033579e765e65bca287d8",
+                "sha256:e1a4f833f1188caab3b5c436fde5b23567b682a333bb7075d5ef23a5e1291da2",
             )
 
     def test_infrastructure_svn(self):

--- a/src/confcom/azext_confcom/tests/latest/test_confcom_scenario.py
+++ b/src/confcom/azext_confcom/tests/latest/test_confcom_scenario.py
@@ -575,8 +575,8 @@ class CustomJsonParsing(unittest.TestCase):
             aci_policy.populate_policy_content_for_all_images()
             layers = aci_policy.get_images()[0]._layers
             expected_layers = [
-                "7b1ae25401fd6ca6c47b8b40aea586716a5097f61319e56fe362b3fc75e23d4b",
-                "458d929fa0c010516795d30c506ba603c4e8a784e8b79ff8f299bab214484232"
+                "0b69f91b136ad63a510c03b03e16ca56696868643918549e0271473f39f104f1",
+                "13e566df4074c2107b765d3d16aede04a79281a99839a05fa693d679e6e33413"
             ]
             self.assertEqual(len(layers), len(expected_layers))
             for i in range(len(expected_layers)):
@@ -601,7 +601,7 @@ class CustomJsonParsing(unittest.TestCase):
 
             self.assertEqual(
                 image.id,
-                "sha256:c86070f98acd42b18ef21eefac32fead5d5b0291e0f0fc554e6c3eb9acc0cb60",
+                "sha256:378a3707f10cca088b84a8d6d550ee2636053761d4e033579e765e65bca287d8",
             )
 
     def test_infrastructure_svn(self):

--- a/src/confcom/azext_confcom/tests/latest/test_confcom_tar.py
+++ b/src/confcom/azext_confcom/tests/latest/test_confcom_tar.py
@@ -23,7 +23,7 @@ from azext_confcom.template_util import DockerClient
 def create_tar_file(image_path: str) -> None:
     if not os.path.isfile(image_path):
         with DockerClient() as client:
-            image = client.images.get("nginx:1.22")
+            image = client.images.get("mcr.microsoft.com/aks/e2e/library-busybox:master.220314.1-linux-amd64")
             f = open(image_path, "wb")
             for chunk in image.save(named=True):
                 f.write(chunk)
@@ -61,7 +61,7 @@ class PolicyGeneratingArmParametersCleanRoomTarFile(unittest.TestCase):
                 "metadata": {
                     "description": "Name for the container group"
                 },
-                "defaultValue":"nginx:1.22"
+                "defaultValue":"mcr.microsoft.com/aks/e2e/library-busybox:master.220314.1-linux-amd64"
             },
             "containername": {
                 "type": "string",
@@ -177,8 +177,8 @@ class PolicyGeneratingArmParametersCleanRoomTarFile(unittest.TestCase):
         )[0]
 
         try:
-            filename = os.path.join(self.path, "./nginx.tar")
-            tar_mapping_file = {"nginx:1.22": filename}
+            filename = os.path.join(self.path, "./mariner.tar")
+            tar_mapping_file = {"mcr.microsoft.com/aks/e2e/library-busybox:master.220314.1-linux-amd64": filename}
             create_tar_file(filename)
             clean_room_image.populate_policy_content_for_all_images(
                 tar_mapping=tar_mapping_file
@@ -226,7 +226,7 @@ class PolicyGeneratingArmParametersCleanRoomTarFile(unittest.TestCase):
                 "metadata": {
                     "description": "Name for the container group"
                 },
-                "defaultValue":"nginx:1.22"
+                "defaultValue":"mcr.microsoft.com/aks/e2e/library-busybox:master.220314.1-linux-amd64"
             },
             "containername": {
                 "type": "string",
@@ -240,7 +240,7 @@ class PolicyGeneratingArmParametersCleanRoomTarFile(unittest.TestCase):
                 "metadata": {
                     "description": "Name for the container group"
                 },
-                "defaultValue":"python:3.6.14-slim-buster"
+                "defaultValue":"mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
             },
             "containername2": {
                 "type": "string",
@@ -382,7 +382,7 @@ class PolicyGeneratingArmParametersCleanRoomTarFile(unittest.TestCase):
             custom_arm_json_default_value, ""
         )[0]
 
-        filename = os.path.join(self.path, "./nginx2.tar")
+        filename = os.path.join(self.path, "./mariner2.tar")
         create_tar_file(filename)
         clean_room_image.populate_policy_content_for_all_images(
             tar_mapping=filename
@@ -427,7 +427,7 @@ class PolicyGeneratingArmParametersCleanRoomTarFile(unittest.TestCase):
                 "metadata": {
                     "description": "Name for the container group"
                 },
-                "defaultValue":"alpine:3.16"
+                "defaultValue":"mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0"
             },
             "containername": {
                 "type": "string",
@@ -536,7 +536,7 @@ class PolicyGeneratingArmParametersCleanRoomTarFile(unittest.TestCase):
             custom_arm_json_default_value, ""
         )[0]
 
-        filename = os.path.join(self.path, "./nginx3.tar")
+        filename = os.path.join(self.path, "./mariner3.tar")
 
         try:
             create_tar_file(filename)
@@ -569,7 +569,7 @@ class PolicyGeneratingArmParametersCleanRoomTarFile(unittest.TestCase):
                 "metadata": {
                     "description": "Name for the container group"
                 },
-                "defaultValue":"alpine:3.16"
+                "defaultValue":"mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0"
             },
             "containername": {
                 "type": "string",

--- a/src/confcom/azext_confcom/tests/latest/test_confcom_template_util.py
+++ b/src/confcom/azext_confcom/tests/latest/test_confcom_template_util.py
@@ -350,7 +350,7 @@ LmZyYW1ld29yay5lcnJvcnN9Cg=="""
             "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
             "contentVersion": "1.0.0.0",
             "variables": {
-                "image": "python:3.6.14-slim-buster"
+                "image": "mcr.microsoft.com/cbl-mariner/distroless/python:3.9-nonroot"
             },
 
 

--- a/src/confcom/setup.py
+++ b/src/confcom/setup.py
@@ -18,7 +18,7 @@ except ImportError:
 
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
 
-VERSION = "0.3.5"
+VERSION = "0.3.6"
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Also updating tests to use images hosted on MCR instead of Docker Hub
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
az confcom


### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
