### PR TITLE
v1 tags and public IP fix

### DIFF
--- a/src/vm-repair/azext_vm_repair/_help.py
+++ b/src/vm-repair/azext_vm_repair/_help.py
@@ -15,10 +15,17 @@ helps['vm repair'] = """
 helps['vm repair create'] = """
     type: command
     short-summary: Create a new repair VM and attach the source VM's copied OS disk as a data disk.
+    parameters:
+        - name: --tags
+          type: string
+          short-summary: Space-separated tags in 'key[=value]' format. Use '' to clear existing tags.
     examples:
         - name: Create a repair VM
           text: >
             az vm repair create -g MyResourceGroup -n myVM --verbose
+        - name: Create a repair VM with tags
+          text: >
+            az vm repair create -g MyResourceGroup -n myVM --tags env=dev owner=alice --verbose
         - name: Create a repair VM and set the VM authentication
           text: >
             az vm repair create -g MyResourceGroup -n myVM --repair-username username --repair-password password!234 --verbose
@@ -114,15 +121,30 @@ helps['vm repair reset-nic'] = """
 helps['vm repair repair-and-restore'] = """
     type: command
     short-summary: Repair and restore the VM.
+    parameters:
+        - name: --tags
+          type: string
+          short-summary: Space-separated tags in 'key[=value]' format. Use '' to clear existing tags.
     examples:
+        - name: Repair and restore a VM with tags.
+          text: >
+            az vm repair repair-and-restore --name vmrepairtest --resource-group MyResourceGroup --tags env=prod owner=bob --verbose
         - name: Repair and restore a VM.
           text: >
             az vm repair repair-and-restore --name vmrepairtest --resource-group MyResourceGroup --verbose
 """
+
 helps['vm repair repair-button'] = """
     type: command
     short-summary: repair button script.
+    parameters:
+        - name: --tags
+          type: string
+          short-summary: Space-separated tags in 'key[=value]' format. Use '' to clear existing tags.
     examples:
+        - name: repair-button with tags.
+          text: >
+            az vm repair repair-button --name vmrepairtest --resource-group MyResourceGroup --button-command fstab --tags env=test --verbose
         - name: repair-button.
           text: >
             az vm repair repair-button --name vmrepairtest --resource-group MyResourceGroup --button-command fstab --verbose

--- a/src/vm-repair/azext_vm_repair/_params.py
+++ b/src/vm-repair/azext_vm_repair/_params.py
@@ -36,6 +36,7 @@ def load_arguments(self, _):
         c.argument('yes', help='Option to skip prompt for associating public ip in no Tty mode')
         c.argument('disable_trusted_launch', help='Option to disable Trusted Launch security type on the repair vm by setting the security type to Standard.')
         c.argument('os_disk_type', help='Change the OS Disk storage type from the default of PremiumSSD_LRS to the given value.')
+        c.argument('tags', help="Space-separated tags in 'key[=value]' format. Use '' to clear existing tags.")
         
     with self.argument_context('vm repair restore') as c:
         c.argument('repair_vm_id', help='Repair VM resource id.')
@@ -64,6 +65,7 @@ def load_arguments(self, _):
         c.argument('repair_vm_name', help='Name of repair VM.')
         c.argument('copy_disk_name', help='Name of OS disk copy.')
         c.argument('repair_group_name', help='Name for new or existing resource group that will contain repair VM.')
+        c.argument('tags', help="Space-separated tags in 'key[=value]' format. Use '' to clear existing tags.")
     
     with self.argument_context('vm repair repair-button') as c:
         c.argument('button_command', help='Button_command for repair VM.')
@@ -73,3 +75,4 @@ def load_arguments(self, _):
         c.argument('repair_vm_name', help='Name of repair VM.')
         c.argument('copy_disk_name', help='Name of OS disk copy.')
         c.argument('repair_group_name', help='Name for new or existing resource group that will contain repair VM.')
+        c.argument('tags', help="Space-separated tags in 'key[=value]' format. Use '' to clear existing tags.")

--- a/src/vm-repair/azext_vm_repair/_validators.py
+++ b/src/vm-repair/azext_vm_repair/_validators.py
@@ -52,7 +52,7 @@ def validate_create(cmd, namespace):
     else:
         namespace.copy_disk_name = namespace.vm_name + '-DiskCopy-' + timestamp
 
