### PR TITLE
Change to new azurearcdata whl link

### DIFF
--- a/src/azure-firewall/azext_firewall/tests/latest/recordings/test_firewall_v2.yaml
+++ b/src/azure-firewall/azext_firewall/tests/latest/recordings/test_firewall_v2.yaml
@@ -6230,7 +6230,7 @@ interactions:
         Extension\",\n                    \"version\": \"0.2.31\"\n                },\n
         \               \"sha256Digest\": \"bf5bc6569b94c744acc417831b8dc58055a8e8437492231f2bca4cf0752e34ad\"\n
         \           }\n        ],\n        \"arcdata\": [\n            {\n                \"downloadUrl\":
-        \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.12-py2.py3-none-any.whl\",\n
+        \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.12-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.4.12-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6262,7 +6262,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.4.12\"\n
         \               },\n                \"sha256Digest\": \"f25bba4a4893c86eb1bb97ce7756ccff52414979f06b796ec881017a95811e04\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.11-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.11-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.4.11-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6294,7 +6294,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.4.11\"\n
         \               },\n                \"sha256Digest\": \"658b8e1a70644c140d05552f81ba22e04cdf523e48bb0123b83d16ba77369e2f\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.10-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.10-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.4.10-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6326,7 +6326,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.4.10\"\n
         \               },\n                \"sha256Digest\": \"5a66ae32b6fe2bf76ec9174f7c22ac1fac2325dea06f8e8ba46496d4ac24aa09\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.9-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.9-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.4.9-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6358,7 +6358,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.4.9\"\n
         \               },\n                \"sha256Digest\": \"e41a664bc431ced3fa5b4988c0155d124b93bbe74a828f0c26e28a4e5dc64c86\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.8-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.8-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.4.8-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6390,7 +6390,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.4.8\"\n
         \               },\n                \"sha256Digest\": \"de3b3b1675508c65cd65adfc3626a732f1c54df4abddb4d37de1df034076c22a\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.7-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.7-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.4.7-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6422,7 +6422,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.4.7\"\n
         \               },\n                \"sha256Digest\": \"cc93f2e345df2612dae91f5794ffbd5308a5c3649a9fb0d5d15dd07577b9ce8a\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.6-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.6-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.4.6-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6454,7 +6454,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.4.6\"\n
         \               },\n                \"sha256Digest\": \"d4111d3dc70de9c13e55becb3844f5fe1cf70e496c925a6b6e2d6c7db1666594\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.5-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.5-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.4.5-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6486,7 +6486,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.4.5\"\n
         \               },\n                \"sha256Digest\": \"707adc5e23d30706b53ae2a660f74fbd58ac087b21530d86d9f32be41f0e5adb\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.4-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.4-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.4.4-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6518,7 +6518,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.4.4\"\n
         \               },\n                \"sha256Digest\": \"43a1bf1f68b90484f6eae647e25e87ef6b03cb722f43c1917ef6bf8e5d919e8f\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.3-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.3-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.4.3-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6550,7 +6550,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.4.3\"\n
         \               },\n                \"sha256Digest\": \"2248da81432c9e2be1ce5a70c7288a6feb1f785256c19cb51bec934252401ee6\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.2-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.2-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.4.2-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6582,7 +6582,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.4.2\"\n
         \               },\n                \"sha256Digest\": \"f5c0a29bda9f7e914347dc00481c89d21dea17abf98d1038ec0c7fa337049d97\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.1-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.1-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.4.1-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6614,7 +6614,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.4.1\"\n
         \               },\n                \"sha256Digest\": \"702c8b02f0a2e2d3ad9110ec464ce04619a972d52875b76f839d1b3e0ce3817e\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.0-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.0-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.4.0-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6646,7 +6646,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.4.0\"\n
         \               },\n                \"sha256Digest\": \"26e67d2d3920902c12330a53f831d7916a1461926c0efd3b7929416bd04c78b0\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.3.1-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.3.1-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.3.1-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6678,7 +6678,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.3.1\"\n
         \               },\n                \"sha256Digest\": \"c7040d903665c23b592462225ad32bdff90af40a99fa73ba440b87857c3e1e5b\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.3.0-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.3.0-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.3.0-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6710,7 +6710,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.3.0\"\n
         \               },\n                \"sha256Digest\": \"abb61b170c3b830212f12bcb199e5d5106e7cb6ff880b7f7793ce1359667d072\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.2.3-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.2.3-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.2.3-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6743,7 +6743,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.2.3\"\n
         \               },\n                \"sha256Digest\": \"b4757151ad2796cac8fcc43a363c0fbbf5de270f043d8fd8ccd51b377abfd61c\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.2.2-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.2.2-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.2.2-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6776,7 +6776,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.2.2\"\n
         \               },\n                \"sha256Digest\": \"2011cf5d186b713df3b14c09cfb63e52e843c015f0cc4a7ff558b161c9e225cf\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.2.1-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.2.1-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.2.1-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6809,7 +6809,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.2.1\"\n
         \               },\n                \"sha256Digest\": \"0d5bfcbed4e418f5ce79377a2e392f5f61abb0d5e6f8ce164940b83b5cfdbcd5\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.2.0-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.2.0-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.2.0-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6842,7 +6842,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.2.0\"\n
         \               },\n                \"sha256Digest\": \"308d953ecabc7b59fa6b3e545404279bc18376b8c129580124c443e866e3cb54\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.1.3-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.1.3-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.1.3-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6875,7 +6875,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.1.3\"\n
         \               },\n                \"sha256Digest\": \"63573d92742ab3ff2cdb73de39ea17821d3044503382c528e39a28f6224b8acb\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.1.2-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.1.2-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.1.2-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6908,7 +6908,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.1.2\"\n
         \               },\n                \"sha256Digest\": \"ffcb38d3653195dc30ce93066b5aff3ff7037be81232db4afcb11ef99f3de844\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.1.1-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.1.1-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.1.1-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6941,7 +6941,7 @@ interactions:
         (==4.8.0)\"\n                            ]\n                        }\n                    ],\n
         \                   \"summary\": \"Tools for managing ArcData.\",\n                    \"version\":
         \"1.1.1\"\n                },\n                \"sha256Digest\": \"1cb2dcfadd539cdc7f6acbfcd44db5f7d380ec9a896f5eaa47ebabbe89786d07\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.1.0-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.1.0-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.1.0-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6974,7 +6974,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.1.0\"\n
         \               },\n                \"sha256Digest\": \"dedb4ac6de099d8fd565d427ac339cc23a10be76ca0147f6babec6096fc377e7\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.0.0-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.0.0-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.0.0-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -7006,7 +7006,7 @@ interactions:
         (==4.8.0)\"\n                            ]\n                        }\n                    ],\n
         \                   \"summary\": \"Tools for managing ArcData.\",\n                    \"version\":
         \"1.0.0\"\n                },\n                \"sha256Digest\": \"4045fabe61c0287003a4626d0f8d27c2839b3575a63ce2bdfe57ed214171acf8\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-0.0.2-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-0.0.2-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-0.0.2-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.isPreview\":
         true,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n                    \"classifiers\":
