### PR TITLE
[Microsoft Connected Cache] Change is_preview flags on all commands to true and increment mcc version to v1.0.0b2 from v1.0.0b1

### DIFF
--- a/src/mcc/azext_mcc/aaz/latest/mcc/__cmd_group.py
+++ b/src/mcc/azext_mcc/aaz/latest/mcc/__cmd_group.py
@@ -13,6 +13,7 @@ from azure.cli.core.aaz import *
 
 @register_command_group(
     "mcc",
+    is_preview=True,
 )
 class __CMDGroup(AAZCommandGroup):
     """Microsoft Connected Cache CLI Commands

--- a/src/mcc/azext_mcc/aaz/latest/mcc/ent/__cmd_group.py
+++ b/src/mcc/azext_mcc/aaz/latest/mcc/ent/__cmd_group.py
@@ -13,6 +13,7 @@ from azure.cli.core.aaz import *
 
 @register_command_group(
     "mcc ent",
+    is_preview=True,
 )
 class __CMDGroup(AAZCommandGroup):
     """Microsoft Connected Cache for Enterprise CLI commands

--- a/src/mcc/azext_mcc/aaz/latest/mcc/ent/node/__cmd_group.py
+++ b/src/mcc/azext_mcc/aaz/latest/mcc/ent/node/__cmd_group.py
@@ -13,6 +13,7 @@ from azure.cli.core.aaz import *
 
 @register_command_group(
     "mcc ent node",
+    is_preview=True,
 )
 class __CMDGroup(AAZCommandGroup):
     """Microsoft Connected Cache for Enterprise cache node CLI commands

--- a/src/mcc/azext_mcc/aaz/latest/mcc/ent/node/_create.py
+++ b/src/mcc/azext_mcc/aaz/latest/mcc/ent/node/_create.py
@@ -13,6 +13,7 @@ from azure.cli.core.aaz import *
 
 @register_command(
     "mcc ent node create",
+    is_preview=True,
 )
 class Create(AAZCommand):
     """Creates a Microsoft Connected Cache for Enterprise cache node with specified parameters.
@@ -47,7 +48,7 @@ class Create(AAZCommand):
             help="Name of Microsoft Connected Cache for Enterprise cache node.",
             required=True,
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z0-9\_\-]*",
+                pattern="^[a-zA-Z0-9\\_\\-]*",
                 max_length=90,
                 min_length=1,
             ),
@@ -57,7 +58,7 @@ class Create(AAZCommand):
             help="Name of Microsoft Connected Cache for Enterprise resource.",
             required=True,
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z0-9\_\-]*",
+                pattern="^[a-zA-Z0-9\\_\\-]*",
                 max_length=90,
                 min_length=1,
             ),

--- a/src/mcc/azext_mcc/aaz/latest/mcc/ent/node/_delete.py
+++ b/src/mcc/azext_mcc/aaz/latest/mcc/ent/node/_delete.py
@@ -13,6 +13,7 @@ from azure.cli.core.aaz import *
 
 @register_command(
     "mcc ent node delete",
+    is_preview=True,
     confirmation="Are you sure you want to perform this operation?",
 )
 class Delete(AAZCommand):
@@ -49,7 +50,7 @@ class Delete(AAZCommand):
             required=True,
             id_part="child_name_1",
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z0-9\_\-]*",
+                pattern="^[a-zA-Z0-9\\_\\-]*",
                 max_length=90,
                 min_length=1,
             ),
@@ -60,7 +61,7 @@ class Delete(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z0-9\_\-]*",
+                pattern="^[a-zA-Z0-9\\_\\-]*",
                 max_length=90,
                 min_length=1,
             ),

--- a/src/mcc/azext_mcc/aaz/latest/mcc/ent/node/_get_provisioning_details.py
+++ b/src/mcc/azext_mcc/aaz/latest/mcc/ent/node/_get_provisioning_details.py
@@ -13,6 +13,7 @@ from azure.cli.core.aaz import *
 
 @register_command(
     "mcc ent node get-provisioning-details",
+    is_preview=True,
 )
 class GetProvisioningDetails(AAZCommand):
     """Retrieves Microsoft Connected Cache for Enterprise cache node details and keys needed to provision cache node.
@@ -47,7 +48,7 @@ class GetProvisioningDetails(AAZCommand):
             required=True,
             id_part="child_name_1",
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z0-9\_\-]*",
+                pattern="^[a-zA-Z0-9\\_\\-]*",
                 max_length=90,
                 min_length=1,
             ),
@@ -58,7 +59,7 @@ class GetProvisioningDetails(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z0-9\_\-]*",
+                pattern="^[a-zA-Z0-9\\_\\-]*",
                 max_length=90,
                 min_length=1,
             ),

--- a/src/mcc/azext_mcc/aaz/latest/mcc/ent/node/_list.py
+++ b/src/mcc/azext_mcc/aaz/latest/mcc/ent/node/_list.py
@@ -13,6 +13,7 @@ from azure.cli.core.aaz import *
 
 @register_command(
     "mcc ent node list",
+    is_preview=True,
 )
 class List(AAZCommand):
     """Retrieves relevant information about all Microsoft Connected Cache for Enterprise cache nodes under the Microsoft Connected Cache for Enterprise resource.