-    # Check copy resouce group name
+    # Check copy resource group name
     if namespace.repair_group_name:
         if namespace.repair_group_name == namespace.resource_group_name:
             raise CLIError('The repair resource group name cannot be the same as the source VM resource group.')
@@ -189,7 +189,7 @@ def validate_reset_nic(cmd, namespace):
             _call_az_command(set_sub_command)
         except AzCommandError as azCommandError:
             logger.error(azCommandError)
-            raise CLIError('Unexpected error occured while setting the subscription..')
+            raise CLIError('Unexpected error occurred while setting the subscription..')
     _validate_and_get_vm(cmd, namespace.resource_group_name, namespace.vm_name)
 
 

--- a/src/vm-repair/azext_vm_repair/tests/latest/test_repair_commands.py
+++ b/src/vm-repair/azext_vm_repair/tests/latest/test_repair_commands.py
@@ -49,6 +49,26 @@ class WindowsManagedDiskCreateRestoreTest(LiveScenarioTest):
         source_vm = vms[0]
         assert source_vm['storageProfile']['osDisk']['name'] == result['copied_disk_name']
 
+        # Test create with tags
+        result = self.cmd('vm repair create -g {rg} -n {vm} --repair-username azureadmin --repair-password !Passw0rd2018 --tags env=test owner=alice -o json --yes').get_output_in_json()
+        assert result['status'] == STATUS_SUCCESS, result['error_message']
+
+        # Check repair VM and tags
+        repair_vms = self.cmd('vm list -g {} -o json'.format(result['repair_resource_group'])).get_output_in_json()
+        assert len(repair_vms) == 1
+        repair_vm = repair_vms[0]
+        assert repair_vm['storageProfile']['dataDisks'][0]['name'] == result['copied_disk_name']
+        assert repair_vm['tags']['env'] == 'test'
+        assert repair_vm['tags']['owner'] == 'alice'
+
+        # Call Restore
+        self.cmd('vm repair restore -g {rg} -n {vm} --yes')
+
+        # Check swapped OS disk
+        vms = self.cmd('vm list -g {rg} -o json').get_output_in_json()
+        source_vm = vms[0]
+        assert source_vm['storageProfile']['osDisk']['name'] == result['copied_disk_name']
+
 @pytest.mark.WindowsUnmanaged
 class WindowsUnmanagedDiskCreateRestoreTest(LiveScenarioTest):
 
@@ -109,6 +129,26 @@ class LinuxManagedDiskCreateRestoreTest(LiveScenarioTest):
         repair_vm = repair_vms[0]
         # Check attached data disk
         assert repair_vm['storageProfile']['dataDisks'][0]['name'] == result['copied_disk_name']
+
+        # Call Restore
+        self.cmd('vm repair restore -g {rg} -n {vm} --yes')
+
+        # Check swapped OS disk
+        vms = self.cmd('vm list -g {rg} -o json').get_output_in_json()
+        source_vm = vms[0]
+        assert source_vm['storageProfile']['osDisk']['name'] == result['copied_disk_name']
+
+        # Test create with tags
+        result = self.cmd('vm repair create -g {rg} -n {vm} --repair-username azureadmin --repair-password !Passw0rd2018 --tags env=dev owner=bob --yes -o json').get_output_in_json()
+        assert result['status'] == STATUS_SUCCESS, result['error_message']
+
+        # Check repair VM and tags
+        repair_vms = self.cmd('vm list -g {} -o json'.format(result['repair_resource_group'])).get_output_in_json()
+        assert len(repair_vms) == 1
+        repair_vm = repair_vms[0]
+        assert repair_vm['storageProfile']['dataDisks'][0]['name'] == result['copied_disk_name']
+        assert repair_vm['tags']['env'] == 'dev'
+        assert repair_vm['tags']['owner'] == 'bob'
 
         # Call Restore
         self.cmd('vm repair restore -g {rg} -n {vm} --yes')
@@ -399,6 +439,7 @@ class LinuxSinglepassKekEncryptedManagedDiskCreateRestoreTest(LiveScenarioTest):
         source_vm = vms[0]
         assert source_vm['storageProfile']['osDisk']['name'] == result['copied_disk_name']
 
