### PR TITLE
NeworkCloud 2024-07-01 API version update to include BYOSA for baremetalmachine commands(run/runread/rundataextract command)

### DIFF
--- a/src/networkcloud/HISTORY.rst
+++ b/src/networkcloud/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+
+2.0.0b5
+++++++++
+* This version updates the baremetalmachine resource commands (run-command, run-read-command, and run-data-extract) to utilize a customer-provided Storage Account for storing command execution results.
+
 2.0.0b4
 ++++++++
 * This beta version supports NetworkCloud 2024-07-01 APIs.

--- a/src/networkcloud/azext_networkcloud/operations/custom_properties.py
+++ b/src/networkcloud/azext_networkcloud/operations/custom_properties.py
@@ -11,6 +11,8 @@
 Helper class for all POST commands that return extra properties back to the customer
 """
 
+import os
+import subprocess
 import tarfile
 import urllib
 
@@ -24,7 +26,7 @@ logger = get_logger(__name__)
 class CustomActionProperties:
     """Helper class for all POST commands that return extra properties back to the customer"""
 
-    # Custom handling of response will display the output head and the result URL
+    # Custom handling of response will display the output head and the result_URL/result_ref
     # it will also save files into output directory if provided
     @staticmethod
     def _output(parent_cmd, *args, **kwargs):  # pylint: disable=unused-argument
@@ -37,15 +39,22 @@ class CustomActionProperties:
             logger.warning("\n================================")
 
         # Display the result URL
-        if has_value(properties.result_url):
-            result_url = properties.result_url.to_serialized_data()
+        if (
+            has_value(properties.resultUrl)
+            and properties.resultUrl.to_serialized_data() != ""
+        ):
+            result_url = properties.resultUrl.to_serialized_data()
             logger.warning(
                 "Script execution result can be found in storage account: \n %s \n",
                 result_url,
             )
             # extract result to the provided directory
             if has_value(args.output):
-                output_directory = args.output.to_serialized_data()
+                output_directory = (
+                    args.output
+                    if isinstance(args.output, str)
+                    else args.output.to_serialized_data()
+                )
 
                 try:
                     with urllib.request.urlopen(result_url) as result:
@@ -59,6 +68,74 @@ class CustomActionProperties:
                     raise AzureInternalError(
                         f"failed to retrieve output, error {excep}"
                     ) from excep
+        elif (
+            has_value(properties.resultRef)
+            and properties.resultRef.to_serialized_data() != ""
+        ):
+            result_ref = properties.resultRef.to_serialized_data()
+            # parse the resultRef to get .gz filename
+            try:
+                parsed_url = urllib.parse.urlparse(result_ref)
+                path = parsed_url.path
+                downloaded_blob_name = path.split("/")[-1]
+            except Exception as ex:
+                error_message = (
+                    f"failed to parse resultRef URL for download. Error: {str(ex)}"
+                )
+                logger.error(error_message)
+                raise AzureInternalError(error_message) from ex
+
+            logger.warning(
+                "Script execution result can be download from storage account using the "
+                "command: \n az storage blob download --blob-url %s --file %s --auth-mode login  > /dev/null 2>&1 \n",
+                result_ref,
+                downloaded_blob_name,
+            )
+            # extract result to the provided directory
+            if has_value(args.output):
+                output_directory = (
+                    args.output
+                    if isinstance(args.output, str)
+                    else args.output.to_serialized_data()
+                )
+                # download the blob using "az storage blob download --blob-url %s --auth-mode login"
+                download_command = [
+                    "az",
+                    "storage",
+                    "blob",
+                    "download",
+                    "--blob-url",
+                    result_ref,
+                    "--file",
+                    downloaded_blob_name,
+                    "--auth-mode",
+                    "login",
+                ]
+                try:
+                    result = subprocess.run(
+                        download_command, check=True, capture_output=True, text=True
+                    )
+                    logger.info("Blob downloaded successfully.")
+                except subprocess.CalledProcessError as e:
+                    error_message = (
+                        f"Failed to download blob. Error: {e.stderr.strip()}"
+                    )
+                    logger.error(error_message)
+                    raise AzureInternalError(error_message) from e
+
+                try:
+                    # Extract the downloaded blob
+                    with tarfile.open(downloaded_blob_name, mode="r:gz") as tar:
+                        tar.extractall(path=output_directory)
+                        logger.warning(
+                            "Extracted results are available in directory: %s",
+                            output_directory,
+                        )
+                        os.remove(downloaded_blob_name)
+                except tarfile.TarError as e:
+                    error_message = f"Failed to extract blob. Error: {str(e)}"
+                    logger.error(error_message)
+                    raise AzureInternalError(error_message) from e
         else:
             result = parent_cmd.deserialize_output(
                 parent_cmd.ctx.vars.instance, client_flatten=True

--- a/src/networkcloud/azext_networkcloud/tests/unit/test_custom_properties.py
+++ b/src/networkcloud/azext_networkcloud/tests/unit/test_custom_properties.py
@@ -4,17 +4,19 @@
 # --------------------------------------------------------------------------------------------
 # flake8: noqa
 
+import subprocess
 import unittest
 from unittest import mock
 
 from azext_networkcloud.operations.custom_properties import CustomActionProperties
 from azure.cli.core.aaz._base import AAZUndefined
+from azure.cli.core.azclierror import AzureInternalError
 
 
 class TestCustomProperties(unittest.TestCase):
     """Test CustomProperties methods"""
 
-    def test_output(self):
+    def test_resulturl_output(self):
         self.cmd = mock.Mock()
 
         # Mock args
@@ -42,15 +44,16 @@ class TestCustomProperties(unittest.TestCase):
             self.cmd.ctx.args.output = AAZUndefined
 
             # Set result url to undefined
-            self.cmd.ctx.vars.instance.properties.result_url = AAZUndefined
+            self.cmd.ctx.vars.instance.properties.resultUrl = AAZUndefined
+            self.cmd.ctx.vars.instance.properties.resultRef = AAZUndefined
 
             CustomActionProperties()._output(self.cmd, args)
             mock_urlopen.assert_not_called()
 
         # Mock result URL
         test_url = "https://aka.ms/fakeurl"
-        self.cmd.ctx.vars.instance.properties.result_url = mock.Mock()
-        self.cmd.ctx.vars.instance.properties.result_url.to_serialized_data = mock.Mock(
+        self.cmd.ctx.vars.instance.properties.resultUrl = mock.Mock()
+        self.cmd.ctx.vars.instance.properties.resultUrl.to_serialized_data = mock.Mock(
             side_effect=test_url
         )
 
@@ -77,4 +80,53 @@ class TestCustomProperties(unittest.TestCase):
             # Raise exception when calling URL
             mock_urlopen.side_effect = Exception
             with self.assertRaises(Exception):
+                CustomActionProperties()._output(self.cmd, args)
+
+    def test_resultref_output(self):
+        self.cmd = mock.Mock()
+
+        # Mock args
+        args = mock.Mock()
+        self.cmd.ctx = mock.Mock()
+        self.cmd.ctx.args = args
+
+        # Validate URL download skipped when resultRef not provided
+        with mock.patch("subprocess.run") as mock_subprocess_run:
+            # Set output dir to undefined
+            self.cmd.ctx.args.output = AAZUndefined
+
+            # Set result url to undefined
+            self.cmd.ctx.vars.instance.properties.resultRef = AAZUndefined
+
+            CustomActionProperties()._output(self.cmd, args)
+            mock_subprocess_run.assert_not_called()
+
+        # Mock result URL
+        test_url = "https://aka.ms/fakeurl"
+        self.cmd.ctx.vars.instance.properties.resultRef = mock.Mock()
+        self.cmd.ctx.vars.instance.properties.resultRef.to_serialized_data = mock.Mock(
+            side_effect=test_url
+        )
+
+        # Validate results not downloaded when no output dir provided
+        with mock.patch("subprocess.run") as mock_subprocess_run:
+            # Set output dir to undefined
+            self.cmd.ctx.args.output = AAZUndefined
+
+            CustomActionProperties()._output(self.cmd, args)
+            mock_subprocess_run.assert_not_called()
+
+        # Validate exceptions handled
+        with mock.patch("subprocess.run") as mock_subprocess_run:
+            test_output_dir = "/path/to/test/output/dir"
+            self.cmd.ctx.args.output = test_output_dir
+
+            # Simulate subprocess.run raising an error
+            mock_subprocess_run.side_effect = subprocess.CalledProcessError(
+                returncode=1, cmd="az storage blob download", stderr="Simulated error"
+            )
+
+            # Raise exception when downloading blob
+            mock_subprocess_run.side_effect = Exception
+            with self.assertRaises(AzureInternalError) as cm:
                 CustomActionProperties()._output(self.cmd, args)

--- a/src/networkcloud/setup.py
+++ b/src/networkcloud/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 
 
 # HISTORY.rst entry.
-VERSION = '2.0.0b4'
+VERSION = '2.0.0b5'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
NeworkCloud 2024-07-01 API version update to include BYOSA for baremetalmachine commands(run/runread/rundataextract command)

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
