### PR TITLE
[Containerapp] `az containerapp create/update`: Fix --bind/--unbind when cloud is not AzureCloud

### DIFF
--- a/src/containerapp/HISTORY.rst
+++ b/src/containerapp/HISTORY.rst
@@ -4,6 +4,7 @@ Release History
 ===============
 upcoming
 ++++++
+* 'az containerapp create/update': Fix an issue about `--bind`/`--unbind` when the cloud is not AzureCloud.
 * 'az containerapp debug': Open an SSH-like interactive shell within a container app debug console.
 * 'az containerapp connected-env certificate upload/remove': Support `--no-wait`.
 * 'az containerapp connected-env dapr-component set/remove': Support `--no-wait`.

--- a/src/containerapp/azext_containerapp/_client_factory.py
+++ b/src/containerapp/azext_containerapp/_client_factory.py
@@ -152,3 +152,9 @@ def connected_k8s_client_factory(cli_ctx, subscription_id=None):
 
     r = get_mgmt_service_client(cli_ctx, ConnectedKubernetesClient, subscription_id=subscription_id)
     return r.connected_cluster
+
+
+def get_linker_client(cmd):
+    from azure.mgmt.servicelinker import ServiceLinkerManagementClient
+    linker_client = get_mgmt_service_client(cmd.cli_ctx, ServiceLinkerManagementClient, subscription_bound=False)
+    return linker_client

--- a/src/containerapp/azext_containerapp/_utils.py
+++ b/src/containerapp/azext_containerapp/_utils.py
@@ -117,6 +117,8 @@ def validate_binding_name(binding_name):
 
 
 def check_unique_bindings(cmd, service_connectors_def_list, service_bindings_def_list, resource_group_name, name):
+    from ._client_factory import get_linker_client
+
     linker_client = get_linker_client(cmd)
     containerapp_def = None
 
@@ -127,7 +129,10 @@ def check_unique_bindings(cmd, service_connectors_def_list, service_bindings_def
     all_bindings = []
 
     if containerapp_def:
-        managed_bindings = linker_client.linker.list(resource_uri=containerapp_def["id"])
+        if is_cloud_supported_by_service_connector(cmd.cli_ctx):
+            managed_bindings = linker_client.linker.list(resource_uri=containerapp_def["id"])
+        else:
+            managed_bindings = []
         service_binds = containerapp_def["properties"].get("template", {}).get("serviceBinds", [])
 
         if managed_bindings:
@@ -730,6 +735,12 @@ def parse_build_env_vars(env_list):
 
 
 def is_cloud_supported_by_connected_env(cli_ctx):
+    if cli_ctx.cloud.name == 'AzureCloud':
+        return True
+    return False
+
+
+def is_cloud_supported_by_service_connector(cli_ctx):
     if cli_ctx.cloud.name == 'AzureCloud':
         return True
     return False


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az containerapp create/updtae`: Fix --bind/--unbind for java component when cloud is not AzureCloud
Currently when customer is using AzureChinaCloud, the command throw error due to it always list service connector, but service connector is not supported on AzureChinaCloud.

cli.azure.cli.core.azclierror: (pii). Status: Response_Status.Status_IncorrectConfiguration, Error code: 3399614475, Tag: 508634112

![image](https://github.com/user-attachments/assets/685c9432-3248-4825-a765-9fdba5a20163)

Tested by change the location to chinaeast3:
![image](https://github.com/user-attachments/assets/60162e70-1bcc-4ee9-a4f3-d9f35a2f6c62)


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
