### PR TITLE
[DataMigration] - [CLI] - Publish stable API version - 2025-06-30

### DIFF
--- a/src/datamigration/HISTORY.rst
+++ b/src/datamigration/HISTORY.rst
@@ -4,6 +4,11 @@ Release History
 ===============
 
 =======
+1.0.0b6
+++++++
+* Added support for stable version 2025-06-30 of the DMS services.
+
+=======
 1.0.0b5
 ++++++
 * [PARAMETER UPDATE] `az datamigration sql-managed-instance create`: `--source-location` now supports Managed Identity for accessing Azure Blob.

--- a/src/datamigration/azext_datamigration/tests/latest/recordings/test_datamigration_Scenario.yaml
+++ b/src/datamigration/azext_datamigration/tests/latest/recordings/test_datamigration_Scenario.yaml
@@ -19,13 +19,13 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLIUnitTest/providers/Microsoft.DataMigration/sqlMigrationServices/sqlServiceUnitTest-Pipeline2?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLIUnitTest/providers/Microsoft.DataMigration/sqlMigrationServices/sqlServiceUnitTest-Pipeline2?api-version=2025-06-30
   response:
     body:
       string: '{"properties":{"provisioningState":"Provisioning"},"location":"eastus2euap","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLIUnitTest/providers/Microsoft.DataMigration/sqlMigrationServices/sqlServiceUnitTest-Pipeline2","name":"sqlServiceUnitTest-Pipeline2","type":"Microsoft.DataMigration/sqlMigrationServices"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/createsqlmigrationservice/operationResults/129aa1b4-dee8-4824-84a5-7def79fef836?api-version=2022-03-30-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/createsqlmigrationservice/operationResults/129aa1b4-dee8-4824-84a5-7def79fef836?api-version=2025-06-30
       cache-control:
       - no-cache
       content-length:
@@ -65,7 +65,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/createsqlmigrationservice/operationResults/129aa1b4-dee8-4824-84a5-7def79fef836?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/createsqlmigrationservice/operationResults/129aa1b4-dee8-4824-84a5-7def79fef836?api-version=2025-06-30
   response:
     body:
       string: '{"name":"129aa1b4-dee8-4824-84a5-7def79fef836","status":"Succeeded","startTime":"2022-04-18T10:54:28.597Z"}'
@@ -111,7 +111,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLIUnitTest/providers/Microsoft.DataMigration/sqlMigrationServices/sqlServiceUnitTest-Pipeline2?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLIUnitTest/providers/Microsoft.DataMigration/sqlMigrationServices/sqlServiceUnitTest-Pipeline2?api-version=2025-06-30
   response:
     body:
       string: '{"properties":{"provisioningState":"Succeeded","integrationRuntimeState":"NeedRegistration"},"location":"eastus2euap","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLIUnitTest/providers/Microsoft.DataMigration/sqlMigrationServices/sqlServiceUnitTest-Pipeline2","name":"sqlServiceUnitTest-Pipeline2","type":"Microsoft.DataMigration/sqlMigrationServices"}'
@@ -157,7 +157,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLIUnitTest/providers/Microsoft.DataMigration/sqlMigrationServices/dmsCliUnitTest?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLIUnitTest/providers/Microsoft.DataMigration/sqlMigrationServices/dmsCliUnitTest?api-version=2025-06-30
   response:
     body:
       string: '{"properties":{"provisioningState":"Succeeded","integrationRuntimeState":"NeedRegistration"},"location":"eastus2euap","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLIUnitTest/providers/Microsoft.DataMigration/sqlMigrationServices/dmsCliUnitTest","name":"dmsCliUnitTest","type":"Microsoft.DataMigration/sqlMigrationServices"}'
@@ -203,7 +203,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLIUnitTest/providers/Microsoft.DataMigration/sqlMigrationServices?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLIUnitTest/providers/Microsoft.DataMigration/sqlMigrationServices?api-version=2025-06-30
   response:
     body:
       string: '{"value":[{"properties":{"provisioningState":"Succeeded","integrationRuntimeState":""},"location":"eastus2euap","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLIUnitTest/providers/Microsoft.DataMigration/sqlMigrationServices/dmsCliUnitTest","name":"dmsCliUnitTest","type":"Microsoft.DataMigration/sqlMigrationServices"},{"properties":{"provisioningState":"Succeeded","integrationRuntimeState":""},"location":"eastus2euap","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLIUnitTest/providers/Microsoft.DataMigration/sqlMigrationServices/sqlServiceUnitTest-Pipeline1","name":"sqlServiceUnitTest-Pipeline1","type":"Microsoft.DataMigration/sqlMigrationServices"},{"properties":{"provisioningState":"Succeeded","integrationRuntimeState":""},"location":"eastus2euap","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLIUnitTest/providers/Microsoft.DataMigration/sqlMigrationServices/sqlServiceUnitTest-Pipeline2","name":"sqlServiceUnitTest-Pipeline2","type":"Microsoft.DataMigration/sqlMigrationServices"}]}'
@@ -249,7 +249,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLIUnitTest/providers/Microsoft.DataMigration/sqlMigrationServices/dmsCliUnitTest/listMigrations?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLIUnitTest/providers/Microsoft.DataMigration/sqlMigrationServices/dmsCliUnitTest/listMigrations?api-version=2025-06-30
   response:
     body:
       string: '{"value":[]}'
@@ -297,7 +297,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLIUnitTest/providers/Microsoft.DataMigration/sqlMigrationServices/dmsCliUnitTest/listAuthKeys?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLIUnitTest/providers/Microsoft.DataMigration/sqlMigrationServices/dmsCliUnitTest/listAuthKeys?api-version=2025-06-30
   response:
     body:
       string: '{"authKey1":"IR@XXXXXXXXXX","authKey2":"IR@XXXXXXXXXX"}'
@@ -349,7 +349,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLIUnitTest/providers/Microsoft.DataMigration/sqlMigrationServices/dmsCliUnitTest/regenerateAuthKeys?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLIUnitTest/providers/Microsoft.DataMigration/sqlMigrationServices/dmsCliUnitTest/regenerateAuthKeys?api-version=2025-06-30
   response:
     body:
       string: '{"authKey1":"IR@XXXXXXXXXX"}'
@@ -399,7 +399,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLIUnitTest/providers/Microsoft.DataMigration/sqlMigrationServices/dmsCliUnitTest/listMonitoringData?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLIUnitTest/providers/Microsoft.DataMigration/sqlMigrationServices/dmsCliUnitTest/listMonitoringData?api-version=2025-06-30
   response:
     body:
       string: '{"name":"default-ir","nodes":[]}'
@@ -449,13 +449,13 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLIUnitTest/providers/Microsoft.DataMigration/sqlMigrationServices/sqlServiceUnitTest-Pipeline2?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLIUnitTest/providers/Microsoft.DataMigration/sqlMigrationServices/sqlServiceUnitTest-Pipeline2?api-version=2025-06-30
   response:
     body:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/deletesqlmigrationservice/operationResults/43e1b622-463a-4488-97fc-7c7552f40bc9?api-version=2022-03-30-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/deletesqlmigrationservice/operationResults/43e1b622-463a-4488-97fc-7c7552f40bc9?api-version=2025-06-30
       cache-control:
       - no-cache
       content-length:
@@ -465,7 +465,7 @@ interactions:
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/sqlMigrationServiceOperationResults/43e1b622-463a-4488-97fc-7c7552f40bc9?api-version=2022-03-30-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/sqlMigrationServiceOperationResults/43e1b622-463a-4488-97fc-7c7552f40bc9?api-version=2025-06-30
       pragma:
       - no-cache
       server:
@@ -495,7 +495,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/deletesqlmigrationservice/operationResults/43e1b622-463a-4488-97fc-7c7552f40bc9?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/deletesqlmigrationservice/operationResults/43e1b622-463a-4488-97fc-7c7552f40bc9?api-version=2025-06-30
   response:
     body:
       string: '{"name":"43e1b622-463a-4488-97fc-7c7552f40bc9","status":"Succeeded","startTime":"2022-04-18T10:54:53.923Z"}'
@@ -541,7 +541,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MigrationTesting/providers/Microsoft.Sql/managedInstances/migrationtestmi/providers/Microsoft.DataMigration/databaseMigrations/tsum-CLI-MIOnline?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MigrationTesting/providers/Microsoft.Sql/managedInstances/migrationtestmi/providers/Microsoft.DataMigration/databaseMigrations/tsum-CLI-MIOnline?api-version=2025-06-30
   response:
     body:
       string: '{"properties":{"backupConfiguration":{"sourceLocation":{"fileShare":{"path":"\\\\aalab03-2k8.redmond.corp.microsoft.com\\SharedBackup\\tsuman"},"fileStorageType":"FileShare"}},"scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MigrationTesting/providers/Microsoft.Sql/managedInstances/migrationtestmi","provisioningState":"Succeeded","migrationStatus":"Succeeded","startedOn":"2021-12-30T06:16:43.983Z","endedOn":"2021-12-30T07:34:46.553Z","sourceServerName":"AALAB03-2K8.REDMOND.CORP.MICROSOFT.COM","sourceDatabaseName":"AdventureWorks","migrationService":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.DataMigration/sqlMigrationServices/IR1","migrationOperationId":"c20c73a6-9cf4-488e-b458-243b9eb43e24","kind":"SqlMi"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MigrationTesting/providers/Microsoft.Sql/managedInstances/migrationtestmi/providers/Microsoft.DataMigration/databaseMigrations/tsum-CLI-MIOnline","name":"tsum-CLI-MIOnline","type":"Microsoft.DataMigration/databaseMigrations"}'
