### PR TITLE
[confcom] bugfix for json input being case-insensitive

### DIFF
--- a/src/confcom/HISTORY.rst
+++ b/src/confcom/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+1.2.6
+++++++
+* bugfix making it so the fields in the --input format are case-insensitive
+
 1.2.5
 ++++++
 * consolidating functions for --input policygen

--- a/src/confcom/azext_confcom/data/internal_config.json
+++ b/src/confcom/azext_confcom/data/internal_config.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.2.5",
+    "version": "1.2.6",
     "hcsshim_config": {
         "maxVersion": "1.0.0",
         "minVersion": "0.0.1"

--- a/src/confcom/azext_confcom/tests/latest/test_confcom_policy_conversion.py
+++ b/src/confcom/azext_confcom/tests/latest/test_confcom_policy_conversion.py
@@ -48,6 +48,11 @@ class ConvertConfigTests(unittest.TestCase):
                     "mountType": "azureFile",
                     "mountPath": "/mnt/af",
                     "readonly": true
+                },
+                {
+                    "mountType": "emptyDir",
+                    "mountPath": "/mnt/empty",
+                    "readOnly": false
                 }]
             }]
         }
@@ -105,6 +110,13 @@ class ConvertConfigTests(unittest.TestCase):
         self.assertEqual(vm[cfg.ACI_FIELD_TEMPLATE_MOUNTS_PATH], "/mnt/af")
         self.assertEqual(vm[cfg.ACI_FIELD_TEMPLATE_MOUNTS_TYPE], "azureFile")
         self.assertTrue(vm[cfg.ACI_FIELD_TEMPLATE_MOUNTS_READONLY])
+
+        vm = props[cfg.ACI_FIELD_TEMPLATE_VOLUME_MOUNTS][1]
+
+        self.assertEqual(vm[cfg.ACI_FIELD_CONTAINERS_ENVS_NAME], "emptydir")
+        self.assertEqual(vm[cfg.ACI_FIELD_TEMPLATE_MOUNTS_PATH], "/mnt/empty")
+        self.assertEqual(vm[cfg.ACI_FIELD_TEMPLATE_MOUNTS_TYPE], "emptyDir")
+        self.assertFalse(vm[cfg.ACI_FIELD_TEMPLATE_MOUNTS_READONLY])
 
     def test_workingdir_and_allow_elevated_migrated(self) -> None:
         props = self._new_cfg[cfg.ACI_FIELD_CONTAINERS][0][

--- a/src/confcom/azext_confcom/tests/latest/test_confcom_scenario.py
+++ b/src/confcom/azext_confcom/tests/latest/test_confcom_scenario.py
@@ -586,9 +586,9 @@ class CustomJsonParsing(unittest.TestCase):
             aci_policy.populate_policy_content_for_all_images()
             layers = aci_policy.get_images()[0]._layers
             expected_layers = [
-                "1824eb49720f59202136bd38681f32e57239676c9a423fb1e025aa210aaa22aa",
-                "8d68e2b0c2c32fa7fab2a5543d94e0b70b5bea400ca7f89f4c925a02ae15f453",
-                "44e8e0480dc3c0d04564ba87b3ba851cfab008717abdf6be83baf47963599614"
+                "4b17d51a118cfa6405698048bbb9f258f70c44235cf54dab8977e689d4422c1d",
+                "374b10f7af01a18c4408738ec38b302f4766ab62c033208c4b86eb7434ed8217",
+                "c9d8b0df7e0ab9ff83672dd67f154f28fdee0ae0b62c82a3451a44c8e2e29838"
             ]
             self.assertEqual(len(layers), len(expected_layers))
             for i in range(len(expected_layers)):

--- a/src/confcom/setup.py
+++ b/src/confcom/setup.py
@@ -19,7 +19,7 @@ except ImportError:
 
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
 
-VERSION = "1.2.5"
+VERSION = "1.2.6"
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Fixing case sensitivity for fields in json
---
Fields are typically case-insensitive in confcom. In #8835 a bug was introduced where the input.json format was no longer case-insensitive. This PR fixes that.

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
az confcom


### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
