### PR TITLE
{CI} Replace deprecated `assertRaisesRegexp` and `assertEquals`

### DIFF
--- a/src/account/azext_account/tests/latest/test_account_scenario.py
+++ b/src/account/azext_account/tests/latest/test_account_scenario.py
@@ -60,7 +60,7 @@ class SubscriptionClientScenarioTest(ScenarioTest):
                                    self.check('subscriptionId', sub_id)]).get_output_in_json()
             if sub['state'] != 'Warned':
                 time.sleep(180)
-        self.assertEquals(sub['state'], 'Warned')
+        self.assertEqual(sub['state'], 'Warned')
 
         self.cmd('az account subscription enable --subscription-id {subscription_id}',
                  checks=[self.check('subscriptionId', '{subscription_id}')])
@@ -71,7 +71,7 @@ class SubscriptionClientScenarioTest(ScenarioTest):
                                    self.check('subscriptionId', sub_id)]).get_output_in_json()
             if sub['state'] != 'Enabled':
                 time.sleep(180)
-        self.assertEquals(sub['state'], 'Enabled')
+        self.assertEqual(sub['state'], 'Enabled')
 
         self.cmd('az account subscription rename --subscription-id {subscription_id} --name "{new_display_name}"',
                  checks=[self.check('subscriptionId', '{subscription_id}')])

--- a/src/apic-extension/azext_apic_extension/tests/latest/test_definition_commands.py
+++ b/src/apic-extension/azext_apic_extension/tests/latest/test_definition_commands.py
@@ -204,7 +204,7 @@ class DefinitionCommandsTests(ScenarioTest):
             with open(self.kwargs['file_name'], 'w') as file:
                 file.write('a' * 4 * 1024 * 1024) # generate a 4MB file
 
-            with self.assertRaisesRegexp(CLIError, 'The size of "value" is greater than 3 MB. Please use --format "link" to import the specification from a URL for size greater than 3 mb.') as cm:
+            with self.assertRaisesRegex(CLIError, 'The size of "value" is greater than 3 MB. Please use --format "link" to import the specification from a URL for size greater than 3 mb.') as cm:
                 self.cmd('az apic api definition import-specification -g {rg} -n {s} --api-id {api} --version-id {v} --definition-id {d} --format "inline" --specification \'{specification}\' --value "@{file_name}"')
         finally:
             os.remove(self.kwargs['file_name'])

--- a/src/authV2/azext_authV2/tests/latest/test_authV2_scenario.py
+++ b/src/authV2/azext_authV2/tests/latest/test_authV2_scenario.py
@@ -38,42 +38,42 @@ class Authv2ScenarioTest(ScenarioTest):
                     JMESPathCheck('platform', "{'enabled': True, 'runtimeVersion': '1.2.8'}")
         ])
         