@@ -587,7 +587,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines/DMSCmdletTest-SqlVM/providers/Microsoft.DataMigration/databaseMigrations/tsum-Db-VM?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines/DMSCmdletTest-SqlVM/providers/Microsoft.DataMigration/databaseMigrations/tsum-Db-VM?api-version=2025-06-30
   response:
     body:
       string: '{"properties":{"backupConfiguration":{"sourceLocation":{"fileShare":{"path":"\\\\aalab03-2k8.redmond.corp.microsoft.com\\SharedBackup\\tsuman"},"fileStorageType":"FileShare"}},"scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines/DMSCmdletTest-SqlVM","provisioningState":"Succeeded","migrationStatus":"Succeeded","startedOn":"2021-12-28T17:31:36.843Z","endedOn":"2021-12-28T17:45:08.573Z","sourceServerName":"AALAB03-2K8.REDMOND.CORP.MICROSOFT.COM","sourceDatabaseName":"AdventureWorks","migrationService":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.DataMigration/sqlMigrationServices/IR1","migrationOperationId":"18aff4bb-892a-4c9a-bc31-49110101255d","kind":"SqlVm"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines/DMSCmdletTest-SqlVM/providers/Microsoft.DataMigration/databaseMigrations/tsum-Db-VM","name":"tsum-Db-VM","type":"Microsoft.DataMigration/databaseMigrations"}'
@@ -648,13 +648,13 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MigrationTesting/providers/Microsoft.Sql/managedInstances/migrationtestmi/providers/Microsoft.DataMigration/databaseMigrations/tsum-Db-mi-online-blob9?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MigrationTesting/providers/Microsoft.Sql/managedInstances/migrationtestmi/providers/Microsoft.DataMigration/databaseMigrations/tsum-Db-mi-online-blob9?api-version=2025-06-30
   response:
     body:
       string: '{"properties":{"backupConfiguration":{"sourceLocation":{"fileStorageType":"AzureBlob"}},"scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MigrationTesting/providers/Microsoft.Sql/managedInstances/migrationtestmi","provisioningState":"Creating","sourceDatabaseName":"AdventureWorks","migrationService":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.DataMigration/sqlMigrationServices/tsuman-IR2","kind":"SqlMi"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MigrationTesting/providers/Microsoft.Sql/managedInstances/migrationtestmi/providers/Microsoft.DataMigration/databaseMigrations/tsum-Db-mi-online-blob9","name":"tsum-Db-mi-online-blob9","type":"Microsoft.DataMigration/databaseMigrations"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/createsqlmimigration/operationResults/b6507332-c794-497d-ab75-e9ad5fff963f?api-version=2022-03-30-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/createsqlmimigration/operationResults/b6507332-c794-497d-ab75-e9ad5fff963f?api-version=2025-06-30
       cache-control:
       - no-cache
       content-length:
@@ -699,7 +699,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/createsqlmimigration/operationResults/b6507332-c794-497d-ab75-e9ad5fff963f?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/createsqlmimigration/operationResults/b6507332-c794-497d-ab75-e9ad5fff963f?api-version=2025-06-30
   response:
     body:
       string: '{"name":"b6507332-c794-497d-ab75-e9ad5fff963f","status":"Succeeded","startTime":"2022-04-18T10:55:14.117Z"}'
@@ -746,7 +746,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MigrationTesting/providers/Microsoft.Sql/managedInstances/migrationtestmi/providers/Microsoft.DataMigration/databaseMigrations/tsum-Db-mi-online-blob9?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MigrationTesting/providers/Microsoft.Sql/managedInstances/migrationtestmi/providers/Microsoft.DataMigration/databaseMigrations/tsum-Db-mi-online-blob9?api-version=2025-06-30
   response:
     body:
       string: '{"properties":{"backupConfiguration":{"sourceLocation":{"fileStorageType":"AzureBlob"}},"scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MigrationTesting/providers/Microsoft.Sql/managedInstances/migrationtestmi","provisioningState":"Succeeded","migrationStatus":"InProgress","startedOn":"2022-04-18T10:55:15.18Z","sourceDatabaseName":"AdventureWorks","migrationService":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.DataMigration/sqlMigrationServices/tsuman-IR2","migrationOperationId":"6f808196-44c7-477f-b0d3-7cc1a4255cdf","kind":"SqlMi"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MigrationTesting/providers/Microsoft.Sql/managedInstances/migrationtestmi/providers/Microsoft.DataMigration/databaseMigrations/tsum-Db-mi-online-blob9","name":"tsum-Db-mi-online-blob9","type":"Microsoft.DataMigration/databaseMigrations"}'
@@ -792,7 +792,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MigrationTesting/providers/Microsoft.Sql/managedInstances/migrationtestmi/providers/Microsoft.DataMigration/databaseMigrations/tsum-Db-mi-online-blob9?$expand=MigrationStatusDetails&api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MigrationTesting/providers/Microsoft.Sql/managedInstances/migrationtestmi/providers/Microsoft.DataMigration/databaseMigrations/tsum-Db-mi-online-blob9?$expand=MigrationStatusDetails&api-version=2025-06-30
   response:
     body:
       string: '{"properties":{"migrationStatusDetails":{"migrationState":"MonitorMigration","blobContainerName":"tsum38-adventureworks","pendingLogBackupsCount":0},"backupConfiguration":{"sourceLocation":{"fileStorageType":"AzureBlob"}},"scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MigrationTesting/providers/Microsoft.Sql/managedInstances/migrationtestmi","provisioningState":"Succeeded","migrationStatus":"InProgress","startedOn":"2022-04-18T10:55:15.18Z","sourceDatabaseName":"AdventureWorks","migrationService":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.DataMigration/sqlMigrationServices/tsuman-IR2","migrationOperationId":"6f808196-44c7-477f-b0d3-7cc1a4255cdf","kind":"SqlMi"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MigrationTesting/providers/Microsoft.Sql/managedInstances/migrationtestmi/providers/Microsoft.DataMigration/databaseMigrations/tsum-Db-mi-online-blob9","name":"tsum-Db-mi-online-blob9","type":"Microsoft.DataMigration/databaseMigrations"}'
@@ -842,13 +842,13 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MigrationTesting/providers/Microsoft.Sql/managedInstances/migrationtestmi/providers/Microsoft.DataMigration/databaseMigrations/tsum-Db-mi-online-blob9/cancel?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MigrationTesting/providers/Microsoft.Sql/managedInstances/migrationtestmi/providers/Microsoft.DataMigration/databaseMigrations/tsum-Db-mi-online-blob9/cancel?api-version=2025-06-30
   response:
     body:
       string: '{"properties":{"scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MigrationTesting/providers/Microsoft.Sql/managedInstances/migrationtestmi","provisioningState":"Canceling","sourceDatabaseName":"AdventureWorks","kind":"SqlMi"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MigrationTesting/providers/Microsoft.Sql/managedInstances/migrationtestmi/providers/Microsoft.DataMigration/databaseMigrations/tsum-Db-mi-online-blob9","name":"tsum-Db-mi-online-blob9","type":"Microsoft.DataMigration/databaseMigrations"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/cancelsqlmimigration/operationResults/994ed8f7-6169-4c3f-b05e-2eb7b9f1eae6?api-version=2022-03-30-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/cancelsqlmimigration/operationResults/994ed8f7-6169-4c3f-b05e-2eb7b9f1eae6?api-version=2025-06-30
       cache-control:
       - no-cache
       content-length:
@@ -892,7 +892,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/cancelsqlmimigration/operationResults/994ed8f7-6169-4c3f-b05e-2eb7b9f1eae6?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/cancelsqlmimigration/operationResults/994ed8f7-6169-4c3f-b05e-2eb7b9f1eae6?api-version=2025-06-30
   response:
     body:
       string: '{"name":"994ed8f7-6169-4c3f-b05e-2eb7b9f1eae6","status":"InProgress","startTime":"2022-04-18T10:55:32.847Z"}'
@@ -938,7 +938,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/cancelsqlmimigration/operationResults/994ed8f7-6169-4c3f-b05e-2eb7b9f1eae6?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/cancelsqlmimigration/operationResults/994ed8f7-6169-4c3f-b05e-2eb7b9f1eae6?api-version=2025-06-30
   response:
     body:
       string: '{"name":"994ed8f7-6169-4c3f-b05e-2eb7b9f1eae6","status":"InProgress","startTime":"2022-04-18T10:55:32.847Z"}'