@@ -7038,7 +7038,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"0.0.2\"\n
         \               },\n                \"sha256Digest\": \"d14aa3046b7a9c3bca67c735eeb35fb24ff5ed240212724d3f229eb23280abae\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-0.0.1-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-0.0.1-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-0.0.1-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development

--- a/src/azure-firewall/azext_firewall/tests/latest/recordings/test_firewall_v2.yaml
+++ b/src/azure-firewall/azext_firewall/tests/latest/recordings/test_firewall_v2.yaml
@@ -6230,7 +6230,7 @@ interactions:
         Extension\",\n                    \"version\": \"0.2.31\"\n                },\n
         \               \"sha256Digest\": \"bf5bc6569b94c744acc417831b8dc58055a8e8437492231f2bca4cf0752e34ad\"\n
         \           }\n        ],\n        \"arcdata\": [\n            {\n                \"downloadUrl\":
-        \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.12-py2.py3-none-any.whl\",\n
+        \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.12-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.4.12-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6262,7 +6262,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.4.12\"\n
         \               },\n                \"sha256Digest\": \"f25bba4a4893c86eb1bb97ce7756ccff52414979f06b796ec881017a95811e04\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.11-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.11-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.4.11-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6294,7 +6294,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.4.11\"\n
         \               },\n                \"sha256Digest\": \"658b8e1a70644c140d05552f81ba22e04cdf523e48bb0123b83d16ba77369e2f\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.10-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.10-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.4.10-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6326,7 +6326,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.4.10\"\n
         \               },\n                \"sha256Digest\": \"5a66ae32b6fe2bf76ec9174f7c22ac1fac2325dea06f8e8ba46496d4ac24aa09\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.9-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.9-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.4.9-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6358,7 +6358,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.4.9\"\n
         \               },\n                \"sha256Digest\": \"e41a664bc431ced3fa5b4988c0155d124b93bbe74a828f0c26e28a4e5dc64c86\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.8-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.8-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.4.8-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6390,7 +6390,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.4.8\"\n
         \               },\n                \"sha256Digest\": \"de3b3b1675508c65cd65adfc3626a732f1c54df4abddb4d37de1df034076c22a\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.7-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.7-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.4.7-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6422,7 +6422,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.4.7\"\n
         \               },\n                \"sha256Digest\": \"cc93f2e345df2612dae91f5794ffbd5308a5c3649a9fb0d5d15dd07577b9ce8a\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.6-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.6-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.4.6-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6454,7 +6454,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.4.6\"\n
         \               },\n                \"sha256Digest\": \"d4111d3dc70de9c13e55becb3844f5fe1cf70e496c925a6b6e2d6c7db1666594\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.5-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.5-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.4.5-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6486,7 +6486,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.4.5\"\n
         \               },\n                \"sha256Digest\": \"707adc5e23d30706b53ae2a660f74fbd58ac087b21530d86d9f32be41f0e5adb\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.4-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.4-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.4.4-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6518,7 +6518,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.4.4\"\n
         \               },\n                \"sha256Digest\": \"43a1bf1f68b90484f6eae647e25e87ef6b03cb722f43c1917ef6bf8e5d919e8f\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.3-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.3-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.4.3-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6550,7 +6550,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.4.3\"\n
         \               },\n                \"sha256Digest\": \"2248da81432c9e2be1ce5a70c7288a6feb1f785256c19cb51bec934252401ee6\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.2-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.2-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.4.2-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6582,7 +6582,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.4.2\"\n
         \               },\n                \"sha256Digest\": \"f5c0a29bda9f7e914347dc00481c89d21dea17abf98d1038ec0c7fa337049d97\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.1-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.1-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.4.1-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6614,7 +6614,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.4.1\"\n
         \               },\n                \"sha256Digest\": \"702c8b02f0a2e2d3ad9110ec464ce04619a972d52875b76f839d1b3e0ce3817e\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.0-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.0-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.4.0-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6646,7 +6646,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.4.0\"\n
         \               },\n                \"sha256Digest\": \"26e67d2d3920902c12330a53f831d7916a1461926c0efd3b7929416bd04c78b0\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.3.1-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.3.1-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.3.1-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6678,7 +6678,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.3.1\"\n
         \               },\n                \"sha256Digest\": \"c7040d903665c23b592462225ad32bdff90af40a99fa73ba440b87857c3e1e5b\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.3.0-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.3.0-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.3.0-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6710,7 +6710,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.3.0\"\n
         \               },\n                \"sha256Digest\": \"abb61b170c3b830212f12bcb199e5d5106e7cb6ff880b7f7793ce1359667d072\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.2.3-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.2.3-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.2.3-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6743,7 +6743,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.2.3\"\n
         \               },\n                \"sha256Digest\": \"b4757151ad2796cac8fcc43a363c0fbbf5de270f043d8fd8ccd51b377abfd61c\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.2.2-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.2.2-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.2.2-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6776,7 +6776,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.2.2\"\n
         \               },\n                \"sha256Digest\": \"2011cf5d186b713df3b14c09cfb63e52e843c015f0cc4a7ff558b161c9e225cf\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.2.1-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.2.1-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.2.1-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6809,7 +6809,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.2.1\"\n
         \               },\n                \"sha256Digest\": \"0d5bfcbed4e418f5ce79377a2e392f5f61abb0d5e6f8ce164940b83b5cfdbcd5\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.2.0-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.2.0-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.2.0-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6842,7 +6842,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.2.0\"\n
         \               },\n                \"sha256Digest\": \"308d953ecabc7b59fa6b3e545404279bc18376b8c129580124c443e866e3cb54\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.1.3-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.1.3-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.1.3-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6875,7 +6875,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.1.3\"\n
         \               },\n                \"sha256Digest\": \"63573d92742ab3ff2cdb73de39ea17821d3044503382c528e39a28f6224b8acb\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.1.2-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.1.2-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.1.2-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6908,7 +6908,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.1.2\"\n
         \               },\n                \"sha256Digest\": \"ffcb38d3653195dc30ce93066b5aff3ff7037be81232db4afcb11ef99f3de844\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.1.1-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.1.1-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.1.1-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6941,7 +6941,7 @@ interactions:
         (==4.8.0)\"\n                            ]\n                        }\n                    ],\n
         \                   \"summary\": \"Tools for managing ArcData.\",\n                    \"version\":
         \"1.1.1\"\n                },\n                \"sha256Digest\": \"1cb2dcfadd539cdc7f6acbfcd44db5f7d380ec9a896f5eaa47ebabbe89786d07\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.1.0-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.1.0-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.1.0-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -6974,7 +6974,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"1.1.0\"\n
         \               },\n                \"sha256Digest\": \"dedb4ac6de099d8fd565d427ac339cc23a10be76ca0147f6babec6096fc377e7\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.0.0-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.0.0-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-1.0.0-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development