@@ -47,7 +48,7 @@ class List(AAZCommand):
             help="Name of Microsoft Connected Cache for Enterprise resource.",
             required=True,
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z0-9\_\-]*",
+                pattern="^[a-zA-Z0-9\\_\\-]*",
                 max_length=90,
                 min_length=1,
             ),

--- a/src/mcc/azext_mcc/aaz/latest/mcc/ent/node/_show.py
+++ b/src/mcc/azext_mcc/aaz/latest/mcc/ent/node/_show.py
@@ -13,6 +13,7 @@ from azure.cli.core.aaz import *
 
 @register_command(
     "mcc ent node show",
+    is_preview=True,
 )
 class Show(AAZCommand):
     """Retrieves relevant information for a Microsoft Connected Cache for Enterprise cache node.
@@ -47,7 +48,7 @@ class Show(AAZCommand):
             required=True,
             id_part="child_name_1",
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z0-9\_\-]*",
+                pattern="^[a-zA-Z0-9\\_\\-]*",
                 max_length=90,
                 min_length=1,
             ),
@@ -58,7 +59,7 @@ class Show(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z0-9\_\-]*",
+                pattern="^[a-zA-Z0-9\\_\\-]*",
                 max_length=90,
                 min_length=1,
             ),

--- a/src/mcc/azext_mcc/aaz/latest/mcc/ent/node/_update.py
+++ b/src/mcc/azext_mcc/aaz/latest/mcc/ent/node/_update.py
@@ -13,6 +13,7 @@ from azure.cli.core.aaz import *
 
 @register_command(
     "mcc ent node update",
+    is_preview=True,
 )
 class Update(AAZCommand):
     """Configures a Microsoft Connected Cache for Enterprise cache node with specified configuration parameters.
@@ -50,7 +51,7 @@ class Update(AAZCommand):
             required=True,
             id_part="child_name_1",
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z0-9\_\-]*",
+                pattern="^[a-zA-Z0-9\\_\\-]*",
                 max_length=90,
                 min_length=1,
             ),
@@ -61,7 +62,7 @@ class Update(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z0-9\_\-]*",
+                pattern="^[a-zA-Z0-9\\_\\-]*",
                 max_length=90,
                 min_length=1,
             ),

--- a/src/mcc/azext_mcc/aaz/latest/mcc/ent/node/_wait.py
+++ b/src/mcc/azext_mcc/aaz/latest/mcc/ent/node/_wait.py
@@ -46,7 +46,7 @@ class Wait(AAZWaitCommand):
             required=True,
             id_part="child_name_1",
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z0-9\_\-]*",
+                pattern="^[a-zA-Z0-9\\_\\-]*",
                 max_length=90,
                 min_length=1,
             ),
@@ -57,7 +57,7 @@ class Wait(AAZWaitCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z0-9\_\-]*",
+                pattern="^[a-zA-Z0-9\\_\\-]*",
                 max_length=90,
                 min_length=1,
             ),

--- a/src/mcc/azext_mcc/aaz/latest/mcc/ent/resource/__cmd_group.py
+++ b/src/mcc/azext_mcc/aaz/latest/mcc/ent/resource/__cmd_group.py
@@ -13,6 +13,7 @@ from azure.cli.core.aaz import *
 
 @register_command_group(
     "mcc ent resource",
+    is_preview=True,
 )
 class __CMDGroup(AAZCommandGroup):
     """Microsoft Connected Cache for Enterprise resource CLI Commands

--- a/src/mcc/azext_mcc/aaz/latest/mcc/ent/resource/_create.py
+++ b/src/mcc/azext_mcc/aaz/latest/mcc/ent/resource/_create.py
@@ -13,6 +13,7 @@ from azure.cli.core.aaz import *
 
 @register_command(
     "mcc ent resource create",
+    is_preview=True,
 )
 class Create(AAZCommand):
     """Creates a Microsoft Connected Cache for Enterprise resource with specified create parameters.