@@ -984,7 +984,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/cancelsqlmimigration/operationResults/994ed8f7-6169-4c3f-b05e-2eb7b9f1eae6?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/cancelsqlmimigration/operationResults/994ed8f7-6169-4c3f-b05e-2eb7b9f1eae6?api-version=2025-06-30
   response:
     body:
       string: '{"name":"994ed8f7-6169-4c3f-b05e-2eb7b9f1eae6","status":"InProgress","startTime":"2022-04-18T10:55:32.847Z"}'
@@ -1030,7 +1030,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/cancelsqlmimigration/operationResults/994ed8f7-6169-4c3f-b05e-2eb7b9f1eae6?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/cancelsqlmimigration/operationResults/994ed8f7-6169-4c3f-b05e-2eb7b9f1eae6?api-version=2025-06-30
   response:
     body:
       string: '{"name":"994ed8f7-6169-4c3f-b05e-2eb7b9f1eae6","status":"InProgress","startTime":"2022-04-18T10:55:32.847Z"}'
@@ -1076,7 +1076,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/cancelsqlmimigration/operationResults/994ed8f7-6169-4c3f-b05e-2eb7b9f1eae6?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/cancelsqlmimigration/operationResults/994ed8f7-6169-4c3f-b05e-2eb7b9f1eae6?api-version=2025-06-30
   response:
     body:
       string: '{"name":"994ed8f7-6169-4c3f-b05e-2eb7b9f1eae6","status":"InProgress","startTime":"2022-04-18T10:55:32.847Z"}'
@@ -1122,7 +1122,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/cancelsqlmimigration/operationResults/994ed8f7-6169-4c3f-b05e-2eb7b9f1eae6?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/cancelsqlmimigration/operationResults/994ed8f7-6169-4c3f-b05e-2eb7b9f1eae6?api-version=2025-06-30
   response:
     body:
       string: '{"name":"994ed8f7-6169-4c3f-b05e-2eb7b9f1eae6","status":"InProgress","startTime":"2022-04-18T10:55:32.847Z"}'
@@ -1168,7 +1168,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/cancelsqlmimigration/operationResults/994ed8f7-6169-4c3f-b05e-2eb7b9f1eae6?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/cancelsqlmimigration/operationResults/994ed8f7-6169-4c3f-b05e-2eb7b9f1eae6?api-version=2025-06-30
   response:
     body:
       string: '{"name":"994ed8f7-6169-4c3f-b05e-2eb7b9f1eae6","status":"InProgress","startTime":"2022-04-18T10:55:32.847Z"}'
@@ -1214,7 +1214,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/cancelsqlmimigration/operationResults/994ed8f7-6169-4c3f-b05e-2eb7b9f1eae6?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/cancelsqlmimigration/operationResults/994ed8f7-6169-4c3f-b05e-2eb7b9f1eae6?api-version=2025-06-30
   response:
     body:
       string: '{"name":"994ed8f7-6169-4c3f-b05e-2eb7b9f1eae6","status":"Succeeded","startTime":"2022-04-18T10:55:32.847Z"}'
@@ -1275,13 +1275,13 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines/DMSCmdletTest-SqlVM/providers/Microsoft.DataMigration/databaseMigrations/tsum-Db-vm-online-blob10?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines/DMSCmdletTest-SqlVM/providers/Microsoft.DataMigration/databaseMigrations/tsum-Db-vm-online-blob10?api-version=2025-06-30
   response:
     body:
       string: '{"properties":{"backupConfiguration":{"sourceLocation":{"fileStorageType":"AzureBlob"}},"scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines/DMSCmdletTest-SqlVM","provisioningState":"Creating","sourceDatabaseName":"AdventureWorks","migrationService":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.DataMigration/sqlMigrationServices/tsuman-IR2","kind":"SqlVm"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines/DMSCmdletTest-SqlVM/providers/Microsoft.DataMigration/databaseMigrations/tsum-Db-vm-online-blob10","name":"tsum-Db-vm-online-blob10","type":"Microsoft.DataMigration/databaseMigrations"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/createsqlvmmigration/operationResults/5c89b1d2-954f-44c7-945d-7c9e3cfc6933?api-version=2022-03-30-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/createsqlvmmigration/operationResults/5c89b1d2-954f-44c7-945d-7c9e3cfc6933?api-version=2025-06-30
       cache-control:
       - no-cache
       content-length:
@@ -1326,7 +1326,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/createsqlvmmigration/operationResults/5c89b1d2-954f-44c7-945d-7c9e3cfc6933?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/createsqlvmmigration/operationResults/5c89b1d2-954f-44c7-945d-7c9e3cfc6933?api-version=2025-06-30
   response:
     body:
       string: '{"name":"5c89b1d2-954f-44c7-945d-7c9e3cfc6933","status":"InProgress","startTime":"2022-04-18T10:57:37.26Z"}'
@@ -1373,7 +1373,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/createsqlvmmigration/operationResults/5c89b1d2-954f-44c7-945d-7c9e3cfc6933?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/createsqlvmmigration/operationResults/5c89b1d2-954f-44c7-945d-7c9e3cfc6933?api-version=2025-06-30
   response:
     body:
       string: '{"name":"5c89b1d2-954f-44c7-945d-7c9e3cfc6933","status":"InProgress","startTime":"2022-04-18T10:57:37.26Z"}'
@@ -1420,7 +1420,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/createsqlvmmigration/operationResults/5c89b1d2-954f-44c7-945d-7c9e3cfc6933?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/createsqlvmmigration/operationResults/5c89b1d2-954f-44c7-945d-7c9e3cfc6933?api-version=2025-06-30
   response:
     body:
       string: '{"name":"5c89b1d2-954f-44c7-945d-7c9e3cfc6933","status":"InProgress","startTime":"2022-04-18T10:57:37.26Z"}'
@@ -1467,7 +1467,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/createsqlvmmigration/operationResults/5c89b1d2-954f-44c7-945d-7c9e3cfc6933?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/createsqlvmmigration/operationResults/5c89b1d2-954f-44c7-945d-7c9e3cfc6933?api-version=2025-06-30
   response:
     body:
       string: '{"name":"5c89b1d2-954f-44c7-945d-7c9e3cfc6933","status":"InProgress","startTime":"2022-04-18T10:57:37.26Z"}'
@@ -1514,7 +1514,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/createsqlvmmigration/operationResults/5c89b1d2-954f-44c7-945d-7c9e3cfc6933?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/createsqlvmmigration/operationResults/5c89b1d2-954f-44c7-945d-7c9e3cfc6933?api-version=2025-06-30
   response:
     body:
       string: '{"name":"5c89b1d2-954f-44c7-945d-7c9e3cfc6933","status":"InProgress","startTime":"2022-04-18T10:57:37.26Z"}'
@@ -1561,7 +1561,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/createsqlvmmigration/operationResults/5c89b1d2-954f-44c7-945d-7c9e3cfc6933?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/createsqlvmmigration/operationResults/5c89b1d2-954f-44c7-945d-7c9e3cfc6933?api-version=2025-06-30
   response:
     body:
       string: '{"name":"5c89b1d2-954f-44c7-945d-7c9e3cfc6933","status":"Succeeded","startTime":"2022-04-18T10:57:37.26Z"}'
@@ -1608,7 +1608,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines/DMSCmdletTest-SqlVM/providers/Microsoft.DataMigration/databaseMigrations/tsum-Db-vm-online-blob10?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines/DMSCmdletTest-SqlVM/providers/Microsoft.DataMigration/databaseMigrations/tsum-Db-vm-online-blob10?api-version=2025-06-30
   response:
     body:
       string: '{"properties":{"backupConfiguration":{"sourceLocation":{"fileStorageType":"AzureBlob"}},"scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines/DMSCmdletTest-SqlVM","provisioningState":"Succeeded","migrationStatus":"InProgress","startedOn":"2022-04-18T10:59:09.107Z","sourceDatabaseName":"AdventureWorks","migrationService":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.DataMigration/sqlMigrationServices/tsuman-IR2","migrationOperationId":"2e8b78cf-f22e-4475-8f3d-3a0836b2843f","kind":"SqlVm"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines/DMSCmdletTest-SqlVM/providers/Microsoft.DataMigration/databaseMigrations/tsum-Db-vm-online-blob10","name":"tsum-Db-vm-online-blob10","type":"Microsoft.DataMigration/databaseMigrations"}'
@@ -1654,7 +1654,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines/DMSCmdletTest-SqlVM/providers/Microsoft.DataMigration/databaseMigrations/tsum-Db-vm-online-blob10?$expand=MigrationStatusDetails&api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines/DMSCmdletTest-SqlVM/providers/Microsoft.DataMigration/databaseMigrations/tsum-Db-vm-online-blob10?$expand=MigrationStatusDetails&api-version=2025-06-30
   response:
     body:
       string: '{"properties":{"migrationStatusDetails":{"migrationState":"MonitorMigration","blobContainerName":"tsum38-adventureworks","pendingLogBackupsCount":0},"backupConfiguration":{"sourceLocation":{"fileStorageType":"AzureBlob"}},"scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines/DMSCmdletTest-SqlVM","provisioningState":"Succeeded","migrationStatus":"InProgress","startedOn":"2022-04-18T10:59:09.107Z","sourceDatabaseName":"AdventureWorks","migrationService":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.DataMigration/sqlMigrationServices/tsuman-IR2","migrationOperationId":"2e8b78cf-f22e-4475-8f3d-3a0836b2843f","kind":"SqlVm"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines/DMSCmdletTest-SqlVM/providers/Microsoft.DataMigration/databaseMigrations/tsum-Db-vm-online-blob10","name":"tsum-Db-vm-online-blob10","type":"Microsoft.DataMigration/databaseMigrations"}'
