### PR TITLE
{Storage-Blob-Preview} Bump main cli version requirement to 2.75.0 

### DIFF
--- a/src/storage-blob-preview/HISTORY.rst
+++ b/src/storage-blob-preview/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+1.0.0b3
+++++++
+* Bump main cli version requirement to 2.75.0
+
 1.0.0b2
 ++++++
 * Remove DATA_COSMOS_TABLE and DATA_STORAGE references

--- a/src/storage-blob-preview/azext_storage_blob_preview/azext_metadata.json
+++ b/src/storage-blob-preview/azext_storage_blob_preview/azext_metadata.json
@@ -1,4 +1,4 @@
 {
     "azext.isPreview": true,
-    "azext.minCliCoreVersion": "2.27.0"
+    "azext.minCliCoreVersion": "2.75.0"
 }

--- a/src/storage-blob-preview/setup.py
+++ b/src/storage-blob-preview/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     from distutils import log as logger
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
 
-VERSION = '1.0.0b2'
+VERSION = '1.0.0b3'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Bump CLI version to 2.75.0 because of previous change not compatible with 2.74.0
Fix https://github.com/Azure/azure-cli/issues/31768

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
