### PR TITLE
[ImageCopy] Fixing accessSAS according to latest CodeGen migration

### DIFF
--- a/src/image-copy/HISTORY.rst
+++ b/src/image-copy/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+1.0.1
+++++++
+*Fix issue related to apiVersion update in azurecli for image-copy-extention
+
 1.0.0
 ++++++
 * Remove direct call to `msrestazure`

--- a/src/image-copy/azext_imagecopy/azext_metadata.json
+++ b/src/image-copy/azext_imagecopy/azext_metadata.json
@@ -1,3 +1,3 @@
 {
-    "azext.minCliCoreVersion": "2.66.0"
+    "azext.minCliCoreVersion": "2.68.0"
 }

--- a/src/image-copy/azext_imagecopy/custom.py
+++ b/src/image-copy/azext_imagecopy/custom.py
@@ -142,7 +142,7 @@ def imagecopy(cmd, source_resource_group_name, source_object_name, target_locati
 
     json_output = run_cli_command(cli_cmd, return_as_json=True)
 
-    source_os_disk_snapshot_url = json_output['accessSas']
+    source_os_disk_snapshot_url = json_output.get('accessSAS')
     logger.debug("source os disk snapshot url: %s",
                  source_os_disk_snapshot_url)
 

--- a/src/image-copy/setup.py
+++ b/src/image-copy/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup, find_packages
 
-VERSION = "1.0.0"
+VERSION = "1.0.1"
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',


### PR DESCRIPTION
---

Changes related to breaking changes in azure-cli v2.68.0
https://github.com/Azure/azure-cli/pull/30430

Changes for API 2024-12-01-preview

apiVersion has been changed in azCli, keeping it working for older versions of azure-cli too as fallback

### Related command
az image copy --source-resource-group production --target-location eastus2 --source-type image --source-object-name ubuntu-2004-20250124 --target-resource-group production --target-name test-image-eus2 --tags current=true


### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