@@ -1704,13 +1704,13 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines/DMSCmdletTest-SqlVM/providers/Microsoft.DataMigration/databaseMigrations/tsum-Db-vm-online-blob10/cancel?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines/DMSCmdletTest-SqlVM/providers/Microsoft.DataMigration/databaseMigrations/tsum-Db-vm-online-blob10/cancel?api-version=2025-06-30
   response:
     body:
       string: '{"properties":{"scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines/DMSCmdletTest-SqlVM","provisioningState":"Canceling","sourceDatabaseName":"AdventureWorks","kind":"SqlVm"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines/DMSCmdletTest-SqlVM/providers/Microsoft.DataMigration/databaseMigrations/tsum-Db-vm-online-blob10","name":"tsum-Db-vm-online-blob10","type":"Microsoft.DataMigration/databaseMigrations"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/cancelsqlvmmigration/operationResults/98b22b3b-659d-4464-804c-74f12ccaf749?api-version=2022-03-30-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/cancelsqlvmmigration/operationResults/98b22b3b-659d-4464-804c-74f12ccaf749?api-version=2025-06-30
       cache-control:
       - no-cache
       content-length:
@@ -1754,7 +1754,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/cancelsqlvmmigration/operationResults/98b22b3b-659d-4464-804c-74f12ccaf749?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/cancelsqlvmmigration/operationResults/98b22b3b-659d-4464-804c-74f12ccaf749?api-version=2025-06-30
   response:
     body:
       string: '{"name":"98b22b3b-659d-4464-804c-74f12ccaf749","status":"InProgress","startTime":"2022-04-18T11:01:11.297Z"}'
@@ -1800,7 +1800,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/cancelsqlvmmigration/operationResults/98b22b3b-659d-4464-804c-74f12ccaf749?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/cancelsqlvmmigration/operationResults/98b22b3b-659d-4464-804c-74f12ccaf749?api-version=2025-06-30
   response:
     body:
       string: '{"name":"98b22b3b-659d-4464-804c-74f12ccaf749","status":"InProgress","startTime":"2022-04-18T11:01:11.297Z"}'
@@ -1846,7 +1846,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/cancelsqlvmmigration/operationResults/98b22b3b-659d-4464-804c-74f12ccaf749?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/cancelsqlvmmigration/operationResults/98b22b3b-659d-4464-804c-74f12ccaf749?api-version=2025-06-30
   response:
     body:
       string: '{"name":"98b22b3b-659d-4464-804c-74f12ccaf749","status":"InProgress","startTime":"2022-04-18T11:01:11.297Z"}'
@@ -1892,7 +1892,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/cancelsqlvmmigration/operationResults/98b22b3b-659d-4464-804c-74f12ccaf749?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/cancelsqlvmmigration/operationResults/98b22b3b-659d-4464-804c-74f12ccaf749?api-version=2025-06-30
   response:
     body:
       string: '{"name":"98b22b3b-659d-4464-804c-74f12ccaf749","status":"InProgress","startTime":"2022-04-18T11:01:11.297Z"}'
@@ -1938,7 +1938,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/cancelsqlvmmigration/operationResults/98b22b3b-659d-4464-804c-74f12ccaf749?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/cancelsqlvmmigration/operationResults/98b22b3b-659d-4464-804c-74f12ccaf749?api-version=2025-06-30
   response:
     body:
       string: '{"name":"98b22b3b-659d-4464-804c-74f12ccaf749","status":"Succeeded","startTime":"2022-04-18T11:01:11.297Z"}'
@@ -1984,7 +1984,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines/DMSCmdletTest-SqlVM/providers/Microsoft.DataMigration/databaseMigrations/tsum-Db-vm-online-blob10?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines/DMSCmdletTest-SqlVM/providers/Microsoft.DataMigration/databaseMigrations/tsum-Db-vm-online-blob10?api-version=2025-06-30
   response:
     body:
       string: '{"properties":{"backupConfiguration":{"sourceLocation":{"fileStorageType":"AzureBlob"}},"scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines/DMSCmdletTest-SqlVM","provisioningState":"Succeeded","migrationStatus":"Canceled","startedOn":"2022-04-18T10:59:09.107Z","endedOn":"2022-04-18T11:02:23.15Z","sourceDatabaseName":"AdventureWorks","migrationService":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.DataMigration/sqlMigrationServices/tsuman-IR2","migrationOperationId":"2e8b78cf-f22e-4475-8f3d-3a0836b2843f","kind":"SqlVm"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines/DMSCmdletTest-SqlVM/providers/Microsoft.DataMigration/databaseMigrations/tsum-Db-vm-online-blob10","name":"tsum-Db-vm-online-blob10","type":"Microsoft.DataMigration/databaseMigrations"}'
@@ -2030,7 +2030,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb?api-version=2025-06-30
   response:
     body:
       string: '{"properties":{"offlineConfiguration":{"offline":true},"backupConfiguration":{"sourceLocation":{"fileStorageType":"None"}},"scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb","provisioningState":"Succeeded","migrationStatus":"Canceled","startedOn":"2022-04-18T10:13:44.08Z","endedOn":"2022-04-18T10:13:52.983Z","sourceServerName":"AALAB03-2K8.REDMOND.CORP.MICROSOFT.COM","sourceDatabaseName":"Brih","migrationService":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.DataMigration/sqlMigrationServices/tsuman-IR2","migrationOperationId":"b1f1aafa-42bc-4479-9172-5855d4fdb4f1","kind":"SqlDb"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb","name":"NewDb","type":"Microsoft.DataMigration/databaseMigrations"}'
@@ -2086,13 +2086,13 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb?api-version=2025-06-30
   response:
     body:
       string: '{"properties":{"offlineConfiguration":{"offline":true},"backupConfiguration":{"sourceLocation":{"fileStorageType":"None"}},"scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb","provisioningState":"Creating","sourceServerName":"AALAB03-2K8.REDMOND.CORP.MICROSOFT.COM","sourceDatabaseName":"Brih","migrationService":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.DataMigration/sqlMigrationServices/tsuman-IR2","kind":"SqlDb"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb","name":"NewDb","type":"Microsoft.DataMigration/databaseMigrations"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/createsqldbmigration/operationResults/45dcdf4c-3d17-4abc-9a78-24b7ec6729b4?api-version=2022-03-30-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/createsqldbmigration/operationResults/45dcdf4c-3d17-4abc-9a78-24b7ec6729b4?api-version=2025-06-30
       cache-control:
       - no-cache
       content-length:
@@ -2137,7 +2137,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/createsqldbmigration/operationResults/45dcdf4c-3d17-4abc-9a78-24b7ec6729b4?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/createsqldbmigration/operationResults/45dcdf4c-3d17-4abc-9a78-24b7ec6729b4?api-version=2025-06-30
   response:
     body:
       string: '{"name":"45dcdf4c-3d17-4abc-9a78-24b7ec6729b4","status":"InProgress","startTime":"2022-04-18T11:02:32.077Z"}'
@@ -2184,7 +2184,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/createsqldbmigration/operationResults/45dcdf4c-3d17-4abc-9a78-24b7ec6729b4?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/createsqldbmigration/operationResults/45dcdf4c-3d17-4abc-9a78-24b7ec6729b4?api-version=2025-06-30
   response:
     body:
       string: '{"name":"45dcdf4c-3d17-4abc-9a78-24b7ec6729b4","status":"Succeeded","startTime":"2022-04-18T11:02:32.077Z"}'
@@ -2231,7 +2231,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb?api-version=2025-06-30
   response:
     body:
       string: '{"properties":{"offlineConfiguration":{"offline":true},"backupConfiguration":{"sourceLocation":{"fileStorageType":"None"}},"scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb","provisioningState":"Succeeded","migrationStatus":"InProgress","startedOn":"2022-04-18T11:02:50.483Z","sourceServerName":"AALAB03-2K8.REDMOND.CORP.MICROSOFT.COM","sourceDatabaseName":"Brih","migrationService":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.DataMigration/sqlMigrationServices/tsuman-IR2","migrationOperationId":"54dd90ce-149f-4221-a74b-e85b37e18b46","kind":"SqlDb"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb","name":"NewDb","type":"Microsoft.DataMigration/databaseMigrations"}'
