### PR TITLE
[DataMigration]: Update SQL Assessment Console App Package Download URL.

### DIFF
--- a/src/datamigration/HISTORY.rst
+++ b/src/datamigration/HISTORY.rst
@@ -4,6 +4,11 @@ Release History
 ===============
 
 =======
+1.0.0b3
+++++++
+* Updated the URL to download the SQL Assessment Zip to `https://aka.ms/sqlassessmentpackage`
+
+=======
 1.0.0b2
 ++++++
 * Minor bug fixes and improvements.

--- a/src/datamigration/azext_datamigration/manual/helper.py
+++ b/src/datamigration/azext_datamigration/manual/helper.py
@@ -279,7 +279,7 @@ def check_and_download_console_app(exePath, baseFolder):
 
     # Downloading console app zip and extracting it
     if not testPath:
-        zipSource = "https://sqlassess.blob.core.windows.net/app/SqlAssessment.zip"
+        zipSource = "https://aka.ms/sqlassessmentpackage"
         zipDestination = os.path.join(baseFolder, "SqlAssessment.zip")
 
         urllib.request.urlretrieve(zipSource, filename=zipDestination)

--- a/src/datamigration/setup.py
+++ b/src/datamigration/setup.py
@@ -10,7 +10,7 @@ from codecs import open
 from setuptools import setup, find_packages
 
 # HISTORY.rst entry.
-VERSION = '1.0.0b2'
+VERSION = '1.0.0b3'
 try:
     from azext_datamigration.manual.version import VERSION
 except ImportError:


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Description

- The URL for downloading the SQL Assessment Zip has been updated to https://aka.ms/sqlassessmentpackage.
- The URL https://aka.ms/sqlassessmentpackage now redirects to the actual download URL: https://sqlassess.z13.web.core.windows.net/SqlAssessment.zip.
- This change ensures that the PowerShell module will not require any code modifications in the future, even if the actual download URL changes.


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