-        with self.assertRaisesRegexp(ArgumentUsageError, 'Usage Error: --client-secret and --client-secret-setting-name cannot both be '
+        with self.assertRaisesRegex(ArgumentUsageError, 'Usage Error: --client-secret and --client-secret-setting-name cannot both be '
                        'configured to non empty strings'):
             self.cmd('webapp auth Microsoft update -g {} -n {} --client-secret test --client-secret-setting-name test2'
                 .format(resource_group, webapp_name))
 
-        with self.assertRaisesRegexp(ArgumentUsageError, 'Usage Error: --client-secret-setting-name and --thumbprint cannot both be '
+        with self.assertRaisesRegex(ArgumentUsageError, 'Usage Error: --client-secret-setting-name and --thumbprint cannot both be '
                        'configured to non empty strings'):
             self.cmd('webapp auth Microsoft update -g {} -n {} --client-secret-setting-name test --thumbprint test2'
                 .format(resource_group, webapp_name))
 
-        with self.assertRaisesRegexp(ArgumentUsageError, 'Usage Error: --client-secret and --thumbprint cannot both be '
+        with self.assertRaisesRegex(ArgumentUsageError, 'Usage Error: --client-secret and --thumbprint cannot both be '
                        'configured to non empty strings'):
             self.cmd('webapp auth Microsoft update -g {} -n {} --client-secret test --thumbprint test2'
                 .format(resource_group, webapp_name))
 
-        with self.assertRaisesRegexp(ArgumentUsageError, 'Usage Error: --client-secret and --san cannot both be '
+        with self.assertRaisesRegex(ArgumentUsageError, 'Usage Error: --client-secret and --san cannot both be '
                        'configured to non empty strings'):
             self.cmd('webapp auth Microsoft update -g {} -n {} --client-secret test --san test2'
                 .format(resource_group, webapp_name))
 
-        with self.assertRaisesRegexp(ArgumentUsageError, 'Usage Error: --client-secret-setting-name and --san cannot both be '
+        with self.assertRaisesRegex(ArgumentUsageError, 'Usage Error: --client-secret-setting-name and --san cannot both be '
                        'configured to non empty strings'):
             self.cmd('webapp auth Microsoft update -g {} -n {} --client-secret-setting-name test --san test2'
                 .format(resource_group, webapp_name))
 
-        with self.assertRaisesRegexp(ArgumentUsageError, 'Usage Error: --thumbprint and --san cannot both be '
+        with self.assertRaisesRegex(ArgumentUsageError, 'Usage Error: --thumbprint and --san cannot both be '
                        'configured to non empty strings'):
             self.cmd('webapp auth Microsoft update -g {} -n {} --thumbprint test --san test2'
                 .format(resource_group, webapp_name))
 
-        with self.assertRaisesRegexp(ArgumentUsageError, 'Usage Error: --san and --certificate-issuer must both be '
+        with self.assertRaisesRegex(ArgumentUsageError, 'Usage Error: --san and --certificate-issuer must both be '
                        'configured to non empty strings'):
             self.cmd('webapp auth Microsoft update -g {} -n {} --san test'
                 .format(resource_group, webapp_name))
 
-        with self.assertRaisesRegexp(ArgumentUsageError, 'Usage Error: --issuer and --tenant-id cannot be configured '
+        with self.assertRaisesRegex(ArgumentUsageError, 'Usage Error: --issuer and --tenant-id cannot be configured '
                        'to non empty strings at the same time.'):
             self.cmd('webapp auth Microsoft update -g {} -n {} --issuer test --tenant-id test2'
                 .format(resource_group, webapp_name))

--- a/src/automation/azext_automation/tests/latest/test_automation_scenario_manual.py
+++ b/src/automation/azext_automation/tests/latest/test_automation_scenario_manual.py
@@ -363,13 +363,13 @@ class AutomationScenarioTest(ScenarioTest):
         ])
 
         config_content = self.cmd('automation configuration show-content -g {rg} --automation-account-name {account} -n {config}')
-        self.assertEquals(self.kwargs['source_content_retrieved'], config_content.output)
+        self.assertEqual(self.kwargs['source_content_retrieved'], config_content.output)
 
         self.cmd('automation configuration update -g {rg} --automation-account-name {account} -n {config} --location {location} '
                  '--source-type embeddedContent --source {source_content2}')
 
         config_content = self.cmd('automation configuration show-content -g {rg} --automation-account-name {account} -n {config}')
-        self.assertEquals(self.kwargs['source_content2_retrieved'], config_content.output)
+        self.assertEqual(self.kwargs['source_content2_retrieved'], config_content.output)
 
         self.cmd('automation configuration delete -g {rg} --automation-account-name {account} -n {config} -y')
         self.cmd('automation configuration list -g {rg} --automation-account-name {account}', checks=[

--- a/src/azure-firewall/azext_firewall/tests/latest/test_azure_firewall_scenario.py
+++ b/src/azure-firewall/azext_firewall/tests/latest/test_azure_firewall_scenario.py
@@ -274,7 +274,7 @@ class AzureFirewallScenario(ScenarioTest):
         # self.cmd('network firewall create -g {rg} -n {af} --sku AZFW_Hub --count 1 --vhub {vhub}')
         # self.cmd('network firewall update -g {rg} -n {af} --vhub ""')
 
-        # with self.assertRaisesRegexp(CLIError, "allow active ftp is not allowed for azure firewall on virtual hub."):
+        # with self.assertRaisesRegex(CLIError, "allow active ftp is not allowed for azure firewall on virtual hub."):
         #     self.cmd('network firewall create -g {rg} -n {af} --sku AZFW_Hub --count 1 --vhub {vhub} --allow-active-ftp')
 
         self.cmd('network vwan create -n {vwan2} -g {rg} --type Standard')

--- a/src/connectedk8s/azext_connectedk8s/tests/latest/test_connectedk8s_scenario.py
+++ b/src/connectedk8s/azext_connectedk8s/tests/latest/test_connectedk8s_scenario.py
@@ -452,7 +452,7 @@ class Connectedk8sScenarioTest(LiveScenarioTest):
         ] == bool(1)
 
         # scenario-2 : custom loc is enabled , check if disabling cluster connect results in an error
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             CLIError,
             "Disabling 'cluster-connect' feature is not allowed when \
 'custom-locations' feature is enabled.",
@@ -678,7 +678,7 @@ class Connectedk8sScenarioTest(LiveScenarioTest):
             "-ojson",
         ]
 
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             CLIError,
             "az connectedk8s upgrade to manually upgrade agents and extensions is \
 only supported when auto-upgrade is set to false",

--- a/src/containerapp/azext_containerapp/tests/latest/test_containerapp_patch.py
+++ b/src/containerapp/azext_containerapp/tests/latest/test_containerapp_patch.py
@@ -48,7 +48,7 @@ class ContainerAppPatchTest(ScenarioTest):
             # Execute and verify patch list command
             patchable_images = self.cmd(f'containerapp patch list -g {resource_group}').get_output_in_json()
             self.assertTrue(len(patchable_images) == 1)
-            self.assertEquals(patchable_images[0]["oldRunImage"], builder_runtime_image)
+            self.assertEqual(patchable_images[0]["oldRunImage"], builder_runtime_image)
 
             # Execute and verify patch apply command
             self.cmd(f'containerapp patch apply -g {resource_group}')
@@ -91,7 +91,7 @@ class ContainerAppPatchTest(ScenarioTest):
             # Execute and verify patch list command
             patchable_images = self.cmd(f'containerapp patch list -g {resource_group} --environment {env_name}').get_output_in_json()
             self.assertTrue(len(patchable_images) == 1)
-            self.assertEquals(patchable_images[0]["oldRunImage"], builder_runtime_image)
+            self.assertEqual(patchable_images[0]["oldRunImage"], builder_runtime_image)
 
             # Execute and verify patch apply command
             self.cmd(f'containerapp patch apply -g {resource_group} --environment {env_name}')
@@ -119,13 +119,13 @@ class ContainerAppPatchTest(ScenarioTest):
         # Execute and verify patch list command
         patch_cmd = f'containerapp patch list -g {resource_group} --environment {env_name} --show-all'
         output = self.cmd(patch_cmd).get_output_in_json()
-        self.assertEquals(output[0]["targetImageName"], "mcr.microsoft.com/k8se/quickstart:latest")
+        self.assertEqual(output[0]["targetImageName"], "mcr.microsoft.com/k8se/quickstart:latest")
 
         # Execute and verify patch apply command
         self.cmd(f'containerapp patch apply -g {resource_group} --environment {env_name} --show-all')
         app = self.cmd(f"containerapp show -g {resource_group} -n {app_name}").get_output_in_json()
         image = app["properties"]["template"]["containers"][0]["image"]
-        self.assertEquals(image, "mcr.microsoft.com/k8se/quickstart:latest")
+        self.assertEqual(image, "mcr.microsoft.com/k8se/quickstart:latest")
 
 
     @live_only()
@@ -158,7 +158,7 @@ class ContainerAppPatchTest(ScenarioTest):
             self.cmd(f'configure --defaults group={resource_group}')
             patchable_images = self.cmd(f'containerapp patch list').get_output_in_json()
             self.assertTrue(len(patchable_images) == 1)
-            self.assertEquals(patchable_images[0]["oldRunImage"], builder_runtime_image)
+            self.assertEqual(patchable_images[0]["oldRunImage"], builder_runtime_image)
 
             # Execute and verify patch apply command
             self.cmd(f'containerapp patch apply')
@@ -198,7 +198,7 @@ class ContainerAppPatchTest(ScenarioTest):
             self.cmd(f'configure --defaults group={resource_group}')
             patchable_images = self.cmd(f'containerapp patch list').get_output_in_json()
             self.assertTrue(len(patchable_images) == 1)
-            self.assertEquals(patchable_images[0]["oldRunImage"], builder_runtime_image)
+            self.assertEqual(patchable_images[0]["oldRunImage"], builder_runtime_image)
 
             # Execute and verify patch apply command
             self.cmd(f'containerapp patch apply')
@@ -239,7 +239,7 @@ class ContainerAppPatchTest(ScenarioTest):
             self.cmd(f'configure --defaults group={resource_group}')
             patchable_images = self.cmd(f'containerapp patch list').get_output_in_json()
             self.assertTrue(len(patchable_images) == 1)
-            self.assertEquals(patchable_images[0]["oldRunImage"], builder_runtime_image)
+            self.assertEqual(patchable_images[0]["oldRunImage"], builder_runtime_image)
 
             # Execute and verify patch apply command
             self.cmd(f'containerapp patch apply')

--- a/src/hpc-cache/azext_hpc_cache/tests/latest/test_hpc_cache_scenario.py
+++ b/src/hpc-cache/azext_hpc_cache/tests/latest/test_hpc_cache_scenario.py
@@ -58,7 +58,7 @@ class StorageCacheScenarioTest(ScenarioTest):
         self.cmd('az hpc-cache upgrade-firmware --resource-group {rg} --name {cache_name}', checks=[])
 
         from azure.core.exceptions import ResourceNotFoundError
-        with self.assertRaisesRegexp(ResourceNotFoundError, 'ResourceNotFound'):
+        with self.assertRaisesRegex(ResourceNotFoundError, 'ResourceNotFound'):
             self.cmd('az hpc-cache update '
                      '--resource-group {rg} '
                      '--name "{cache_name}123" '

--- a/src/network-analytics/azext_network_analytics/tests/latest/test_network_analytics.py
+++ b/src/network-analytics/azext_network_analytics/tests/latest/test_network_analytics.py
@@ -33,7 +33,7 @@ class NetworkAnalyticsScenario(ScenarioTest):
 
         #List DP
         dplistinrg = self.cmd('az network-analytics data-product list --resource-group {group}').get_output_in_json()
-        self.assertEquals(len(dplistinrg), 1, msg="Data product list should have exactly one element")
+        self.assertEqual(len(dplistinrg), 1, msg="Data product list should have exactly one element")
 
         #Get DP
         self.cmd('az network-analytics data-product show --name {name} --resource-group {group}', checks=[
@@ -49,8 +49,8 @@ class NetworkAnalyticsScenario(ScenarioTest):
 
         #List User Role
         rolelist = self.cmd('az network-analytics data-product list-roles-assignment --data-product-name {name} --resource-group {group}').get_output_in_json()
-        self.assertEquals(rolelist['count'], 1, msg="Expected role count is 1")
-        self.assertEquals(rolelist['roleAssignmentResponse'][0]['principalId'], user_id, msg="Principal ID is not matching with the user ID")
+        self.assertEqual(rolelist['count'], 1, msg="Expected role count is 1")
+        self.assertEqual(rolelist['roleAssignmentResponse'][0]['principalId'], user_id, msg="Principal ID is not matching with the user ID")
 
         #Remove User Role
         self.cmd('az network-analytics data-product remove-user-role --data-product-name {name} --resource-group {group} --data-type-scope " " --principal-id {id} --principal-type user --role reader --role-id " " --user-name " " --role-assignment-id " "')
@@ -60,7 +60,7 @@ class NetworkAnalyticsScenario(ScenarioTest):
 
         #List User Role
         emptyrolelist = self.cmd('az network-analytics data-product list-roles-assignment --data-product-name {name} --resource-group {group}').get_output_in_json()
-        self.assertEquals(emptyrolelist['count'], 0, msg="role list ia not empty after role is deleted")
+        self.assertEqual(emptyrolelist['count'], 0, msg="role list ia not empty after role is deleted")
 
         #Delete DP
         self.cmd('az network-analytics data-product delete --name {name} --resource-group {group} --yes')
@@ -70,6 +70,6 @@ class NetworkAnalyticsScenario(ScenarioTest):
 
         #List DP
         dplistinrg = self.cmd('az network-analytics data-product list --resource-group {group}').get_output_in_json()
-        self.assertEquals(len(dplistinrg), 0, msg="Data product list is not empty after deletion")
+        self.assertEqual(len(dplistinrg), 0, msg="Data product list is not empty after deletion")
 
     pass

--- a/src/networkcloud/azext_networkcloud/tests/unit/test_custom_managedidentity.py
+++ b/src/networkcloud/azext_networkcloud/tests/unit/test_custom_managedidentity.py
@@ -106,7 +106,7 @@ class TestManagedIdentity(unittest.TestCase):
 
         self.managed_identity.pre_operations_create(args)
 
-        self.assertEquals(
+        self.assertEqual(
             args.identity.type, "None"
         )  # Expecting None as identity type is passed
         self.assertIsNone(

--- a/src/quantum/azext_quantum/tests/latest/test_quantum_jobs.py
+++ b/src/quantum/azext_quantum/tests/latest/test_quantum_jobs.py
@@ -48,10 +48,10 @@ class QuantumJobsScenarioTest(ScenarioTest):
         url = f"https://accountname.blob.core.windows.net/containername/rawOutputData?{sas}"
         args = _parse_blob_url(url)
 
-        self.assertEquals(args['account_name'], "accountname")
-        self.assertEquals(args['container'], "containername")
-        self.assertEquals(args['blob'], "rawOutputData")
-        self.assertEquals(args['sas_token'], sas)
+        self.assertEqual(args['account_name'], "accountname")
+        self.assertEqual(args['container'], "containername")
+        self.assertEqual(args['blob'], "rawOutputData")
+        self.assertEqual(args['sas_token'], sas)
 
     def test_transform_output(self):
         # Call with a good histogram
@@ -60,12 +60,12 @@ class QuantumJobsScenarioTest(ScenarioTest):
         table_row = table[0]
         hist_row = table_row['']
         second_char = hist_row[1]
-        self.assertEquals(second_char, "\u2588")    # Expecting a "Full Block" character here
+        self.assertEqual(second_char, "\u2588")    # Expecting a "Full Block" character here
 
         # Give it a malformed histogram
         test_job_results = '{"Histogram":["[0,0,0]",0.125,"[1,0,0]",0.125,"[0,1,0]",0.125,"[1,1,0]"]}'
         table = transform_output(json.loads(test_job_results))
-        self.assertEquals(table, json.loads(test_job_results))    # No transform should be done if input param is bad
+        self.assertEqual(table, json.loads(test_job_results))    # No transform should be done if input param is bad
 
         # Call with output from a failed job
         test_job_results = \
@@ -101,12 +101,12 @@ class QuantumJobsScenarioTest(ScenarioTest):
             }'
 
         table = transform_output(json.loads(test_job_results))
-        self.assertEquals(table['Status'], "Failed")
-        self.assertEquals(table['Error Code'], "InsufficientResources")
-        self.assertEquals(table['Error Message'], "Too many qubits requested")
-        self.assertEquals(table['Target'], "ionq.simulator")
-        self.assertEquals(table['Job ID'], "11111111-2222-3333-4444-555555555555")
-        self.assertEquals(table['Submission Time'], "2022-02-25T18:56:53.275035+00:00")
+        self.assertEqual(table['Status'], "Failed")
+        self.assertEqual(table['Error Code'], "InsufficientResources")
+        self.assertEqual(table['Error Message'], "Too many qubits requested")
+        self.assertEqual(table['Target'], "ionq.simulator")
+        self.assertEqual(table['Job ID'], "11111111-2222-3333-4444-555555555555")
+        self.assertEqual(table['Submission Time'], "2022-02-25T18:56:53.275035+00:00")
 
         # Call with missing "status", "code", "message", "target", "id", and "creationTime"
         test_job_results = \
@@ -137,21 +137,21 @@ class QuantumJobsScenarioTest(ScenarioTest):
 
         table = transform_output(json.loads(test_job_results))
         notFound = "Not found"
-        self.assertEquals(table['Status'], notFound)
-        self.assertEquals(table['Error Code'], notFound)
-        self.assertEquals(table['Error Message'], notFound)
-        self.assertEquals(table['Target'], notFound)
-        self.assertEquals(table['Job ID'], notFound)
-        self.assertEquals(table['Submission Time'], notFound)
+        self.assertEqual(table['Status'], notFound)
+        self.assertEqual(table['Error Code'], notFound)
+        self.assertEqual(table['Error Message'], notFound)
+        self.assertEqual(table['Target'], notFound)
+        self.assertEqual(table['Job ID'], notFound)
+        self.assertEqual(table['Submission Time'], notFound)
 
     def test_validate_max_poll_wait_secs(self):
         wait_secs = _validate_max_poll_wait_secs(1)
-        self.assertEquals(type(wait_secs), float)
-        self.assertEquals(wait_secs, 1.0)
+        self.assertEqual(type(wait_secs), float)
+        self.assertEqual(wait_secs, 1.0)
 
         wait_secs = _validate_max_poll_wait_secs("60")
-        self.assertEquals(type(wait_secs), float)
-        self.assertEquals(wait_secs, 60.0)
+        self.assertEqual(type(wait_secs), float)
+        self.assertEqual(wait_secs, 60.0)
 
         # Invalid values should raise errors
         try:

--- a/src/scheduled-query/azext_scheduled_query/tests/latest/test_scheduled_query_scenario.py
+++ b/src/scheduled-query/azext_scheduled_query/tests/latest/test_scheduled_query_scenario.py
@@ -108,7 +108,7 @@ class Scheduled_queryScenarioTest(ScenarioTest):
                  checks=[
                  ])
         self.cmd('monitor scheduled-query delete -g {rg} -n {name1} -y')
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('monitor scheduled-query show -g {rg} -n {name1}')
 
 
@@ -245,7 +245,7 @@ class Scheduled_queryScenarioTest(ScenarioTest):
                      self.check('criteria.allOf[0].operator', 'Equal')
                  ])
         self.cmd('monitor scheduled-query delete -g {rg} -n {name1} -y')
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('monitor scheduled-query show -g {rg} -n {name1}')
 
 

--- a/src/spring-cloud/azext_spring_cloud/tests/latest/app_managed_identity/test_app_managed_identity_force_set_scenario.py
+++ b/src/spring-cloud/azext_spring_cloud/tests/latest/app_managed_identity/test_app_managed_identity_force_set_scenario.py
@@ -67,7 +67,7 @@ class AppIdentityForceSet(ScenarioTest):
             ]).json_value
         user_identity_dict = self._to_lower(app['identity']['userAssignedIdentities'])
         self.assertTrue(type(user_identity_dict) == dict)
-        self.assertEquals(1, len(user_identity_dict))
+        self.assertEqual(1, len(user_identity_dict))
         self.assertTrue(self._contains_user_id_1(user_identity_dict.keys()))
 
         app = self.cmd(
@@ -80,7 +80,7 @@ class AppIdentityForceSet(ScenarioTest):
             ]).json_value
         user_identity_dict = self._to_lower(app['identity']['userAssignedIdentities'])
         self.assertTrue(type(user_identity_dict) == dict)
-        self.assertEquals(1, len(user_identity_dict))
+        self.assertEqual(1, len(user_identity_dict))
         self.assertTrue(self._contains_user_id_2(user_identity_dict.keys()))
 
         app = self.cmd(
@@ -93,7 +93,7 @@ class AppIdentityForceSet(ScenarioTest):
             ]).json_value
         user_identity_dict = self._to_lower(app['identity']['userAssignedIdentities'])
         self.assertTrue(type(user_identity_dict) == dict)
-        self.assertEquals(2, len(user_identity_dict))
+        self.assertEqual(2, len(user_identity_dict))
         self.assertTrue(self._contains_user_id_1(user_identity_dict.keys()))
         self.assertTrue(self._contains_user_id_2(user_identity_dict.keys()))
 

--- a/src/spring-cloud/azext_spring_cloud/tests/latest/app_managed_identity/test_app_managed_identity_force_set_validator.py
+++ b/src/spring-cloud/azext_spring_cloud/tests/latest/app_managed_identity/test_app_managed_identity_force_set_validator.py
@@ -66,32 +66,32 @@ class TestAppForceSetUserIdentityValitor(unittest.TestCase):
     def test_valid_input_1(self):
         ns = Namespace(user_assigned=["DISable"])
         validate_app_force_set_user_identity_or_warning(ns)
-        self.assertEquals("disable", ns.user_assigned[0])
+        self.assertEqual("disable", ns.user_assigned[0])
 
 
     def test_valid_input_2(self):
         ns = Namespace(user_assigned=["disable"])
         validate_app_force_set_user_identity_or_warning(ns)
-        self.assertEquals("disable", ns.user_assigned[0])
+        self.assertEqual("disable", ns.user_assigned[0])
 
 
     def test_valid_input_3(self):
         ns = Namespace(user_assigned=["DISABLE"])
         validate_app_force_set_user_identity_or_warning(ns)
-        self.assertEquals("disable", ns.user_assigned[0])
+        self.assertEqual("disable", ns.user_assigned[0])
 
 
     def test_valid_input_4(self):
         ns = Namespace(user_assigned=[FAKE_UPPER_USER_IDENTITY_RESOURCE_ID_0])
         validate_app_force_set_user_identity_or_warning(ns)
-        self.assertEquals(FAKE_LOWER_USER_IDENTITY_RESOURCE_ID_0, ns.user_assigned[0])
+        self.assertEqual(FAKE_LOWER_USER_IDENTITY_RESOURCE_ID_0, ns.user_assigned[0])
 
 
     def test_valid_input_5(self):
         ns = Namespace(user_assigned=[FAKE_UPPER_USER_IDENTITY_RESOURCE_ID_0, FAKE_LOWER_USER_IDENTITY_RESOURCE_ID_1])
         validate_app_force_set_user_identity_or_warning(ns)
-        self.assertEquals(FAKE_LOWER_USER_IDENTITY_RESOURCE_ID_0, ns.user_assigned[0])
-        self.assertEquals(FAKE_LOWER_USER_IDENTITY_RESOURCE_ID_1, ns.user_assigned[1])
+        self.assertEqual(FAKE_LOWER_USER_IDENTITY_RESOURCE_ID_0, ns.user_assigned[0])
+        self.assertEqual(FAKE_LOWER_USER_IDENTITY_RESOURCE_ID_1, ns.user_assigned[1])
 
 
     def test_invalid_input_1(self):

--- a/src/spring-cloud/azext_spring_cloud/tests/latest/app_managed_identity/test_create_app_with_both_identity_scenario.py
+++ b/src/spring-cloud/azext_spring_cloud/tests/latest/app_managed_identity/test_create_app_with_both_identity_scenario.py
@@ -50,7 +50,7 @@ class CreateAppWithBothIdentity(ScenarioTest):
         ]).json_value
         user_identity_dict = self._to_lower(app['identity']['userAssignedIdentities'])
         self.assertTrue(type(user_identity_dict) == dict)
-        self.assertEquals(len(user_identity_dict), 2)
+        self.assertEqual(len(user_identity_dict), 2)
         self.assertTrue(self._contains_user_id_1(user_identity_dict.keys()))
         self.assertTrue(self._contains_user_id_2(user_identity_dict.keys()))
 

--- a/src/spring-cloud/azext_spring_cloud/tests/latest/app_managed_identity/test_create_app_with_managed_identity_validator.py
+++ b/src/spring-cloud/azext_spring_cloud/tests/latest/app_managed_identity/test_create_app_with_managed_identity_validator.py
@@ -19,28 +19,28 @@ class TestCreateAppWithManagedIdentityValitorWithConflict(unittest.TestCase):
         ns = Namespace(system_assigned=None,
                        assign_identity=False)
         validate_create_app_with_system_identity_or_warning(ns)
-        self.assertEquals(ns.system_assigned, False)
+        self.assertEqual(ns.system_assigned, False)
 
 
     def test_system_identity_override_2(self):
         ns = Namespace(system_assigned=None,
                        assign_identity=True)
         validate_create_app_with_system_identity_or_warning(ns)
-        self.assertEquals(ns.system_assigned, True)
+        self.assertEqual(ns.system_assigned, True)
 
 
     def test_system_identity_override_3(self):
         ns = Namespace(system_assigned=True,
                        assign_identity=None)
         validate_create_app_with_system_identity_or_warning(ns)
-        self.assertEquals(ns.system_assigned, True)
+        self.assertEqual(ns.system_assigned, True)
 
 
     def test_system_identity_override_4(self):
         ns = Namespace(system_assigned=False,
                        assign_identity=None)
         validate_create_app_with_system_identity_or_warning(ns)
-        self.assertEquals(ns.system_assigned, False)
+        self.assertEqual(ns.system_assigned, False)
 
 
 class TestCreateAppWithManagedIdentityValitorWithConflict(unittest.TestCase):

--- a/src/spring-cloud/azext_spring_cloud/tests/latest/app_managed_identity/test_create_app_with_user_identity_scenario.py
+++ b/src/spring-cloud/azext_spring_cloud/tests/latest/app_managed_identity/test_create_app_with_user_identity_scenario.py
@@ -50,7 +50,7 @@ class CreateAppWithUserIdentity(ScenarioTest):
         ]).json_value
         user_identity_dict = self._to_lower(app['identity']['userAssignedIdentities'])
         self.assertTrue(type(user_identity_dict) == dict)
