### PR TITLE
[AKS] `az aks nodepool add/update/upgrade`: Add `--max-blocked-nodes` to specify maximum number or percentage of extra nodes that are allowed to be blocked in the agent pool during an upgrade

### DIFF
--- a/src/aks-preview/azext_aks_preview/_help.py
+++ b/src/aks-preview/azext_aks_preview/_help.py
@@ -1788,6 +1788,9 @@ helps['aks nodepool add'] = """
         - name: --max-unavailable
           type: string
           short-summary: The maximum number or percentage of nodes that can be simultaneously unavailable during upgrade. When specified, it represents the number or percent used, eg. 1 or 5%
+        - name: --max-blocked-nodes
+          type: string
+          short-summary: The maximum number or percentage of extra nodes that are allowed to be blocked in the agent pool during an upgrade when undrainable node behavior is Cordon. When specified, it represents the number or percent used, eg. 1 or 5%.
         - name: --kubelet-config
           type: string
           short-summary: Kubelet configurations for agent nodes.
@@ -1930,6 +1933,9 @@ helps['aks nodepool upgrade'] = """
         - name: --max-unavailable
           type: string
           short-summary: The maximum number or percentage of nodes that can be simultaneously unavailable during upgrade. When specified, it represents the number or percent used, eg. 1 or 5%
+        - name: --max-blocked-nodes
+          type: string
+          short-summary: The maximum number or percentage of extra nodes that are allowed to be blocked in the agent pool during an upgrade when undrainable node behavior is Cordon. When specified, it represents the number or percent used, eg. 1 or 5%.
         - name: --aks-custom-headers
           type: string
           short-summary: Send custom headers. When specified, format should be Key1=Value1,Key2=Value2
