### PR TITLE
Update list-template.md | fix metadata to conform to new guidelines

### DIFF
--- a/scripts/ci/avail-ext-doc/list-template.md
+++ b/scripts/ci/avail-ext-doc/list-template.md
@@ -5,7 +5,7 @@ author: haroldrandom
 ms.author: jianzen
 manager: yonzhan,yungezz
 ms.date: {{ date }}
-ms.topic: language-reference
+ms.topic: generated-reference
 ms.service: azure-cli
 ms.custom: devx-track-azurecli
 ---

--- a/scripts/ci/avail-ext-doc/list-template.md
+++ b/scripts/ci/avail-ext-doc/list-template.md
@@ -5,12 +5,9 @@ author: haroldrandom
 ms.author: jianzen
 manager: yonzhan,yungezz
 ms.date: {{ date }}
-ms.topic: article
+ms.topic: language-reference
 ms.service: azure-cli
-ms.devlang: azure-cli
-ms.tool: azure-cli
 ms.custom: devx-track-azurecli
-keywords: az extension, azure cli extensions, azure extensions
 ---
 
 # Available Azure CLI extensions


### PR DESCRIPTION
According to the allowed values for `ms.topic` as now showing in the Contributor's Guide (https://review.learn.microsoft.com/en-us/help/platform/metadata-taxonomies/mstopic?branch=main), the ms.topic for autogenerated reference content should be `language-reference`. By making this update, the available extensions report will also be removed from MSFT's broken link report. We'll still be able to monitor broken links from the azure-docs-cli repo's daily build report.

Second, the ms.devlang, ms.tool and keyword metadata has been deprecated.

**This PR fixes the following build error:**

![image](https://github.com/user-attachments/assets/b896fb11-0d55-4a62-af75-569a8f0b8488)