-        self.assertEquals(len(user_identity_dict), 2)
+        self.assertEqual(len(user_identity_dict), 2)
         self.assertTrue(self._contains_user_id_1(user_identity_dict.keys()))
         self.assertTrue(self._contains_user_id_2(user_identity_dict.keys()))
 

--- a/src/spring-cloud/azext_spring_cloud/tests/latest/test_asc_app.py
+++ b/src/spring-cloud/azext_spring_cloud/tests/latest/test_asc_app.py
@@ -355,7 +355,7 @@ class TestAppDeploy_Enterprise_Patch(BasicTest):
             self._get_result_resource(status='Failed')
         ]
         deployment=self._get_deployment()
-        with self.assertRaisesRegexp(CLIError, 'Failed to build docker image'):
+        with self.assertRaisesRegex(CLIError, 'Failed to build docker image'):
             self._execute('rg', 'asc', 'app', deployment=deployment, artifact_path='my-path', client=client)
 
 
@@ -448,7 +448,7 @@ class TestAppUpdate(BasicTest):
         self.assertEqual(True, resource.properties.public)
 
     def test_invalid_app_update_deployment_settings_without_deployment(self):
-        with self.assertRaisesRegexp(CLIError, '--jvm-options cannot be set when there is no active deployment.'):
+        with self.assertRaisesRegex(CLIError, '--jvm-options cannot be set when there is no active deployment.'):
             self._execute('rg', 'asc', 'app', jvm_options='test-option')
     
     def test_app_update_jvm_options(self):
@@ -536,7 +536,7 @@ class TestAppUpdate(BasicTest):
         deployment.properties.source.type = 'NetCoreZip'
         deployment.properties.source.runtime_version = 'NetCore_31'
         deployment.properties.source.net_core_main_entry_path = 'main-entry'
-        with self.assertRaisesRegexp(CLIError, '--jvm-options cannot be set when --runtime-version is NetCore_31.'):
+        with self.assertRaisesRegex(CLIError, '--jvm-options cannot be set when --runtime-version is NetCore_31.'):
             self._execute('rg', 'asc', 'app', jvm_options='test-option', deployment=deployment)
 
 class TestAppCreate(BasicTest):
@@ -601,21 +601,21 @@ class TestAppCreate(BasicTest):
 
     def test_app_with_large_instance_count_enterprise(self):
         client = self._get_basic_mock_client(sku='Enterprise')
-        with self.assertRaisesRegexp(CLIError, 'Invalid --instance-count, should be in range \[1, 500\]'):
+        with self.assertRaisesRegex(CLIError, 'Invalid --instance-count, should be in range \[1, 500\]'):
             self._execute('rg', 'asc', 'app', cpu='500m', memory='2Gi', instance_count=501, client=client)
 
     def test_app_with_large_instance_count(self):
-        with self.assertRaisesRegexp(CLIError, 'Invalid --instance-count, should be in range \[1, 500\]'):
+        with self.assertRaisesRegex(CLIError, 'Invalid --instance-count, should be in range \[1, 500\]'):
             self._execute('rg', 'asc', 'app', cpu='500m', memory='2Gi', instance_count=501)
 
     def test_app_with_large_instance_count_basic(self):
         client = self._get_basic_mock_client(sku='Basic')
-        with self.assertRaisesRegexp(CLIError, 'Invalid --instance-count, should be in range \[1, 25\]'):
+        with self.assertRaisesRegex(CLIError, 'Invalid --instance-count, should be in range \[1, 25\]'):
             self._execute('rg', 'asc', 'app', cpu='500m', memory='2Gi', instance_count=26, client=client)
 
     def test_app_with_persistent_storage_enterprise(self):
         client = self._get_basic_mock_client(sku='Enterprise')
-        with self.assertRaisesRegexp(CLIError, 'Enterprise tier Spring-Cloud instance does not support --enable-persistent-storage'):
+        with self.assertRaisesRegex(CLIError, 'Enterprise tier Spring-Cloud instance does not support --enable-persistent-storage'):
             self._execute('rg', 'asc', 'app', cpu='500m', memory='2Gi', instance_count=1, enable_persistent_storage=True, client=client)
 
     def test_app_with_persistent_storage(self):

--- a/src/spring-cloud/azext_spring_cloud/tests/latest/test_asc_app_insights_scenario.py
+++ b/src/spring-cloud/azext_spring_cloud/tests/latest/test_asc_app_insights_scenario.py
@@ -346,11 +346,11 @@ class AzureSpringCloudCreateTests(ScenarioTest):
 
     def _test_app_insights_enable_status(self, rg, service_name, target_status):
         result = self.cmd('spring-cloud app-insights show -n {} -g {}'.format(service_name, rg)).get_output_in_json()
-        self.assertEquals(result['traceEnabled'], target_status)
+        self.assertEqual(result['traceEnabled'], target_status)
 
     def _test_sampling_rate(self, rg, service_name, target_sampling_rate):
         result = self.cmd('spring-cloud app-insights show -n {} -g {}'.format(service_name, rg)).get_output_in_json()
