### PR TITLE
[webpubsub] Upgrade minimum core version for webpubsub

### DIFF
--- a/src/webpubsub/HISTORY.rst
+++ b/src/webpubsub/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+1.5.1
++++++
+* Update the min core version to `2.56.0`
+
 1.5.0
 +++++
 * Add `service-mode` for Web PubSub for Socket.IO

--- a/src/webpubsub/azext_webpubsub/azext_metadata.json
+++ b/src/webpubsub/azext_webpubsub/azext_metadata.json
@@ -1,4 +1,4 @@
 {
     "azext.isPreview": false,
-    "azext.minCliCoreVersion": "2.39.0"
+    "azext.minCliCoreVersion": "2.56.0"
 }

--- a/src/webpubsub/setup.py
+++ b/src/webpubsub/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
-VERSION = '1.5.0'
+VERSION = '1.5.1'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Upgrade minimum core version to 2.56.0 to fix missing attrute 'SensitiveHeaderCleanupPolicy' issue

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
