### PR TITLE
Use raw docstring to allow backslashes

### DIFF
--- a/src/monitor-control-service/azext_amcs/aaz/latest/monitor/data_collection/rule/_create.py
+++ b/src/monitor-control-service/azext_amcs/aaz/latest/monitor/data_collection/rule/_create.py
@@ -15,7 +15,7 @@ from azure.cli.core.aaz import *
     "monitor data-collection rule create",
 )
 class Create(AAZCommand):
-    """Create a data collection rule.
+    r"""Create a data collection rule.
 
     :example: Create data collection rule
         az monitor data-collection rule create --resource-group "myResourceGroup" --location "eastus" --name "myCollectionRule" --rule-file "C:\samples\dcrEx1.json"


### PR DESCRIPTION
Using a raw docstring will allow backslashes like c:\samples and will fix the warning shown below.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

Running this command:
  az login SCOPE --service-principle -u USER --tenant TENANT -p SECRET
gives a warning:

/root/.azure/cliextensions/monitor-control-service/azext_amcs/aaz/latest/monitor/data_collection/rule/_create.py:18: SyntaxWarning: invalid escape sequence '\s'  """Create a data collection rule.

This PR should fix the warning.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
