### PR TITLE
[Quantum] Quantum CLI Extension Release, Version 1.0.0b5

### DIFF
--- a/src/quantum/HISTORY.rst
+++ b/src/quantum/HISTORY.rst
@@ -3,6 +3,15 @@
 Release History
 ===============
 
+1.0.0b5
+++++++
+* [2025-03-12] Version intended to work with QDK version 1.14.0
+* `az quantum job list` has several new parameters to filter, sort, and paginate the job list, see https://learn.microsoft.com/cli/azure/quantum/job?view=azure-cli-latest#az-quantum-job-list
+* The `az quantum run`, `az quantum execute`, and `az quantum job submit` commands can access workspace storage accounts not owned by the user.
+* Storage blob anonymous access is disabled when new workspace storage accounts are created.
+* Service-based Resource Estimation is now fully deprecated. Please use the local Resource Estimator tool, see https://learn.microsoft.com/azure/quantum/intro-to-resource-estimation
+* GitHub Issue 30947 has been fixed, https://github.com/Azure/azure-cli/issues/30947
+
 1.0.0b4
 ++++++
 * [2024-10-16] Version intended to work with QDK version 1.9.0

--- a/src/quantum/HISTORY.rst
+++ b/src/quantum/HISTORY.rst
@@ -7,7 +7,7 @@ Release History
 ++++++
 * [2025-03-12] Version intended to work with QDK version 1.14.0
 * `az quantum job list` has several new parameters to filter, sort, and paginate the job list, see https://learn.microsoft.com/cli/azure/quantum/job?view=azure-cli-latest#az-quantum-job-list
-* The `az quantum run`, `az quantum execute`, and `az quantum job submit` commands can access workspace storage accounts not owned by the user.
+* The `az quantum run`, `az quantum execute`, and `az quantum job submit` commands can access workspace storage accounts using the workspace managed identity.
 * Storage blob anonymous access is disabled when new workspace storage accounts are created.
 * Service-based Resource Estimation is now fully deprecated. Please use the local Resource Estimator tool, see https://learn.microsoft.com/azure/quantum/intro-to-resource-estimation
 * GitHub Issue 30947 has been fixed, https://github.com/Azure/azure-cli/issues/30947

--- a/src/quantum/azext_quantum/__init__.py
+++ b/src/quantum/azext_quantum/__init__.py
@@ -13,7 +13,7 @@ import azext_quantum._help  # pylint: disable=unused-import
 # This is the version reported by the CLI to the service when submitting requests.
 # This should be in sync with the extension version in 'setup.py', unless we need to
 # submit using a different version.
-CLI_REPORTED_VERSION = "1.0.0b4"
+CLI_REPORTED_VERSION = "1.0.0b5"
 
 
 class QuantumCommandsLoader(AzCommandsLoader):

--- a/src/quantum/setup.py
+++ b/src/quantum/setup.py
@@ -17,7 +17,7 @@ except ImportError:
 # This version should match the latest entry in HISTORY.rst
 # Also, when updating this, please review the version used by the extension to
 # submit requests, which can be found at './azext_quantum/__init__.py'
-VERSION = '1.0.0b4'
+VERSION = '1.0.0b5'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION

Incremented version number and added release notes

---

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)
