### PR TITLE
[connectedk8s] Optimize the logic of checking completion for cluster-diagnostic-checks-job

### DIFF
--- a/src/connectedk8s/azext_connectedk8s/_precheckutils.py
+++ b/src/connectedk8s/azext_connectedk8s/_precheckutils.py
@@ -188,8 +188,7 @@ def executing_cluster_diagnostic_checks_job(corev1_api_instance, batchv1_api_ins
                         logger.debug("Cluster Diagnostic Checks job Failed")
                         w.stop()
                         break
-                    elif job["object"].status.conditions is not None and \
-                        job["object"].status.conditions[0].type == "Complete":
+                    elif any(condition.type == "Complete" for condition in job["object"].status.conditions):
                         is_job_complete = True
                         logger.debug("Cluster Diagnostic Checks Job reached completed state")
                         w.stop()


### PR DESCRIPTION
For `az connectedk8s create`, the prerequisites check will fail unexpectedly with below message:
```
Cluster diagnostics job didn't reach completed state in the kubernetes cluster
```
As investigated, there's one minor issue related to the checking logic of job status. The condition containing `Complete` is not always the first item. This PR will iterate all items to detect the completion for cluster-diagnostic-checks-job.



---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
connectedk8s

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