@@ -2279,13 +2279,13 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb?force=true&api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb?force=true&api-version=2025-06-30
   response:
     body:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/dropsqldbmigration/operationResults/f6f64497-897a-4832-b758-284c837af112?api-version=2022-03-30-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/dropsqldbmigration/operationResults/f6f64497-897a-4832-b758-284c837af112?api-version=2025-06-30
       cache-control:
       - no-cache
       content-length:
@@ -2323,7 +2323,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/dropsqldbmigration/operationResults/f6f64497-897a-4832-b758-284c837af112?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/dropsqldbmigration/operationResults/f6f64497-897a-4832-b758-284c837af112?api-version=2025-06-30
   response:
     body:
       string: '{"name":"f6f64497-897a-4832-b758-284c837af112","status":"Succeeded","startTime":"2022-04-18T11:03:05.953Z"}'
@@ -2379,13 +2379,13 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb?api-version=2025-06-30
   response:
     body:
       string: '{"properties":{"offlineConfiguration":{"offline":true},"backupConfiguration":{"sourceLocation":{"fileStorageType":"None"}},"scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb","provisioningState":"Creating","sourceServerName":"AALAB03-2K8.REDMOND.CORP.MICROSOFT.COM","sourceDatabaseName":"Brih","migrationService":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.DataMigration/sqlMigrationServices/tsuman-IR2","kind":"SqlDb"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb","name":"NewDb","type":"Microsoft.DataMigration/databaseMigrations"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/createsqldbmigration/operationResults/f9c6e635-000e-4e50-8d99-c147010b83c5?api-version=2022-03-30-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/createsqldbmigration/operationResults/f9c6e635-000e-4e50-8d99-c147010b83c5?api-version=2025-06-30
       cache-control:
       - no-cache
       content-length:
@@ -2426,7 +2426,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/createsqldbmigration/operationResults/f9c6e635-000e-4e50-8d99-c147010b83c5?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/createsqldbmigration/operationResults/f9c6e635-000e-4e50-8d99-c147010b83c5?api-version=2025-06-30
   response:
     body:
       string: '{"name":"f9c6e635-000e-4e50-8d99-c147010b83c5","status":"Succeeded","startTime":"2022-04-18T11:03:23.073Z"}'
@@ -2473,7 +2473,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb?api-version=2025-06-30
   response:
     body:
       string: '{"properties":{"offlineConfiguration":{"offline":true},"backupConfiguration":{"sourceLocation":{"fileStorageType":"None"}},"scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb","provisioningState":"Succeeded","migrationStatus":"InProgress","startedOn":"2022-04-18T11:03:34.51Z","sourceServerName":"AALAB03-2K8.REDMOND.CORP.MICROSOFT.COM","sourceDatabaseName":"Brih","migrationService":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.DataMigration/sqlMigrationServices/tsuman-IR2","migrationOperationId":"cbe6ae9c-f5eb-4500-9247-cd5f4a03c9b4","kind":"SqlDb"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb","name":"NewDb","type":"Microsoft.DataMigration/databaseMigrations"}'
@@ -2519,7 +2519,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb?$expand=MigrationStatusDetails&api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb?$expand=MigrationStatusDetails&api-version=2025-06-30
   response:
     body:
       string: '{"properties":{"migrationStatusDetails":{"migrationState":"StartSqlDataCopy","listOfCopyProgressDetails":[]},"offlineConfiguration":{"offline":true},"backupConfiguration":{"sourceLocation":{"fileStorageType":"None"}},"scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb","provisioningState":"Succeeded","migrationStatus":"InProgress","startedOn":"2022-04-18T11:03:34.51Z","sourceServerName":"AALAB03-2K8.REDMOND.CORP.MICROSOFT.COM","sourceDatabaseName":"Brih","migrationService":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.DataMigration/sqlMigrationServices/tsuman-IR2","migrationOperationId":"cbe6ae9c-f5eb-4500-9247-cd5f4a03c9b4","kind":"SqlDb"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb","name":"NewDb","type":"Microsoft.DataMigration/databaseMigrations"}'
@@ -2569,13 +2569,13 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb/cancel?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb/cancel?api-version=2025-06-30
   response:
     body:
       string: '{"properties":{"offlineConfiguration":{"offline":true},"backupConfiguration":{"sourceLocation":{"fileStorageType":"None"}},"scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb","provisioningState":"Canceling","sourceServerName":"AALAB03-2K8.REDMOND.CORP.MICROSOFT.COM","sourceDatabaseName":"Brih","kind":"SqlDb"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb","name":"NewDb","type":"Microsoft.DataMigration/databaseMigrations"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/cancelsqldbmigration/operationResults/b0d5fb4c-4a23-403d-bb2a-0e3b056c829b?api-version=2022-03-30-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/cancelsqldbmigration/operationResults/b0d5fb4c-4a23-403d-bb2a-0e3b056c829b?api-version=2025-06-30
       cache-control:
       - no-cache
       content-length:
@@ -2619,7 +2619,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/cancelsqldbmigration/operationResults/b0d5fb4c-4a23-403d-bb2a-0e3b056c829b?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/cancelsqldbmigration/operationResults/b0d5fb4c-4a23-403d-bb2a-0e3b056c829b?api-version=2025-06-30
   response:
     body:
       string: '{"name":"b0d5fb4c-4a23-403d-bb2a-0e3b056c829b","status":"Succeeded","startTime":"2022-04-18T11:03:41.953Z"}'
@@ -2676,13 +2676,13 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb?api-version=2025-06-30
   response:
     body:
       string: '{"properties":{"offlineConfiguration":{"offline":true},"backupConfiguration":{"sourceLocation":{"fileStorageType":"None"}},"tableList":["[dbo].[Table_1]"],"scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb","provisioningState":"Creating","sourceServerName":"AALAB03-2K8.REDMOND.CORP.MICROSOFT.COM","sourceDatabaseName":"Brih","migrationService":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.DataMigration/sqlMigrationServices/tsuman-IR2","kind":"SqlDb"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb","name":"NewDb","type":"Microsoft.DataMigration/databaseMigrations"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/createsqldbmigration/operationResults/9c5bd682-81a8-41c5-87c7-65b4b4123e32?api-version=2022-03-30-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/createsqldbmigration/operationResults/9c5bd682-81a8-41c5-87c7-65b4b4123e32?api-version=2025-06-30
       cache-control:
       - no-cache
       content-length:
@@ -2727,7 +2727,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/createsqldbmigration/operationResults/9c5bd682-81a8-41c5-87c7-65b4b4123e32?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DataMigration/locations/eastus2euap/operationTypes/createsqldbmigration/operationResults/9c5bd682-81a8-41c5-87c7-65b4b4123e32?api-version=2025-06-30
   response:
     body:
       string: '{"name":"9c5bd682-81a8-41c5-87c7-65b4b4123e32","status":"Succeeded","startTime":"2022-04-18T11:04:00.653Z"}'
@@ -2774,7 +2774,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb?api-version=2025-06-30
   response:
     body:
       string: '{"properties":{"offlineConfiguration":{"offline":true},"backupConfiguration":{"sourceLocation":{"fileStorageType":"None"}},"tableList":["[dbo].[Table_1]"],"scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb","provisioningState":"Succeeded","migrationStatus":"InProgress","startedOn":"2022-04-18T11:04:10.497Z","sourceServerName":"AALAB03-2K8.REDMOND.CORP.MICROSOFT.COM","sourceDatabaseName":"Brih","migrationService":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.DataMigration/sqlMigrationServices/tsuman-IR2","migrationOperationId":"ea36f793-8bd1-4ceb-a82a-e0faf0d0dfcb","kind":"SqlDb"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb","name":"NewDb","type":"Microsoft.DataMigration/databaseMigrations"}'
@@ -2820,7 +2820,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb?$expand=MigrationStatusDetails&api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb?$expand=MigrationStatusDetails&api-version=2025-06-30
   response:
     body:
       string: '{"properties":{"migrationStatusDetails":{"migrationState":"MonitorMigration","listOfCopyProgressDetails":[]},"offlineConfiguration":{"offline":true},"backupConfiguration":{"sourceLocation":{"fileStorageType":"None"}},"tableList":["[dbo].[Table_1]"],"scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb","provisioningState":"Succeeded","migrationStatus":"InProgress","startedOn":"2022-04-18T11:04:10.497Z","sourceServerName":"AALAB03-2K8.REDMOND.CORP.MICROSOFT.COM","sourceDatabaseName":"Brih","migrationService":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.DataMigration/sqlMigrationServices/tsuman-IR2","migrationOperationId":"ea36f793-8bd1-4ceb-a82a-e0faf0d0dfcb","kind":"SqlDb"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb","name":"NewDb","type":"Microsoft.DataMigration/databaseMigrations"}'