@@ -47,7 +48,7 @@ class Create(AAZCommand):
             help="Name of Microsoft Connected Cache for Enterprise resource.",
             required=True,
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z0-9\_\-]*",
+                pattern="^[a-zA-Z0-9\\_\\-]*",
                 max_length=90,
                 min_length=1,
             ),
@@ -668,9 +669,7 @@ class _CreateHelper:
         )
 
         details = _schema_error_detail_read.details
-        details.Element = AAZObjectType(
-            flags={"read_only": True},
-        )
+        details.Element = AAZObjectType()
         cls._build_schema_error_detail_read(details.Element)
 
         _schema.additional_info = cls._schema_error_detail_read.additional_info

--- a/src/mcc/azext_mcc/aaz/latest/mcc/ent/resource/_delete.py
+++ b/src/mcc/azext_mcc/aaz/latest/mcc/ent/resource/_delete.py
@@ -13,13 +13,11 @@ from azure.cli.core.aaz import *
 
 @register_command(
     "mcc ent resource delete",
+    is_preview=True,
     confirmation="Are you sure you want to perform this operation?",
 )
 class Delete(AAZCommand):
     """Deletes an existing Microsoft Connected Cache for Enterprise resource.
-
-    :example: Delete an MCC resource
-        az mcc ent resource delete --mcc-resource-name MyMCCResourceName --resource-group MyResourceGroupName
     """
 
     _aaz_info = {
@@ -52,7 +50,7 @@ class Delete(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z0-9\_\-]*",
+                pattern="^[a-zA-Z0-9\\_\\-]*",
                 max_length=90,
                 min_length=1,
             ),

