### PR TITLE
[AKS] BREAKING CHANGE: `az aks trustedaccess rolebinding create`: Remove deprecated `-r` and `-s` options

### DIFF
--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -18,6 +18,10 @@ To release a new version, please select a new version number (usually plus 1 to 
 * [BREAKING CHANGE]: Remove advanced container networking service (acns) enablement preview parameters `--enable-advanced-network-observability`, `--disable-advanced-network-observability`, `--enable-fqdn-policy`, `--disable-fqdn-policy`, and `--advanced-networking-observability-tls-management` from `az aks create/update` command.
 * Add advanced container networking service (acns) enablement GA parameters `--disable-acns-observability` and `--disable-acns-security` to `az aks create/update` command.
 
+12.0.0b1
++++++++
+* [BREAKING CHANGE]: `az aks trustedaccess rolebinding create`: Remove deprecated `-r` and `-s` options
+
 11.0.0b1
 +++++++
 * [BREAKING CHANGE]: `az aks create`: Remove AAD-legacy properties `--aad-client-app-id`, `--aad-server-app-id` and `--aad-server-app-secret` when creating cluster.

--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -9,6 +9,10 @@ If there is no rush to release a new version, please just add a description of t
 
 To release a new version, please select a new version number (usually plus 1 to last patch version, X.Y.Z -> Major.Minor.Patch, more details in `\doc <https://semver.org/>`_), and then add a new section named as the new version number in this file, the content should include the new modifications and everything from the *Pending* section. Finally, update the `VERSION` variable in `setup.py` with this new version number.
 
+13.0.0b1
++++++++
+* [BREAKING CHANGE]: `az aks trustedaccess rolebinding create`: Remove deprecated `-r` and `-s` options.
+
 12.0.0b2
 ++++++++
 * `az aks create/update`: Fix storage pool name validation for Azure Container Storage.
@@ -17,10 +21,6 @@ To release a new version, please select a new version number (usually plus 1 to 
 +++++++
 * [BREAKING CHANGE]: Remove advanced container networking service (acns) enablement preview parameters `--enable-advanced-network-observability`, `--disable-advanced-network-observability`, `--enable-fqdn-policy`, `--disable-fqdn-policy`, and `--advanced-networking-observability-tls-management` from `az aks create/update` command.
 * Add advanced container networking service (acns) enablement GA parameters `--disable-acns-observability` and `--disable-acns-security` to `az aks create/update` command.
-
-12.0.0b1
-+++++++
-* [BREAKING CHANGE]: `az aks trustedaccess rolebinding create`: Remove deprecated `-r` and `-s` options
 
 11.0.0b1
 +++++++

--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -2,7 +2,6 @@
 
 Release History
 ===============
-* [BREAKING CHANGE]: `az aks trustedaccess rolebinding create`: Remove deprecated `-r` and `-s` options
 
 Guidance
 ++++++++

--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -2,6 +2,7 @@
 
 Release History
 ===============
+* [BREAKING CHANGE]: `az aks trustedaccess rolebinding create`: Remove deprecated `-r` and `-s` options
 
 Guidance
 ++++++++

--- a/src/aks-preview/azext_aks_preview/_params.py
+++ b/src/aks-preview/azext_aks_preview/_params.py
@@ -2208,11 +2208,6 @@ def load_arguments(self, _):
         )
         c.argument(
             "source_resource_id",
-            options_list=[
-                "--source-resource-id",
-                c.deprecate(target="-s", redirect="--source-resource-id", hide=True),
-                c.deprecate(target="-r", redirect="--source-resource-id", hide=True),
-            ],
             help="The source resource id of the binding",
         )
 

--- a/src/aks-preview/setup.py
+++ b/src/aks-preview/setup.py
@@ -9,7 +9,7 @@ from codecs import open as open1
 
 from setuptools import setup, find_packages
 
-VERSION = "12.0.0b2"
+VERSION = "13.0.0b1"
 
 CLASSIFIERS = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
az aks trustedaccess rolebinding create

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
