### PR TITLE
chore(s360):  Update  pycryptodomex

### DIFF
--- a/src/connectedk8s/setup.py
+++ b/src/connectedk8s/setup.py
@@ -36,7 +36,7 @@ CLASSIFIERS = [
 # TODO: Add any additional SDK dependencies here
 DEPENDENCIES = [
     'kubernetes==24.2.0',
-    'pycryptodome==3.14.1',
+    'pycryptodome==3.19.1',
     'azure-mgmt-hybridcompute==7.0.0'
 ]
 


### PR DESCRIPTION
chore(s360):  Update  pycryptodomex

PyCryptodome and pycryptodomex side-channel leakage for OAEP decryption.

PyCryptodome and pycryptodomex before 3.19.1 allow side-channel leakage for OAEP decryption, exploitable for a Manger attack. [More information](https://github.com/advisories/GHSA-j225-cvw7-qrx7)