@@ -1982,6 +1988,9 @@ helps['aks nodepool update'] = """
         - name: --max-unavailable
           type: string
           short-summary: The maximum number or percentage of nodes that can be simultaneously unavailable during upgrade. When specified, it represents the number or percent used, eg. 1 or 5%
+        - name: --max-blocked-nodes
+          type: string
+          short-summary: The maximum number or percentage of extra nodes that are allowed to be blocked in the agent pool during an upgrade when undrainable node behavior is Cordon. When specified, it represents the number or percent used, eg. 1 or 5%.
         - name: --mode
           type: string
           short-summary: The mode for a node pool which defines a node pool's primary function. If set as "System", AKS prefers system pods scheduling to node pools with mode `System`. Learn more at https://aka.ms/aks/nodepool/mode.

--- a/src/aks-preview/azext_aks_preview/_params.py
+++ b/src/aks-preview/azext_aks_preview/_params.py
@@ -203,6 +203,7 @@ from azext_aks_preview._validators import (
     validate_bootstrap_container_registry_resource_id,
     validate_gateway_prefix_size,
     validate_max_unavailable,
+    validate_max_blocked_nodes,
     validate_location_cluster_name_resource_group_mutually_exclusive,
     validate_resource_group_parameter,
 )
@@ -1510,6 +1511,7 @@ def load_arguments(self, _):
         c.argument("node_soak_duration", type=int)
         c.argument("undrainable_node_behavior")
         c.argument("max_unavailable", validator=validate_max_unavailable)
+        c.argument("max_blocked_nodes", validator=validate_max_blocked_nodes)
         c.argument("mode", arg_type=get_enum_type(node_mode_types))
         c.argument("scale_down_mode", arg_type=get_enum_type(scale_down_modes))
         c.argument("max_pods", type=int, options_list=["--max-pods", "-m"])
@@ -1642,6 +1644,7 @@ def load_arguments(self, _):
         c.argument("node_soak_duration", type=int)
         c.argument("undrainable_node_behavior")
         c.argument("max_unavailable", validator=validate_max_unavailable)
+        c.argument("max_blocked_nodes", validator=validate_max_blocked_nodes)
         c.argument("mode", arg_type=get_enum_type(node_mode_types))
         c.argument("scale_down_mode", arg_type=get_enum_type(scale_down_modes))
         # extensions
@@ -1713,6 +1716,7 @@ def load_arguments(self, _):
         c.argument("node_soak_duration", type=int)
         c.argument("undrainable_node_behavior")
         c.argument("max_unavailable", validator=validate_max_unavailable)
+        c.argument("max_blocked_nodes", validator=validate_max_blocked_nodes)
         c.argument("snapshot_id", validator=validate_snapshot_id)
         c.argument(
             "yes",

--- a/src/aks-preview/azext_aks_preview/_validators.py
+++ b/src/aks-preview/azext_aks_preview/_validators.py
@@ -479,7 +479,21 @@ def validate_max_unavailable(namespace):
     except ValueError:
         # pylint: disable=raise-missing-from
         raise CLIError("--max-unavailable should be an int or percentage")
+    
+def validate_max_blocked_nodes(namespace):
+    """validates parameters max blocked nodes is positive integers or percents."""
+    if namespace.max_blocked_nodes is None:
+        return
+    int_or_percent = namespace.max_blocked_nodes
+    if int_or_percent.endswith('%'):
+        int_or_percent = int_or_percent.rstrip('%s')
 
+    try:
+        if int(int_or_percent) < 0:
+            raise CLIError("--max-blocked-nodes must be positive")
+    except ValueError:
+        # pylint: disable=raise-missing-from
+        raise CLIError("--max-blocked-nodes should be an int or percentage")
 
 def validate_assign_identity(namespace):
     if namespace.assign_identity is not None:

--- a/src/aks-preview/azext_aks_preview/agentpool_decorator.py
+++ b/src/aks-preview/azext_aks_preview/agentpool_decorator.py
@@ -502,6 +502,26 @@ class AKSPreviewAgentPoolContext(AKSAgentPoolContext):
         # this parameter does not need dynamic completion
         # this parameter does not need validation
         return max_unavailable
+    
+    def get_max_blocked_nodes(self) -> str:
+        """Obtain the value of max_blocked_nodes.
+
+        :return: string
+        """
+         # read the original value passed by the command
+        max_blocked_nodes = self.raw_param.get("max_blocked_nodes")
+        # In create mode, try to read the property value corresponding to the parameter from the `agentpool` object
+        if self.decorator_mode == DecoratorMode.CREATE:
+            if (
+                self.agentpool and
+                self.agentpool.upgrade_settings and
+                self.agentpool.upgrade_settings.max_blocked_nodes is not None
+            ):
+                max_blocked_nodes = self.agentpool.upgrade_settings.max_blocked_nodes
+
+        # this parameter does not need dynamic completion
+        # this parameter does not need validation
+        return max_blocked_nodes
 
     def get_enable_artifact_streaming(self) -> bool:
         """Obtain the value of enable_artifact_streaming.
@@ -1126,6 +1146,10 @@ class AKSPreviewAgentPoolAddDecorator(AKSAgentPoolAddDecorator):
         max_unavailable = self.context.get_max_unavailable()
         if max_unavailable:
             upgrade_settings.max_unavailable = max_unavailable
+        
+        max_blocked_nodes = self.context.get_max_blocked_nodes()
+        if max_blocked_nodes:
+            upgrade_settings.max_blocked_nodes = max_blocked_nodes
 
         agentpool.upgrade_settings = upgrade_settings
         return agentpool
@@ -1350,6 +1374,11 @@ class AKSPreviewAgentPoolUpdateDecorator(AKSAgentPoolUpdateDecorator):
         undrainable_node_behavior = self.context.get_undrainable_node_behavior()
         if undrainable_node_behavior:
             upgrade_settings.undrainable_node_behavior = undrainable_node_behavior
