### PR TITLE
Fix Quantum e2e tests to obfuscate test recording data

### DIFF
--- a/src/quantum/tests.live/Run.ps1
+++ b/src/quantum/tests.live/Run.ps1
@@ -25,6 +25,87 @@ function Invoke-SASTokenObfuscation {
     }
 }
 
+function Invoke-APIKeyObfuscation {
+    param (
+        [Parameter(mandatory=$true)]
+        $RecordingsFolderPath
+    )
+
+    Get-ChildItem "$RecordingsFolderPath" -Filter *.yaml | 
+    Foreach-Object {
+        $RecordingFileName = $_.Name
+        $PathToRecording = "$RecordingsFolderPath\$RecordingFileName"
+        Write-Verbose -Message "Searching for API Keys in ""$PathToRecording"" and obfuscating it..."
+        (Get-Content $PathToRecording) -replace 'api_key=[\w%]+','api_key=REDACTED' | Set-Content $PathToRecording
+    }
+}
+
+function Invoke-QuantumWorkspaceDataObfuscation {
+    param (
+        [Parameter(mandatory=$true)]
+        $RecordingsFolderPath
+    )
+
+    Get-ChildItem "$RecordingsFolderPath" -Filter *.yaml | 
+    Foreach-Object {
+        $RecordingFileName = $_.Name
+        $PathToRecording = "$RecordingsFolderPath\$RecordingFileName"
+        Write-Host "Starting obfuscation of sensitive fields in recording file: $PathToRecording"
+
+        # Read full content
+        $content = Get-Content $PathToRecording -Raw
+        Write-Host "Loaded file content."
+
+        # Obfuscate primaryKey and secondaryKey inside JSON strings
+        $content = $content -replace '"primaryKey"\s*:\s*\{[^}]*"key"\s*:\s*"[^"]+"', '"primaryKey":{"key":"REDACTED"'
+        Write-Host "Obfuscated 'primaryKey'."
+
+        $content = $content -replace '"secondaryKey"\s*:\s*\{[^}]*"key"\s*:\s*"[^"]+"', '"secondaryKey":{"key":"REDACTED"'
+        Write-Host "Obfuscated 'secondaryKey'."
+
+        # Obfuscate primary and secondary connection strings
+        $connectionPattern = '"(primary|secondary)ConnectionString"\s*:\s*"SubscriptionId=[^;]+;ResourceGroupName=[^;]+;WorkspaceName=[^;]+;ApiKey=[^;]+;QuantumEndpoint=[^"]+"'
+        $replacementConnection = '"$1ConnectionString":"SubscriptionId=REDACTED;ResourceGroupName=REDACTED;WorkspaceName=REDACTED;ApiKey=REDACTED;QuantumEndpoint=REDACTED"'
+        $content = $content -replace $connectionPattern, $replacementConnection
+        Write-Host "Obfuscated primary and secondary connection strings."
+
+        # Obfuscate standalone ApiKey
+        $content = $content -replace 'ApiKey=[\w-]+;', 'ApiKey=REDACTED;'
+        Write-Host "Obfuscated standalone ApiKey values."
+
+        # Obfuscate apiKeyEnabled boolean
+        $content = $content -replace '"apiKeyEnabled"\s*:\s*(true|false)', '"apiKeyEnabled":REDACTED'
+        Write-Host "Obfuscated 'apiKeyEnabled' values."
+
+        # Obfuscate resourceName
+        $content = $content -replace '"resourceName"\s*:\s*"[^"]+"', '"resourceName":"REDACTED"'
+        Write-Host "Obfuscated 'resourceName' values."
+
+        # Obfuscate quantumWorkspaceName
+        $content = $content -replace '"quantumWorkspaceName"\s*:\s*\{\s*"type"\s*:\s*"String",\s*"value"\s*:\s*"[^"]+"\s*\}', '"quantumWorkspaceName":{"type":"String","value":"REDACTED"}'
+        Write-Host "Obfuscated 'quantumWorkspaceName'."
+
+        # Obfuscate location and storageAccountLocation
+        $content = $content -replace '"(location|storageAccountLocation)"\s*:\s*\{\s*"type"\s*:\s*"String",\s*"value"\s*:\s*"[^"]+"\s*\}', '"$1":{"type":"String","value":"REDACTED"}'
+        Write-Host "Obfuscated 'location' and 'storageAccountLocation'."
+
+        # Obfuscate workspaceName in connection strings
+        $content = $content -replace 'WorkspaceName=[^;]+;', 'WorkspaceName=REDACTED;'
+        Write-Host "Obfuscated 'WorkspaceName' in connection strings."
+
+        # Obfuscate Set-Cookie headers
+        $content = $content -replace 'ApplicationGatewayAffinityCORS=[\w-]+;', 'ApplicationGatewayAffinityCORS=REDACTED;'
+        $content = $content -replace 'ApplicationGatewayAffinity=[\w-]+;', 'ApplicationGatewayAffinity=REDACTED;'
+        $content = $content -replace 'ARRAffinity=[\w-]+;', 'ARRAffinity=REDACTED;'
+        $content = $content -replace 'ARRAffinitySameSite=[\w-]+;', 'ARRAffinitySameSite=REDACTED;'
+        Write-Host "Obfuscated sensitive Set-Cookie headers."
+
+        # Save the modified content
+        Set-Content -Path $PathToRecording -Value $content
+        Write-Host "Finished obfuscation. Changes saved to: $PathToRecording"
+    }
+}
+
 # For debug, print all relevant environment variables:
 Get-ChildItem env:AZURE*, env:*VERSION, env:*OUTDIR | ForEach-Object {
     Write-Host $_.Name "=" $_.Value
@@ -46,6 +127,9 @@ azdev test quantum --live --verbose --xml-path $RecordingsFolderPath
 
 # Make sure we don't check-in SAS-tokens
 Invoke-SASTokenObfuscation -RecordingsFolderPath $RecordingsFolderPath
+
+# Make sure we don't check-in API keys, Connection strings and quantum workspace data
+Invoke-QuantumWorkspaceDataObfuscation -RecordingsFolderPath $RecordingsFolderPath
 
 # Restoring to initial folder location
 Pop-Location


### PR DESCRIPTION
Obfuscate api keys, connection strings, subscription id, resource group name, resource name in recordings.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