@@ -7006,7 +7006,7 @@ interactions:
         (==4.8.0)\"\n                            ]\n                        }\n                    ],\n
         \                   \"summary\": \"Tools for managing ArcData.\",\n                    \"version\":
         \"1.0.0\"\n                },\n                \"sha256Digest\": \"4045fabe61c0287003a4626d0f8d27c2839b3575a63ce2bdfe57ed214171acf8\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-0.0.2-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-0.0.2-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-0.0.2-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.isPreview\":
         true,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n                    \"classifiers\":
@@ -7038,7 +7038,7 @@ interactions:
         \                       }\n                    ],\n                    \"summary\":
         \"Tools for managing ArcData.\",\n                    \"version\": \"0.0.2\"\n
         \               },\n                \"sha256Digest\": \"d14aa3046b7a9c3bca67c735eeb35fb24ff5ed240212724d3f229eb23280abae\"\n
-        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-0.0.1-py2.py3-none-any.whl\",\n
+        \           },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-0.0.1-py2.py3-none-any.whl\",\n
         \               \"filename\": \"arcdata-0.0.1-py2.py3-none-any.whl\",\n                \"metadata\":
         {\n                    \"azext.isExperimental\": false,\n                    \"azext.minCliCoreVersion\":
         \"2.3.1\",\n                    \"classifiers\": [\n                        \"Development

--- a/src/azure-firewall/azext_firewall/tests/latest/recordings/test_firewall_with_route_server.yaml
+++ b/src/azure-firewall/azext_firewall/tests/latest/recordings/test_firewall_with_route_server.yaml
@@ -7969,7 +7969,7 @@ interactions:
         \                    \"version\": \"0.2.32\"\n                },\n       \
         \         \"sha256Digest\": \"57dda9d482808104f7261e56d2aec722971d22fb46eee0d81fa8dcc219a3179c\"\
         \n            }\n        ],\n        \"arcdata\": [\n            {\n     \
-        \           \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.5.3-py2.py3-none-any.whl\"\
+        \           \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.5.3-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.5.3-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8007,7 +8007,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.5.3\"\n     \
         \           },\n                \"sha256Digest\": \"4c420b270d32c1b2c70ec1e6496fdad07bfd311be159638f44a97d159449183c\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.5.2-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.5.2-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.5.2-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8045,7 +8045,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.5.2\"\n     \
         \           },\n                \"sha256Digest\": \"d5b4fabc9f1285c4060c45195de8aae8e7b68f54369f998bc7036cde0fd622a5\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.5.1-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.5.1-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.5.1-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8083,7 +8083,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.5.1\"\n     \
         \           },\n                \"sha256Digest\": \"1d5d6d3ff7c18a7ce6ccdc5ac3dd4fc38b7b028fa9cf2e03ab58a05e6b733081\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.5.0-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.5.0-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.5.0-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8121,7 +8121,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.5.0\"\n     \
         \           },\n                \"sha256Digest\": \"9b1fd4f95a69ce545586d4bebdd7a1e561d966f1a2569a99c50f18ce9d91c0e2\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.13-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.13-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.4.13-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8159,7 +8159,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.4.13\"\n    \
         \            },\n                \"sha256Digest\": \"4241f12e3e45007cc55ded3361527ee8f67c683486039185c8a6075b75a8d35c\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.12-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.12-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.4.12-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8197,7 +8197,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.4.12\"\n    \
         \            },\n                \"sha256Digest\": \"f25bba4a4893c86eb1bb97ce7756ccff52414979f06b796ec881017a95811e04\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.11-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.11-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.4.11-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8235,7 +8235,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.4.11\"\n    \
         \            },\n                \"sha256Digest\": \"658b8e1a70644c140d05552f81ba22e04cdf523e48bb0123b83d16ba77369e2f\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.10-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.10-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.4.10-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8273,7 +8273,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.4.10\"\n    \
         \            },\n                \"sha256Digest\": \"5a66ae32b6fe2bf76ec9174f7c22ac1fac2325dea06f8e8ba46496d4ac24aa09\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.9-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.9-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.4.9-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8311,7 +8311,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.4.9\"\n     \
         \           },\n                \"sha256Digest\": \"e41a664bc431ced3fa5b4988c0155d124b93bbe74a828f0c26e28a4e5dc64c86\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.8-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.8-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.4.8-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8349,7 +8349,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.4.8\"\n     \
         \           },\n                \"sha256Digest\": \"de3b3b1675508c65cd65adfc3626a732f1c54df4abddb4d37de1df034076c22a\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.7-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.7-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.4.7-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8387,7 +8387,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.4.7\"\n     \
         \           },\n                \"sha256Digest\": \"cc93f2e345df2612dae91f5794ffbd5308a5c3649a9fb0d5d15dd07577b9ce8a\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.6-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.6-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.4.6-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8425,7 +8425,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.4.6\"\n     \
         \           },\n                \"sha256Digest\": \"d4111d3dc70de9c13e55becb3844f5fe1cf70e496c925a6b6e2d6c7db1666594\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.5-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.5-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.4.5-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8463,7 +8463,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.4.5\"\n     \
         \           },\n                \"sha256Digest\": \"707adc5e23d30706b53ae2a660f74fbd58ac087b21530d86d9f32be41f0e5adb\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.4-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.4-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.4.4-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8501,7 +8501,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.4.4\"\n     \
         \           },\n                \"sha256Digest\": \"43a1bf1f68b90484f6eae647e25e87ef6b03cb722f43c1917ef6bf8e5d919e8f\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.3-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.3-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.4.3-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8539,7 +8539,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.4.3\"\n     \
         \           },\n                \"sha256Digest\": \"2248da81432c9e2be1ce5a70c7288a6feb1f785256c19cb51bec934252401ee6\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.2-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.2-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.4.2-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8577,7 +8577,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.4.2\"\n     \
         \           },\n                \"sha256Digest\": \"f5c0a29bda9f7e914347dc00481c89d21dea17abf98d1038ec0c7fa337049d97\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.1-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.1-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.4.1-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8615,7 +8615,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.4.1\"\n     \
         \           },\n                \"sha256Digest\": \"702c8b02f0a2e2d3ad9110ec464ce04619a972d52875b76f839d1b3e0ce3817e\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.0-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.0-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.4.0-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8653,7 +8653,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.4.0\"\n     \
         \           },\n                \"sha256Digest\": \"26e67d2d3920902c12330a53f831d7916a1461926c0efd3b7929416bd04c78b0\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.3.1-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.3.1-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.3.1-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8691,7 +8691,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.3.1\"\n     \
         \           },\n                \"sha256Digest\": \"c7040d903665c23b592462225ad32bdff90af40a99fa73ba440b87857c3e1e5b\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.3.0-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.3.0-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.3.0-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8729,7 +8729,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.3.0\"\n     \
         \           },\n                \"sha256Digest\": \"abb61b170c3b830212f12bcb199e5d5106e7cb6ff880b7f7793ce1359667d072\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.2.3-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.2.3-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.2.3-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8768,7 +8768,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.2.3\"\n     \
         \           },\n                \"sha256Digest\": \"b4757151ad2796cac8fcc43a363c0fbbf5de270f043d8fd8ccd51b377abfd61c\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.2.2-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.2.2-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.2.2-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8807,7 +8807,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.2.2\"\n     \
         \           },\n                \"sha256Digest\": \"2011cf5d186b713df3b14c09cfb63e52e843c015f0cc4a7ff558b161c9e225cf\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.2.1-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.2.1-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.2.1-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8846,7 +8846,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.2.1\"\n     \
         \           },\n                \"sha256Digest\": \"0d5bfcbed4e418f5ce79377a2e392f5f61abb0d5e6f8ce164940b83b5cfdbcd5\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.2.0-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.2.0-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.2.0-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8885,7 +8885,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.2.0\"\n     \
         \           },\n                \"sha256Digest\": \"308d953ecabc7b59fa6b3e545404279bc18376b8c129580124c443e866e3cb54\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.1.3-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.1.3-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.1.3-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8924,7 +8924,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.1.3\"\n     \
         \           },\n                \"sha256Digest\": \"63573d92742ab3ff2cdb73de39ea17821d3044503382c528e39a28f6224b8acb\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.1.2-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.1.2-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.1.2-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8963,7 +8963,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.1.2\"\n     \
         \           },\n                \"sha256Digest\": \"ffcb38d3653195dc30ce93066b5aff3ff7037be81232db4afcb11ef99f3de844\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.1.1-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.1.1-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.1.1-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -9003,7 +9003,7 @@ interactions:
         \       ],\n                    \"summary\": \"Tools for managing ArcData.\"\
         ,\n                    \"version\": \"1.1.1\"\n                },\n      \
         \          \"sha256Digest\": \"1cb2dcfadd539cdc7f6acbfcd44db5f7d380ec9a896f5eaa47ebabbe89786d07\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.1.0-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.1.0-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.1.0-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -9042,7 +9042,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.1.0\"\n     \
         \           },\n                \"sha256Digest\": \"dedb4ac6de099d8fd565d427ac339cc23a10be76ca0147f6babec6096fc377e7\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.0.0-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.0.0-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.0.0-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -9080,7 +9080,7 @@ interactions:
         \                 }\n                    ],\n                    \"summary\"\
         : \"Tools for managing ArcData.\",\n                    \"version\": \"1.0.0\"\
         \n                },\n                \"sha256Digest\": \"4045fabe61c0287003a4626d0f8d27c2839b3575a63ce2bdfe57ed214171acf8\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-0.0.2-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-0.0.2-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-0.0.2-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.isPreview\": true,\n               \
@@ -9118,7 +9118,7 @@ interactions:
         \   ],\n                    \"summary\": \"Tools for managing ArcData.\",\n\
         \                    \"version\": \"0.0.2\"\n                },\n        \
         \        \"sha256Digest\": \"d14aa3046b7a9c3bca67c735eeb35fb24ff5ed240212724d3f229eb23280abae\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-0.0.1-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-0.0.1-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-0.0.1-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \

--- a/src/azure-firewall/azext_firewall/tests/latest/recordings/test_firewall_with_route_server.yaml
+++ b/src/azure-firewall/azext_firewall/tests/latest/recordings/test_firewall_with_route_server.yaml
@@ -7969,7 +7969,7 @@ interactions:
         \                    \"version\": \"0.2.32\"\n                },\n       \
         \         \"sha256Digest\": \"57dda9d482808104f7261e56d2aec722971d22fb46eee0d81fa8dcc219a3179c\"\
         \n            }\n        ],\n        \"arcdata\": [\n            {\n     \
-        \           \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.5.3-py2.py3-none-any.whl\"\
+        \           \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.5.3-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.5.3-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8007,7 +8007,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.5.3\"\n     \
         \           },\n                \"sha256Digest\": \"4c420b270d32c1b2c70ec1e6496fdad07bfd311be159638f44a97d159449183c\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.5.2-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.5.2-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.5.2-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8045,7 +8045,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.5.2\"\n     \
         \           },\n                \"sha256Digest\": \"d5b4fabc9f1285c4060c45195de8aae8e7b68f54369f998bc7036cde0fd622a5\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.5.1-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.5.1-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.5.1-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8083,7 +8083,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.5.1\"\n     \
         \           },\n                \"sha256Digest\": \"1d5d6d3ff7c18a7ce6ccdc5ac3dd4fc38b7b028fa9cf2e03ab58a05e6b733081\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.5.0-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.5.0-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.5.0-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8121,7 +8121,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.5.0\"\n     \
         \           },\n                \"sha256Digest\": \"9b1fd4f95a69ce545586d4bebdd7a1e561d966f1a2569a99c50f18ce9d91c0e2\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.13-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.13-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.4.13-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8159,7 +8159,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.4.13\"\n    \
         \            },\n                \"sha256Digest\": \"4241f12e3e45007cc55ded3361527ee8f67c683486039185c8a6075b75a8d35c\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.12-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.12-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.4.12-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8197,7 +8197,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.4.12\"\n    \
         \            },\n                \"sha256Digest\": \"f25bba4a4893c86eb1bb97ce7756ccff52414979f06b796ec881017a95811e04\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.11-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.11-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.4.11-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8235,7 +8235,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.4.11\"\n    \
         \            },\n                \"sha256Digest\": \"658b8e1a70644c140d05552f81ba22e04cdf523e48bb0123b83d16ba77369e2f\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.10-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.10-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.4.10-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8273,7 +8273,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.4.10\"\n    \
         \            },\n                \"sha256Digest\": \"5a66ae32b6fe2bf76ec9174f7c22ac1fac2325dea06f8e8ba46496d4ac24aa09\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.9-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.9-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.4.9-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8311,7 +8311,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.4.9\"\n     \
         \           },\n                \"sha256Digest\": \"e41a664bc431ced3fa5b4988c0155d124b93bbe74a828f0c26e28a4e5dc64c86\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.8-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.8-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.4.8-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8349,7 +8349,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.4.8\"\n     \
         \           },\n                \"sha256Digest\": \"de3b3b1675508c65cd65adfc3626a732f1c54df4abddb4d37de1df034076c22a\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.7-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.7-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.4.7-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8387,7 +8387,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.4.7\"\n     \
         \           },\n                \"sha256Digest\": \"cc93f2e345df2612dae91f5794ffbd5308a5c3649a9fb0d5d15dd07577b9ce8a\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.6-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.6-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.4.6-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8425,7 +8425,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.4.6\"\n     \
         \           },\n                \"sha256Digest\": \"d4111d3dc70de9c13e55becb3844f5fe1cf70e496c925a6b6e2d6c7db1666594\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.5-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.5-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.4.5-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8463,7 +8463,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.4.5\"\n     \
         \           },\n                \"sha256Digest\": \"707adc5e23d30706b53ae2a660f74fbd58ac087b21530d86d9f32be41f0e5adb\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.4-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.4-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.4.4-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8501,7 +8501,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.4.4\"\n     \
         \           },\n                \"sha256Digest\": \"43a1bf1f68b90484f6eae647e25e87ef6b03cb722f43c1917ef6bf8e5d919e8f\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.3-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.3-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.4.3-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8539,7 +8539,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.4.3\"\n     \
         \           },\n                \"sha256Digest\": \"2248da81432c9e2be1ce5a70c7288a6feb1f785256c19cb51bec934252401ee6\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.2-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.2-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.4.2-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8577,7 +8577,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.4.2\"\n     \
         \           },\n                \"sha256Digest\": \"f5c0a29bda9f7e914347dc00481c89d21dea17abf98d1038ec0c7fa337049d97\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.1-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.1-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.4.1-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8615,7 +8615,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.4.1\"\n     \
         \           },\n                \"sha256Digest\": \"702c8b02f0a2e2d3ad9110ec464ce04619a972d52875b76f839d1b3e0ce3817e\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.4.0-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.4.0-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.4.0-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8653,7 +8653,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.4.0\"\n     \
         \           },\n                \"sha256Digest\": \"26e67d2d3920902c12330a53f831d7916a1461926c0efd3b7929416bd04c78b0\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.3.1-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.3.1-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.3.1-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8691,7 +8691,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.3.1\"\n     \
         \           },\n                \"sha256Digest\": \"c7040d903665c23b592462225ad32bdff90af40a99fa73ba440b87857c3e1e5b\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.3.0-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.3.0-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.3.0-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8729,7 +8729,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.3.0\"\n     \
         \           },\n                \"sha256Digest\": \"abb61b170c3b830212f12bcb199e5d5106e7cb6ff880b7f7793ce1359667d072\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.2.3-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.2.3-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.2.3-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8768,7 +8768,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.2.3\"\n     \
         \           },\n                \"sha256Digest\": \"b4757151ad2796cac8fcc43a363c0fbbf5de270f043d8fd8ccd51b377abfd61c\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.2.2-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.2.2-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.2.2-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8807,7 +8807,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.2.2\"\n     \
         \           },\n                \"sha256Digest\": \"2011cf5d186b713df3b14c09cfb63e52e843c015f0cc4a7ff558b161c9e225cf\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.2.1-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.2.1-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.2.1-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8846,7 +8846,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.2.1\"\n     \
         \           },\n                \"sha256Digest\": \"0d5bfcbed4e418f5ce79377a2e392f5f61abb0d5e6f8ce164940b83b5cfdbcd5\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.2.0-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.2.0-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.2.0-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8885,7 +8885,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.2.0\"\n     \
         \           },\n                \"sha256Digest\": \"308d953ecabc7b59fa6b3e545404279bc18376b8c129580124c443e866e3cb54\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.1.3-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.1.3-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.1.3-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8924,7 +8924,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.1.3\"\n     \
         \           },\n                \"sha256Digest\": \"63573d92742ab3ff2cdb73de39ea17821d3044503382c528e39a28f6224b8acb\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.1.2-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.1.2-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.1.2-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -8963,7 +8963,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.1.2\"\n     \
         \           },\n                \"sha256Digest\": \"ffcb38d3653195dc30ce93066b5aff3ff7037be81232db4afcb11ef99f3de844\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.1.1-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.1.1-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.1.1-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -9003,7 +9003,7 @@ interactions:
         \       ],\n                    \"summary\": \"Tools for managing ArcData.\"\
         ,\n                    \"version\": \"1.1.1\"\n                },\n      \
         \          \"sha256Digest\": \"1cb2dcfadd539cdc7f6acbfcd44db5f7d380ec9a896f5eaa47ebabbe89786d07\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.1.0-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.1.0-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.1.0-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -9042,7 +9042,7 @@ interactions:
         \  }\n                    ],\n                    \"summary\": \"Tools for\
         \ managing ArcData.\",\n                    \"version\": \"1.1.0\"\n     \
         \           },\n                \"sha256Digest\": \"dedb4ac6de099d8fd565d427ac339cc23a10be76ca0147f6babec6096fc377e7\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-1.0.0-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.0.0-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-1.0.0-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \
@@ -9080,7 +9080,7 @@ interactions:
         \                 }\n                    ],\n                    \"summary\"\
         : \"Tools for managing ArcData.\",\n                    \"version\": \"1.0.0\"\
         \n                },\n                \"sha256Digest\": \"4045fabe61c0287003a4626d0f8d27c2839b3575a63ce2bdfe57ed214171acf8\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-0.0.2-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-0.0.2-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-0.0.2-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.isPreview\": true,\n               \
@@ -9118,7 +9118,7 @@ interactions:
         \   ],\n                    \"summary\": \"Tools for managing ArcData.\",\n\
         \                    \"version\": \"0.0.2\"\n                },\n        \
         \        \"sha256Digest\": \"d14aa3046b7a9c3bca67c735eeb35fb24ff5ed240212724d3f229eb23280abae\"\
-        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.blob.core.windows.net/cli-extensions/arcdata-0.0.1-py2.py3-none-any.whl\"\
+        \n            },\n            {\n                \"downloadUrl\": \"https://azurearcdatacli.z13.web.core.windows.net/arcdata-0.0.1-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"arcdata-0.0.1-py2.py3-none-any.whl\",\n\
         \                \"metadata\": {\n                    \"azext.isExperimental\"\
         : false,\n                    \"azext.minCliCoreVersion\": \"2.3.1\",\n  \


### PR DESCRIPTION
---
### Description
Update links to arcdata whl files as we are moving the files to a different location with the motive to remove the old locations.

### Related command
az extension add --name arcdata


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
