### PR TITLE
Changing default windows image from the old 2016 to the new 2022

### DIFF
--- a/src/vm-repair/azext_vm_repair/custom.py
+++ b/src/vm-repair/azext_vm_repair/custom.py
@@ -91,10 +91,7 @@ def create(cmd, vm_name, resource_group_name, repair_password=None, repair_usern
             else:
                 os_image_urn = _select_distro_linux(distro)
         else:
-            if encrypt_recovery_key:
-                os_image_urn = _fetch_compatible_windows_os_urn_v2(source_vm)
-            else:
-                os_image_urn = _fetch_compatible_windows_os_urn(source_vm)
+            os_image_urn = _fetch_compatible_windows_os_urn_v2(source_vm)
             os_type = 'Windows'
 
         # Set up base create vm command


### PR DESCRIPTION
---
This is technically a breaking change, with the messaging being sent here: [Default windows image change breaking change warning, Win2016 to Win2022 by Sandido · Pull Request #8045 · Azure/azure-cli-extensions (github.com)](https://github.com/Azure/azure-cli-extensions/pull/8045)

This change prevents the old 2016 image from being used by default, rather to a newer method that first tries to use the source VM image, and if that cannot be found it uses the 2022 image.  
This PR should be released in time for the November Ignite breaking change release. 

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