@@ -2866,7 +2866,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb?$expand=MigrationStatusDetails&api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb?$expand=MigrationStatusDetails&api-version=2025-06-30
   response:
     body:
       string: '{"properties":{"migrationStatusDetails":{"migrationState":"MonitorMigration","listOfCopyProgressDetails":[]},"offlineConfiguration":{"offline":true},"backupConfiguration":{"sourceLocation":{"fileStorageType":"None"}},"tableList":["[dbo].[Table_1]"],"scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb","provisioningState":"Succeeded","migrationStatus":"InProgress","startedOn":"2022-04-18T11:04:10.497Z","sourceServerName":"AALAB03-2K8.REDMOND.CORP.MICROSOFT.COM","sourceDatabaseName":"Brih","migrationService":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.DataMigration/sqlMigrationServices/tsuman-IR2","migrationOperationId":"ea36f793-8bd1-4ceb-a82a-e0faf0d0dfcb","kind":"SqlDb"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb","name":"NewDb","type":"Microsoft.DataMigration/databaseMigrations"}'
@@ -2912,7 +2912,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb?$expand=MigrationStatusDetails&api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb?$expand=MigrationStatusDetails&api-version=2025-06-30
   response:
     body:
       string: '{"properties":{"migrationStatusDetails":{"migrationState":"MonitorMigration","listOfCopyProgressDetails":[]},"offlineConfiguration":{"offline":true},"backupConfiguration":{"sourceLocation":{"fileStorageType":"None"}},"tableList":["[dbo].[Table_1]"],"scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb","provisioningState":"Succeeded","migrationStatus":"InProgress","startedOn":"2022-04-18T11:04:10.497Z","sourceServerName":"AALAB03-2K8.REDMOND.CORP.MICROSOFT.COM","sourceDatabaseName":"Brih","migrationService":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.DataMigration/sqlMigrationServices/tsuman-IR2","migrationOperationId":"ea36f793-8bd1-4ceb-a82a-e0faf0d0dfcb","kind":"SqlDb"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb","name":"NewDb","type":"Microsoft.DataMigration/databaseMigrations"}'
@@ -2958,7 +2958,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb?$expand=MigrationStatusDetails&api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb?$expand=MigrationStatusDetails&api-version=2025-06-30
   response:
     body:
       string: '{"properties":{"migrationStatusDetails":{"migrationState":"MonitorMigration","listOfCopyProgressDetails":[]},"offlineConfiguration":{"offline":true},"backupConfiguration":{"sourceLocation":{"fileStorageType":"None"}},"tableList":["[dbo].[Table_1]"],"scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb","provisioningState":"Succeeded","migrationStatus":"InProgress","startedOn":"2022-04-18T11:04:10.497Z","sourceServerName":"AALAB03-2K8.REDMOND.CORP.MICROSOFT.COM","sourceDatabaseName":"Brih","migrationService":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.DataMigration/sqlMigrationServices/tsuman-IR2","migrationOperationId":"ea36f793-8bd1-4ceb-a82a-e0faf0d0dfcb","kind":"SqlDb"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb","name":"NewDb","type":"Microsoft.DataMigration/databaseMigrations"}'
@@ -3004,7 +3004,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb?$expand=MigrationStatusDetails&api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb?$expand=MigrationStatusDetails&api-version=2025-06-30
   response:
     body:
       string: '{"properties":{"migrationStatusDetails":{"migrationState":"MonitorMigration","listOfCopyProgressDetails":[]},"offlineConfiguration":{"offline":true},"backupConfiguration":{"sourceLocation":{"fileStorageType":"None"}},"tableList":["[dbo].[Table_1]"],"scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb","provisioningState":"Succeeded","migrationStatus":"InProgress","startedOn":"2022-04-18T11:04:10.497Z","sourceServerName":"AALAB03-2K8.REDMOND.CORP.MICROSOFT.COM","sourceDatabaseName":"Brih","migrationService":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.DataMigration/sqlMigrationServices/tsuman-IR2","migrationOperationId":"ea36f793-8bd1-4ceb-a82a-e0faf0d0dfcb","kind":"SqlDb"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb","name":"NewDb","type":"Microsoft.DataMigration/databaseMigrations"}'
@@ -3050,7 +3050,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb?$expand=MigrationStatusDetails&api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb?$expand=MigrationStatusDetails&api-version=2025-06-30
   response:
     body:
       string: '{"properties":{"migrationStatusDetails":{"migrationState":"MonitorMigration","listOfCopyProgressDetails":[]},"offlineConfiguration":{"offline":true},"backupConfiguration":{"sourceLocation":{"fileStorageType":"None"}},"tableList":["[dbo].[Table_1]"],"scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb","provisioningState":"Succeeded","migrationStatus":"InProgress","startedOn":"2022-04-18T11:04:10.497Z","sourceServerName":"AALAB03-2K8.REDMOND.CORP.MICROSOFT.COM","sourceDatabaseName":"Brih","migrationService":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.DataMigration/sqlMigrationServices/tsuman-IR2","migrationOperationId":"ea36f793-8bd1-4ceb-a82a-e0faf0d0dfcb","kind":"SqlDb"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb","name":"NewDb","type":"Microsoft.DataMigration/databaseMigrations"}'
@@ -3096,7 +3096,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb?$expand=MigrationStatusDetails&api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb?$expand=MigrationStatusDetails&api-version=2025-06-30
   response:
     body:
       string: '{"properties":{"migrationStatusDetails":{"migrationState":"MonitorMigration","listOfCopyProgressDetails":[{"tableName":"dbo.Table_1","status":"Succeeded","parallelCopyType":"None","usedParallelCopies":1,"dataRead":400,"dataWritten":400,"rowsRead":20,"rowsCopied":20,"copyStart":"2022-04-18T11:06:50.003Z","copyThroughput":0.014000000432133675,"copyDuration":27}]},"offlineConfiguration":{"offline":true},"backupConfiguration":{"sourceLocation":{"fileStorageType":"None"}},"tableList":["[dbo].[Table_1]"],"scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb","provisioningState":"Succeeded","migrationStatus":"InProgress","startedOn":"2022-04-18T11:04:10.497Z","sourceServerName":"AALAB03-2K8.REDMOND.CORP.MICROSOFT.COM","sourceDatabaseName":"Brih","migrationService":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.DataMigration/sqlMigrationServices/tsuman-IR2","migrationOperationId":"ea36f793-8bd1-4ceb-a82a-e0faf0d0dfcb","kind":"SqlDb"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb","name":"NewDb","type":"Microsoft.DataMigration/databaseMigrations"}'
@@ -3142,7 +3142,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb?$expand=MigrationStatusDetails&api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb?$expand=MigrationStatusDetails&api-version=2025-06-30
   response:
     body:
       string: '{"properties":{"migrationStatusDetails":{"migrationState":"MonitorMigration","listOfCopyProgressDetails":[{"tableName":"dbo.Table_1","status":"Succeeded","parallelCopyType":"None","usedParallelCopies":1,"dataRead":400,"dataWritten":400,"rowsRead":20,"rowsCopied":20,"copyStart":"2022-04-18T11:06:50.003Z","copyThroughput":0.014000000432133675,"copyDuration":27}]},"offlineConfiguration":{"offline":true},"backupConfiguration":{"sourceLocation":{"fileStorageType":"None"}},"tableList":["[dbo].[Table_1]"],"scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb","provisioningState":"Succeeded","migrationStatus":"InProgress","startedOn":"2022-04-18T11:04:10.497Z","sourceServerName":"AALAB03-2K8.REDMOND.CORP.MICROSOFT.COM","sourceDatabaseName":"Brih","migrationService":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.DataMigration/sqlMigrationServices/tsuman-IR2","migrationOperationId":"ea36f793-8bd1-4ceb-a82a-e0faf0d0dfcb","kind":"SqlDb"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb","name":"NewDb","type":"Microsoft.DataMigration/databaseMigrations"}'
@@ -3188,7 +3188,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb?$expand=MigrationStatusDetails&api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb?$expand=MigrationStatusDetails&api-version=2025-06-30
   response:
     body:
       string: '{"properties":{"migrationStatusDetails":{"migrationState":"Succeeded","listOfCopyProgressDetails":[{"tableName":"dbo.Table_1","status":"Succeeded","parallelCopyType":"None","usedParallelCopies":1,"dataRead":400,"dataWritten":400,"rowsRead":20,"rowsCopied":20,"copyStart":"2022-04-18T11:06:50.003Z","copyThroughput":0.014000000432133675,"copyDuration":27}]},"offlineConfiguration":{"offline":true},"backupConfiguration":{"sourceLocation":{"fileStorageType":"None"}},"tableList":["[dbo].[Table_1]"],"scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb","provisioningState":"Succeeded","migrationStatus":"Succeeded","startedOn":"2022-04-18T11:04:10.497Z","endedOn":"2022-04-18T11:08:19.237Z","sourceServerName":"AALAB03-2K8.REDMOND.CORP.MICROSOFT.COM","sourceDatabaseName":"Brih","migrationService":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.DataMigration/sqlMigrationServices/tsuman-IR2","migrationOperationId":"ea36f793-8bd1-4ceb-a82a-e0faf0d0dfcb","kind":"SqlDb"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb","name":"NewDb","type":"Microsoft.DataMigration/databaseMigrations"}'
