### PR TITLE
Update azure Policy key under addonProfiles matching Azure Portal casing

### DIFF
--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -9,6 +9,10 @@ If there is no rush to release a new version, please just add a description of t
 
 To release a new version, please select a new version number (usually plus 1 to last patch version, X.Y.Z -> Major.Minor.Patch, more details in `\doc <https://semver.org/>`_), and then add a new section named as the new version number in this file, the content should include the new modifications and everything from the *Pending* section. Finally, update the `VERSION` variable in `setup.py` with this new version number.
 
+13.0.0b6
++++++++
+* `az aks enable-addons`: Fix azure policy key under addonProfiles
+
 13.0.0b5
 +++++++
 * `az aks create/az aks nodepool add`: Emit error message when using `--asg-ids` alone without `--allowed-host-ports`.

--- a/src/aks-preview/azext_aks_preview/_consts.py
+++ b/src/aks-preview/azext_aks_preview/_consts.py
@@ -150,7 +150,7 @@ CONST_VIRTUAL_NODE_SUBNET_NAME = "SubnetName"
 CONST_KUBE_DASHBOARD_ADDON_NAME = "kubeDashboard"
 
 # azure policy
-CONST_AZURE_POLICY_ADDON_NAME = "azurepolicy"
+CONST_AZURE_POLICY_ADDON_NAME = "azurePolicy"
 
 # ingressApplicaitonGateway configuration keys
 CONST_INGRESS_APPGW_ADDON_NAME = "ingressApplicationGateway"

--- a/src/aks-preview/setup.py
+++ b/src/aks-preview/setup.py
@@ -9,7 +9,7 @@ from codecs import open as open1
 
 from setuptools import setup, find_packages
 
-VERSION = "13.0.0b5"
+VERSION = "13.0.0b6"
 
 CLASSIFIERS = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
When user enable policy via Portal the key added to addonProfiles is azurePolicy. Matching name in CLI as well.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
az aks enable-addons 
az aks addon list

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
