### PR TITLE
[Service Connector] Fix PostgreSQL passwordless connection not working because of deprecated command

### DIFF
--- a/src/serviceconnector-passwordless/azext_serviceconnector_passwordless/_credential_free.py
+++ b/src/serviceconnector-passwordless/azext_serviceconnector_passwordless/_credential_free.py
@@ -690,7 +690,7 @@ class PostgresFlexHandler(TargetHandler):
             self.target_id))
 
     def set_user_admin(self, user_object_id, **kwargs):
-        admins = run_cli_cmd('az postgres flexible-server ad-admin list -g "{}" -s "{}" --subscription "{}"'.format(
+        admins = run_cli_cmd('az postgres flexible-server microsoft-entra-admin list -g "{}" -s "{}" --subscription "{}"'.format(
             self.resource_group, self.db_server, self.subscription))
 
         if not user_object_id:
@@ -706,7 +706,7 @@ class PostgresFlexHandler(TargetHandler):
         admin_info = next((ad for ad in admins if ad.get('objectId', "") == user_object_id), None)
         if not admin_info:
             logger.warning('Set current user as DB Server Microsoft Entra Administrators.')
-            admin_info = run_cli_cmd('az postgres flexible-server ad-admin create -u "{}" -i "{}" -g "{}" -s "{}" --subscription "{}" -t {}'.format(
+            admin_info = run_cli_cmd('az postgres flexible-server microsoft-entra-admin create -u "{}" -i "{}" -g "{}" -s "{}" --subscription "{}" -t {}'.format(
                 self.login_username, user_object_id, self.resource_group, self.db_server, self.subscription, self.login_usertype))
         self.admin_username = admin_info.get('principalName', self.login_username)
 


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
az webapp/containerapp connection create postgres-flexible --user-identity client-id=XX subs-id=XX --source-id XX --target-id XX
az webapp/containerapp connection create postgres-flexible --system-identity -source-id XX --target-id XX

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
