### PR TITLE
[connectedk8s] Add checks for the Graytown bundle feature flag in the connectedk8s extension

### DIFF
--- a/src/connectedk8s/HISTORY.rst
+++ b/src/connectedk8s/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+1.10.8
+++++++
+* Add checks for the Graytown bundle feature flag in the 'connectedk8s connect' and 'connectedk8s update' commands.
+* Display a more detailed error message from the agent-update-validator in the 'connectedk8s upgrade' command.
+
 1.10.7
 ++++++
 * Added support for discovering additional k8s distributions and Infrastructure.

--- a/src/connectedk8s/azext_connectedk8s/_constants.py
+++ b/src/connectedk8s/azext_connectedk8s/_constants.py
@@ -517,3 +517,15 @@ Doc_Agent_Version_Support_Policy_Url = "https://learn.microsoft.com/en-us/azure/
 # "Application code shouldn't block the creation of resources for a resource provider that is in the registering state."
 # See https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-providers-and-types#register-resource-provider
 allowed_rp_registration_states = ["Registering", "Registered"]
+
+Connected_Cluster_Type = "connectedclusters"
+
+Arc_Agentry_Bundle_Feature = "extensionSets"
+Arc_Agentry_Bundle_Feature_Setting = "versionManagedExtensions"
+
+Bundle_Feature_Value_List = ["enabled", "disabled", "preview"]
+Bundle_Extension_Type_List = ["microsoft.iotoperations", "microsoft.extensiondiagnostics", "microsoft.arc.containerstorage", "microsoft.azure.secretstore"]
+
+CONST_K8S_EXTENSION_NAME = "k8s-extension"
+CONST_K8S_EXTENSION_CLIENT_FACTORY_MOD_NAME = "azext_k8s_extension._client_factory"
+CONST_K8S_EXTENSION_CUSTOM_MOD_NAME = "azext_k8s_extension.custom"