+            agentpool.upgrade_settings = upgrade_settings
+
+        max_blocked_nodes = self.context.get_max_blocked_nodes()
+        if max_blocked_nodes:
+            upgrade_settings.max_blocked_nodes = max_blocked_nodes
             agentpool.upgrade_settings = upgrade_settings
 
         max_unavailable = self.context.get_max_unavailable()

--- a/src/aks-preview/azext_aks_preview/custom.py
+++ b/src/aks-preview/azext_aks_preview/custom.py
@@ -1192,6 +1192,7 @@ def aks_agentpool_add(
     node_soak_duration=None,
     undrainable_node_behavior=None,
     max_unavailable=None,
+    max_blocked_nodes=None,
     mode=CONST_NODEPOOL_MODE_USER,
     scale_down_mode=CONST_SCALE_DOWN_MODE_DELETE,
     max_pods=0,
@@ -1275,6 +1276,7 @@ def aks_agentpool_update(
     node_soak_duration=None,
     undrainable_node_behavior=None,
     max_unavailable=None,
+    max_blocked_nodes=None,
     mode=None,
     scale_down_mode=None,
     no_wait=False,
@@ -1367,6 +1369,7 @@ def aks_agentpool_upgrade(cmd,
                           node_soak_duration=None,
                           undrainable_node_behavior=None,
                           max_unavailable=None,
+                          max_blocked_nodes=None,
                           snapshot_id=None,
                           no_wait=False,
                           aks_custom_headers=None,
@@ -1386,13 +1389,13 @@ def aks_agentpool_upgrade(cmd,
         )
 
     # Note: we exclude this option because node image upgrade can't accept nodepool put fields like max surge
-    hasUpgradeSetting = max_surge or drain_timeout or node_soak_duration or undrainable_node_behavior or max_unavailable
+    hasUpgradeSetting = max_surge or drain_timeout or node_soak_duration or undrainable_node_behavior or max_unavailable or max_blocked_nodes
     if hasUpgradeSetting and node_image_only:
         raise MutuallyExclusiveArgumentError(
-            "Conflicting flags. Unable to specify max-surge/drain-timeout/node-soak-duration with node-image-only."
-            "If you want to use max-surge/drain-timeout/node-soak-duration with a node image upgrade, please first "
-            "update max-surge/drain-timeout/node-soak-duration using "
-            '"az aks nodepool update --max-surge/--drain-timeout/--node-soak-duration".'
+            "Conflicting flags. Unable to specify max-surge/drain-timeout/node-soak-duration/undrainable-node-behavior/max-unavailable/max-blocked-nodes with node-image-only."
+            "If you want to use max-surge/drain-timeout/node-soak-duration/undrainable-node-behavior/max-unavailable/max-blocked-nodes with a node image upgrade, please first "
+            "update max-surge/drain-timeout/node-soak-duration/undrainable-node-behavior/max-unavailable/max-blocked-nodes using "
+            '"az aks nodepool update --max-surge/--drain-timeout/--node-soak-duration/--undrainable-node-behavior/--max-unavailable/--max-blocked-nodes".'
         )
 
     if node_image_only:
@@ -1454,6 +1457,8 @@ def aks_agentpool_upgrade(cmd,
         instance.upgrade_settings.undrainable_node_behavior = undrainable_node_behavior
     if max_unavailable:
         instance.upgrade_settings.max_unavailable = max_unavailable
+    if max_blocked_nodes:
+        instance.upgrade_settings.max_blocked_nodes = max_blocked_nodes
 
     # custom headers
     aks_custom_headers = extract_comma_separated_string(

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -3259,6 +3259,70 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             checks=[self.is_empty()],
         )
 
+    @AllowLargeResponse()
+    @AKSCustomResourceGroupPreparer(
+        random_name_length=17, name_prefix="clitest", location="westus2"
+    )
+    def test_aks_nodepool_max_blocked_nodes(
+        self, resource_group, resource_group_location
+    ):
+        aks_name = self.create_random_name("cliakstest", 16)
+        np_name = self.create_random_name("clinp", 12)
+        self.kwargs.update(
+            {
+                "name": aks_name,
+                "resource_group": resource_group,
+                "nodepool_name": np_name,
+                "ssh_key_value": self.generate_ssh_keys(),
+            }
+        )
+
+        # create
+        create_cmd = (
+            "aks create --resource-group={resource_group} --name={name} "
+            "--ssh-key-value={ssh_key_value} -c 1"
+        )
+        self.cmd(
+            create_cmd,
+            checks=[
+                self.check("provisioningState", "Succeeded"),
+            ],
+        )
+
+        add_nodepool_cmd = (
+            "aks nodepool add -g {resource_group} --cluster-name {name} -n {nodepool_name} --node-count 2 --undrainable-node-behavior Cordon"
+            "--mode user --max-surge 1 --max-blocked-nodes 1"
+        )
+        self.cmd(
+            add_nodepool_cmd,
+            checks=[
+                self.check("provisioningState", "Succeeded"),
+                self.check("upgradeSettings.undrainableNodeBehavior", "Cordon"),
+                self.check("upgradeSettings.maxBlockedNodes", "1"),
+            ],
+        )
+
+        update_nodepool_cmd = (
+            "aks nodepool update -g {resource_group} --cluster-name {name} -n {nodepool_name} "
+            "--max-blocked-nodes 2"
+        )
+        self.cmd(
+            update_nodepool_cmd,
+            checks=[
+                self.check("provisioningState", "Succeeded"),
+                self.check("upgradeSettings.undrainableNodeBehavior", "Cordon"),
+                self.check("upgradeSettings.maxBlockedNodes", "1"),
+            ],
+        )
+
+        # actually running an upgrade is too expensive for these tests.
+
+        # delete
+        self.cmd(
+            "aks delete -g {resource_group} -n {name} --yes --no-wait",
+            checks=[self.is_empty()],
+        )
+
 
     @AllowLargeResponse()
     @AKSCustomResourceGroupPreparer(

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_validators.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_validators.py
@@ -112,6 +112,10 @@ class MaxUnavailableNamespace:
     def __init__(self, max_unavailable):
         self.max_unavailable = max_unavailable
 
+class MaxBlockedNodesNamespace:
+    def __init__(self, max_blocked_nodes):
+        self.max_blocked_nodes = max_blocked_nodes
+
 class SpotMaxPriceNamespace:
     def __init__(self, spot_max_price):
         self.priority = "Spot"
@@ -172,6 +176,22 @@ class TestMaxUnavailable(unittest.TestCase):
     def test_throws_on_negative(self):
         with self.assertRaises(CLIError) as cm:
             validators.validate_max_unavailable(MaxUnavailableNamespace("-3"))
+        self.assertTrue("positive" in str(cm.exception), msg=str(cm.exception))
+
+class TestMaxBlockedNodes(unittest.TestCase):
+    def test_valid_cases(self):
+        valid = ["5", "33%", "1", "100%", "0"]
+        for v in valid:
+            validators.validate_max_blocked_nodes(MaxUnavailableNamespace(v))
+
+    def test_throws_on_string(self):
+        with self.assertRaises(CLIError) as cm:
+            validators.validate_max_blocked_nodes(MaxUnavailableNamespace("foobar"))
+        self.assertTrue("int or percentage" in str(cm.exception), msg=str(cm.exception))
+
+    def test_throws_on_negative(self):
+        with self.assertRaises(CLIError) as cm:
+            validators.validate_max_blocked_nodes(MaxUnavailableNamespace("-3"))
         self.assertTrue("positive" in str(cm.exception), msg=str(cm.exception))
 
 class TestSpotMaxPrice(unittest.TestCase):


### PR DESCRIPTION
### Related command
az aks nodepool add/update/upgrade --max-blocked-nodes


### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
