### PR TITLE
[Draft - Do not merge] [Quantum] Use Post Storage URI and SAS token like Quantum Python SDK

### DIFF
--- a/src/quantum/azext_quantum/__init__.py
+++ b/src/quantum/azext_quantum/__init__.py
@@ -13,7 +13,7 @@ import azext_quantum._help  # pylint: disable=unused-import
 # This is the version reported by the CLI to the service when submitting requests.
 # This should be in sync with the extension version in 'setup.py', unless we need to
 # submit using a different version.
-CLI_REPORTED_VERSION = "1.0.0b4"
+CLI_REPORTED_VERSION = "1.0.0b4.dev3"
 
 
 class QuantumCommandsLoader(AzCommandsLoader):

--- a/src/quantum/setup.py
+++ b/src/quantum/setup.py
@@ -17,7 +17,7 @@ except ImportError:
 # This version should match the latest entry in HISTORY.rst
 # Also, when updating this, please review the version used by the extension to
 # submit requests, which can be found at './azext_quantum/__init__.py'
-VERSION = '1.0.0b4'
+VERSION = '1.0.0b4.dev3'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
### NOTE: Restore old version number before clicking "Ready for review"

The Azure Quantum CLI should use a Post Storage URI and a SAS token like Python SDK, azure-quantum-python.

Our CLI extension has a potential issue with directly using a user's credentials to access storage account to upload input or download output files, when our other SDK uses the PostStorageUri endpoint in our service. If we had the CLI extension use the same method, then we won't run into user permission issues with using CLI (if they have access to workspace, but not to storage account).

---

### Related commands
`az quantum job submit`
`az quantum execute`
`az run`

---


- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)
