### PR TITLE
AMG: Set service-account token default TTL to 1 day

### DIFF
--- a/src/amg/HISTORY.rst
+++ b/src/amg/HISTORY.rst
@@ -118,3 +118,7 @@ Release History
 2.5.2
 ++++++
 * `az grafana create`: fix issue with principal type implicit selection during role assignment step
+
+2.5.3
+++++++
+* `az grafana service-account token create`: set token default expiration time to 1 day as stated in the documentation

--- a/src/amg/azext_amg/custom.py
+++ b/src/amg/azext_amg/custom.py
@@ -720,6 +720,8 @@ def create_service_account_token(cmd, grafana_name, service_account, token, time
 
     if time_to_live:
         data['secondsToLive'] = _convert_duration_to_seconds(time_to_live)
+    else:
+        data['secondsToLive'] = _convert_duration_to_seconds("1d")
 
     response = _send_request(cmd, resource_group_name, grafana_name, "post",
                              "/api/serviceaccounts/" + service_account_id + '/tokens', data)

--- a/src/amg/setup.py
+++ b/src/amg/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
-VERSION = '2.5.2'
+VERSION = '2.5.3'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az grafana service-account token create`

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

Fixes #8155 