--- a/src/mcc/azext_mcc/aaz/latest/mcc/ent/resource/_list.py
+++ b/src/mcc/azext_mcc/aaz/latest/mcc/ent/resource/_list.py
@@ -13,6 +13,7 @@ from azure.cli.core.aaz import *
 
 @register_command(
     "mcc ent resource list",
+    is_preview=True,
 )
 class List(AAZCommand):
     """Retrieves relevant information about all Microsoft Connected Cache for Enterprise resources under the resource group.
@@ -779,9 +780,7 @@ class _ListHelper:
         )
 
         details = _schema_error_detail_read.details
-        details.Element = AAZObjectType(
-            flags={"read_only": True},
-        )
+        details.Element = AAZObjectType()
         cls._build_schema_error_detail_read(details.Element)
 
         _schema.additional_info = cls._schema_error_detail_read.additional_info

--- a/src/mcc/azext_mcc/aaz/latest/mcc/ent/resource/_show.py
+++ b/src/mcc/azext_mcc/aaz/latest/mcc/ent/resource/_show.py
@@ -44,7 +44,7 @@ class Show(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z0-9\_\-]*",
+                pattern="^[a-zA-Z0-9\\_\\-]*",
                 max_length=90,
                 min_length=1,
             ),
@@ -446,9 +446,7 @@ class _ShowHelper:
         )
 
         details = _schema_error_detail_read.details
-        details.Element = AAZObjectType(
-            flags={"read_only": True},
-        )
+        details.Element = AAZObjectType()
         cls._build_schema_error_detail_read(details.Element)
 
         _schema.additional_info = cls._schema_error_detail_read.additional_info

--- a/src/mcc/azext_mcc/aaz/latest/mcc/ent/resource/_update.py
+++ b/src/mcc/azext_mcc/aaz/latest/mcc/ent/resource/_update.py
@@ -47,7 +47,7 @@ class Update(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z0-9\_\-]*",
+                pattern="^[a-zA-Z0-9\\_\\-]*",
                 max_length=90,
                 min_length=1,
             ),
@@ -832,9 +832,7 @@ class _UpdateHelper:
         )
 
         details = _schema_error_detail_read.details
-        details.Element = AAZObjectType(
-            flags={"read_only": True},
-        )
+        details.Element = AAZObjectType()
         cls._build_schema_error_detail_read(details.Element)
 
         _schema.additional_info = cls._schema_error_detail_read.additional_info

--- a/src/mcc/azext_mcc/aaz/latest/mcc/ent/resource/_wait.py
+++ b/src/mcc/azext_mcc/aaz/latest/mcc/ent/resource/_wait.py
@@ -46,7 +46,7 @@ class Wait(AAZWaitCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z0-9\_\-]*",
+                pattern="^[a-zA-Z0-9\\_\\-]*",
                 max_length=90,
                 min_length=1,
             ),
@@ -448,9 +448,7 @@ class _WaitHelper:
         )
 
         details = _schema_error_detail_read.details
-        details.Element = AAZObjectType(
-            flags={"read_only": True},
-        )
+        details.Element = AAZObjectType()
         cls._build_schema_error_detail_read(details.Element)
 
         _schema.additional_info = cls._schema_error_detail_read.additional_info

--- a/src/mcc/azext_mcc/aaz/latest/mcc/isp/node/_create.py
+++ b/src/mcc/azext_mcc/aaz/latest/mcc/isp/node/_create.py
@@ -44,7 +44,7 @@ class Create(AAZCommand):
             help="Name of Microsoft Connected Cache for Enterprise cache node.",
             required=True,
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z0-9\_\-]*",
+                pattern="^[a-zA-Z0-9\\_\\-]*",
                 max_length=90,
                 min_length=1,
             ),
@@ -54,7 +54,7 @@ class Create(AAZCommand):
             help="Name of Microsoft Connected Cache for Enterprise resource.",
             required=True,
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z0-9\_\-]*",
+                pattern="^[a-zA-Z0-9\\_\\-]*",
                 max_length=90,
                 min_length=1,
             ),

--- a/src/mcc/azext_mcc/aaz/latest/mcc/isp/node/_delete.py
+++ b/src/mcc/azext_mcc/aaz/latest/mcc/isp/node/_delete.py
@@ -45,7 +45,7 @@ class Delete(AAZCommand):
             required=True,
             id_part="child_name_1",
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z0-9\_\-]*",
+                pattern="^[a-zA-Z0-9\\_\\-]*",
                 max_length=90,
                 min_length=1,
             ),
@@ -56,7 +56,7 @@ class Delete(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z0-9\_\-]*",
+                pattern="^[a-zA-Z0-9\\_\\-]*",
                 max_length=90,
                 min_length=1,
             ),

--- a/src/mcc/azext_mcc/aaz/latest/mcc/isp/node/_get_provisioning_details.py
+++ b/src/mcc/azext_mcc/aaz/latest/mcc/isp/node/_get_provisioning_details.py
@@ -44,7 +44,7 @@ class GetProvisioningDetails(AAZCommand):
             required=True,
             id_part="child_name_1",
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z0-9\_\-]*",
+                pattern="^[a-zA-Z0-9\\_\\-]*",
                 max_length=90,
                 min_length=1,
             ),
@@ -55,7 +55,7 @@ class GetProvisioningDetails(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z0-9\_\-]*",
+                pattern="^[a-zA-Z0-9\\_\\-]*",
                 max_length=90,
                 min_length=1,
             ),

--- a/src/mcc/azext_mcc/aaz/latest/mcc/isp/node/_list.py
+++ b/src/mcc/azext_mcc/aaz/latest/mcc/isp/node/_list.py
@@ -44,7 +44,7 @@ class List(AAZCommand):
             help="Name of Microsoft Connected Cache for Enterprise resource.",
             required=True,
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z0-9\_\-]*",
+                pattern="^[a-zA-Z0-9\\_\\-]*",
                 max_length=90,
                 min_length=1,
             ),

--- a/src/mcc/azext_mcc/aaz/latest/mcc/isp/node/_show.py
+++ b/src/mcc/azext_mcc/aaz/latest/mcc/isp/node/_show.py
@@ -44,7 +44,7 @@ class Show(AAZCommand):
             required=True,
             id_part="child_name_1",
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z0-9\_\-]*",
+                pattern="^[a-zA-Z0-9\\_\\-]*",
                 max_length=90,
                 min_length=1,
             ),
@@ -55,7 +55,7 @@ class Show(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z0-9\_\-]*",
+                pattern="^[a-zA-Z0-9\\_\\-]*",
                 max_length=90,
                 min_length=1,
             ),

--- a/src/mcc/azext_mcc/aaz/latest/mcc/isp/node/_update.py
+++ b/src/mcc/azext_mcc/aaz/latest/mcc/isp/node/_update.py
@@ -47,7 +47,7 @@ class Update(AAZCommand):
             required=True,
             id_part="child_name_1",
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z0-9\_\-]*",
+                pattern="^[a-zA-Z0-9\\_\\-]*",
                 max_length=90,
                 min_length=1,
             ),
@@ -58,7 +58,7 @@ class Update(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z0-9\_\-]*",
+                pattern="^[a-zA-Z0-9\\_\\-]*",
                 max_length=90,
                 min_length=1,
             ),

--- a/src/mcc/azext_mcc/aaz/latest/mcc/isp/resource/_create.py
+++ b/src/mcc/azext_mcc/aaz/latest/mcc/isp/resource/_create.py
@@ -44,7 +44,7 @@ class Create(AAZCommand):
             help="Name of Microsoft Connected Cache for Enterprise resource.",
             required=True,
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z0-9\_\-]*",
+                pattern="^[a-zA-Z0-9\\_\\-]*",
                 max_length=90,
                 min_length=1,
             ),
@@ -665,9 +665,7 @@ class _CreateHelper:
         )
 
         details = _schema_error_detail_read.details
-        details.Element = AAZObjectType(
-            flags={"read_only": True},
-        )
+        details.Element = AAZObjectType()
         cls._build_schema_error_detail_read(details.Element)
 
         _schema.additional_info = cls._schema_error_detail_read.additional_info

--- a/src/mcc/azext_mcc/aaz/latest/mcc/isp/resource/_delete.py
+++ b/src/mcc/azext_mcc/aaz/latest/mcc/isp/resource/_delete.py
@@ -45,7 +45,7 @@ class Delete(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z0-9\_\-]*",
+                pattern="^[a-zA-Z0-9\\_\\-]*",
                 max_length=90,
                 min_length=1,
             ),

--- a/src/mcc/azext_mcc/aaz/latest/mcc/isp/resource/_list.py
+++ b/src/mcc/azext_mcc/aaz/latest/mcc/isp/resource/_list.py
@@ -776,9 +776,7 @@ class _ListHelper:
         )
 
         details = _schema_error_detail_read.details
-        details.Element = AAZObjectType(
-            flags={"read_only": True},
-        )
+        details.Element = AAZObjectType()
         cls._build_schema_error_detail_read(details.Element)
 
         _schema.additional_info = cls._schema_error_detail_read.additional_info

--- a/src/mcc/azext_mcc/aaz/latest/mcc/isp/resource/_show.py
+++ b/src/mcc/azext_mcc/aaz/latest/mcc/isp/resource/_show.py
@@ -44,7 +44,7 @@ class Show(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z0-9\_\-]*",
+                pattern="^[a-zA-Z0-9\\_\\-]*",
                 max_length=90,
                 min_length=1,
             ),
@@ -446,9 +446,7 @@ class _ShowHelper:
         )
 
         details = _schema_error_detail_read.details
-        details.Element = AAZObjectType(
-            flags={"read_only": True},
-        )
+        details.Element = AAZObjectType()
         cls._build_schema_error_detail_read(details.Element)
 
         _schema.additional_info = cls._schema_error_detail_read.additional_info

--- a/src/mcc/azext_mcc/aaz/latest/mcc/isp/resource/_update.py
+++ b/src/mcc/azext_mcc/aaz/latest/mcc/isp/resource/_update.py
@@ -47,7 +47,7 @@ class Update(AAZCommand):
             required=True,
             id_part="name",
             fmt=AAZStrArgFormat(
-                pattern="^[a-zA-Z0-9\_\-]*",
+                pattern="^[a-zA-Z0-9\\_\\-]*",
                 max_length=90,
                 min_length=1,
             ),
@@ -565,9 +565,7 @@ class _UpdateHelper:
         )
 
         details = _schema_error_detail_read.details
-        details.Element = AAZObjectType(
-            flags={"read_only": True},
-        )
+        details.Element = AAZObjectType()
         cls._build_schema_error_detail_read(details.Element)
 
         _schema.additional_info = cls._schema_error_detail_read.additional_info

--- a/src/mcc/azext_mcc/azext_metadata.json
+++ b/src/mcc/azext_mcc/azext_metadata.json
@@ -1,4 +1,4 @@
 {
     "azext.isPreview": true,
-    "azext.minCliCoreVersion": "2.57.0"
+    "azext.minCliCoreVersion": "2.61.0"
 }

--- a/src/mcc/setup.py
+++ b/src/mcc/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 
 
 # HISTORY.rst entry.
-VERSION = '1.0.0b1'
+VERSION = '1.0.0b2'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Change is_preview flags on all commands to true and increment mcc version to v1.0.0b2 from v1.0.0b1.

We are in public preview and we did not want the auto generated docs to say we were in GA and this is what was recommended we do in the teams channel.
 
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