-        self.assertEquals(result['appInsightsSamplingRate'], target_sampling_rate)
+        self.assertEqual(result['appInsightsSamplingRate'], target_sampling_rate)
 
     def _asc_update_disable_ai(self, rg, service_name):
         self.cmd('spring-cloud update -g {} -n {} --disable-app-insights --no-wait'.format(rg, service_name))

--- a/src/spring-cloud/azext_spring_cloud/tests/latest/test_asc_app_scenario.py
+++ b/src/spring-cloud/azext_spring_cloud/tests/latest/test_asc_app_scenario.py
@@ -37,7 +37,7 @@ class AppDeploy(ScenarioTest):
         ])
 
         # deploy fake file, the fail is expected
-        with self.assertRaisesRegexp(CLIError, "Failed to wait for deployment instances to be ready"):
+        with self.assertRaisesRegex(CLIError, "Failed to wait for deployment instances to be ready"):
             self.cmd('spring-cloud app deploy -n {app} -g {rg} -s {serviceName} --artifact-path {file} --version v1')
         deployment = self.cmd('spring-cloud app deployment show -n default --app {app} -g {rg} -s {serviceName}', checks=[
             self.check('name', 'default'),
@@ -64,7 +64,7 @@ class AppDeploy(ScenarioTest):
         ])
 
         # deploy change to .Net
-        with self.assertRaisesRegexp(CLIError, "Failed to wait for deployment instances to be ready"):
+        with self.assertRaisesRegex(CLIError, "Failed to wait for deployment instances to be ready"):
             self.cmd('spring-cloud app deploy -n {app} -g {rg} -s {serviceName} --artifact-path {file} --version v2 --runtime-version NetCore_31 --main-entry test')
         deployment = self.cmd('spring-cloud app deployment show -n default --app {app} -g {rg} -s {serviceName}', checks=[
             self.check('name', 'default'),
@@ -92,7 +92,7 @@ class AppDeploy(ScenarioTest):
         ])
 
         # keep deploy .net
-        with self.assertRaisesRegexp(CLIError, "Failed to wait for deployment instances to be ready"):
+        with self.assertRaisesRegex(CLIError, "Failed to wait for deployment instances to be ready"):
             self.cmd('spring-cloud app deploy -n {app} -g {rg} -s {serviceName} --artifact-path {file} --version v3 --main-entry test3')
         self.cmd('spring-cloud app deployment show -n default --app {app} -g {rg} -s {serviceName}', checks=[
             self.check('name', 'default'),

--- a/src/spring-cloud/azext_spring_cloud/tests/latest/test_asc_scenario.py
+++ b/src/spring-cloud/azext_spring_cloud/tests/latest/test_asc_scenario.py
@@ -219,7 +219,7 @@ class CustomImageTest(ScenarioTest):
             self.check('name', 'green'),
         ])
 
-        with self.assertRaisesRegexp(CLIError, "Failed to wait for deployment instances to be ready"):
+        with self.assertRaisesRegex(CLIError, "Failed to wait for deployment instances to be ready"):
             self.cmd('spring-cloud app deploy -g {resourceGroup} -s {serviceName} -n {app} --artifact-path {file}')
 
         self.cmd('spring-cloud app deployment show -g {resourceGroup} -s {serviceName} -n default --app {app} ', checks=[

--- a/src/spring/azext_spring/tests/latest/app_managed_identity/test_app_managed_identity_force_set_scenario.py
+++ b/src/spring/azext_spring/tests/latest/app_managed_identity/test_app_managed_identity_force_set_scenario.py
@@ -71,7 +71,7 @@ class AppIdentityForceSet(ScenarioTest):
             ]).json_value
         user_identity_dict = self._to_lower(app['identity']['userAssignedIdentities'])
         self.assertTrue(isinstance(user_identity_dict, dict))
-        self.assertEquals(1, len(user_identity_dict))
+        self.assertEqual(1, len(user_identity_dict))
         self.assertTrue(self._contains_user_id_1(user_identity_dict.keys()))
 
         app = self.cmd(
@@ -84,7 +84,7 @@ class AppIdentityForceSet(ScenarioTest):
             ]).json_value
         user_identity_dict = self._to_lower(app['identity']['userAssignedIdentities'])
         self.assertTrue(isinstance(user_identity_dict, dict))
-        self.assertEquals(1, len(user_identity_dict))
+        self.assertEqual(1, len(user_identity_dict))
         self.assertTrue(self._contains_user_id_2(user_identity_dict.keys()))
 
         app = self.cmd(
@@ -97,7 +97,7 @@ class AppIdentityForceSet(ScenarioTest):
             ]).json_value
         user_identity_dict = self._to_lower(app['identity']['userAssignedIdentities'])
         self.assertTrue(isinstance(user_identity_dict, dict))
-        self.assertEquals(2, len(user_identity_dict))
+        self.assertEqual(2, len(user_identity_dict))
         self.assertTrue(self._contains_user_id_1(user_identity_dict.keys()))
         self.assertTrue(self._contains_user_id_2(user_identity_dict.keys()))
 

--- a/src/spring/azext_spring/tests/latest/app_managed_identity/test_app_managed_identity_force_set_validator.py
+++ b/src/spring/azext_spring/tests/latest/app_managed_identity/test_app_managed_identity_force_set_validator.py
@@ -59,28 +59,28 @@ class TestAppForceSetUserIdentityValitor(unittest.TestCase):
     def test_valid_input_1(self):
         ns = Namespace(user_assigned=["DISable"])
         validate_app_force_set_user_identity_or_warning(ns)
-        self.assertEquals("disable", ns.user_assigned[0])
+        self.assertEqual("disable", ns.user_assigned[0])
 
     def test_valid_input_2(self):
         ns = Namespace(user_assigned=["disable"])
         validate_app_force_set_user_identity_or_warning(ns)
-        self.assertEquals("disable", ns.user_assigned[0])
+        self.assertEqual("disable", ns.user_assigned[0])
 
     def test_valid_input_3(self):
         ns = Namespace(user_assigned=["DISABLE"])
         validate_app_force_set_user_identity_or_warning(ns)
-        self.assertEquals("disable", ns.user_assigned[0])
+        self.assertEqual("disable", ns.user_assigned[0])
 
     def test_valid_input_4(self):
         ns = Namespace(user_assigned=[FAKE_UPPER_USER_IDENTITY_RESOURCE_ID_0])
         validate_app_force_set_user_identity_or_warning(ns)
-        self.assertEquals(FAKE_LOWER_USER_IDENTITY_RESOURCE_ID_0, ns.user_assigned[0])
+        self.assertEqual(FAKE_LOWER_USER_IDENTITY_RESOURCE_ID_0, ns.user_assigned[0])
 
     def test_valid_input_5(self):
         ns = Namespace(user_assigned=[FAKE_UPPER_USER_IDENTITY_RESOURCE_ID_0, FAKE_LOWER_USER_IDENTITY_RESOURCE_ID_1])
         validate_app_force_set_user_identity_or_warning(ns)
-        self.assertEquals(FAKE_LOWER_USER_IDENTITY_RESOURCE_ID_0, ns.user_assigned[0])
-        self.assertEquals(FAKE_LOWER_USER_IDENTITY_RESOURCE_ID_1, ns.user_assigned[1])
+        self.assertEqual(FAKE_LOWER_USER_IDENTITY_RESOURCE_ID_0, ns.user_assigned[0])
+        self.assertEqual(FAKE_LOWER_USER_IDENTITY_RESOURCE_ID_1, ns.user_assigned[1])
 
     def test_invalid_input_1(self):
         ns = Namespace(user_assigned=["random_input"])

--- a/src/spring/azext_spring/tests/latest/app_managed_identity/test_create_app_with_both_identity_scenario.py
+++ b/src/spring/azext_spring/tests/latest/app_managed_identity/test_create_app_with_both_identity_scenario.py
@@ -56,7 +56,7 @@ class CreateAppWithBothIdentity(ScenarioTest):
             ]).json_value
         user_identity_dict = self._to_lower(app['identity']['userAssignedIdentities'])
         self.assertTrue(isinstance(user_identity_dict, dict))
-        self.assertEquals(len(user_identity_dict), 2)
+        self.assertEqual(len(user_identity_dict), 2)
         self.assertTrue(self._contains_user_id_1(user_identity_dict.keys()))
         self.assertTrue(self._contains_user_id_2(user_identity_dict.keys()))
 

--- a/src/spring/azext_spring/tests/latest/app_managed_identity/test_create_app_with_managed_identity_validator.py
+++ b/src/spring/azext_spring/tests/latest/app_managed_identity/test_create_app_with_managed_identity_validator.py
@@ -18,25 +18,25 @@ class TestCreateAppWithManagedIdentityValitorWithConflict(unittest.TestCase):
         ns = Namespace(system_assigned=None,
                        assign_identity=False)
         validate_create_app_with_system_identity_or_warning(ns)
-        self.assertEquals(ns.system_assigned, False)
+        self.assertEqual(ns.system_assigned, False)
 
     def test_system_identity_override_2(self):
         ns = Namespace(system_assigned=None,
                        assign_identity=True)
         validate_create_app_with_system_identity_or_warning(ns)
-        self.assertEquals(ns.system_assigned, True)
+        self.assertEqual(ns.system_assigned, True)
 
     def test_system_identity_override_3(self):
         ns = Namespace(system_assigned=True,
                        assign_identity=None)
         validate_create_app_with_system_identity_or_warning(ns)
-        self.assertEquals(ns.system_assigned, True)
+        self.assertEqual(ns.system_assigned, True)
 
     def test_system_identity_override_4(self):
         ns = Namespace(system_assigned=False,
                        assign_identity=None)
         validate_create_app_with_system_identity_or_warning(ns)
-        self.assertEquals(ns.system_assigned, False)
+        self.assertEqual(ns.system_assigned, False)
 
 
 class TestCreateAppWithManagedIdentityValitorWithConflict(unittest.TestCase):

--- a/src/spring/azext_spring/tests/latest/app_managed_identity/test_create_app_with_user_identity_scenario.py
+++ b/src/spring/azext_spring/tests/latest/app_managed_identity/test_create_app_with_user_identity_scenario.py
@@ -54,7 +54,7 @@ class CreateAppWithUserIdentity(ScenarioTest):
         ]).json_value
         user_identity_dict = self._to_lower(app['identity']['userAssignedIdentities'])
         self.assertTrue(isinstance(user_identity_dict, dict))
-        self.assertEquals(len(user_identity_dict), 2)
+        self.assertEqual(len(user_identity_dict), 2)
         self.assertTrue(self._contains_user_id_1(user_identity_dict.keys()))
         self.assertTrue(self._contains_user_id_2(user_identity_dict.keys()))
 

--- a/src/spring/azext_spring/tests/latest/application_configuration_service/test_acs_validators.py
+++ b/src/spring/azext_spring/tests/latest/application_configuration_service/test_acs_validators.py
@@ -53,7 +53,7 @@ class TestAcsValidators(unittest.TestCase):
                            service="service",
                            config_file_pattern=pattern)
             validate_pattern_for_show_acs_configs(ns)
-            self.assertEquals(valid_pattern_dict[pattern], ns.config_file_pattern)
+            self.assertEqual(valid_pattern_dict[pattern], ns.config_file_pattern)
 
     def test_invalid_pattern_for_show_acs_configs(self):
         expectedErr = "Pattern should be in the format of 'application' or 'application/profile'"

--- a/src/spring/azext_spring/tests/latest/jobs/test_asa_job_deploy_scenario.py
+++ b/src/spring/azext_spring/tests/latest/jobs/test_asa_job_deploy_scenario.py
@@ -30,5 +30,5 @@ class JobDeploy(ScenarioTest):
         ])
 
         # deploy unexist file, the fail is expected