@@ -3234,7 +3234,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.35.0 azsdk-python-mgmt-datamigration/1.0.0b1 Python/3.10.0 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb?api-version=2022-03-30-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb?api-version=2025-06-30
   response:
     body:
       string: '{"properties":{"offlineConfiguration":{"offline":true},"backupConfiguration":{"sourceLocation":{"fileStorageType":"None"}},"tableList":["[dbo].[Table_1]"],"scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb","provisioningState":"Succeeded","migrationStatus":"Succeeded","startedOn":"2022-04-18T11:04:10.497Z","endedOn":"2022-04-18T11:08:19.237Z","sourceServerName":"AALAB03-2K8.REDMOND.CORP.MICROSOFT.COM","sourceDatabaseName":"Brih","migrationService":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.DataMigration/sqlMigrationServices/tsuman-IR2","migrationOperationId":"ea36f793-8bd1-4ceb-a82a-e0faf0d0dfcb","kind":"SqlDb"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tsum38RG/providers/Microsoft.Sql/servers/dmstestsqldb/providers/Microsoft.DataMigration/databaseMigrations/NewDb","name":"NewDb","type":"Microsoft.DataMigration/databaseMigrations"}'

--- a/src/datamigration/azext_datamigration/vendored_sdks/datamigration/_configuration.py
+++ b/src/datamigration/azext_datamigration/vendored_sdks/datamigration/_configuration.py
@@ -48,7 +48,7 @@ class DataMigrationManagementClientConfiguration(Configuration):
 
         self.credential = credential
         self.subscription_id = subscription_id
-        self.api_version = "2022-03-30-preview"
+        self.api_version = "2025-06-30"
         self.credential_scopes = kwargs.pop('credential_scopes', ['https://management.azure.com/.default'])
         kwargs.setdefault('sdk_moniker', 'mgmt-datamigration/{}'.format(VERSION))
         self._configure(**kwargs)

--- a/src/datamigration/azext_datamigration/vendored_sdks/datamigration/aio/_configuration.py
+++ b/src/datamigration/azext_datamigration/vendored_sdks/datamigration/aio/_configuration.py
@@ -45,7 +45,7 @@ class DataMigrationManagementClientConfiguration(Configuration):
 
         self.credential = credential
         self.subscription_id = subscription_id
-        self.api_version = "2022-03-30-preview"
+        self.api_version = "2025-06-30"
         self.credential_scopes = kwargs.pop('credential_scopes', ['https://management.azure.com/.default'])
         kwargs.setdefault('sdk_moniker', 'mgmt-datamigration/{}'.format(VERSION))
         self._configure(**kwargs)

--- a/src/datamigration/azext_datamigration/vendored_sdks/datamigration/aio/operations/_database_migrations_sql_db_operations.py
+++ b/src/datamigration/azext_datamigration/vendored_sdks/datamigration/aio/operations/_database_migrations_sql_db_operations.py
@@ -76,7 +76,7 @@ class DatabaseMigrationsSqlDbOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -130,7 +130,7 @@ class DatabaseMigrationsSqlDbOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -266,7 +266,7 @@ class DatabaseMigrationsSqlDbOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
 
         # Construct URL
         url = self._delete_initial.metadata['url']  # type: ignore
@@ -388,7 +388,7 @@ class DatabaseMigrationsSqlDbOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
 
         # Construct URL

--- a/src/datamigration/azext_datamigration/vendored_sdks/datamigration/aio/operations/_database_migrations_sql_mi_operations.py
+++ b/src/datamigration/azext_datamigration/vendored_sdks/datamigration/aio/operations/_database_migrations_sql_mi_operations.py
@@ -76,7 +76,7 @@ class DatabaseMigrationsSqlMiOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -130,7 +130,7 @@ class DatabaseMigrationsSqlMiOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -266,7 +266,7 @@ class DatabaseMigrationsSqlMiOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
 
         # Construct URL
@@ -390,7 +390,7 @@ class DatabaseMigrationsSqlMiOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
 
         # Construct URL

--- a/src/datamigration/azext_datamigration/vendored_sdks/datamigration/aio/operations/_database_migrations_sql_vm_operations.py
+++ b/src/datamigration/azext_datamigration/vendored_sdks/datamigration/aio/operations/_database_migrations_sql_vm_operations.py
@@ -76,7 +76,7 @@ class DatabaseMigrationsSqlVmOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -130,7 +130,7 @@ class DatabaseMigrationsSqlVmOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -266,7 +266,7 @@ class DatabaseMigrationsSqlVmOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
 
         # Construct URL
@@ -390,7 +390,7 @@ class DatabaseMigrationsSqlVmOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
 
         # Construct URL

--- a/src/datamigration/azext_datamigration/vendored_sdks/datamigration/aio/operations/_files_operations.py
+++ b/src/datamigration/azext_datamigration/vendored_sdks/datamigration/aio/operations/_files_operations.py
@@ -69,7 +69,7 @@ class FilesOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         def prepare_request(next_link=None):
@@ -154,7 +154,7 @@ class FilesOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -226,7 +226,7 @@ class FilesOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -304,7 +304,7 @@ class FilesOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -373,7 +373,7 @@ class FilesOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -448,7 +448,7 @@ class FilesOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -517,7 +517,7 @@ class FilesOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL

--- a/src/datamigration/azext_datamigration/vendored_sdks/datamigration/aio/operations/_operations.py
+++ b/src/datamigration/azext_datamigration/vendored_sdks/datamigration/aio/operations/_operations.py
@@ -57,7 +57,7 @@ class Operations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         def prepare_request(next_link=None):

--- a/src/datamigration/azext_datamigration/vendored_sdks/datamigration/aio/operations/_projects_operations.py
+++ b/src/datamigration/azext_datamigration/vendored_sdks/datamigration/aio/operations/_projects_operations.py
@@ -66,7 +66,7 @@ class ProjectsOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         def prepare_request(next_link=None):
@@ -150,7 +150,7 @@ class ProjectsOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -225,7 +225,7 @@ class ProjectsOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -294,7 +294,7 @@ class ProjectsOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -362,7 +362,7 @@ class ProjectsOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 

--- a/src/datamigration/azext_datamigration/vendored_sdks/datamigration/aio/operations/_resource_skus_operations.py
+++ b/src/datamigration/azext_datamigration/vendored_sdks/datamigration/aio/operations/_resource_skus_operations.py
@@ -59,7 +59,7 @@ class ResourceSkusOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         def prepare_request(next_link=None):

--- a/src/datamigration/azext_datamigration/vendored_sdks/datamigration/aio/operations/_service_tasks_operations.py
+++ b/src/datamigration/azext_datamigration/vendored_sdks/datamigration/aio/operations/_service_tasks_operations.py
@@ -71,7 +71,7 @@ class ServiceTasksOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         def prepare_request(next_link=None):
@@ -159,7 +159,7 @@ class ServiceTasksOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -237,7 +237,7 @@ class ServiceTasksOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -308,7 +308,7 @@ class ServiceTasksOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -377,7 +377,7 @@ class ServiceTasksOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -448,7 +448,7 @@ class ServiceTasksOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL

--- a/src/datamigration/azext_datamigration/vendored_sdks/datamigration/aio/operations/_services_operations.py
+++ b/src/datamigration/azext_datamigration/vendored_sdks/datamigration/aio/operations/_services_operations.py
@@ -55,7 +55,7 @@ class ServicesOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -207,7 +207,7 @@ class ServicesOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -256,7 +256,7 @@ class ServicesOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -375,7 +375,7 @@ class ServicesOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -521,7 +521,7 @@ class ServicesOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -569,7 +569,7 @@ class ServicesOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -681,7 +681,7 @@ class ServicesOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -808,7 +808,7 @@ class ServicesOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         def prepare_request(next_link=None):
@@ -888,7 +888,7 @@ class ServicesOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -952,7 +952,7 @@ class ServicesOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         def prepare_request(next_link=None):
@@ -1023,7 +1023,7 @@ class ServicesOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         def prepare_request(next_link=None):
@@ -1098,7 +1098,7 @@ class ServicesOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 

--- a/src/datamigration/azext_datamigration/vendored_sdks/datamigration/aio/operations/_sql_migration_services_operations.py
+++ b/src/datamigration/azext_datamigration/vendored_sdks/datamigration/aio/operations/_sql_migration_services_operations.py
@@ -66,7 +66,7 @@ class SqlMigrationServicesOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -114,7 +114,7 @@ class SqlMigrationServicesOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -242,7 +242,7 @@ class SqlMigrationServicesOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
 
         # Construct URL
         url = self._delete_initial.metadata['url']  # type: ignore
@@ -350,7 +350,7 @@ class SqlMigrationServicesOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -487,7 +487,7 @@ class SqlMigrationServicesOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         def prepare_request(next_link=None):
@@ -561,7 +561,7 @@ class SqlMigrationServicesOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -623,7 +623,7 @@ class SqlMigrationServicesOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -690,7 +690,7 @@ class SqlMigrationServicesOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -754,7 +754,7 @@ class SqlMigrationServicesOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         def prepare_request(next_link=None):
@@ -830,7 +830,7 @@ class SqlMigrationServicesOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -882,7 +882,7 @@ class SqlMigrationServicesOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         def prepare_request(next_link=None):

