### PR TITLE
Update service_name.json | remove old mappings

### DIFF
--- a/src/service_name.json
+++ b/src/service_name.json
@@ -200,11 +200,6 @@
     "URL": "https://learn.microsoft.com/azure/dedicated-hsm"
   },
   {
-    "Command": "az deidservice",
-    "AzureServiceName": "DeIdService",
-    "URL": "https://learn.microsoft.com/azure/healthcare-apis/deidentification"
-  },
-  {
     "Command": "az desktopvirtualization",
     "AzureServiceName": "Virtual Desktop",
     "URL": "https://learn.microsoft.com/azure/virtual-desktop/overview"
@@ -695,11 +690,6 @@
     "URL": "https://learn.microsoft.com/azure/azure-arc/kubernetes/conceptual-custom-locations"
   },
   {
-    "Command": "az vm-repair",
-    "AzureServiceName": "Virtual Machines",
-    "URL": "https://learn.microsoft.com/cli/azure/vm/repair"
-  },
-  {
     "Command": "az vm",
     "AzureServiceName": "Virtual Machines",
     "URL": "https://learn.microsoft.com/azure/virtual-machines"
@@ -780,11 +770,6 @@
     "URL": "https://learn.microsoft.com/azure/cost-management-billing/reservations"
   },
   {
-    "Command": "az hybridaks",
-    "AzureServiceName": "Kubernetes Service (AKS)",
-    "URL": "https://learn.microsoft.com/azure-stack/aks-hci/aks-hybrid-preview-overview"
-  },
-  {
     "Command": "az akshybrid",
     "AzureServiceName": "Kubernetes Service (AKS)",
     "URL": "https://learn.microsoft.com/azure-stack/aks-hci/aks-hybrid-preview-overview"
@@ -798,11 +783,6 @@
     "Command": "az dynatrace",
     "AzureServiceName": "Dynatrace Observability",
     "URL": "https://learn.microsoft.com/azure/partner-solutions/dynatrace"
-  },
-  {
-    "Command": "az adp",
-    "AzureServiceName": "Autonomous Development Platform",
-    "URL": ""
   },
   {
     "Command": "az partnercenter",
@@ -873,11 +853,6 @@
     "Command": "az eventgrid",
     "AzureServiceName": "Event Grid",
     "URL": "https://learn.microsoft.com/en-us/azure/event-grid"
-  },
-  {
-    "Command": "az mariner-baremetal",
-    "AzureServiceName": "Mariner BareMetal Platform",
-    "URL": ""
   },
   {
     "Command": "az hdinsight-on-aks",


### PR DESCRIPTION
The following Azure CLI reference groups are no longer being published but still exist in the `service_name.json` file.

![image](https://github.com/user-attachments/assets/004f2da6-4df1-4e0a-87f6-6cf055748646)