-        with self.assertRaisesRegexp(CLIError, "artifact path {} does not exist.".format(file_path)):
+        with self.assertRaisesRegex(CLIError, "artifact path {} does not exist.".format(file_path)):
             self.cmd('spring job deploy -n {job} -g {rg} -s {serviceName} --artifact-path {file}')

--- a/src/spring/azext_spring/tests/latest/jobs/test_asa_job_execution_instance.py
+++ b/src/spring/azext_spring/tests/latest/jobs/test_asa_job_execution_instance.py
@@ -73,17 +73,17 @@ class JobExecutionInstanceTest(unittest.TestCase):
         collection = JobExecutionInstanceCollection.deserialize(json.loads(NORMAL_LIST_RESPONSE_WITH_1_INSTANCE))
         self.assertIsNotNone(collection)
         self.assertIsNotNone(collection.value)
-        self.assertEquals(type(collection.value), list)
-        self.assertEquals(len(collection.value), 1)
+        self.assertEqual(type(collection.value), list)
+        self.assertEqual(len(collection.value), 1)
         instance_0 = collection.value[0]
-        self.assertEquals("sample-job-execution-instance-0", instance_0.name)
+        self.assertEqual("sample-job-execution-instance-0", instance_0.name)
 
     def testDeserializeNoInstance(self):
         collection = JobExecutionInstanceCollection.deserialize(json.loads(NORMAL_LIST_RESPONSE_WITH_0_INSTANCES))
         self.assertIsNotNone(collection)
         self.assertIsNotNone(collection.value)
-        self.assertEquals(type(collection.value), list)
-        self.assertEquals(len(collection.value), 0)
+        self.assertEqual(type(collection.value), list)
+        self.assertEqual(len(collection.value), 0)
 
     def testDeserializeInvalidResponse(self):
         json_object = json.loads(LIST_RESPONSE_WITH_INVALID_FIELDS)
@@ -95,10 +95,10 @@ class JobExecutionInstanceTest(unittest.TestCase):
         collection = JobExecutionInstanceCollection.deserialize(json.loads(responseStr))
         self.assertIsNotNone(collection)
         self.assertIsNotNone(collection.value)
-        self.assertEquals(type(collection.value), list)
-        self.assertEquals(len(collection.value), 2)
+        self.assertEqual(type(collection.value), list)
+        self.assertEqual(len(collection.value), 2)
         instance_0 = collection.value[0]
-        self.assertEquals("sample-job-execution-instance-0", instance_0.name)
+        self.assertEqual("sample-job-execution-instance-0", instance_0.name)
 
         instance_1 = collection.value[1]
-        self.assertEquals("sample-job-execution-instance-1", instance_1.name)
+        self.assertEqual("sample-job-execution-instance-1", instance_1.name)

--- a/src/spring/azext_spring/tests/latest/jobs/test_asa_job_log_stream_validators.py
+++ b/src/spring/azext_spring/tests/latest/jobs/test_asa_job_log_stream_validators.py
@@ -29,7 +29,7 @@ class TestValidateJobLogStream(unittest.TestCase):
         with self.assertRaises(InvalidArgumentValueError) as context:
             validate_job_log_stream(get_test_cmd(), ns)
 
-        self.assertEquals("--all-instances cannot be set together with --instance/-i.", str(context.exception))
+        self.assertEqual("--all-instances cannot be set together with --instance/-i.", str(context.exception))
 
     @mock.patch('azext_spring.jobs.job_validators.only_support_enterprise', autospec=True)
     def test_execution_name_not_set_and_instance_is_none(self, only_support_enterprise_mock):
@@ -70,7 +70,7 @@ class TestValidateJobLogStream(unittest.TestCase):
                 max_log_requests=5
             )
             validate_job_log_stream(get_test_cmd(), ns)
-            self.assertEquals(lines, ns.lines)
+            self.assertEqual(lines, ns.lines)
 
     def test_log_lines_too_small(self):
         ns = Namespace(
@@ -87,7 +87,7 @@ class TestValidateJobLogStream(unittest.TestCase):
         )
         with self.assertRaises(InvalidArgumentValueError) as context:
             validate_job_log_stream(get_test_cmd(), ns)
-        self.assertEquals('--lines must be in the range [1,10000]', str(context.exception))
+        self.assertEqual('--lines must be in the range [1,10000]', str(context.exception))
 
     @mock.patch('azext_spring.jobs.job_validators.only_support_enterprise', autospec=True)
     def test_log_lines_too_big(self, only_support_enterprise_mock):
@@ -109,8 +109,8 @@ class TestValidateJobLogStream(unittest.TestCase):
             validate_job_log_stream(get_test_cmd(), ns)
         expect_error_msgs = ['ERROR:cli.azext_spring.log_stream.log_stream_validators:'
                              '--lines can not be more than 10000, using 10000 instead']
-        self.assertEquals(expect_error_msgs, cm.output)
-        self.assertEquals(10000, ns.lines)
+        self.assertEqual(expect_error_msgs, cm.output)
+        self.assertEqual(10000, ns.lines)
 
     @mock.patch('azext_spring.jobs.job_validators.only_support_enterprise', autospec=True)
     def test_valid_log_since(self, only_support_enterprise_mock):
@@ -141,7 +141,7 @@ class TestValidateJobLogStream(unittest.TestCase):
                 since_in_seconds = since_in_seconds * 3600
             elif last == 'm':
                 since_in_seconds = since_in_seconds * 60
-            self.assertEquals(since_in_seconds, ns.since)
+            self.assertEqual(since_in_seconds, ns.since)
 
     def test_invalid_log_since(self):
         invalid_log_since = ['asdf1h', '1masdf', 'asdfe2m', 'asd5m', '1efef0m', '11mm']
@@ -161,7 +161,7 @@ class TestValidateJobLogStream(unittest.TestCase):
             )
             with self.assertRaises(InvalidArgumentValueError) as context:
                 validate_job_log_stream(get_test_cmd(), ns)
-            self.assertEquals("--since contains invalid characters", str(context.exception))
+            self.assertEqual("--since contains invalid characters", str(context.exception))
 
     def test_log_since_too_big(self):
         invalid_log_since = ['2h', '61m', '3601s', '9000s', '9000']
@@ -181,7 +181,7 @@ class TestValidateJobLogStream(unittest.TestCase):
             )
             with self.assertRaises(InvalidArgumentValueError) as context:
                 validate_job_log_stream(get_test_cmd(), ns)
-            self.assertEquals("--since can not be more than 1h", str(context.exception))
+            self.assertEqual("--since can not be more than 1h", str(context.exception))
 
     @mock.patch('azext_spring.jobs.job_validators.only_support_enterprise', autospec=True)
     def test_valid_log_limit(self, only_support_enterprise_mock):
@@ -203,7 +203,7 @@ class TestValidateJobLogStream(unittest.TestCase):
                 max_log_requests=5
             )
             validate_job_log_stream(get_test_cmd(), ns)
-            self.assertEquals(limit * 1024, ns.limit)
+            self.assertEqual(limit * 1024, ns.limit)
 
     def test_negative_log_limit(self):
         invalid_log_limit = [-1, -2, -3, -4, -10, -100, -1000]
@@ -223,7 +223,7 @@ class TestValidateJobLogStream(unittest.TestCase):
             )
             with self.assertRaises(InvalidArgumentValueError) as context:
                 validate_job_log_stream(get_test_cmd(), ns)
-            self.assertEquals('--limit must be in the range [1,2048]', str(context.exception))
+            self.assertEqual('--limit must be in the range [1,2048]', str(context.exception))
 
     @mock.patch('azext_spring.jobs.job_validators.only_support_enterprise', autospec=True)
     def test_log_limit_too_big(self, only_support_enterprise_mock):
@@ -248,5 +248,5 @@ class TestValidateJobLogStream(unittest.TestCase):
                 validate_job_log_stream(get_test_cmd(), ns)
             error_msgs = ['ERROR:cli.azext_spring.log_stream.log_stream_validators:'
                           '--limit can not be more than 2048, using 2048 instead']
-            self.assertEquals(error_msgs, cm.output)
-            self.assertEquals(2048 * 1024, ns.limit)
+            self.assertEqual(error_msgs, cm.output)
+            self.assertEqual(2048 * 1024, ns.limit)

--- a/src/spring/azext_spring/tests/latest/jobs/test_asa_job_scenario.py
+++ b/src/spring/azext_spring/tests/latest/jobs/test_asa_job_scenario.py
@@ -36,16 +36,16 @@ class AsaJobScenarioTest(ScenarioTest):
         """
 
         def verify_http_put_request(resource_group, service, name, job: models.JobResource, **kwargs):
-            self.assertEquals(resource_group, self.kwargs['g'])
-            self.assertEquals(service, self.kwargs['s'])
-            self.assertEquals(name, self.kwargs['j'])
-            self.assertEquals(kwargs.get('cpu'), job.properties.template.resource_requests.cpu)
-            self.assertEquals(kwargs.get('memory'), job.properties.template.resource_requests.memory)
+            self.assertEqual(resource_group, self.kwargs['g'])
+            self.assertEqual(service, self.kwargs['s'])
+            self.assertEqual(name, self.kwargs['j'])
+            self.assertEqual(kwargs.get('cpu'), job.properties.template.resource_requests.cpu)
+            self.assertEqual(kwargs.get('memory'), job.properties.template.resource_requests.memory)
             self.assertTrue(isinstance(job.properties.trigger_config, models.ManualJobTriggerConfig))
-            self.assertEquals(kwargs.get('parallelism'), job.properties.trigger_config.parallelism)
-            self.assertEquals(kwargs.get('retry_limit'), job.properties.trigger_config.retry_limit)
-            self.assertEquals(kwargs.get('timeout'), job.properties.trigger_config.timeout_in_seconds)
-            self.assertEquals(kwargs.get('trigger_type'), job.properties.trigger_config.trigger_type)
+            self.assertEqual(kwargs.get('parallelism'), job.properties.trigger_config.parallelism)
+            self.assertEqual(kwargs.get('retry_limit'), job.properties.trigger_config.retry_limit)
+            self.assertEqual(kwargs.get('timeout'), job.properties.trigger_config.timeout_in_seconds)
+            self.assertEqual(kwargs.get('trigger_type'), job.properties.trigger_config.trigger_type)
 
         def construct_job_create_command_str(cpu,
                                              memory,
@@ -190,9 +190,9 @@ class AsaJobScenarioTest(ScenarioTest):
                                     timeout_verifier,
                                     all_envs_verifier,
                                     args_verifier):
-            self.assertEquals(resource_group, self.kwargs['g'])
-            self.assertEquals(service, self.kwargs['s'])
-            self.assertEquals(name, self.kwargs['j'])
+            self.assertEqual(resource_group, self.kwargs['g'])
+            self.assertEqual(service, self.kwargs['s'])
+            self.assertEqual(name, self.kwargs['j'])
             cpu_verifier(job)
             memory_verifier(job)
             parallelism_verifier(job)
@@ -228,22 +228,22 @@ class AsaJobScenarioTest(ScenarioTest):
             """
             expected_value = param_input if param_input is not None else \
                 job_current.properties.template.resource_requests.cpu
-            self.assertEquals(expected_value, job_for_put.properties.template.resource_requests.cpu)
+            self.assertEqual(expected_value, job_for_put.properties.template.resource_requests.cpu)
 
         def memory_verifier(param_input, job_current: models.JobResource, job_for_put: models.JobResource):
             expected_value = param_input if param_input is not None else \
                 job_current.properties.template.resource_requests.memory
