### PR TITLE
Image detection updates

### DIFF
--- a/src/vm-repair/azext_vm_repair/custom.py
+++ b/src/vm-repair/azext_vm_repair/custom.py
@@ -123,7 +123,7 @@ def create(cmd, vm_name, resource_group_name, repair_password=None, repair_usern
                 # If the Hyper-V generation is 'V2', log this information and select the Linux distribution for a Gen2 VM.  
                 logger.info('Generation 2 VM detected')  
                 os_image_urn = _select_distro_linux_gen2(distro)  
-            if architecture_type == 'Arm64':  
+            elif architecture_type == 'Arm64':  
                 # If the architecture type is 'Arm64', log this information and select the Linux distribution for an Arm64 VM.  
                 logger.info('ARM64 VM detected')  
                 os_image_urn = _select_distro_linux_Arm64(distro)  

--- a/src/vm-repair/azext_vm_repair/repair_utils.py
+++ b/src/vm-repair/azext_vm_repair/repair_utils.py
@@ -526,11 +526,16 @@ def _fetch_compatible_windows_os_urn_v2(source_vm):
 
 
 def _select_distro_linux(distro):
+    # list of images needs to be added to before the docs reflect, and the docs need to remove the keywords long before we remove the reference from the extension
+    # https://learn.microsoft.com/cli/azure/vm/repair?view=azure-cli-latest#az-vm-repair-create-optional-parameters
     image_lookup = {
         'rhel7': 'RedHat:rhel-raw:7-raw:latest',
         'rhel8': 'RedHat:rhel-raw:8-raw:latest',
+        'rhel9': 'RedHat:rhel-raw:9-raw:latest',
         'ubuntu18': 'Canonical:UbuntuServer:18.04-LTS:latest',
         'ubuntu20': 'Canonical:0001-com-ubuntu-server-focal:20_04-lts:latest',
+        'ubuntu22': 'Canonical:0001-com-ubuntu-server-jammy:22_04-lts:latest',
+        'ubuntu24': 'Canonical:ubuntu-24_04-lts:server-gen1:latest',
         'centos6': 'OpenLogic:CentOS:6.10:latest',
         'centos7': 'OpenLogic:CentOS:7_9:latest',
         'centos8': 'OpenLogic:CentOS:8_4:latest',
@@ -547,16 +552,20 @@ def _select_distro_linux(distro):
             os_image_urn = distro
         else:
             logger.info('No specific distro was provided , using the default Ubuntu distro')
-            os_image_urn = "Ubuntu2204"
+            os_image_urn = "Canonical:ubuntu-24_04-lts:server-gen1:latest"
     return os_image_urn
 
 
 def _select_distro_linux_Arm64(distro):
+    # list of images needs to be added to before the docs reflect, and the docs need to remove the keywords long before we remove the reference from the extension
+    # https://learn.microsoft.com/cli/azure/vm/repair?view=azure-cli-latest#az-vm-repair-create-optional-parameters
     image_lookup = {
         'rhel8': 'RedHat:rhel-arm64:8_8-arm64-gen2:latest',
-        'rhel9': 'RedHat:rhel-arm64:9_2-arm64:latest',
+        'rhel9': 'RedHat:rhel-arm64:9_3-arm64:latest',
         'ubuntu18': 'Canonical:UbuntuServer:18_04-lts-arm64:latest',
         'ubuntu20': 'Canonical:0001-com-ubuntu-server-focal:20_04-lts-arm64:latest',
+        'ubuntu22': 'Canonical:0001-com-ubuntu-server-jammy:22_04-lts-arm64:latest',
+        'ubuntu24': 'Canonical:ubuntu-24_04-lts:server-arm64:latest',
         'centos7': 'OpenLogic:CentOS:7_9-arm64:latest',
     }
     if distro in image_lookup:
@@ -567,23 +576,27 @@ def _select_distro_linux_Arm64(distro):
             os_image_urn = distro
         else:
             logger.info('No specific distro was provided , using the default ARM64 Ubuntu distro')
-            os_image_urn = "Canonical:UbuntuServer:18_04-lts-arm64:latest"
+            os_image_urn = "Canonical:ubuntu-24_04-lts:server-arm64:latest"
     return os_image_urn
 
 
 def _select_distro_linux_gen2(distro):
-    # base on the document : https://learn.microsoft.com/en-us/azure/virtual-machines/generation-2#generation-2-vm-images-in-azure-marketplace
+    # list of images needs to be added to before the docs reflect, and the docs need to remove the keywords long before we remove the reference from the extension
+    # https://learn.microsoft.com/cli/azure/vm/repair?view=azure-cli-latest#az-vm-repair-create-optional-parameters
     image_lookup = {
         'rhel7': 'RedHat:rhel-raw:7-raw-gen2:latest',
         'rhel8': 'RedHat:rhel-raw:8-raw-gen2:latest',
+        'rhel9': 'RedHat:rhel-raw:9-raw-gen2:latest',
         'ubuntu18': 'Canonical:UbuntuServer:18_04-lts-gen2:latest',
         'ubuntu20': 'Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:latest',
+        'ubuntu22': 'Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest',
+        'ubuntu24': 'Canonical:ubuntu-24_04-lts:server:latest',
         'centos7': 'OpenLogic:CentOS:7_9-gen2:latest',
         'centos8': 'OpenLogic:CentOS:8_4-gen2:latest',
         'oracle7': 'Oracle:Oracle-Linux:ol79-gen2:latest',
         'oracle8': 'Oracle:Oracle-Linux:ol82-gen2:latest',
         'sles12': 'SUSE:sles-12-sp5:gen2:latest',
-        'sles15': 'SUSE:sles-15-sp3:gen2:latest',
+        'sles15': 'SUSE:sles-15-sp6:gen2:latest',
     }
     if distro in image_lookup:
         os_image_urn = image_lookup[distro]
@@ -597,7 +610,7 @@ def _select_distro_linux_gen2(distro):
                 os_image_urn = "Canonical:UbuntuServer:18_04-lts-gen2:latest"
         else:
             logger.info('No specific distro was provided , using the default Ubuntu distro')
-            os_image_urn = "Canonical:UbuntuServer:18_04-lts-gen2:latest"
+            os_image_urn = "Canonical:ubuntu-24_04-lts:server:latest"
     return os_image_urn
 
 


### PR DESCRIPTION
Updates for Linux image detection for az vm repair creation.  New images are added, and the Gen 1 default is made to match Gen2 and ARM64.  The Gen1 default turned out to actually be a Gen2 VM in practice, as it was dependent on the marketplace aliases.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
az vm repair create --verbose -g BADRG -n BADVM --repair-username USERNAME --repair-password 'yourPassHere!!!1' --distro=KEYWORD

### General Guidelines

- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)
-- this is probably a revision/update - need a hand with the version info update

### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
