### PR TITLE
[confcom] Rollback genpolicy version to Azure Linux V2

### DIFF
--- a/src/confcom/HISTORY.rst
+++ b/src/confcom/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+1.2.4
+++++++
+* rolling back genpolicy version for Azure Linux V2 support instead of V3
+
 1.2.3
 ++++++
 * adding fragment support for VN2

--- a/src/confcom/azext_confcom/data/internal_config.json
+++ b/src/confcom/azext_confcom/data/internal_config.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.2.3",
+    "version": "1.2.4",
     "hcsshim_config": {
         "maxVersion": "1.0.0",
         "minVersion": "0.0.1"

--- a/src/confcom/azext_confcom/kata_proxy.py
+++ b/src/confcom/azext_confcom/kata_proxy.py
@@ -40,7 +40,8 @@ class KataPolicyGenProxy:  # pylint: disable=too-few-public-methods
         needed_assets = ["genpolicy", "genpolicy.exe"]
         # search for genpolicy in the assets from kata-container releases
         for release in r.json():
-            if "genpolicy" in release.get("tag_name"):
+            is_target = "genpolicy" in release.get("tag_name") and not release.get("draft") and not release.get("prerelease")
+            if is_target:
                 # these should be newest to oldest
                 for asset in release["assets"]:
                     # download the file if it contains genpolicy

--- a/src/confcom/azext_confcom/kata_proxy.py
+++ b/src/confcom/azext_confcom/kata_proxy.py
@@ -40,7 +40,11 @@ class KataPolicyGenProxy:  # pylint: disable=too-few-public-methods
         needed_assets = ["genpolicy", "genpolicy.exe"]
         # search for genpolicy in the assets from kata-container releases
         for release in r.json():
-            is_target = "genpolicy" in release.get("tag_name") and not release.get("draft") and not release.get("prerelease")
+            is_target = (
+                "genpolicy" in release.get("tag_name") and
+                not release.get("draft") and
+                not release.get("prerelease")
+            )
             if is_target:
                 # these should be newest to oldest
                 for asset in release["assets"]:

--- a/src/confcom/azext_confcom/tests/latest/test_confcom_scenario.py
+++ b/src/confcom/azext_confcom/tests/latest/test_confcom_scenario.py
@@ -577,8 +577,8 @@ class CustomJsonParsing(unittest.TestCase):
             aci_policy.populate_policy_content_for_all_images()
             layers = aci_policy.get_images()[0]._layers
             expected_layers = [
-                "f4dbab29a5ddebfa8866d72df10d284ffb2b11292baf8d184b7bc1241d5074fd",
-                "c003cd912b804162760beb676e5b629a297d75fbdcffd2d3ee49bacc0b985a52"
+                "81f4183d118e68e8bb3c8845da3b0fe3cc331a63184b534ea0307d4d01c52418",
+                "3a1edaedd7e7e0072846d74219577c05b25498c233196d38ae0fe6cde8c2c92a"
             ]
             self.assertEqual(len(layers), len(expected_layers))
             for i in range(len(expected_layers)):

--- a/src/confcom/setup.py
+++ b/src/confcom/setup.py
@@ -19,7 +19,7 @@ except ImportError:
 
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
 
-VERSION = "1.2.3"
+VERSION = "1.2.4"
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Picked up the wrong version of genpolicy in the last release.
---
Reverting and adding a check to make sure we don't pick up prerelease or drafts in the future.

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
az confcom


### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