--- a/src/datamigration/azext_datamigration/vendored_sdks/datamigration/aio/operations/_tasks_operations.py
+++ b/src/datamigration/azext_datamigration/vendored_sdks/datamigration/aio/operations/_tasks_operations.py
@@ -73,7 +73,7 @@ class TasksOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         def prepare_request(next_link=None):
@@ -164,7 +164,7 @@ class TasksOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -246,7 +246,7 @@ class TasksOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -321,7 +321,7 @@ class TasksOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -394,7 +394,7 @@ class TasksOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -469,7 +469,7 @@ class TasksOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -542,7 +542,7 @@ class TasksOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 

--- a/src/datamigration/azext_datamigration/vendored_sdks/datamigration/aio/operations/_usages_operations.py
+++ b/src/datamigration/azext_datamigration/vendored_sdks/datamigration/aio/operations/_usages_operations.py
@@ -63,7 +63,7 @@ class UsagesOperations:
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         def prepare_request(next_link=None):

--- a/src/datamigration/azext_datamigration/vendored_sdks/datamigration/operations/_database_migrations_sql_db_operations.py
+++ b/src/datamigration/azext_datamigration/vendored_sdks/datamigration/operations/_database_migrations_sql_db_operations.py
@@ -81,7 +81,7 @@ class DatabaseMigrationsSqlDbOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -136,7 +136,7 @@ class DatabaseMigrationsSqlDbOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -274,7 +274,7 @@ class DatabaseMigrationsSqlDbOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
 
         # Construct URL
         url = self._delete_initial.metadata['url']  # type: ignore
@@ -398,7 +398,7 @@ class DatabaseMigrationsSqlDbOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
 
         # Construct URL

--- a/src/datamigration/azext_datamigration/vendored_sdks/datamigration/operations/_database_migrations_sql_mi_operations.py
+++ b/src/datamigration/azext_datamigration/vendored_sdks/datamigration/operations/_database_migrations_sql_mi_operations.py
@@ -81,7 +81,7 @@ class DatabaseMigrationsSqlMiOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -136,7 +136,7 @@ class DatabaseMigrationsSqlMiOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -274,7 +274,7 @@ class DatabaseMigrationsSqlMiOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
 
         # Construct URL
@@ -400,7 +400,7 @@ class DatabaseMigrationsSqlMiOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
 
         # Construct URL

--- a/src/datamigration/azext_datamigration/vendored_sdks/datamigration/operations/_database_migrations_sql_vm_operations.py
+++ b/src/datamigration/azext_datamigration/vendored_sdks/datamigration/operations/_database_migrations_sql_vm_operations.py
@@ -81,7 +81,7 @@ class DatabaseMigrationsSqlVmOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -136,7 +136,7 @@ class DatabaseMigrationsSqlVmOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -274,7 +274,7 @@ class DatabaseMigrationsSqlVmOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
 
         # Construct URL
@@ -400,7 +400,7 @@ class DatabaseMigrationsSqlVmOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
 
         # Construct URL

--- a/src/datamigration/azext_datamigration/vendored_sdks/datamigration/operations/_files_operations.py
+++ b/src/datamigration/azext_datamigration/vendored_sdks/datamigration/operations/_files_operations.py
@@ -74,7 +74,7 @@ class FilesOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         def prepare_request(next_link=None):
@@ -160,7 +160,7 @@ class FilesOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -233,7 +233,7 @@ class FilesOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -312,7 +312,7 @@ class FilesOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -382,7 +382,7 @@ class FilesOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -458,7 +458,7 @@ class FilesOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -528,7 +528,7 @@ class FilesOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL

--- a/src/datamigration/azext_datamigration/vendored_sdks/datamigration/operations/_operations.py
+++ b/src/datamigration/azext_datamigration/vendored_sdks/datamigration/operations/_operations.py
@@ -62,7 +62,7 @@ class Operations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         def prepare_request(next_link=None):

--- a/src/datamigration/azext_datamigration/vendored_sdks/datamigration/operations/_projects_operations.py
+++ b/src/datamigration/azext_datamigration/vendored_sdks/datamigration/operations/_projects_operations.py
@@ -71,7 +71,7 @@ class ProjectsOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         def prepare_request(next_link=None):
@@ -156,7 +156,7 @@ class ProjectsOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -232,7 +232,7 @@ class ProjectsOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -302,7 +302,7 @@ class ProjectsOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -371,7 +371,7 @@ class ProjectsOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 

--- a/src/datamigration/azext_datamigration/vendored_sdks/datamigration/operations/_resource_skus_operations.py
+++ b/src/datamigration/azext_datamigration/vendored_sdks/datamigration/operations/_resource_skus_operations.py
@@ -64,7 +64,7 @@ class ResourceSkusOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         def prepare_request(next_link=None):

--- a/src/datamigration/azext_datamigration/vendored_sdks/datamigration/operations/_service_tasks_operations.py
+++ b/src/datamigration/azext_datamigration/vendored_sdks/datamigration/operations/_service_tasks_operations.py
@@ -76,7 +76,7 @@ class ServiceTasksOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         def prepare_request(next_link=None):
@@ -165,7 +165,7 @@ class ServiceTasksOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -244,7 +244,7 @@ class ServiceTasksOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -316,7 +316,7 @@ class ServiceTasksOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -386,7 +386,7 @@ class ServiceTasksOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -458,7 +458,7 @@ class ServiceTasksOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL

--- a/src/datamigration/azext_datamigration/vendored_sdks/datamigration/operations/_services_operations.py
+++ b/src/datamigration/azext_datamigration/vendored_sdks/datamigration/operations/_services_operations.py
@@ -60,7 +60,7 @@ class ServicesOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -214,7 +214,7 @@ class ServicesOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -264,7 +264,7 @@ class ServicesOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -385,7 +385,7 @@ class ServicesOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -533,7 +533,7 @@ class ServicesOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -582,7 +582,7 @@ class ServicesOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -696,7 +696,7 @@ class ServicesOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -825,7 +825,7 @@ class ServicesOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         def prepare_request(next_link=None):
@@ -906,7 +906,7 @@ class ServicesOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -971,7 +971,7 @@ class ServicesOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         def prepare_request(next_link=None):
@@ -1043,7 +1043,7 @@ class ServicesOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         def prepare_request(next_link=None):
@@ -1119,7 +1119,7 @@ class ServicesOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 

--- a/src/datamigration/azext_datamigration/vendored_sdks/datamigration/operations/_sql_migration_services_operations.py
+++ b/src/datamigration/azext_datamigration/vendored_sdks/datamigration/operations/_sql_migration_services_operations.py
@@ -71,7 +71,7 @@ class SqlMigrationServicesOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -120,7 +120,7 @@ class SqlMigrationServicesOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -250,7 +250,7 @@ class SqlMigrationServicesOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
 
         # Construct URL
         url = self._delete_initial.metadata['url']  # type: ignore
@@ -360,7 +360,7 @@ class SqlMigrationServicesOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -499,7 +499,7 @@ class SqlMigrationServicesOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         def prepare_request(next_link=None):
@@ -574,7 +574,7 @@ class SqlMigrationServicesOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -637,7 +637,7 @@ class SqlMigrationServicesOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -705,7 +705,7 @@ class SqlMigrationServicesOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -770,7 +770,7 @@ class SqlMigrationServicesOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         def prepare_request(next_link=None):
@@ -847,7 +847,7 @@ class SqlMigrationServicesOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -900,7 +900,7 @@ class SqlMigrationServicesOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         def prepare_request(next_link=None):

--- a/src/datamigration/azext_datamigration/vendored_sdks/datamigration/operations/_tasks_operations.py
+++ b/src/datamigration/azext_datamigration/vendored_sdks/datamigration/operations/_tasks_operations.py
@@ -78,7 +78,7 @@ class TasksOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         def prepare_request(next_link=None):
@@ -170,7 +170,7 @@ class TasksOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -253,7 +253,7 @@ class TasksOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -329,7 +329,7 @@ class TasksOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -403,7 +403,7 @@ class TasksOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 
@@ -479,7 +479,7 @@ class TasksOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         # Construct URL
@@ -553,7 +553,7 @@ class TasksOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 

--- a/src/datamigration/azext_datamigration/vendored_sdks/datamigration/operations/_usages_operations.py
+++ b/src/datamigration/azext_datamigration/vendored_sdks/datamigration/operations/_usages_operations.py
@@ -68,7 +68,7 @@ class UsagesOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2022-03-30-preview"
+        api_version = "2025-06-30"
         accept = "application/json"
 
         def prepare_request(next_link=None):

--- a/src/datamigration/setup.py
+++ b/src/datamigration/setup.py
@@ -10,7 +10,7 @@ from codecs import open
 from setuptools import setup, find_packages
 
 # HISTORY.rst entry.
-VERSION = '1.0.0b5'
+VERSION = '1.0.0b6'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
---

Publishing the stable version of the Data Migration APIs.

### Related command
- az datamigration get-assessment
- az datamigration performance-data-collection
- az datamigration get-sku-recommendation
- az datamigration tde-migration


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
