### PR TITLE
Add dependency on configobj==5.0.8: rdbms-connect

### DIFF
--- a/src/rdbms-connect/HISTORY.rst
+++ b/src/rdbms-connect/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+1.0.8
+++++++
++ Add configobj dependency
+
 1.0.7
 ++++++
 + Remove msrestazure dependency

--- a/src/rdbms-connect/setup.py
+++ b/src/rdbms-connect/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
-VERSION = '1.0.7'
+VERSION = '1.0.8'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
@@ -39,7 +39,8 @@ DEPENDENCIES = [
     'setproctitle~=1.3.3',
     'psycopg2~=2.9.3',
     'mycli~=1.27.0',
-    'pgcli==4.0.1'
+    'pgcli==4.0.1',
+    'configobj==5.0.8'
 ]
 
 with open('README.rst', 'r', encoding='utf-8') as f:


### PR DESCRIPTION
Issue found in #8264
 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
`az extension add --name rdbms-connect`


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