--- a/src/connectedk8s/azext_connectedk8s/clientproxyhelper/_proxylogic.py
+++ b/src/connectedk8s/azext_connectedk8s/clientproxyhelper/_proxylogic.py
@@ -18,7 +18,7 @@ from ..vendored_sdks.models import (
 if TYPE_CHECKING:
     from subprocess import Popen
 
-    from knack.commands import CLICommmand
+    from knack.commands import CLICommand
     from requests.models import Response
 
     from azext_connectedk8s.vendored_sdks.preview_2024_07_01.models import (
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 
 
 def handle_post_at_to_csp(
-    cmd: CLICommmand,
+    cmd: CLICommand,
     api_server_port: int,
     tenant_id: str,
     clientproxy_process: Popen[bytes],

--- a/src/connectedk8s/azext_connectedk8s/custom.py
+++ b/src/connectedk8s/azext_connectedk8s/custom.py
@@ -1556,7 +1556,7 @@ def validate_bundle_feature_flag_value(
     print(f"Step: {utils.get_utctimestring()}: Validating the bundle feature flag value")
     value = get_bundle_feature_flag_from_configuration_settings(configuration_settings)
 
-    if value:
+    if value is not None:
         # Remove leading and trailing whitespace and quotes
         value = value.strip().strip("'\"")
 

--- a/src/connectedk8s/azext_connectedk8s/custom.py
+++ b/src/connectedk8s/azext_connectedk8s/custom.py
@@ -81,7 +81,7 @@ if TYPE_CHECKING:
     from azure.cli.core.commands import AzCliCommand
     from azure.core.polling import LROPoller
     from Crypto.PublicKey.RSA import RsaKey
-    from knack.commands import CLICommmand
+    from knack.commands import CLICommand
     from kubernetes.client import V1NodeList
     from kubernetes.config.kube_config import ConfigNode
     from requests.models import Response
@@ -99,7 +99,7 @@ logger = get_logger(__name__)
 
 
 def create_connectedk8s(
-    cmd: CLICommmand,
+    cmd: CLICommand,
     client: ConnectedClusterOperations,
     resource_group_name: str,
     cluster_name: str,
@@ -1047,7 +1047,7 @@ def validate_existing_provisioned_cluster_for_reput(
                 raise InvalidArgumentValueError(err_msg)
 
 
-def send_cloud_telemetry(cmd: CLICommmand) -> str:
+def send_cloud_telemetry(cmd: CLICommand) -> str:
     telemetry.add_extension_event(
         "connectedk8s", {"Context.Default.AzureCLI.AzureCloud": cmd.cli_ctx.cloud.name}
     )
@@ -1293,7 +1293,7 @@ def connected_cluster_exists(
     return True
 
 
-def get_default_config_dp_endpoint(cmd: CLICommmand, location: str) -> str:
+def get_default_config_dp_endpoint(cmd: CLICommand, location: str) -> str:
     cloud_based_domain = cmd.cli_ctx.cloud.endpoints.active_directory.split(".")[2]
     config_dp_endpoint = (
         f"https://{location}.dp.kubernetesconfiguration.azure.{cloud_based_domain}"
@@ -1302,7 +1302,7 @@ def get_default_config_dp_endpoint(cmd: CLICommmand, location: str) -> str:
 
 
 def get_config_dp_endpoint(
-    cmd: CLICommmand,
+    cmd: CLICommand,
     location: str,
     values_file: str | None,
     arm_metadata: dict[str, Any] | None = None,
@@ -1607,7 +1607,7 @@ def validate_connect_cluster_bundle_feature_flag_value(
 
 
 def validate_update_cluster_bundle_feature_flag_value(
-    cmd: CLICommmand,
+    cmd: CLICommand,
     current_arc_agentry_config: list[ArcAgentryConfigurations],
     configuration_settings: dict[str, Any],
     resource_group_name: str,
@@ -1900,7 +1900,7 @@ def list_connectedk8s(
 
 
 def delete_connectedk8s(
-    cmd: CLICommmand,
+    cmd: CLICommand,
     client: ConnectedClusterOperations,
     resource_group_name: str,
     cluster_name: str,
@@ -2162,7 +2162,7 @@ def update_connected_cluster_internal(
 
 
 def update_connected_cluster(
-    cmd: CLICommmand,
+    cmd: CLICommand,
     client: ConnectedClusterOperations,
     resource_group_name: str,
     cluster_name: str,
@@ -2524,7 +2524,7 @@ def update_connected_cluster(
 
 
 def upgrade_agents(
-    cmd: CLICommmand,
+    cmd: CLICommand,
     client: ConnectedClusterOperations,
     resource_group_name: str,
     cluster_name: str,
@@ -2986,7 +2986,7 @@ def get_all_helm_values(
 
 
 def enable_features(
-    cmd: CLICommmand,
+    cmd: CLICommand,
     client: ConnectedClusterOperations,
     resource_group_name: str,
     cluster_name: str,
@@ -3219,7 +3219,7 @@ def enable_features(
 
 
 def disable_features(
-    cmd: CLICommmand,
+    cmd: CLICommand,
     client: ConnectedClusterOperations,
     resource_group_name: str,
     cluster_name: str,
@@ -3358,7 +3358,7 @@ def disable_features(
 
 
 def get_chart_and_disable_features(
-    cmd: CLICommmand,
+    cmd: CLICommand,
     connected_cluster: ConnectedCluster,
     kube_config: str | None,
     kube_context: str | None,
@@ -3449,7 +3449,7 @@ def get_chart_and_disable_features(
 
 
 def disable_cluster_connect(
-    cmd: CLICommmand,
+    cmd: CLICommand,
     client: ConnectedClusterOperations,
     resource_group_name: str,
     cluster_name: str,
@@ -3656,7 +3656,7 @@ def handle_merge(
 
 
 def client_side_proxy_wrapper(
-    cmd: CLICommmand,
+    cmd: CLICommand,
     client: ConnectedClusterOperations,
     resource_group_name: str,
     cluster_name: str,
@@ -3827,7 +3827,7 @@ def client_side_proxy_wrapper(
 
 
 def client_side_proxy_main(
-    cmd: CLICommmand,
+    cmd: CLICommand,
     tenant_id: str,
     client: ConnectedClusterOperations,
     resource_group_name: str,
@@ -3898,7 +3898,7 @@ def client_side_proxy_main(
 
 
 def client_side_proxy(
-    cmd: CLICommmand,
+    cmd: CLICommand,
     tenant_id: str,
     client: ConnectedClusterOperations,
     resource_group_name: str,
@@ -4031,7 +4031,7 @@ def client_side_proxy(
 
 
 def check_cl_registration_and_get_oid(
-    cmd: CLICommmand, cl_oid: str | None, subscription_id: str | None
+    cmd: CLICommand, cl_oid: str | None, subscription_id: str | None
 ) -> tuple[bool, str]:
     print(
         f"Step: {utils.get_utctimestring()}: Checking Custom Location(Microsoft.ExtendedLocation) RP Registration state for this Subscription, and attempt to get the Custom Location Object ID (OID),if registered"
@@ -4070,7 +4070,7 @@ def check_cl_registration_and_get_oid(
     return enable_custom_locations, custom_locations_oid
 
 
-def get_custom_locations_oid(cmd: CLICommmand, cl_oid: str | None) -> str:
+def get_custom_locations_oid(cmd: CLICommand, cl_oid: str | None) -> str:
     try:
         graph_client = graph_client_factory(cmd.cli_ctx)
         app_id = "bc313c14-388c-4e7d-a58e-70017303ee3b"
@@ -4131,7 +4131,7 @@ def get_custom_locations_oid(cmd: CLICommmand, cl_oid: str | None) -> str:
 
 
 def troubleshoot(
-    cmd: CLICommmand,
+    cmd: CLICommand,
     client: ConnectedClusterOperations,
     resource_group_name: str,
     cluster_name: str,

--- a/src/connectedk8s/azext_connectedk8s/tests/latest/test_connectedk8s_scenario.py
+++ b/src/connectedk8s/azext_connectedk8s/tests/latest/test_connectedk8s_scenario.py
@@ -193,7 +193,7 @@ def get_bundle_feature_flag_from_config_map(
     if cmd_output.returncode == 0:
         return bundle_feature_flag.decode()
     else:
-        print("Error:", stderr.decode())
+        logger.warning("Failed to get bundle feature flag from config map: " + str(stderr.decode()))
         return None
 
 class Connectedk8sScenarioTest(LiveScenarioTest):

--- a/src/connectedk8s/azext_connectedk8s/tests/latest/test_connectedk8s_scenario.py
+++ b/src/connectedk8s/azext_connectedk8s/tests/latest/test_connectedk8s_scenario.py
@@ -290,7 +290,6 @@ class Connectedk8sScenarioTest(LiveScenarioTest):
         # delete the kube config
         os.remove(_get_test_data_file(managed_cluster_name + "-config.yaml"))
 
-
     @live_only()
     @ResourceGroupPreparer(
         name_prefix="conk8stest", location=CONFIG["location"], random_name_length=16
@@ -372,7 +371,7 @@ class Connectedk8sScenarioTest(LiveScenarioTest):
         name_prefix="conk8stest", location=CONFIG["location"], random_name_length=16
     )
     def test_update_withbundlefeatureflag(self, resource_group):
-        managed_cluster_name = self.create_random_name(prefix="test-connect", length=24)
+        managed_cluster_name = self.create_random_name(prefix="test-update", length=24)
         kubeconfig = _get_test_data_file(managed_cluster_name + "-config.yaml")
         self.kwargs.update(
             {
@@ -463,7 +462,7 @@ class Connectedk8sScenarioTest(LiveScenarioTest):
         name_prefix="conk8stest", location=CONFIG["location"], random_name_length=16
     )
     def test_upgrade_with_agentupdatevalidator(self, resource_group):
-        managed_cluster_name = self.create_random_name(prefix="test-connect", length=24)
+        managed_cluster_name = self.create_random_name(prefix="test-upgrade", length=24)
         kubeconfig = _get_test_data_file(managed_cluster_name + "-config.yaml")
         self.kwargs.update(
             {

--- a/src/connectedk8s/setup.py
+++ b/src/connectedk8s/setup.py
@@ -13,7 +13,7 @@ from setuptools import find_packages, setup
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
 
-VERSION = "1.10.7"
+VERSION = "1.10.8"
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
* Add checks for the Graytown bundle feature flag in the 'connectedk8s connect' and 'connectedk8s update' commands.
* Display a more detailed error message from the agent-update-validator in the 'connectedk8s upgrade' command.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