-            self.assertEquals(expected_value, job_for_put.properties.template.resource_requests.memory)
+            self.assertEqual(expected_value, job_for_put.properties.template.resource_requests.memory)
 
         def parallelism_verifier(param_input, job_current: models.JobResource, job_for_put: models.JobResource):
             expected_value = param_input if param_input is not None else \
                 job_current.properties.trigger_config.parallelism
-            self.assertEquals(expected_value, job_for_put.properties.trigger_config.parallelism)
+            self.assertEqual(expected_value, job_for_put.properties.trigger_config.parallelism)
 
         def retry_limit_verifier(param_input, job_current: models.JobResource, job_for_put: models.JobResource):
             expected_value = param_input if param_input is not None else \
                 job_current.properties.trigger_config.retry_limit
-            self.assertEquals(expected_value, job_for_put.properties.trigger_config.retry_limit)
+            self.assertEqual(expected_value, job_for_put.properties.trigger_config.retry_limit)
 
         def timeout_verifier(param_input, job_current: models.JobResource, job_for_put: models.JobResource):
             expected_value = job_current.properties.trigger_config.timeout_in_seconds
@@ -251,7 +251,7 @@ class AsaJobScenarioTest(ScenarioTest):
                 expected_value = None
             elif param_input is not None:
                 expected_value = param_input
-            self.assertEquals(expected_value, job_for_put.properties.trigger_config.timeout_in_seconds)
+            self.assertEqual(expected_value, job_for_put.properties.trigger_config.timeout_in_seconds)
 
         def all_envs_verifier(envs_param_input, secret_envs_param_input, job_current: models.JobResource,
                               job_for_put: models.JobResource):
@@ -288,7 +288,7 @@ class AsaJobScenarioTest(ScenarioTest):
                     )
                 ]
             expected_all_envs = expected_envs + expected_secret_envs
-            self.assertEquals(len(expected_all_envs), len(job_for_put.properties.template.environment_variables))
+            self.assertEqual(len(expected_all_envs), len(job_for_put.properties.template.environment_variables))
             if len(expected_all_envs) == 0:
                 return
 

--- a/src/spring/azext_spring/tests/latest/jobs/test_asa_jobs.py
+++ b/src/spring/azext_spring/tests/latest/jobs/test_asa_jobs.py
@@ -48,7 +48,7 @@ class TestAsaJobs(unittest.TestCase):
     def test_create_env_list(self):
         env_list = _update_envs(None, self.envs_dict, self.secrets_dict)
 
-        self.assertEquals(4, len(env_list))
+        self.assertEqual(4, len(env_list))
         for env in env_list:
             self.assertTrue(isinstance(env, EnvVar))
 
@@ -75,7 +75,7 @@ class TestAsaJobs(unittest.TestCase):
 
         env_list = _update_envs(existed_env_list, envs_dict, secrets_dict)
 
-        self.assertEquals(4, len(env_list))
+        self.assertEqual(4, len(env_list))
         for env in env_list:
             self.assertIsNotNone(env)
             self.assertTrue(isinstance(env, EnvVar))
@@ -99,7 +99,7 @@ class TestAsaJobs(unittest.TestCase):
 
         env_list = _update_envs(existed_env_list, None, secrets_dict)
 
-        self.assertEquals(3, len(env_list))
+        self.assertEqual(3, len(env_list))
         for env in env_list:
             self.assertIsNotNone(env)
             self.assertTrue(isinstance(env, EnvVar))
@@ -187,12 +187,12 @@ class TestAsaJobs(unittest.TestCase):
     def test_create_args(self):
         args = self.args_str
         target_args = _update_args(None, args)
-        self.assertEquals(["random-args", "sleep", "2"], target_args)
+        self.assertEqual(["random-args", "sleep", "2"], target_args)
 
     def test_update_args(self):
         args = self.args_str
         target_args = _update_args(["current-args"], args)
-        self.assertEquals(["random-args", "sleep", "2"], target_args)
+        self.assertEqual(["random-args", "sleep", "2"], target_args)
 
     def test_create_job_properties(self):
         existed_properties = None
@@ -205,7 +205,7 @@ class TestAsaJobs(unittest.TestCase):
         self._verify_env_var(target_properties.template.environment_variables[1], "prop2", "value2", None)
         self._verify_env_var(target_properties.template.environment_variables[2], "secret1", None, "secret_value1")
         self._verify_env_var(target_properties.template.environment_variables[3], "secret2", None, "secret_value2")
