### PR TITLE
Remove ingress min-replicas, max-replicas parameters

### DIFF
--- a/src/containerapp/HISTORY.rst
+++ b/src/containerapp/HISTORY.rst
@@ -4,6 +4,7 @@ Release History
 ===============
 upcoming
 ++++++
+* 'az containerapp env premium-ingress': remove `--min-replicas` and `--max-replicas` parameters, use workload profile scale instead.
 * 'az containerapp session code-interpreter execute': Extend maximum supported value of `--timeout-in-seconds` from 60 to 220.
 * 'az containerapp job create': Fix message with `--help`
 

--- a/src/containerapp/azext_containerapp/_help.py
+++ b/src/containerapp/azext_containerapp/_help.py
@@ -2384,7 +2384,7 @@ helps['containerapp env premium-ingress'] = """
     examples:
     - name: Enable premium ingress for the environment.
       text: |
-          az containerapp env premium-ingress add -g MyResourceGroup -n MyEnvironment -w WorkloadProfileName --min-replicas 2 --max-replicas 10
+          az containerapp env premium-ingress add -g MyResourceGroup -n MyEnvironment -w WorkloadProfileName
 """
 
 helps['containerapp env premium-ingress add'] = """
@@ -2395,7 +2395,7 @@ helps['containerapp env premium-ingress add'] = """
     examples:
     - name: Add the premium ingress settings for the environment.
       text: |
-          az containerapp env premium-ingress add -g MyResourceGroup -n MyEnvironment -w WorkloadProfileName --min-replicas 2 --max-replicas 10
+          az containerapp env premium-ingress add -g MyResourceGroup -n MyEnvironment -w WorkloadProfileName
 """
 
 helps['containerapp env premium-ingress update'] = """

--- a/src/containerapp/azext_containerapp/_params.py
+++ b/src/containerapp/azext_containerapp/_params.py
@@ -515,8 +515,6 @@ def load_arguments(self, _):
         c.argument('resource_group_name', arg_type=resource_group_name_type, id_part=None)
         c.argument('name', options_list=['--name', '-n'], help="The name of the managed environment.")
         c.argument('workload_profile_name', options_list=['--workload-profile-name', '-w'], help="The workload profile to run ingress replicas on. This profile must not be shared with any container app or job.")
-        c.argument('min_replicas', options_list=['--min-replicas'], type=int, help="Minimum number of replicas to run. Default 2, minimum 2.")
-        c.argument('max_replicas', options_list=['--max-replicas'], type=int, help="Maximum number of replicas to run. Default 10. The upper limit is the maximum cores available in the workload profile.")
         c.argument('termination_grace_period', options_list=['--termination-grace-period', '-t'], type=int, help="Time in seconds to drain requests during ingress shutdown. Default 500, minimum 0, maximum 3600.")
         c.argument('request_idle_timeout', options_list=['--request-idle-timeout'], type=int, help="Timeout in minutes for idle requests. Default 4, minimum 1.")
         c.argument('header_count_limit', options_list=['--header-count-limit'], type=int, help="Limit of http headers per request. Default 100, minimum 1.")

--- a/src/containerapp/azext_containerapp/custom.py
+++ b/src/containerapp/azext_containerapp/custom.py
@@ -3823,7 +3823,7 @@ def show_environment_premium_ingress(cmd, name, resource_group_name):
         handle_raw_exception(e)
 
 
-def add_environment_premium_ingress(cmd, name, resource_group_name, workload_profile_name, min_replicas, max_replicas, termination_grace_period=None, request_idle_timeout=None, header_count_limit=None, no_wait=False):
+def add_environment_premium_ingress(cmd, name, resource_group_name, workload_profile_name, termination_grace_period=None, request_idle_timeout=None, header_count_limit=None, no_wait=False):
     _validate_subscription_registered(cmd, CONTAINER_APPS_RP)
 
     try:
@@ -3831,13 +3831,9 @@ def add_environment_premium_ingress(cmd, name, resource_group_name, workload_pro
         env_patch = {}
         ingress_config = {}
         safe_set(env_patch, "properties", "ingressConfiguration", value=ingress_config)
-        scale = {}
-        ingress_config["scale"] = scale
 
         # Required
         ingress_config["workloadProfileName"] = workload_profile_name
-        scale["minReplicas"] = min_replicas
-        scale["maxReplicas"] = max_replicas
         # Optional, remove if None
         ingress_config["terminationGracePeriodSeconds"] = termination_grace_period
         ingress_config["requestIdleTimeout"] = request_idle_timeout
@@ -3857,23 +3853,16 @@ def add_environment_premium_ingress(cmd, name, resource_group_name, workload_pro
         handle_raw_exception(e)
 
 
-def update_environment_premium_ingress(cmd, name, resource_group_name, workload_profile_name=None, min_replicas=None, max_replicas=None, termination_grace_period=None, request_idle_timeout=None, header_count_limit=None, no_wait=False):
+def update_environment_premium_ingress(cmd, name, resource_group_name, workload_profile_name=None, termination_grace_period=None, request_idle_timeout=None, header_count_limit=None, no_wait=False):
     _validate_subscription_registered(cmd, CONTAINER_APPS_RP)
 
     try:
         ManagedEnvironmentPreviewClient.show(cmd, resource_group_name, name)
         env_patch = {}
         ingress_config = {}
-        scale = {}
 
         if workload_profile_name is not None:
             ingress_config["workloadProfileName"] = workload_profile_name
-        if min_replicas is not None:
-            ingress_config["scale"] = scale
-            scale["minReplicas"] = min_replicas
-        if max_replicas is not None:
-            ingress_config["scale"] = scale
-            scale["maxReplicas"] = max_replicas
         if termination_grace_period is not None:
             ingress_config["terminationGracePeriodSeconds"] = termination_grace_period
         if request_idle_timeout is not None:

--- a/src/containerapp/azext_containerapp/tests/latest/test_containerapp_commands.py
+++ b/src/containerapp/azext_containerapp/tests/latest/test_containerapp_commands.py
@@ -673,10 +673,8 @@ class ContainerappIngressTests(ScenarioTest):
             JMESPathCheck('message', 'No premium ingress configuration found for this environment, using default values.'),
         ])
 
-        self.cmd(f'containerapp env premium-ingress add -g {resource_group} -n {env_name} -w wp-ingress --min-replicas 3 --max-replicas 5', checks=[
+        self.cmd(f'containerapp env premium-ingress add -g {resource_group} -n {env_name} -w wp-ingress', checks=[
             JMESPathCheck('workloadProfileName', 'wp-ingress'),
-            JMESPathCheck('scale.minReplicas', 3),
-            JMESPathCheck('scale.maxReplicas', 5),
             JMESPathCheck('terminationGracePeriodSeconds', None),
             JMESPathCheck('requestIdleTimeout', None),
             JMESPathCheck('headerCountLimit', None),
@@ -684,27 +682,21 @@ class ContainerappIngressTests(ScenarioTest):
         
         self.cmd(f'containerapp env premium-ingress show -g {resource_group} -n {env_name}', checks=[
             JMESPathCheck('workloadProfileName', 'wp-ingress'),
-            JMESPathCheck('scale.minReplicas', 3),
-            JMESPathCheck('scale.maxReplicas', 5),
             JMESPathCheck('terminationGracePeriodSeconds', None),
             JMESPathCheck('requestIdleTimeout', None),
             JMESPathCheck('headerCountLimit', None),
         ])
         
-        self.cmd(f'containerapp env premium-ingress update -g {resource_group} -n {env_name} --min-replicas 4 --max-replicas 20 --termination-grace-period 45 --request-idle-timeout 180 --header-count-limit 40', checks=[
+        self.cmd(f'containerapp env premium-ingress update -g {resource_group} -n {env_name} --termination-grace-period 45 --request-idle-timeout 180 --header-count-limit 40', checks=[
             JMESPathCheck('workloadProfileName', 'wp-ingress'),
-            JMESPathCheck('scale.minReplicas', 4),
-            JMESPathCheck('scale.maxReplicas', 20),
             JMESPathCheck('terminationGracePeriodSeconds', 45),
             JMESPathCheck('requestIdleTimeout', 180),
             JMESPathCheck('headerCountLimit', 40),
         ])
 
         # set removes unspecified optional parameters
-        self.cmd(f'containerapp env premium-ingress add -g {resource_group} -n {env_name} -w wp-ingress --min-replicas 2 --max-replicas 3 --request-idle-timeout 90', checks=[
+        self.cmd(f'containerapp env premium-ingress add -g {resource_group} -n {env_name} -w wp-ingress --request-idle-timeout 90', checks=[
             JMESPathCheck('workloadProfileName', 'wp-ingress'),
-            JMESPathCheck('scale.minReplicas', 2),
-            JMESPathCheck('scale.maxReplicas', 3),
             JMESPathCheck('requestIdleTimeout', 90),
             JMESPathCheck('terminationGracePeriodSeconds', None),
             JMESPathCheck('headerCountLimit', None),


### PR DESCRIPTION
Due to a design change these two parameters are no longer needed. Ingress will instead scale to one large instance per workload profile node.

Contributes to https://msazure.visualstudio.com/Antares/_workitems/edit/33117299

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
az containerapp env premium-ingress add/update


### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)
