### PR TITLE
{CI} Add artifact publishing for built wheels in CI pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -116,6 +116,14 @@ jobs:
       env:
         ADO_PULL_REQUEST_LATEST_COMMIT: HEAD
         ADO_PULL_REQUEST_TARGET_BRANCH: $(System.PullRequest.TargetBranch)
+        WHEELS_OUTPUT_DIR: $(Build.ArtifactStagingDirectory)/wheels-$(python.version)
+
+    - task: PublishPipelineArtifact@1
+      displayName: 'Publish wheels artifacts from tests'
+      inputs:
+        targetPath: '$(Build.ArtifactStagingDirectory)/wheels-$(python.version)'
+        artifact: 'wheels-$(python.version)'
+        publishLocation: 'pipeline'
 
 - job: AzdevStyleModifiedExtensions
   displayName: "azdev style on Modified Extensions"

--- a/scripts/ci/test_source.py
+++ b/scripts/ci/test_source.py
@@ -99,6 +99,18 @@ def test_source_wheels():
             check_output(['python', 'setup.py', 'bdist_wheel', '-q', '-d', built_whl_dir], cwd=s)
         except CalledProcessError as err:
             raise("Unable to build extension {} : {}".format(s, err))
+    # Export built wheels so CI can publish them as artifacts
+    wheels_out_dir = os.environ.get('WHEELS_OUTPUT_DIR')
+    if wheels_out_dir:
+        try:
+            os.makedirs(wheels_out_dir, exist_ok=True)
+            for fname in os.listdir(built_whl_dir):
+                src_path = os.path.join(built_whl_dir, fname)
+                if os.path.isfile(src_path):
+                    shutil.copy2(src_path, os.path.join(wheels_out_dir, fname))
+            logger.warning(f'Exported wheels to: {wheels_out_dir}')
+        except Exception as ex:
+            logger.exception(f'Failed to export wheels to {wheels_out_dir}: {ex}')
     shutil.rmtree(built_whl_dir)
 
 


### PR DESCRIPTION
---
This PR uploads all candidate wheels to Azure DevOps pipeline artifacts for testing.
<img width="1188" height="698" alt="image" src="https://github.com/user-attachments/assets/59dc7a20-6a87-46d4-bd32-abc5448f9244" />


This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