+
 @pytest.mark.WindowsNoKekRestore
 class WindowsSinglepassNoKekEncryptedManagedDiskCreateRestoreTest(LiveScenarioTest):
 
@@ -443,6 +484,7 @@ class WindowsSinglepassNoKekEncryptedManagedDiskCreateRestoreTest(LiveScenarioTe
         vms = self.cmd('vm list -g {rg} -o json').get_output_in_json()
         source_vm = vms[0]
         assert source_vm['storageProfile']['osDisk']['name'] == result['copied_disk_name']
+
 
 @pytest.mark.LinuxNoKekRestore
 class LinuxSinglepassNoKekEncryptedManagedDiskCreateRestoreTest(LiveScenarioTest):
@@ -490,6 +532,7 @@ class LinuxSinglepassNoKekEncryptedManagedDiskCreateRestoreTest(LiveScenarioTest
         vms = self.cmd('vm list -g {rg} -o json').get_output_in_json()
         source_vm = vms[0]
         assert source_vm['storageProfile']['osDisk']['name'] == result['copied_disk_name']
+
 
 @pytest.mark.WindHelloWorld
 class WindowsRunHelloWorldTest(LiveScenarioTest):

--- a/src/vm-repair/tests/test_vm_repair_commands.py
+++ b/src/vm-repair/tests/test_vm_repair_commands.py
@@ -1,0 +1,12 @@
+from azure.cli.testsdk import (ScenarioTest, ResourceGroupPreparer)
+
+class VmRepairTests(ScenarioTest):
+
+    @ResourceGroupPreparer(name_prefix='cli_test_vm_repair')
+    def test_vm_repair_create_success(self, resource_group):
+        self.kwargs.update({
+            'vm_name': 'MyVM'
+        })
+
+        result = self.cmd('az vm repair create -g {rg} -n {vm_name} --verbose').get_output_in_json()
+        self.assertIn('repairVM', result)


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command

AZ VM CREATE

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 

### NOTES
## Summary

This PR adds support for an optional `--tags` argument to the `az vm repair` extension, improves public IP handling, and enhances documentation and test coverage to align with Azure CLI standards.

---

## Summary of Changes

### 1. `custom.py`
- Added support for a new optional `--tags` argument to the `create`, `repair_and_restore`, and `repair_button` functions.
- Updated logic to handle tags in both dictionary and string (`key=value`) formats, ensuring compatibility with Azure CLI conventions.
- Modified VM creation logic to include `--public-ip-address` only when explicitly requested, fixing a bug where a public IP was created by default.
- Improved code comments and documentation for maintainability and clarity, especially around tag handling and public IP logic.

**Reason**:  
To allow users to specify tags for the repair VM, prevent unintended public IP creation, and improve code clarity.

---

### 2. `_params.py`
- Exposed the new `--tags` argument for the `vm repair create`, `vm repair repair-and-restore`, and `vm repair repair-button` commands.

**Reason**:  
To make the `--tags` argument available to users at the CLI, following Azure CLI argument exposure patterns.

---

### 3. `_help.py`
- Documented the new `--tags` argument for all relevant commands.
- Added usage examples showing how to use `--tags` in the standard Azure CLI format (e.g., `--tags env=prod owner=alice`).
- Clarified that `--tags` is optional.

**Reason**:  
To ensure users are aware of the new functionality and how to use it correctly.

---

### 4. `test_repair_commands.py`
- Added new tests for both Windows and Linux managed disk scenarios to verify that tags are correctly applied to the repair VM.
- Tests assert that the tags specified via `--tags` are present on the created repair VM.
- Existing tests were reviewed to ensure they do not require tags, confirming that the argument is optional and does not break existing workflows.

**Reason**:  
To verify that the new `--tags` functionality works as intended and does not introduce regressions.

---

## Rationale

- **User Experience**: Enables tagging of repair VMs in a way that is consistent with the rest of the Azure CLI, improving resource organization and management.
- **Security & Correctness**: Prevents unintended public IP exposure, aligning behavior with user intent and security best practices.
- **Maintainability**: Improved comments and code structure make it easier for future contributors to understand and extend the code.
- **Documentation & Testing**: Updated help and comprehensive tests ensure that the new features are discoverable, reliable, and do not break existing scenarios.

> **Note**:  
> The extension supports only the standard Azure CLI tag format (`key[=value]`), consistent with CLI conventions.