-        self.assertEquals(["random-args", "sleep", "2"], target_properties.template.args)
+        self.assertEqual(["random-args", "sleep", "2"], target_properties.template.args)
 
     def test_update_job_properties(self):
         existed_properties = JobResourceProperties(
@@ -221,11 +221,11 @@ class TestAsaJobs(unittest.TestCase):
         secret_envs = None
         args = self.args_str
         target_properties = _update_job_properties(existed_properties, None, envs, secret_envs, args, None, None)
-        self.assertEquals(3, len(target_properties.template.environment_variables))
+        self.assertEqual(3, len(target_properties.template.environment_variables))
         self._verify_env_var(target_properties.template.environment_variables[0], "prop1", "value1", None)
         self._verify_env_var(target_properties.template.environment_variables[1], "prop2", "value2", None)
         self._verify_env_var(target_properties.template.environment_variables[2], "secret1", None, "secret_value1")
-        self.assertEquals(["random-args", "sleep", "2"], target_properties.template.args)
+        self.assertEqual(["random-args", "sleep", "2"], target_properties.template.args)
 
     def test_is_job_execution_in_final_state(self):
         for status in ("Running", "Pending"):
@@ -251,7 +251,7 @@ class TestAsaJobs(unittest.TestCase):
         To validate the request payload is expected.
         """
         self._verify_group_service_job_name(resource_group, service, name)
-        self.assertEquals(json.dumps(job_resource.serialize(keep_readonly=True)),
+        self.assertEqual(json.dumps(job_resource.serialize(keep_readonly=True)),
                           json.dumps(JobResource.deserialize(json.loads(expected_create_job_payload)).serialize(
                               keep_readonly=True)))
         poller_mock = mock.Mock()
@@ -285,7 +285,7 @@ class TestAsaJobs(unittest.TestCase):
         updated_job = job_update(get_test_cmd(), client_mock, self.resource_group, self.service, self.job_name,
                                  envs=test_case_data.envs(), secret_envs=test_case_data.secret_envs(),
                                  args=test_case_data.args())
-        self.assertEquals(json.dumps(updated_job.serialize(keep_readonly=True)),
+        self.assertEqual(json.dumps(updated_job.serialize(keep_readonly=True)),
                           json.dumps(test_case_data.get_job_after().serialize(keep_readonly=True)))
 
     def _get_job_for_update_job_mock(self, resource_group, service, name, job_before, job_after):
@@ -307,7 +307,7 @@ class TestAsaJobs(unittest.TestCase):
                                                     expected_update_job_payload):
         self._verify_group_service_job_name(resource_group, service, name)
         # Don't need to compare the readonly properties.
-        self.assertEquals(json.dumps(expected_update_job_payload.serialize()), json.dumps(job_resource.serialize()))
+        self.assertEqual(json.dumps(expected_update_job_payload.serialize()), json.dumps(job_resource.serialize()))
         return None
 
     def test_job_start(self):
@@ -325,7 +325,7 @@ class TestAsaJobs(unittest.TestCase):
     def _begin_start_for_start_job_mock(self, resource_group, service, name,
                                         job_execution_template: JobExecutionTemplate):
         self._verify_group_service_job_name(resource_group, service, name)
-        self.assertEquals(
+        self.assertEqual(
             json.dumps(JobExecutionTemplate.deserialize(json.loads(expected_start_job_payload)).serialize()),
             json.dumps(job_execution_template.serialize()))
         name_mock = mock.MagicMock()
@@ -336,18 +336,18 @@ class TestAsaJobs(unittest.TestCase):
 
     def _verify_env_var(self, env: EnvVar, name, value, secret_value):
         self.assertIsNotNone(env)
-        self.assertEquals(name, env.name)
+        self.assertEqual(name, env.name)
         if value is not None:
-            self.assertEquals(value, env.value)
+            self.assertEqual(value, env.value)
             self.assertIsNone(env.secret_value)
         elif secret_value is not None:
             self.assertIsNone(env.value)
-            self.assertEquals(secret_value, env.secret_value)
+            self.assertEqual(secret_value, env.secret_value)
 
     def _verify_group_service_job_name(self, resource_group, service, name):
-        self.assertEquals(self.resource_group, resource_group)
-        self.assertEquals(self.service, service)
-        self.assertEquals(self.job_name, name)
+        self.assertEqual(self.resource_group, resource_group)
+        self.assertEqual(self.service, service)
+        self.assertEqual(self.job_name, name)
 
     def _test_patch_job_trigger_config(self, existed: ManualJobTriggerConfig, patch: ManualJobTriggerConfig,
                                        expected: ManualJobTriggerConfig):
@@ -356,6 +356,6 @@ class TestAsaJobs(unittest.TestCase):
             self.assertIsNone(actual_result)
         else:
             self.assertIsNotNone(actual_result)
-            self.assertEquals(actual_result.parallelism, expected.parallelism)
-            self.assertEquals(actual_result.timeout_in_seconds, expected.timeout_in_seconds)
-            self.assertEquals(actual_result.retry_limit, expected.retry_limit)
+            self.assertEqual(actual_result.parallelism, expected.parallelism)
+            self.assertEqual(actual_result.timeout_in_seconds, expected.timeout_in_seconds)
+            self.assertEqual(actual_result.retry_limit, expected.retry_limit)

--- a/src/spring/azext_spring/tests/latest/log_stream/test_log_stream_validators.py
+++ b/src/spring/azext_spring/tests/latest/log_stream/test_log_stream_validators.py
@@ -27,7 +27,7 @@ class TestLogStreamValidator(unittest.TestCase):
                 lines=lines,
             )
             validate_log_lines(ns)
-            self.assertEquals(lines, ns.lines)
+            self.assertEqual(lines, ns.lines)
 
     def test_log_lines_too_small(self):
         ns = Namespace(
@@ -35,7 +35,7 @@ class TestLogStreamValidator(unittest.TestCase):
         )
         with self.assertRaises(InvalidArgumentValueError) as context:
             validate_log_lines(ns)
-        self.assertEquals('--lines must be in the range [1,10000]', str(context.exception))
+        self.assertEqual('--lines must be in the range [1,10000]', str(context.exception))
 
     def test_log_lines_too_big(self):
         ns = Namespace(
@@ -45,8 +45,8 @@ class TestLogStreamValidator(unittest.TestCase):
             validate_log_lines(ns)
         expect_error_msgs = ['ERROR:cli.azext_spring.log_stream.log_stream_validators:'
                              '--lines can not be more than 10000, using 10000 instead']
-        self.assertEquals(expect_error_msgs, cm.output)
-        self.assertEquals(10000, ns.lines)
+        self.assertEqual(expect_error_msgs, cm.output)
+        self.assertEqual(10000, ns.lines)
 
     def test_valid_log_since(self):
         valid_log_since = ['1h',
@@ -65,7 +65,7 @@ class TestLogStreamValidator(unittest.TestCase):
                 since_in_seconds = since_in_seconds * 3600
             elif last == 'm':
                 since_in_seconds = since_in_seconds * 60
-            self.assertEquals(since_in_seconds, ns.since)
+            self.assertEqual(since_in_seconds, ns.since)
 
     def test_invalid_log_since(self):
         invalid_log_since = ['asdf1h', '1masdf', 'asdfe2m', 'asd5m', '1efef0m', '11mm']
@@ -76,7 +76,7 @@ class TestLogStreamValidator(unittest.TestCase):
             )
             with self.assertRaises(InvalidArgumentValueError) as context:
                 validate_log_since(ns)
-            self.assertEquals("--since contains invalid characters", str(context.exception))
+            self.assertEqual("--since contains invalid characters", str(context.exception))
 
     def test_log_since_too_big(self):
         invalid_log_since = ['2h', '61m', '3601s', '9000s', '9000']
@@ -87,7 +87,7 @@ class TestLogStreamValidator(unittest.TestCase):
             )
             with self.assertRaises(InvalidArgumentValueError) as context:
                 validate_log_since(ns)
-            self.assertEquals("--since can not be more than 1h", str(context.exception))
+            self.assertEqual("--since can not be more than 1h", str(context.exception))
 
     def test_valid_log_limit(self):
         valid_log_limit = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048]
@@ -97,7 +97,7 @@ class TestLogStreamValidator(unittest.TestCase):
                 limit=limit
             )
             validate_log_limit(ns)
-            self.assertEquals(limit * 1024, ns.limit)
+            self.assertEqual(limit * 1024, ns.limit)
 
     def test_negative_log_limit(self):
         invalid_log_limit = [-1, -2, -3, -4, -10, -100, -1000]
@@ -108,7 +108,7 @@ class TestLogStreamValidator(unittest.TestCase):
             )
             with self.assertRaises(InvalidArgumentValueError) as context:
                 validate_log_limit(ns)
-            self.assertEquals('--limit must be in the range [1,2048]', str(context.exception))
+            self.assertEqual('--limit must be in the range [1,2048]', str(context.exception))
 
     def test_log_limit_too_big(self):
         invalid_log_limit = [2049, 2050, 3000, 3001, 10000, 20000, 100000]
@@ -121,8 +121,8 @@ class TestLogStreamValidator(unittest.TestCase):
                 validate_log_limit(ns)
             error_msgs = ['ERROR:cli.azext_spring.log_stream.log_stream_validators:'
                           '--limit can not be more than 2048, using 2048 instead']
-            self.assertEquals(error_msgs, cm.output)
-            self.assertEquals(2048 * 1024, ns.limit)
+            self.assertEqual(error_msgs, cm.output)
+            self.assertEqual(2048 * 1024, ns.limit)
 
     def test_invalid_max_log_requests(self):
         invalid_max_log_requests_number = [-100, -10, -1, 0]
@@ -135,7 +135,7 @@ class TestLogStreamValidator(unittest.TestCase):
             with self.assertRaises(InvalidArgumentValueError) as context:
                 validate_max_log_requests(ns)
 
-            self.assertEquals("--max-log-requests should be larger than 0.", str(context.exception))
+            self.assertEqual("--max-log-requests should be larger than 0.", str(context.exception))
 
     def test_validate_thread_number(self):
         thread_num = 10

--- a/src/spring/azext_spring/tests/latest/managed_component/test_managed_component_validators.py
+++ b/src/spring/azext_spring/tests/latest/managed_component/test_managed_component_validators.py
@@ -115,7 +115,7 @@ class TestValidateComponentLogs(unittest.TestCase):
         with self.assertRaises(InvalidArgumentValueError) as context:
             validate_component_logs(get_test_cmd(), ns)
 
-        self.assertEquals("--all-instances cannot be set together with --instance/-i.", str(context.exception))
+        self.assertEqual("--all-instances cannot be set together with --instance/-i.", str(context.exception))
 
     @mock.patch('azext_spring.managed_components.validators_managed_component.is_enterprise_tier', autospec=True)
     def test_required_param_missing(self, is_enterprise_tier_mock):
@@ -132,7 +132,7 @@ class TestValidateComponentLogs(unittest.TestCase):
         with self.assertRaises(InvalidArgumentValueError) as context:
             validate_component_logs(get_test_cmd(), ns)
 
-        self.assertEquals("When --name/-n is not set, --instance/-i is required.", str(context.exception))
+        self.assertEqual("When --name/-n is not set, --instance/-i is required.", str(context.exception))
 
     @mock.patch('azext_spring.managed_components.validators_managed_component.is_enterprise_tier', autospec=True)
     def test_only_instance_name(self, is_enterprise_tier_mock):
@@ -152,7 +152,7 @@ class TestValidateComponentLogs(unittest.TestCase):
 
         with self.assertLogs('cli.azext_spring.managed_components.validators_managed_component', 'WARNING') as cm:
             validate_component_logs(get_test_cmd(), ns)
-        self.assertEquals(cm.output, ['WARNING:cli.azext_spring.managed_components.validators_managed_component:--instance/-i is specified without --name/-n, will try best effort get logs by instance.'])
+        self.assertEqual(cm.output, ['WARNING:cli.azext_spring.managed_components.validators_managed_component:--instance/-i is specified without --name/-n, will try best effort get logs by instance.'])
 
     @mock.patch('azext_spring.managed_components.validators_managed_component.is_enterprise_tier', autospec=True)
     def test_valid_component_name(self, is_enterprise_tier_mock):
@@ -199,7 +199,7 @@ class TestValidateComponentLogs(unittest.TestCase):
                     max_log_requests=5
                 )
                 validate_component_logs(get_test_cmd(), ns)
-                self.assertEquals(lines, ns.lines)
+                self.assertEqual(lines, ns.lines)
 
     @mock.patch('azext_spring.managed_components.validators_managed_component.is_enterprise_tier', autospec=True)
     def test_log_lines_too_small(self, is_enterprise_tier_mock):
@@ -218,7 +218,7 @@ class TestValidateComponentLogs(unittest.TestCase):
             )
             with self.assertRaises(InvalidArgumentValueError) as context:
                 validate_component_logs(get_test_cmd(), ns)
-            self.assertEquals('--lines must be in the range [1,10000]', str(context.exception))
+            self.assertEqual('--lines must be in the range [1,10000]', str(context.exception))
 
     @mock.patch('azext_spring.managed_components.validators_managed_component.is_enterprise_tier', autospec=True)
     def test_log_lines_too_big(self, is_enterprise_tier_mock):
@@ -240,8 +240,8 @@ class TestValidateComponentLogs(unittest.TestCase):
                 validate_component_logs(get_test_cmd(), ns)
             expect_error_msgs = ['ERROR:cli.azext_spring.log_stream.log_stream_validators:'
                                  '--lines can not be more than 10000, using 10000 instead']
-            self.assertEquals(expect_error_msgs, cm.output)
-            self.assertEquals(10000, ns.lines)
+            self.assertEqual(expect_error_msgs, cm.output)
+            self.assertEqual(10000, ns.lines)
 
     @mock.patch('azext_spring.managed_components.validators_managed_component.is_enterprise_tier', autospec=True)
     def test_valid_log_since(self, is_enterprise_tier_mock):
@@ -272,7 +272,7 @@ class TestValidateComponentLogs(unittest.TestCase):
                     since_in_seconds = since_in_seconds * 3600
                 elif last == 'm':
                     since_in_seconds = since_in_seconds * 60
-                self.assertEquals(since_in_seconds, ns.since)
+                self.assertEqual(since_in_seconds, ns.since)
 
     @mock.patch('azext_spring.managed_components.validators_managed_component.is_enterprise_tier', autospec=True)
     def test_invalid_log_since(self, is_enterprise_tier_mock):
@@ -294,7 +294,7 @@ class TestValidateComponentLogs(unittest.TestCase):
                 )
                 with self.assertRaises(InvalidArgumentValueError) as context:
                     validate_component_logs(get_test_cmd(), ns)
-                self.assertEquals("--since contains invalid characters", str(context.exception))
+                self.assertEqual("--since contains invalid characters", str(context.exception))
 
     @mock.patch('azext_spring.managed_components.validators_managed_component.is_enterprise_tier', autospec=True)
     def test_log_since_too_big(self, is_enterprise_tier_mock):
@@ -316,7 +316,7 @@ class TestValidateComponentLogs(unittest.TestCase):
                 )
                 with self.assertRaises(InvalidArgumentValueError) as context:
                     validate_component_logs(get_test_cmd(), ns)
-                self.assertEquals("--since can not be more than 1h", str(context.exception))
+                self.assertEqual("--since can not be more than 1h", str(context.exception))
 
     @mock.patch('azext_spring.managed_components.validators_managed_component.is_enterprise_tier', autospec=True)
     def test_valid_log_limit(self, is_enterprise_tier_mock):
@@ -338,7 +338,7 @@ class TestValidateComponentLogs(unittest.TestCase):
                     max_log_requests=5
                 )
                 validate_component_logs(get_test_cmd(), ns)
-                self.assertEquals(limit * 1024, ns.limit)
+                self.assertEqual(limit * 1024, ns.limit)
 
     @mock.patch('azext_spring.managed_components.validators_managed_component.is_enterprise_tier', autospec=True)
     def test_negative_log_limit(self, is_enterprise_tier_mock):
@@ -360,7 +360,7 @@ class TestValidateComponentLogs(unittest.TestCase):
                 )
                 with self.assertRaises(InvalidArgumentValueError) as context:
                     validate_component_logs(get_test_cmd(), ns)
-                self.assertEquals('--limit must be in the range [1,2048]', str(context.exception))
+                self.assertEqual('--limit must be in the range [1,2048]', str(context.exception))
 
     @mock.patch('azext_spring.managed_components.validators_managed_component.is_enterprise_tier', autospec=True)
     def test_log_limit_too_big(self, is_enterprise_tier_mock):
@@ -385,8 +385,8 @@ class TestValidateComponentLogs(unittest.TestCase):
                     validate_component_logs(get_test_cmd(), ns)
                 error_msgs = ['ERROR:cli.azext_spring.log_stream.log_stream_validators:'
                               '--limit can not be more than 2048, using 2048 instead']
-                self.assertEquals(error_msgs, cm.output)
-                self.assertEquals(2048 * 1024, ns.limit)
+                self.assertEqual(error_msgs, cm.output)
+                self.assertEqual(2048 * 1024, ns.limit)
 
     @mock.patch('azext_spring.managed_components.validators_managed_component.is_enterprise_tier', autospec=True)
     def test_tier(self, is_enterprise_tier_mock):
@@ -424,4 +424,4 @@ class TestValidateComponentLogs(unittest.TestCase):
 
         with self.assertRaises(NotSupportedPricingTierError) as context:
             validate_component_logs(get_test_cmd(), ns)
-        self.assertEquals("Only enterprise tier service instance is supported in this command.", str(context.exception))
+        self.assertEqual("Only enterprise tier service instance is supported in this command.", str(context.exception))

--- a/src/spring/azext_spring/tests/latest/managed_component/test_writer.py
+++ b/src/spring/azext_spring/tests/latest/managed_component/test_writer.py
@@ -13,10 +13,10 @@ class TestValidateComponentList(unittest.TestCase):
         writer = DefaultWriter()
         buffer = io.StringIO()
         writer.write("test-data", end='', file=buffer)
-        self.assertEquals("test-data", buffer.getvalue().strip())
+        self.assertEqual("test-data", buffer.getvalue().strip())
 
     def test_prefix_writer(self):
         writer = PrefixWriter("prefix")
         buffer = io.StringIO()
         writer.write("test-data", end='', file=buffer)
-        self.assertEquals("prefix test-data", buffer.getvalue().strip())
+        self.assertEqual("prefix test-data", buffer.getvalue().strip())

--- a/src/spring/azext_spring/tests/latest/test_asa_app.py
+++ b/src/spring/azext_spring/tests/latest/test_asa_app.py
@@ -402,7 +402,7 @@ class TestAppDeploy_Enterprise_Patch(BasicTest):
             self._get_result_resource(status='Failed')
         ]
         deployment = self._get_deployment()
-        with self.assertRaisesRegexp(CLIError, 'Failed to build container image'):
+        with self.assertRaisesRegex(CLIError, 'Failed to build container image'):
             self._execute('rg', 'asc', 'app', deployment=deployment, artifact_path='my-path', client=client)
 
 
@@ -517,7 +517,7 @@ class TestAppUpdate(BasicTest):
         self.assertEqual(True, resource.properties.public)
 
     def test_invalid_app_update_deployment_settings_without_deployment(self):
-        with self.assertRaisesRegexp(CLIError, '--jvm-options cannot be set when there is no active deployment.'):
+        with self.assertRaisesRegex(CLIError, '--jvm-options cannot be set when there is no active deployment.'):
             self._execute('rg', 'asc', 'app', jvm_options='test-option')
 
     def test_app_update_jvm_options(self):
@@ -654,7 +654,7 @@ class TestAppUpdate(BasicTest):
         deployment.properties.source.type = 'NetCoreZip'
         deployment.properties.source.runtime_version = 'NetCore_31'
         deployment.properties.source.net_core_main_entry_path = 'main-entry'
-        with self.assertRaisesRegexp(CLIError, '--jvm-options cannot be set when --runtime-version is NetCore_31.'):
+        with self.assertRaisesRegex(CLIError, '--jvm-options cannot be set when --runtime-version is NetCore_31.'):
             self._execute('rg', 'asc', 'app', jvm_options='test-option', deployment=deployment)
 
     def test_vnet_public_endpoint(self):
@@ -767,21 +767,21 @@ class TestAppCreate(BasicTest):
 
     def test_app_with_large_instance_count_enterprise(self):
         client = self._get_basic_mock_client(sku='Enterprise')
-        with self.assertRaisesRegexp(CLIError, f'Invalid --instance-count, should be in range {re.escape("[")}1, 1000{re.escape("]")}'):
+        with self.assertRaisesRegex(CLIError, f'Invalid --instance-count, should be in range {re.escape("[")}1, 1000{re.escape("]")}'):
             self._execute('rg', 'asc', 'app', cpu='500m', memory='2Gi', instance_count=1001, client=client)
 
     def test_app_with_large_instance_count(self):
-        with self.assertRaisesRegexp(CLIError, f'Invalid --instance-count, should be in range {re.escape("[")}1, 500{re.escape("]")}'):
+        with self.assertRaisesRegex(CLIError, f'Invalid --instance-count, should be in range {re.escape("[")}1, 500{re.escape("]")}'):
             self._execute('rg', 'asc', 'app', cpu='500m', memory='2Gi', instance_count=501)
 
     def test_app_with_large_instance_count_basic(self):
         client = self._get_basic_mock_client(sku='Basic')
-        with self.assertRaisesRegexp(CLIError, f'Invalid --instance-count, should be in range {re.escape("[")}1, 25{re.escape("]")}'):
+        with self.assertRaisesRegex(CLIError, f'Invalid --instance-count, should be in range {re.escape("[")}1, 25{re.escape("]")}'):
             self._execute('rg', 'asc', 'app', cpu='500m', memory='2Gi', instance_count=26, client=client)
 
     def test_app_with_persistent_storage_enterprise(self):
         client = self._get_basic_mock_client(sku='Enterprise')
-        with self.assertRaisesRegexp(CLIError,
+        with self.assertRaisesRegex(CLIError,
                                      'Enterprise tier Spring instance does not support --enable-persistent-storage'):
             self._execute('rg', 'asc', 'app', cpu='500m', memory='2Gi', instance_count=1,
                           enable_persistent_storage=True, client=client)

--- a/src/spring/azext_spring/tests/latest/test_asa_app_insights_scenario.py
+++ b/src/spring/azext_spring/tests/latest/test_asa_app_insights_scenario.py
@@ -348,11 +348,11 @@ class AzureSpringCloudCreateTests(ScenarioTest):
 
     def _test_app_insights_enable_status(self, rg, service_name, target_status):
         result = self.cmd('spring app-insights show -n {} -g {}'.format(service_name, rg)).get_output_in_json()
-        self.assertEquals(result['traceEnabled'], target_status)
+        self.assertEqual(result['traceEnabled'], target_status)
 
     def _test_sampling_rate(self, rg, service_name, target_sampling_rate):
         result = self.cmd('spring app-insights show -n {} -g {}'.format(service_name, rg)).get_output_in_json()
-        self.assertEquals(result['appInsightsSamplingRate'], target_sampling_rate)
+        self.assertEqual(result['appInsightsSamplingRate'], target_sampling_rate)
 
     def _asc_update_disable_ai(self, rg, service_name):
         self.cmd('spring update -g {} -n {} --disable-app-insights --no-wait'.format(rg, service_name))

--- a/src/spring/azext_spring/tests/latest/test_asa_app_scenario.py
+++ b/src/spring/azext_spring/tests/latest/test_asa_app_scenario.py
@@ -55,7 +55,7 @@ class AppDeploy(ScenarioTest):
         ])
 
         # deploy fake file, the fail is expected
-        with self.assertRaisesRegexp(CLIError, "112404: Exit code 1: application error"):
+        with self.assertRaisesRegex(CLIError, "112404: Exit code 1: application error"):
             self.cmd('spring app deploy -n {app} -g {rg} -s {serviceName} --artifact-path {file} --version v1')
 
     @SpringResourceGroupPreparer(dev_setting_name=SpringTestEnvironmentEnum.STANDARD['resource_group_name'])
@@ -82,7 +82,7 @@ class AppDeploy(ScenarioTest):
         ])
 
         # deploy change to .Net
-        with self.assertRaisesRegexp(CLIError, "112404: Exit code 0: purposely stopped"):
+        with self.assertRaisesRegex(CLIError, "112404: Exit code 0: purposely stopped"):
             self.cmd('spring app deploy -n {app} -g {rg} -s {serviceName} --artifact-path {file} --version v2 --runtime-version NetCore_31 --main-entry test')
 
     @SpringResourceGroupPreparer(dev_setting_name=SpringTestEnvironmentEnum.STANDARD['resource_group_name'])
@@ -109,7 +109,7 @@ class AppDeploy(ScenarioTest):
         ])
 
         # deploy unexist file, the fail is expected
-        with self.assertRaisesRegexp(CLIError, "artifact path {} does not exist.".format(file_path)):
+        with self.assertRaisesRegex(CLIError, "artifact path {} does not exist.".format(file_path)):
             self.cmd('spring app deploy -n {app} -g {rg} -s {serviceName} --artifact-path {file} --version v3')
 
     @SpringResourceGroupPreparer(dev_setting_name=SpringTestEnvironmentEnum.STANDARD['resource_group_name'])
@@ -136,7 +136,7 @@ class AppDeploy(ScenarioTest):
         ])
 
         # deploy unexist file, the fail is expected
-        with self.assertRaisesRegexp(CLIError, "artifact path {} does not exist.".format(file_path)):
+        with self.assertRaisesRegex(CLIError, "artifact path {} does not exist.".format(file_path)):
             self.cmd('spring app deployment create -n green --app {app} -g {rg} -s {serviceName} --instance-count 2 --artifact-path {file}')
 
 

--- a/src/spring/azext_spring/tests/latest/test_asa_application_configuration_service.py
+++ b/src/spring/azext_spring/tests/latest/test_asa_application_configuration_service.py
@@ -92,7 +92,7 @@ class TestAcsShowConfigurationFiles(unittest.TestCase):
         expected_file_content = r"properties-name: sample-test\nspring.config.activate.on-profile: default"
         file_content_arr = result.get("configurationFiles").get("application.properties")
         self.assertTrue(isinstance(file_content_arr, list))
-        self.assertEquals(len(file_content_arr), 2)
+        self.assertEqual(len(file_content_arr), 2)
         self.assertTrue(r"properties-name: sample-test" in file_content_arr)
         self.assertTrue(r"spring.config.activate.on-profile: default" in file_content_arr)
 
@@ -108,7 +108,7 @@ class TestAcsShowConfigurationFiles(unittest.TestCase):
         expected_file_content = r"properties-name: sample-test\nspring.config.activate.on-profile: default"
         file_content_arr = result.get("configurationFiles").get("application.properties")
         self.assertTrue(isinstance(file_content_arr, list))
-        self.assertEquals(len(file_content_arr), 2)
+        self.assertEqual(len(file_content_arr), 2)
         self.assertTrue(r"properties-name: sample-test" in file_content_arr)
         self.assertTrue(r"spring.config.activate.on-profile: default" in file_content_arr)
         self.assertIsNone(result.get("metadata"))
@@ -129,13 +129,13 @@ class TestAcsShowConfigurationFiles(unittest.TestCase):
         expected_file_content = r"properties-name: sample-test\nspring.config.activate.on-profile: default"
         file_content_arr = result.get("configurationFiles").get("application.properties")
         self.assertTrue(isinstance(file_content_arr, list))
-        self.assertEquals(len(file_content_arr), 2)
+        self.assertEqual(len(file_content_arr), 2)
         self.assertTrue(r"properties-name: sample-test" in file_content_arr)
         self.assertTrue(r"spring.config.activate.on-profile: default" in file_content_arr)
         self.assertIsNotNone(result.get("metadata"))
         metadata = result.get("metadata")
         expected_revisions = "[{\"url\": \"https://sample.url\", \"revision\": \"main@sha1:sample-commit-id\"}]"
-        self.assertEquals(metadata.get("gitRevisions"), expected_revisions)
+        self.assertEqual(metadata.get("gitRevisions"), expected_revisions)
 
     def test_show_configuration_files_for_acs_gen_2_with_null_metadata(self):
         response_str = r'''
@@ -151,7 +151,7 @@ class TestAcsShowConfigurationFiles(unittest.TestCase):
         expected_file_content = r"properties-name: sample-test\nspring.config.activate.on-profile: default"
         file_content_arr = result.get("configurationFiles").get("application.properties")
         self.assertTrue(isinstance(file_content_arr, list))
-        self.assertEquals(len(file_content_arr), 2)
+        self.assertEqual(len(file_content_arr), 2)
         self.assertTrue(r"properties-name: sample-test" in file_content_arr)
         self.assertTrue(r"spring.config.activate.on-profile: default" in file_content_arr)
         self.assertIsNone(result.get("metadata"))

--- a/src/ssh/azext_ssh/tests/latest/test_connectivity_utils.py
+++ b/src/ssh/azext_ssh/tests/latest/test_connectivity_utils.py
@@ -115,9 +115,9 @@ class SshConnectivityUtilsCommandTest(unittest.TestCase):
 
         mock_tar.extractall.assert_called_once_with(members=[mock_file1, mock_file2, mock_file3], path="/tmp/install")
 
-        self.assertEquals(mock_file1.name, "my_proxy")
-        self.assertEquals(mock_file2.name, "license.txt")
-        self.assertEquals(mock_file3.name, "thirdpartynotice.txt")
+        self.assertEqual(mock_file1.name, "my_proxy")
+        self.assertEqual(mock_file2.name, "license.txt")
+        self.assertEqual(mock_file3.name, "thirdpartynotice.txt")
 
     @mock.patch('os.path.isfile')
     @mock.patch('platform.machine')


### PR DESCRIPTION
`assertRaisesRegexp` is removed in 3.12: https://github.com/Azure/azure-cli/pull/29504
`assertEquals` is removed in 3.12: https://github.com/Azure/azure-cli/pull/29515

Apply same changes in extension.

This PR only changes the test file, it should not affect user.