### PR TITLE
[Quantum] Roll back the quantum extension version number to 1.0.0b4

### DIFF
--- a/src/quantum/azext_quantum/__init__.py
+++ b/src/quantum/azext_quantum/__init__.py
@@ -13,7 +13,7 @@ import azext_quantum._help  # pylint: disable=unused-import
 # This is the version reported by the CLI to the service when submitting requests.
 # This should be in sync with the extension version in 'setup.py', unless we need to
 # submit using a different version.
-CLI_REPORTED_VERSION = "1.0.0b5"
+CLI_REPORTED_VERSION = "1.0.0b4"
 
 
 class QuantumCommandsLoader(AzCommandsLoader):

--- a/src/quantum/setup.py
+++ b/src/quantum/setup.py
@@ -17,7 +17,7 @@ except ImportError:
 # This version should match the latest entry in HISTORY.rst
 # Also, when updating this, please review the version used by the extension to
 # submit requests, which can be found at './azext_quantum/__init__.py'
-VERSION = '1.0.0b5'
+VERSION = '1.0.0b4'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Rolling back the quantum extension version number to 1.0.0b4 to avoid auto release.

This is part of retracting the 1.0.0b5 release: See https://github.com/Azure/azure-cli-extensions/pull/8561