### PR TITLE
Fixed issues with public IPs when creating repair VMs in no-tty mode

### DIFF
--- a/src/vm-repair/azext_vm_repair/_params.py
+++ b/src/vm-repair/azext_vm_repair/_params.py
@@ -33,6 +33,8 @@ def load_arguments(self, _):
         c.argument('associate_public_ip', help='Option to create repair vm with public ip')
         c.argument('distro', help='Option to create repair vm from a specific linux distro (rhel7|rhel8|suse12|ubuntu20|centos7|oracle7)')
         c.argument('yes', help='Option to skip prompt for associating public ip and confirm yes to it in no Tty mode')
+        c.argument('no', help='Option to skip prompt for associating public ip and confirm no to it in no Tty mode')
+
 
     with self.argument_context('vm repair restore') as c:
         c.argument('repair_vm_id', help='Repair VM resource id.')

--- a/src/vm-repair/azext_vm_repair/_validators.py
+++ b/src/vm-repair/azext_vm_repair/_validators.py
@@ -88,7 +88,7 @@ def validate_create(cmd, namespace):
     # Validate vm password
     validate_vm_password(namespace.repair_password, is_linux)
     # Prompt input for public ip usage
-    if (not namespace.associate_public_ip) and (not namespace.yes):
+    if (not namespace.associate_public_ip) and (not namespace.yes) and (not namespace.no):
         _prompt_public_ip(namespace)
 
 

--- a/src/vm-repair/azext_vm_repair/custom.py
+++ b/src/vm-repair/azext_vm_repair/custom.py
@@ -51,10 +51,10 @@ from .exceptions import AzCommandError, RunScriptNotFoundForIdError, SupportingR
 logger = get_logger(__name__)
 
 
-def create(cmd, vm_name, resource_group_name, repair_password=None, repair_username=None, repair_vm_name=None, copy_disk_name=None, repair_group_name=None, unlock_encrypted_vm=False, enable_nested=False, associate_public_ip=False, distro='ubuntu', yes=False):
+def create(cmd, vm_name, resource_group_name, repair_password=None, repair_username=None, repair_vm_name=None, copy_disk_name=None, repair_group_name=None, unlock_encrypted_vm=False, enable_nested=False, associate_public_ip=False, distro='ubuntu', yes=False, no=False):
 
     # log all the parameters
-    logger.debug('vm repair create command parameters: vm_name: %s, resource_group_name: %s, repair_password: %s, repair_username: %s, repair_vm_name: %s, copy_disk_name: %s, repair_group_name: %s, unlock_encrypted_vm: %s, enable_nested: %s, associate_public_ip: %s, distro: %s, yes: %s', vm_name, resource_group_name, repair_password, repair_username, repair_vm_name, copy_disk_name, repair_group_name, unlock_encrypted_vm, enable_nested, associate_public_ip, distro, yes)
+    logger.debug('vm repair create command parameters: vm_name: %s, resource_group_name: %s, repair_password: %s, repair_username: %s, repair_vm_name: %s, copy_disk_name: %s, repair_group_name: %s, unlock_encrypted_vm: %s, enable_nested: %s, associate_public_ip: %s, distro: %s, yes: %s, no: %s', vm_name, resource_group_name, repair_password, repair_username, repair_vm_name, copy_disk_name, repair_group_name, unlock_encrypted_vm, enable_nested, associate_public_ip, distro, yes, no)
 
     # Init command helper object
     command = command_helper(logger, cmd, 'vm repair create')
@@ -91,13 +91,17 @@ def create(cmd, vm_name, resource_group_name, repair_password=None, repair_usern
             os_image_urn = _fetch_compatible_windows_os_urn(source_vm)
             os_type = 'Windows'
 
+        public_ip_name = '""'
+        if associate_public_ip or yes and (not no):
+            public_ip_name = ('repair-' + vm_name + '_PublicIP')
+
         # Set up base create vm command
         if is_linux:
             create_repair_vm_command = 'az vm create -g {g} -n {n} --tag {tag} --image {image} --admin-username {username} --admin-password {password} --public-ip-address {option} --custom-data {cloud_init_script}' \
-                .format(g=repair_group_name, n=repair_vm_name, tag=resource_tag, image=os_image_urn, username=repair_username, password=repair_password, option=associate_public_ip, cloud_init_script=_get_cloud_init_script())
+                .format(g=repair_group_name, n=repair_vm_name, tag=resource_tag, image=os_image_urn, username=repair_username, password=repair_password, option=public_ip_name, cloud_init_script=_get_cloud_init_script())
         else:
             create_repair_vm_command = 'az vm create -g {g} -n {n} --tag {tag} --image {image} --admin-username {username} --admin-password {password} --public-ip-address {option}' \
-                .format(g=repair_group_name, n=repair_vm_name, tag=resource_tag, image=os_image_urn, username=repair_username, password=repair_password, option=associate_public_ip)
+                .format(g=repair_group_name, n=repair_vm_name, tag=resource_tag, image=os_image_urn, username=repair_username, password=repair_password, option=public_ip_name)
 
         # Fetch VM size of repair VM
         sku = _fetch_compatible_sku(source_vm, enable_nested)


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
az vm repair create


### General Guidelines

- [ Yes ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ Yes ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ Yes ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ n/a ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 

## PR Notes

Fixed 2 issues with the extension vm-repair.
1. When creating a repair VM with a public IP, the Ip would be named after a boolean and not the proper naming scheme for the resource `repair-<VMName>-<Resource>`
2. Added an option to NOT create a public IP in notty mode. `--no` was added to avoid the prompt for the Pip. Prior to this, there were 2 switches to create a public IP in notty mode. `--yes` and `--associate-public-ip` both create a Pip in notty. No switch existed to do the same without a Pip.

