### PR TITLE
[AKS] Add --enable-opentelemetry-metrics and --enable-opentelemetry-logs to monitoring addons in aks-preview

### DIFF
--- a/src/aks-preview/azext_aks_preview/_help.py
+++ b/src/aks-preview/azext_aks_preview/_help.py
@@ -587,6 +587,24 @@ helps['aks create'] = f"""
         - name: --enable-azure-monitor-app-monitoring
           type: bool
           short-summary: Enable Azure Monitor Application Monitoring
+        - name: --enable-opentelemetry-metrics
+          type: bool
+          short-summary: Enable OpenTelemetry metrics collection. Requires Azure Monitor metrics to be enabled.
+        - name: --opentelemetry-metrics-port
+          type: int
+          short-summary: Port for OpenTelemetry metrics collection (default port will be used if not specified)
+        - name: --disable-opentelemetry-metrics
+          type: bool
+          short-summary: Disable OpenTelemetry metrics collection
+        - name: --enable-opentelemetry-logs
+          type: bool
+          short-summary: Enable OpenTelemetry logs collection. Requires Azure Monitor logs to be enabled.
+        - name: --opentelemetry-logs-port
+          type: int
+          short-summary: Port for OpenTelemetry logs collection (default port will be used if not specified)
+        - name: --disable-opentelemetry-logs
+          type: bool
+          short-summary: Disable OpenTelemetry logs collection
         - name: --nodepool-labels
           type: string
           short-summary: The node labels for all node pools in this cluster. See https://aka.ms/node-labels for syntax of labels.
@@ -1182,6 +1200,24 @@ helps['aks update'] = """
         - name: --disable-azure-monitor-app-monitoring
           type: bool
           short-summary: Disable Azure Monitor Application Monitoring
+        - name: --enable-opentelemetry-metrics
+          type: bool
+          short-summary: Enable OpenTelemetry metrics collection. Requires Azure Monitor metrics to be enabled.
+        - name: --opentelemetry-metrics-port
+          type: int
+          short-summary: Port for OpenTelemetry metrics collection (default port will be used if not specified)
+        - name: --disable-opentelemetry-metrics
+          type: bool
+          short-summary: Disable OpenTelemetry metrics collection
+        - name: --enable-opentelemetry-logs
+          type: bool
+          short-summary: Enable OpenTelemetry logs collection. Requires Azure Monitor logs to be enabled.
+        - name: --opentelemetry-logs-port
+          type: int
+          short-summary: Port for OpenTelemetry logs collection (default port will be used if not specified)
+        - name: --disable-opentelemetry-logs
+          type: bool
+          short-summary: Disable OpenTelemetry logs collection
         - name: --enable-private-cluster
           type: bool
           short-summary: Enable private cluster for apiserver vnet integration cluster.

--- a/src/aks-preview/azext_aks_preview/_params.py
+++ b/src/aks-preview/azext_aks_preview/_params.py
@@ -168,6 +168,8 @@ from azext_aks_preview._validators import (
     validate_assign_kubelet_identity,
     validate_azure_keyvault_kms_key_id,
     validate_azure_keyvault_kms_key_vault_resource_id,
+    validate_azure_monitor_and_opentelemetry_for_create,
+    validate_azure_monitor_and_opentelemetry_for_update,
     validate_azuremonitorworkspaceresourceid,
     validate_cluster_id,
     validate_cluster_snapshot_id,
@@ -985,7 +987,6 @@ def load_arguments(self, _):
                 hide=True,
             ),
         )
-        c.argument("enable_azure_monitor_metrics", action="store_true")
         c.argument(
             "azure_monitor_workspace_resource_id",
             validator=validate_azuremonitorworkspaceresourceid,
@@ -995,6 +996,13 @@ def load_arguments(self, _):
         c.argument("grafana_resource_id", validator=validate_grafanaresourceid)
         c.argument("enable_windows_recording_rules", action="store_true")
         c.argument("enable_azure_monitor_app_monitoring", is_preview=True, action="store_true")
+        # OpenTelemetry parameters
+        c.argument("enable_opentelemetry_metrics", is_preview=True, action="store_true", help="Enable OpenTelemetry metrics collection", validator=validate_azure_monitor_and_opentelemetry_for_create)
+        c.argument("opentelemetry_metrics_port", is_preview=True, type=int, help="Port for OpenTelemetry metrics collection")
+        c.argument("disable_opentelemetry_metrics", is_preview=True, action="store_true", help="Disable OpenTelemetry metrics collection")
+        c.argument("enable_opentelemetry_logs", is_preview=True, action="store_true", help="Enable OpenTelemetry logs collection")
+        c.argument("opentelemetry_logs_port", is_preview=True, type=int, help="Port for OpenTelemetry logs collection")
+        c.argument("disable_opentelemetry_logs", is_preview=True, action="store_true", help="Disable OpenTelemetry logs collection")
         c.argument("enable_cost_analysis", action="store_true")
         c.argument('enable_ai_toolchain_operator', is_preview=True, action='store_true')
         # azure container storage
@@ -1359,9 +1367,15 @@ def load_arguments(self, _):
                 hide=True,
             ),
         )
-        c.argument("disable_azure_monitor_metrics", action="store_true")
         c.argument("enable_azure_monitor_app_monitoring", action="store_true", is_preview=True)
         c.argument("disable_azure_monitor_app_monitoring", action="store_true", is_preview=True)
+        # OpenTelemetry parameters
+        c.argument("enable_opentelemetry_metrics", is_preview=True, action="store_true", help="Enable OpenTelemetry metrics collection", validator=validate_azure_monitor_and_opentelemetry_for_update)
+        c.argument("opentelemetry_metrics_port", is_preview=True, type=int, help="Port for OpenTelemetry metrics collection")
+        c.argument("disable_opentelemetry_metrics", is_preview=True, action="store_true", help="Disable OpenTelemetry metrics collection")
+        c.argument("enable_opentelemetry_logs", is_preview=True, action="store_true", help="Enable OpenTelemetry logs collection")
+        c.argument("opentelemetry_logs_port", is_preview=True, type=int, help="Port for OpenTelemetry logs collection")
+        c.argument("disable_opentelemetry_logs", is_preview=True, action="store_true", help="Disable OpenTelemetry logs collection")
         c.argument(
             "enable_vpa",
             action="store_true",

--- a/src/aks-preview/azext_aks_preview/_validators.py
+++ b/src/aks-preview/azext_aks_preview/_validators.py
@@ -972,3 +972,114 @@ def validate_location_resource_group_cluster_parameters(namespace):
         raise MutuallyExclusiveArgumentError(
             "Cannot specify --location and --resource-group and --cluster at the same time."
         )
+
+
+def validate_opentelemetry_ports(namespace):
+    """Validate that OpenTelemetry metrics and logs ports don't conflict."""
+    metrics_port = getattr(namespace, 'opentelemetry_metrics_port', None)
+    logs_port = getattr(namespace, 'opentelemetry_logs_port', None)
+    
+    # Check if both ports are specified and are the same
+    if metrics_port is not None and logs_port is not None and metrics_port == logs_port:
+        raise ArgumentUsageError(
+            "OpenTelemetry metrics port and logs port cannot be the same. "
+            "Please specify different ports for --opentelemetry-metrics-port and --opentelemetry-logs-port."
+        )
+    
+    # Validate port ranges
+    for port, port_name in [(metrics_port, 'metrics'), (logs_port, 'logs')]:
+        if port is not None and not (1 <= port <= 65535):
+            raise ArgumentUsageError(
+                f"OpenTelemetry {port_name} port must be between 1 and 65535, got {port}."
+            )
+
+
+def validate_opentelemetry_metrics_dependencies(namespace):
+    """Validate OpenTelemetry metrics dependencies for create operations."""
+    enable_otlp_metrics = getattr(namespace, 'enable_opentelemetry_metrics', False)
+    disable_otlp_metrics = getattr(namespace, 'disable_opentelemetry_metrics', False)
+    # Try both new and deprecated parameter names for Azure Monitor metrics
+    enable_azure_monitor_metrics = getattr(namespace, 'enable_azure_monitor_metrics', False)
+    enable_azuremonitormetrics = getattr(namespace, 'enable_azuremonitormetrics', False)  # deprecated flag
+    
+    # Check mutual exclusion
+    if enable_otlp_metrics and disable_otlp_metrics:
+        raise MutuallyExclusiveArgumentError(
+            "Cannot specify both --enable-opentelemetry-metrics and --disable-opentelemetry-metrics at the same time."
+        )
+    
+    # Check if trying to enable OTLP metrics without Azure Monitor metrics
+    # For create operations, require explicit Azure Monitor enablement
+    azure_monitor_enabled_via_params = enable_azure_monitor_metrics or enable_azuremonitormetrics
+    
+    if enable_otlp_metrics and not azure_monitor_enabled_via_params:
+        raise ArgumentUsageError(
+            "OpenTelemetry metrics requires Azure Monitor metrics to be enabled. "
+            "Please add --enable-azure-monitor-metrics or --enable-azuremonitormetrics to your command."
+        )
+
+
+def validate_opentelemetry_metrics_dependencies_for_update(namespace):
+    """Validate OpenTelemetry metrics dependencies for update operations."""
+    enable_otlp_metrics = getattr(namespace, 'enable_opentelemetry_metrics', False)
+    disable_otlp_metrics = getattr(namespace, 'disable_opentelemetry_metrics', False)
+    
+    # Check mutual exclusion
+    if enable_otlp_metrics and disable_otlp_metrics:
+        raise MutuallyExclusiveArgumentError(
+            "Cannot specify both --enable-opentelemetry-metrics and --disable-opentelemetry-metrics at the same time."
+        )
+    
+    # For update operations, validation is deferred to the decorator where we have access to the cluster's Azure Monitor profile
+
+
+def validate_opentelemetry_logs_dependencies(namespace):
+    """Validate OpenTelemetry logs dependencies for create operations."""
+    enable_otlp_logs = getattr(namespace, 'enable_opentelemetry_logs', False)
+    disable_otlp_logs = getattr(namespace, 'disable_opentelemetry_logs', False)
+    # Azure Monitor logs parameter may come from parent class or be set directly
+    enable_azure_monitor_logs = getattr(namespace, 'enable_azure_monitor_logs', False)
+    
+    # Check mutual exclusion
+    if enable_otlp_logs and disable_otlp_logs:
+        raise MutuallyExclusiveArgumentError(
+            "Cannot specify both --enable-opentelemetry-logs and --disable-opentelemetry-logs at the same time."
+        )
+    
+    # Check if trying to enable OTLP logs without Azure Monitor logs
+    # For create operations, require explicit Azure Monitor enablement
+    if enable_otlp_logs and not enable_azure_monitor_logs:
+        raise ArgumentUsageError(
+            "OpenTelemetry logs requires Azure Monitor logs to be enabled. "
+            "Please add --enable-azure-monitor-logs to your command."
+        )
+
+
+def validate_opentelemetry_logs_dependencies_for_update(namespace):
+    """Validate OpenTelemetry logs dependencies for update operations."""
+    enable_otlp_logs = getattr(namespace, 'enable_opentelemetry_logs', False)
+    disable_otlp_logs = getattr(namespace, 'disable_opentelemetry_logs', False)
+    
+    # Check mutual exclusion
+    if enable_otlp_logs and disable_otlp_logs:
+        raise MutuallyExclusiveArgumentError(
+            "Cannot specify both --enable-opentelemetry-logs and --disable-opentelemetry-logs at the same time."
+        )
+    
+    # For update operations, validation is deferred to the decorator where we have access to the cluster's Azure Monitor profile
+
+
+def validate_azure_monitor_and_opentelemetry_for_create(namespace):
+    """Main validator for Azure Monitor and OpenTelemetry configurations for create operations."""
+    # Run all OpenTelemetry-related validations
+    validate_opentelemetry_ports(namespace)
+    validate_opentelemetry_metrics_dependencies(namespace)
+    validate_opentelemetry_logs_dependencies(namespace)
+
+
+def validate_azure_monitor_and_opentelemetry_for_update(namespace):
+    """Main validator for Azure Monitor and OpenTelemetry configurations for update operations."""
+    # Run all OpenTelemetry-related validations
+    validate_opentelemetry_ports(namespace)
+    validate_opentelemetry_metrics_dependencies_for_update(namespace)
+    validate_opentelemetry_logs_dependencies_for_update(namespace)

--- a/src/aks-preview/azext_aks_preview/custom.py
+++ b/src/aks-preview/azext_aks_preview/custom.py
@@ -722,6 +722,15 @@ def aks_create(
     enable_windows_recording_rules=False,
     # azure monitor profile - app monitoring
     enable_azure_monitor_app_monitoring=False,
+    # azure monitor profile - logs
+    enable_azure_monitor_logs=False,
+    # opentelemetry parameters
+    enable_opentelemetry_metrics=False,
+    opentelemetry_metrics_port=None,
+    disable_opentelemetry_metrics=False,
+    enable_opentelemetry_logs=False,
+    opentelemetry_logs_port=None,
+    disable_opentelemetry_logs=False,
     # metrics profile
     enable_cost_analysis=False,
     # AI toolchain operator
@@ -918,6 +927,16 @@ def aks_update(
     # azure monitor profile - app monitoring
     enable_azure_monitor_app_monitoring=False,
     disable_azure_monitor_app_monitoring=False,
+    # azure monitor profile - logs
+    enable_azure_monitor_logs=False,
+    disable_azure_monitor_logs=False,
+    # opentelemetry parameters
+    enable_opentelemetry_metrics=False,
+    opentelemetry_metrics_port=None,
+    disable_opentelemetry_metrics=False,
+    enable_opentelemetry_logs=False,
+    opentelemetry_logs_port=None,
+    disable_opentelemetry_logs=False,
     enable_vpa=False,
     disable_vpa=False,
     enable_optimized_addon_scaling=False,

--- a/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
@@ -2062,17 +2062,14 @@ class AKSPreviewManagedClusterContext(AKSManagedClusterContext):
 
     def _get_enable_azure_monitor_metrics(self, enable_validation: bool = False) -> bool:
         """Internal function to obtain the value of enable_azure_monitor_metrics.
-        This function supports the option of enable_validation. When enabled, if both enable_azure_monitor_metrics and
-        disable_azure_monitor_metrics are specified, raise a MutuallyExclusiveArgumentError.
-
-        :return: bool
+        Delegates to parent class if method exists, otherwise uses legacy azuremonitormetrics parameter.
         """
-        # Read the original value passed by the command.
-        # TODO: should remove get value from enable_azuremonitormetrics once the option is removed
-        enable_azure_monitor_metrics = (
-            self.raw_param.get("enable_azure_monitor_metrics") or
-            self.raw_param.get("enable_azuremonitormetrics")
-        )
+        if hasattr(super(), '_get_enable_azure_monitor_metrics'):
+            return super()._get_enable_azure_monitor_metrics(enable_validation)
+        
+        # Fallback to legacy parameter for backward compatibility
+        enable_azure_monitor_metrics = self.raw_param.get("enable_azuremonitormetrics")
+        
         # In create mode, try to read the property value corresponding to the parameter from the `mc` object.
         if self.decorator_mode == DecoratorMode.CREATE:
             if (
@@ -2084,6 +2081,7 @@ class AKSPreviewManagedClusterContext(AKSManagedClusterContext):
             skuName = self.get_sku_name()
             if skuName == CONST_MANAGED_CLUSTER_SKU_NAME_AUTOMATIC:
                 enable_azure_monitor_metrics = True
+        
         # This parameter does not need dynamic completion.
         if enable_validation:
             if enable_azure_monitor_metrics and self._get_disable_azure_monitor_metrics(False):
@@ -2098,24 +2096,22 @@ class AKSPreviewManagedClusterContext(AKSManagedClusterContext):
 
     def get_enable_azure_monitor_metrics(self) -> bool:
         """Obtain the value of enable_azure_monitor_metrics.
-        This function will verify the parameter by default. If both enable_azure_monitor_metrics and
-        disable_azure_monitor_metrics are specified, raise a MutuallyExclusiveArgumentError.
+        Delegates to parent class if method exists.
         :return: bool
         """
+        if hasattr(super(), 'get_enable_azure_monitor_metrics'):
+            return super().get_enable_azure_monitor_metrics()
         return self._get_enable_azure_monitor_metrics(enable_validation=True)
 
     def _get_disable_azure_monitor_metrics(self, enable_validation: bool = False) -> bool:
         """Internal function to obtain the value of disable_azure_monitor_metrics.
-        This function supports the option of enable_validation. When enabled, if both enable_azure_monitor_metrics and
-        disable_azure_monitor_metrics are specified, raise a MutuallyExclusiveArgumentError.
-        :return: bool
+        Delegates to parent class if method exists, otherwise uses legacy azuremonitormetrics parameter.
         """
-        # Read the original value passed by the command.
-        # TODO: should remove get value from disable_azuremonitormetrics once the option is removed
-        disable_azure_monitor_metrics = (
-            self.raw_param.get("disable_azure_monitor_metrics") or
-            self.raw_param.get("disable_azuremonitormetrics")
-        )
+        if hasattr(super(), '_get_disable_azure_monitor_metrics'):
+            return super()._get_disable_azure_monitor_metrics(enable_validation)
+            
+        # Fallback to legacy parameter for backward compatibility
+        disable_azure_monitor_metrics = self.raw_param.get("disable_azuremonitormetrics")
         if disable_azure_monitor_metrics and self._get_enable_azure_monitor_metrics(False):
             raise MutuallyExclusiveArgumentError(
                 "Cannot specify --enable-azuremonitormetrics and --disable-azuremonitormetrics at the same time."
@@ -2124,11 +2120,68 @@ class AKSPreviewManagedClusterContext(AKSManagedClusterContext):
 
     def get_disable_azure_monitor_metrics(self) -> bool:
         """Obtain the value of disable_azure_monitor_metrics.
-        This function will verify the parameter by default. If both enable_azure_monitor_metrics and
-        disable_azure_monitor_metrics are specified, raise a MutuallyExclusiveArgumentError.
+        Delegates to parent class if method exists.
         :return: bool
         """
+        if hasattr(super(), 'get_disable_azure_monitor_metrics'):
+            return super().get_disable_azure_monitor_metrics()
         return self._get_disable_azure_monitor_metrics(enable_validation=True)
+
+    def _get_enable_azure_monitor_logs(self, enable_validation: bool = False) -> bool:
+        """Internal function to obtain the value of enable_azure_monitor_logs.
+        Delegates to parent class if method exists, otherwise handles it locally.
+        """
+        if hasattr(super(), '_get_enable_azure_monitor_logs'):
+            return super()._get_enable_azure_monitor_logs(enable_validation)
+        
+        # Handle locally if parent doesn't support it
+        enable_azure_monitor_logs = self.raw_param.get("enable_azure_monitor_logs")
+        
+        # In update mode, check for conflicts with disable parameter
+        if enable_validation and enable_azure_monitor_logs:
+            if self._get_disable_azure_monitor_logs(enable_validation=False):
+                raise MutuallyExclusiveArgumentError(
+                    "Cannot specify both --enable-azure-monitor-logs and --disable-azure-monitor-logs."
+                )
+        
+        return enable_azure_monitor_logs
+
+    def get_enable_azure_monitor_logs(self) -> bool:
+        """Obtain the value of enable_azure_monitor_logs.
+        Delegates to parent class if method exists.
+        :return: bool
+        """
+        if hasattr(super(), 'get_enable_azure_monitor_logs'):
+            return super().get_enable_azure_monitor_logs()
+        return self._get_enable_azure_monitor_logs(enable_validation=True)
+
+    def _get_disable_azure_monitor_logs(self, enable_validation: bool = False) -> bool:
+        """Internal function to obtain the value of disable_azure_monitor_logs.
+        Delegates to parent class if method exists, otherwise handles it locally.
+        """
+        if hasattr(super(), '_get_disable_azure_monitor_logs'):
+            return super()._get_disable_azure_monitor_logs(enable_validation)
+        
+        # Handle locally if parent doesn't support it
+        disable_azure_monitor_logs = self.raw_param.get("disable_azure_monitor_logs")
+        
+        # In update mode, check for conflicts with enable parameter
+        if enable_validation and disable_azure_monitor_logs:
+            if self._get_enable_azure_monitor_logs(enable_validation=False):
+                raise MutuallyExclusiveArgumentError(
+                    "Cannot specify both --enable-azure-monitor-logs and --disable-azure-monitor-logs."
+                )
+        
+        return disable_azure_monitor_logs
+
+    def get_disable_azure_monitor_logs(self) -> bool:
+        """Obtain the value of disable_azure_monitor_logs.
+        Delegates to parent class if method exists.
+        :return: bool
+        """
+        if hasattr(super(), 'get_disable_azure_monitor_logs'):
+            return super().get_disable_azure_monitor_logs()
+        return self._get_disable_azure_monitor_logs(enable_validation=True)
 
     def _get_enable_azure_monitor_app_monitoring(self, enable_validation=True) -> bool:
         """Internal function to obtain the value of enable_azure_monitor_app_monitoring.
@@ -2180,6 +2233,169 @@ class AKSPreviewManagedClusterContext(AKSManagedClusterContext):
         :return: bool
         """
         return self._get_disable_azure_monitor_app_monitoring(enable_validation=True)
+
+    # OpenTelemetry methods
+    def _get_enable_opentelemetry_metrics(self, enable_validation: bool = False) -> bool:
+        """Internal function to obtain the value of enable_opentelemetry_metrics.
+        This function supports the option of enable_validation. When enabled, if both enable_opentelemetry_metrics and
+        disable_opentelemetry_metrics are specified, raise a MutuallyExclusiveArgumentError.
+        For update operations, also validates that Azure Monitor metrics is enabled in the cluster's Azure Monitor profile.
+        :return: bool
+        """
+        # Read the original value passed by the command.
+        enable_opentelemetry_metrics = self.raw_param.get("enable_opentelemetry_metrics")
+
+        # This parameter does not need dynamic completion.
+        if enable_validation:
+            if enable_opentelemetry_metrics and self._get_disable_opentelemetry_metrics(enable_validation=False):
+                raise MutuallyExclusiveArgumentError(
+                    "Cannot specify --enable-opentelemetry-metrics and --disable-opentelemetry-metrics at the same time."
+                )
+            
+            # For update operations, validate that Azure Monitor metrics is enabled in the cluster's Azure Monitor profile
+            if (enable_opentelemetry_metrics and 
+                self.decorator_mode == DecoratorMode.UPDATE and
+                self.mc):
+                # Check if Azure Monitor metrics is enabled via command parameters
+                azure_monitor_enabled_via_params = (
+                    self._get_enable_azure_monitor_metrics(enable_validation=False) or
+                    self.raw_param.get("enable_azuremonitormetrics")
+                )
+                
+                # Check if Azure Monitor metrics is already enabled in the cluster's Azure Monitor profile
+                azure_monitor_enabled_in_profile = (
+                    self.mc.azure_monitor_profile and
+                    self.mc.azure_monitor_profile.metrics and
+                    self.mc.azure_monitor_profile.metrics.enabled
+                )
+                
+                if not azure_monitor_enabled_via_params and not azure_monitor_enabled_in_profile:
+                    raise ArgumentUsageError(
+                        "OpenTelemetry metrics requires Azure Monitor metrics to be enabled. "
+                        "Azure Monitor metrics is not currently enabled in the cluster. "
+                        "Please add --enable-azure-monitor-metrics to your command."
+                    )
+        return enable_opentelemetry_metrics
+
+    def get_enable_opentelemetry_metrics(self) -> bool:
+        """Obtain the value of enable_opentelemetry_metrics.
+        This function will verify the parameter by default. If both enable_opentelemetry_metrics and
+        disable_opentelemetry_metrics are specified, raise a MutuallyExclusiveArgumentError.
+        :return: bool
+        """
+        return self._get_enable_opentelemetry_metrics(enable_validation=True)
+
+    def _get_disable_opentelemetry_metrics(self, enable_validation: bool = False) -> bool:
+        """Internal function to obtain the value of disable_opentelemetry_metrics.
+        This function supports the option of enable_validation. When enabled, if both enable_opentelemetry_metrics and
+        disable_opentelemetry_metrics are specified, raise a MutuallyExclusiveArgumentError.
+        :return: bool
+        """
+        # Read the original value passed by the command.
+        disable_opentelemetry_metrics = self.raw_param.get("disable_opentelemetry_metrics")
+        
+        if enable_validation:
+            if disable_opentelemetry_metrics and self._get_enable_opentelemetry_metrics(enable_validation=False):
+                raise MutuallyExclusiveArgumentError(
+                    "Cannot specify --enable-opentelemetry-metrics and --disable-opentelemetry-metrics at the same time."
+                )
+        return disable_opentelemetry_metrics
+
+    def get_disable_opentelemetry_metrics(self) -> bool:
+        """Obtain the value of disable_opentelemetry_metrics.
+        This function will verify the parameter by default. If both enable_opentelemetry_metrics and
+        disable_opentelemetry_metrics are specified, raise a MutuallyExclusiveArgumentError.
+        :return: bool
+        """
+        return self._get_disable_opentelemetry_metrics(enable_validation=True)
+
+    def get_opentelemetry_metrics_port(self) -> Union[int, None]:
+        """Obtain the value of opentelemetry_metrics_port.
+        :return: int or None
+        """
+        return self.raw_param.get("opentelemetry_metrics_port")
+
+    def _get_enable_opentelemetry_logs(self, enable_validation: bool = False) -> bool:
+        """Internal function to obtain the value of enable_opentelemetry_logs.
+        This function supports the option of enable_validation. When enabled, if both enable_opentelemetry_logs and
+        disable_opentelemetry_logs are specified, raise a MutuallyExclusiveArgumentError.
+        For update operations, also validates that Azure Monitor logs is enabled in the cluster's Azure Monitor profile.
+        :return: bool
+        """
+        # Read the original value passed by the command.
+        enable_opentelemetry_logs = self.raw_param.get("enable_opentelemetry_logs")
+
+        # This parameter does not need dynamic completion.
+        if enable_validation:
+            if enable_opentelemetry_logs and self._get_disable_opentelemetry_logs(enable_validation=False):
+                raise MutuallyExclusiveArgumentError(
+                    "Cannot specify --enable-opentelemetry-logs and --disable-opentelemetry-logs at the same time."
+                )
+            
+            # For update operations, validate that Azure Monitor logs is enabled in the cluster's Azure Monitor profile
+            if (enable_opentelemetry_logs and 
+                self.decorator_mode == DecoratorMode.UPDATE and
+                self.mc):
+                # Check if Azure Monitor logs is enabled via command parameters
+                azure_monitor_logs_enabled_via_params = self._get_enable_azure_monitor_logs(enable_validation=False)
+                
+                # Check if Azure Monitor logs is already enabled in the cluster's Azure Monitor profile
+                # Note: Azure Monitor logs enablement is typically found in the container insights profile
+                # but we can also check for general Azure Monitor profile structure
+                azure_monitor_logs_enabled_in_profile = (
+                    # Check if there's any existing Azure Monitor configuration that supports logs
+                    self.mc.azure_monitor_profile and (
+                        # Container insights or other log monitoring configurations
+                        (hasattr(self.mc.azure_monitor_profile, 'container_insights') and 
+                         self.mc.azure_monitor_profile.container_insights)
+                    )
+                )
+                
+                if not azure_monitor_logs_enabled_via_params and not azure_monitor_logs_enabled_in_profile:
+                    raise ArgumentUsageError(
+                        "OpenTelemetry logs requires Azure Monitor logs to be enabled. "
+                        "Azure Monitor logs is not currently enabled in the cluster. "
+                        "Please add --enable-azure-monitor-logs to your command."
+                    )
+        return enable_opentelemetry_logs
+
+    def get_enable_opentelemetry_logs(self) -> bool:
+        """Obtain the value of enable_opentelemetry_logs.
+        This function will verify the parameter by default. If both enable_opentelemetry_logs and
+        disable_opentelemetry_logs are specified, raise a MutuallyExclusiveArgumentError.
+        :return: bool
+        """
+        return self._get_enable_opentelemetry_logs(enable_validation=True)
+
+    def _get_disable_opentelemetry_logs(self, enable_validation: bool = False) -> bool:
+        """Internal function to obtain the value of disable_opentelemetry_logs.
+        This function supports the option of enable_validation. When enabled, if both enable_opentelemetry_logs and
+        disable_opentelemetry_logs are specified, raise a MutuallyExclusiveArgumentError.
+        :return: bool
+        """
+        # Read the original value passed by the command.
+        disable_opentelemetry_logs = self.raw_param.get("disable_opentelemetry_logs")
+        
+        if enable_validation:
+            if disable_opentelemetry_logs and self._get_enable_opentelemetry_logs(enable_validation=False):
+                raise MutuallyExclusiveArgumentError(
+                    "Cannot specify --enable-opentelemetry-logs and --disable-opentelemetry-logs at the same time."
+                )
+        return disable_opentelemetry_logs
+
+    def get_disable_opentelemetry_logs(self) -> bool:
+        """Obtain the value of disable_opentelemetry_logs.
+        This function will verify the parameter by default. If both enable_opentelemetry_logs and
+        disable_opentelemetry_logs are specified, raise a MutuallyExclusiveArgumentError.
+        :return: bool
+        """
+        return self._get_disable_opentelemetry_logs(enable_validation=True)
+
+    def get_opentelemetry_logs_port(self) -> Union[int, None]:
+        """Obtain the value of opentelemetry_logs_port.
+        :return: int or None
+        """
+        return self.raw_param.get("opentelemetry_logs_port")
 
     def _get_enable_vpa(self, enable_validation: bool = False) -> bool:
         """Internal function to obtain the value of enable_vpa.
@@ -3484,12 +3700,114 @@ class AKSPreviewManagedClusterCreateDecorator(AKSManagedClusterCreateDecorator):
             mc.azure_monitor_profile.app_monitoring.auto_instrumentation = (
                 self.models.ManagedClusterAzureMonitorProfileAppMonitoringAutoInstrumentation(enabled=True)
             )
-            mc.azure_monitor_profile.app_monitoring.open_telemetry_metrics = (
-                self.models.ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryMetrics(enabled=True)
-            )
-            mc.azure_monitor_profile.app_monitoring.open_telemetry_logs = (
-                self.models.ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryLogs(enabled=True)
-            )
+
+        # Handle Azure Monitor logs (new parameter) - enables monitoring addon
+        if self.context.get_enable_azure_monitor_logs():
+            # Enable monitoring addon (equivalent to az aks enable-addons --addon monitoring)
+            addon_consts = self.context.get_addon_consts()
+            CONST_MONITORING_ADDON_NAME = addon_consts.get("CONST_MONITORING_ADDON_NAME")
+            CONST_MONITORING_LOG_ANALYTICS_WORKSPACE_RESOURCE_ID = addon_consts.get("CONST_MONITORING_LOG_ANALYTICS_WORKSPACE_RESOURCE_ID")
+            CONST_MONITORING_USING_AAD_MSI_AUTH = addon_consts.get("CONST_MONITORING_USING_AAD_MSI_AUTH")
+            
+            if mc.addon_profiles is None:
+                mc.addon_profiles = {}
+            
+            # Create or update monitoring addon profile
+            addon_profile = mc.addon_profiles.get(CONST_MONITORING_ADDON_NAME, self.models.ManagedClusterAddonProfile(enabled=False))
+            addon_profile.enabled = True
+            
+            # Set up default Log Analytics workspace if needed
+            workspace_resource_id = self.context.raw_param.get("workspace_resource_id")
+            if not workspace_resource_id:
+                # Use the ensure_default_log_analytics_workspace_for_monitoring from external functions
+                workspace_resource_id = self.context.external_functions.ensure_default_log_analytics_workspace_for_monitoring(
+                    self.cmd,
+                    self.context.get_subscription_id(),
+                    self.context.get_resource_group_name()
+                )
+            
+            # Sanitize workspace resource ID
+            workspace_resource_id = self.context.external_functions.sanitize_loganalytics_ws_resource_id(workspace_resource_id)
+            
+            # Configure addon profile
+            addon_profile.config = {CONST_MONITORING_LOG_ANALYTICS_WORKSPACE_RESOURCE_ID: workspace_resource_id}
+            
+            # Set MSI auth based on cluster identity type
+            enable_msi_auth = self.context.get_enable_msi_auth_for_monitoring()
+            addon_profile.config[CONST_MONITORING_USING_AAD_MSI_AUTH] = "true" if enable_msi_auth else "false"
+            
+            mc.addon_profiles[CONST_MONITORING_ADDON_NAME] = addon_profile
+            
+            # Set intermediate flag for postprocessing
+            self.context.set_intermediate("monitoring_addon_enabled", True, overwrite_exists=True)
+            
+            # Also set up Azure Monitor profile container insights for consistency
+            if mc.azure_monitor_profile is None:
+                mc.azure_monitor_profile = self.models.ManagedClusterAzureMonitorProfile()
+            if not hasattr(mc.azure_monitor_profile, 'container_insights') or mc.azure_monitor_profile.container_insights is None:
+                mc.azure_monitor_profile.container_insights = (
+                    self.models.ManagedClusterAzureMonitorProfileContainerInsights(enabled=True)
+                )
+            else:
+                mc.azure_monitor_profile.container_insights.enabled = True
+
+        # Handle OpenTelemetry metrics - these work within the Azure Monitor App Monitoring context
+        if self.context.get_enable_opentelemetry_metrics():
+            if mc.azure_monitor_profile is None:
+                mc.azure_monitor_profile = self.models.ManagedClusterAzureMonitorProfile()
+            if mc.azure_monitor_profile.app_monitoring is None:
+                mc.azure_monitor_profile.app_monitoring = (
+                    self.models.ManagedClusterAzureMonitorProfileAppMonitoring()
+                )
+            
+            # Configure OpenTelemetry metrics with custom port if provided
+            otlp_metrics_config = self.models.ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryMetrics(enabled=True)
+            if self.context.get_opentelemetry_metrics_port():
+                otlp_metrics_config.port = self.context.get_opentelemetry_metrics_port()
+            
+            mc.azure_monitor_profile.app_monitoring.open_telemetry_metrics = otlp_metrics_config
+
+        # Handle disable OpenTelemetry metrics
+        if self.context.get_disable_opentelemetry_metrics():
+            if (
+                mc.azure_monitor_profile is not None and
+                mc.azure_monitor_profile.app_monitoring is not None
+            ):
+                if mc.azure_monitor_profile.app_monitoring.open_telemetry_metrics is None:
+                    mc.azure_monitor_profile.app_monitoring.open_telemetry_metrics = (
+                        self.models.ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryMetrics(enabled=False)
+                    )
+                else:
+                    mc.azure_monitor_profile.app_monitoring.open_telemetry_metrics.enabled = False
+
+        # Handle OpenTelemetry logs - these work within the Azure Monitor App Monitoring context  
+        if self.context.get_enable_opentelemetry_logs():
+            if mc.azure_monitor_profile is None:
+                mc.azure_monitor_profile = self.models.ManagedClusterAzureMonitorProfile()
+            if mc.azure_monitor_profile.app_monitoring is None:
+                mc.azure_monitor_profile.app_monitoring = (
+                    self.models.ManagedClusterAzureMonitorProfileAppMonitoring()
+                )
+            
+            # Configure OpenTelemetry logs with custom port if provided
+            otlp_logs_config = self.models.ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryLogs(enabled=True)
+            if self.context.get_opentelemetry_logs_port():
+                otlp_logs_config.port = self.context.get_opentelemetry_logs_port()
+            
+            mc.azure_monitor_profile.app_monitoring.open_telemetry_logs = otlp_logs_config
+
+        # Handle disable OpenTelemetry logs
+        if self.context.get_disable_opentelemetry_logs():
+            if (
+                mc.azure_monitor_profile is not None and
+                mc.azure_monitor_profile.app_monitoring is not None
+            ):
+                if mc.azure_monitor_profile.app_monitoring.open_telemetry_logs is None:
+                    mc.azure_monitor_profile.app_monitoring.open_telemetry_logs = (
+                        self.models.ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryLogs(enabled=False)
+                    )
+                else:
+                    mc.azure_monitor_profile.app_monitoring.open_telemetry_logs.enabled = False
 
         return mc
 
@@ -4971,12 +5289,6 @@ class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):
             mc.azure_monitor_profile.app_monitoring.auto_instrumentation = (
                 self.models.ManagedClusterAzureMonitorProfileAppMonitoringAutoInstrumentation(enabled=True)
             )
-            mc.azure_monitor_profile.app_monitoring.open_telemetry_metrics = (
-                self.models.ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryMetrics(enabled=True)
-            )
-            mc.azure_monitor_profile.app_monitoring.open_telemetry_logs = (
-                self.models.ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryLogs(enabled=True)
-            )
 
         if self.context.get_disable_azure_monitor_app_monitoring():
             if mc.azure_monitor_profile is None:
@@ -4985,9 +5297,126 @@ class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):
             mc.azure_monitor_profile.app_monitoring.auto_instrumentation = (
                 self.models.ManagedClusterAzureMonitorProfileAppMonitoringAutoInstrumentation(enabled=False)
             )
+
+        # Handle Azure Monitor logs (new parameter in updates) - enables monitoring addon
+        if self.context.get_enable_azure_monitor_logs():
+            # Enable monitoring addon (equivalent to az aks enable-addons --addon monitoring)
+            addon_consts = self.context.get_addon_consts()
+            CONST_MONITORING_ADDON_NAME = addon_consts.get("CONST_MONITORING_ADDON_NAME")
+            CONST_MONITORING_LOG_ANALYTICS_WORKSPACE_RESOURCE_ID = addon_consts.get("CONST_MONITORING_LOG_ANALYTICS_WORKSPACE_RESOURCE_ID")
+            CONST_MONITORING_USING_AAD_MSI_AUTH = addon_consts.get("CONST_MONITORING_USING_AAD_MSI_AUTH")
+            
+            if mc.addon_profiles is None:
+                mc.addon_profiles = {}
+            
+            # Create or update monitoring addon profile
+            addon_profile = mc.addon_profiles.get(CONST_MONITORING_ADDON_NAME, self.models.ManagedClusterAddonProfile(enabled=False))
+            addon_profile.enabled = True
+            
+            # Set up default Log Analytics workspace if needed
+            workspace_resource_id = self.context.raw_param.get("workspace_resource_id")
+            if not workspace_resource_id:
+                # Use the ensure_default_log_analytics_workspace_for_monitoring from external functions
+                workspace_resource_id = self.context.external_functions.ensure_default_log_analytics_workspace_for_monitoring(
+                    self.cmd,
+                    self.context.get_subscription_id(),
+                    self.context.get_resource_group_name()
+                )
+            
+            # Sanitize workspace resource ID
+            workspace_resource_id = self.context.external_functions.sanitize_loganalytics_ws_resource_id(workspace_resource_id)
+            
+            # Configure addon profile
+            addon_profile.config = {CONST_MONITORING_LOG_ANALYTICS_WORKSPACE_RESOURCE_ID: workspace_resource_id}
+            
+            # Set MSI auth based on cluster identity type
+            enable_msi_auth = self.context.get_enable_msi_auth_for_monitoring()
+            addon_profile.config[CONST_MONITORING_USING_AAD_MSI_AUTH] = "true" if enable_msi_auth else "false"
+            
+            mc.addon_profiles[CONST_MONITORING_ADDON_NAME] = addon_profile
+            
+            # Set intermediate flag for postprocessing
+            self.context.set_intermediate("monitoring_addon_enabled", True, overwrite_exists=True)
+            
+            # Also set up Azure Monitor profile container insights for consistency
+            if mc.azure_monitor_profile is None:
+                mc.azure_monitor_profile = self.models.ManagedClusterAzureMonitorProfile()
+            if not hasattr(mc.azure_monitor_profile, 'container_insights') or mc.azure_monitor_profile.container_insights is None:
+                mc.azure_monitor_profile.container_insights = (
+                    self.models.ManagedClusterAzureMonitorProfileContainerInsights(enabled=True)
+                )
+            else:
+                mc.azure_monitor_profile.container_insights.enabled = True
+
+        # Handle disable Azure Monitor logs (new parameter in updates) - disables monitoring addon
+        if self.context.get_disable_azure_monitor_logs():
+            # Disable monitoring addon (equivalent to az aks disable-addons --addon monitoring)
+            addon_consts = self.context.get_addon_consts()
+            CONST_MONITORING_ADDON_NAME = addon_consts.get("CONST_MONITORING_ADDON_NAME")
+            
+            if mc.addon_profiles and CONST_MONITORING_ADDON_NAME in mc.addon_profiles:
+                mc.addon_profiles[CONST_MONITORING_ADDON_NAME].enabled = False
+            
+            # Also disable in Azure Monitor profile container insights for consistency
+            if (mc.azure_monitor_profile and 
+                hasattr(mc.azure_monitor_profile, 'container_insights') and 
+                mc.azure_monitor_profile.container_insights):
+                mc.azure_monitor_profile.container_insights.enabled = False
+
+        # Handle OpenTelemetry metrics updates - these work within the Azure Monitor App Monitoring context
+        if self.context.get_enable_opentelemetry_metrics():
+            if mc.azure_monitor_profile is None:
+                mc.azure_monitor_profile = self.models.ManagedClusterAzureMonitorProfile()
+            if mc.azure_monitor_profile.app_monitoring is None:
+                mc.azure_monitor_profile.app_monitoring = (
+                    self.models.ManagedClusterAzureMonitorProfileAppMonitoring()
+                )
+            
+            # Configure OpenTelemetry metrics with custom port if provided
+            otlp_metrics_config = self.models.ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryMetrics(enabled=True)
+            if self.context.get_opentelemetry_metrics_port():
+                otlp_metrics_config.port = self.context.get_opentelemetry_metrics_port()
+            
+            mc.azure_monitor_profile.app_monitoring.open_telemetry_metrics = otlp_metrics_config
+
+        # Handle OpenTelemetry logs updates - these work within the Azure Monitor App Monitoring context
+        if self.context.get_enable_opentelemetry_logs():
+            if mc.azure_monitor_profile is None:
+                mc.azure_monitor_profile = self.models.ManagedClusterAzureMonitorProfile()
+            if mc.azure_monitor_profile.app_monitoring is None:
+                mc.azure_monitor_profile.app_monitoring = (
+                    self.models.ManagedClusterAzureMonitorProfileAppMonitoring()
+                )
+            
+            # Configure OpenTelemetry logs with custom port if provided
+            otlp_logs_config = self.models.ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryLogs(enabled=True)
+            if self.context.get_opentelemetry_logs_port():
+                otlp_logs_config.port = self.context.get_opentelemetry_logs_port()
+            
+            mc.azure_monitor_profile.app_monitoring.open_telemetry_logs = otlp_logs_config
+
+        # Handle disable OpenTelemetry metrics updates
+        if self.context.get_disable_opentelemetry_metrics():
+            if mc.azure_monitor_profile is None:
+                mc.azure_monitor_profile = self.models.ManagedClusterAzureMonitorProfile()
+            if mc.azure_monitor_profile.app_monitoring is None:
+                mc.azure_monitor_profile.app_monitoring = (
+                    self.models.ManagedClusterAzureMonitorProfileAppMonitoring()
+                )
+            
             mc.azure_monitor_profile.app_monitoring.open_telemetry_metrics = (
                 self.models.ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryMetrics(enabled=False)
             )
+
+        # Handle disable OpenTelemetry logs updates
+        if self.context.get_disable_opentelemetry_logs():
+            if mc.azure_monitor_profile is None:
+                mc.azure_monitor_profile = self.models.ManagedClusterAzureMonitorProfile()
+            if mc.azure_monitor_profile.app_monitoring is None:
+                mc.azure_monitor_profile.app_monitoring = (
+                    self.models.ManagedClusterAzureMonitorProfileAppMonitoring()
+                )
+            
             mc.azure_monitor_profile.app_monitoring.open_telemetry_logs = (
                 self.models.ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryLogs(enabled=False)
             )
@@ -4995,10 +5424,15 @@ class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):
         # TODO: should remove get value from enable_azuremonitormetrics once the option is removed
         # TODO: should remove get value from disable_azuremonitormetrics once the option is removed
         if (
-            self.context.raw_param.get("enable_azure_monitor_metrics") or
             self.context.raw_param.get("enable_azuremonitormetrics") or
-            self.context.raw_param.get("disable_azure_monitor_metrics") or
-            self.context.raw_param.get("disable_azuremonitormetrics")
+            self.context.raw_param.get("disable_azuremonitormetrics") or
+            self.context.get_enable_azure_monitor_metrics() or
+            self.context.get_disable_azure_monitor_metrics() or
+            self.context.get_enable_azure_monitor_logs() or
+            self.context.raw_param.get("enable_opentelemetry_metrics") or
+            self.context.raw_param.get("enable_opentelemetry_logs") or
+            self.context.raw_param.get("disable_opentelemetry_metrics") or
+            self.context.raw_param.get("disable_opentelemetry_logs")
         ):
             ensure_azure_monitor_profile_prerequisites(
                 self.cmd,

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
@@ -5755,6 +5755,229 @@ class AKSPreviewManagedClusterCreateDecoratorTestCase(unittest.TestCase):
         )
         self.assertEqual(dec_mc_2, ground_truth_mc_2)
 
+    def test_get_enable_opentelemetry_metrics(self):
+        # Test default behavior
+        dec_1 = AKSPreviewManagedClusterCreateDecorator(
+            self.cmd,
+            self.client,
+            {},
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        self.assertFalse(dec_1.get_enable_opentelemetry_metrics())
+
+        # Test explicit enable
+        dec_2 = AKSPreviewManagedClusterCreateDecorator(
+            self.cmd,
+            self.client,
+            {"enable_opentelemetry_metrics": True},
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        self.assertTrue(dec_2.get_enable_opentelemetry_metrics())
+
+        # Test explicit disable
+        dec_3 = AKSPreviewManagedClusterCreateDecorator(
+            self.cmd,
+            self.client,
+            {"enable_opentelemetry_metrics": False},
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        self.assertFalse(dec_3.get_enable_opentelemetry_metrics())
+
+    def test_get_disable_opentelemetry_metrics(self):
+        # Test default behavior
+        dec_1 = AKSPreviewManagedClusterCreateDecorator(
+            self.cmd,
+            self.client,
+            {},
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        self.assertFalse(dec_1.get_disable_opentelemetry_metrics())
+
+        # Test explicit disable
+        dec_2 = AKSPreviewManagedClusterCreateDecorator(
+            self.cmd,
+            self.client,
+            {"disable_opentelemetry_metrics": True},
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        self.assertTrue(dec_2.get_disable_opentelemetry_metrics())
+
+    def test_get_opentelemetry_metrics_port(self):
+        # Test default behavior
+        dec_1 = AKSPreviewManagedClusterCreateDecorator(
+            self.cmd,
+            self.client,
+            {},
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        self.assertIsNone(dec_1.get_opentelemetry_metrics_port())
+
+        # Test explicit port
+        dec_2 = AKSPreviewManagedClusterCreateDecorator(
+            self.cmd,
+            self.client,
+            {"opentelemetry_metrics_port": 8080},
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        self.assertEqual(dec_2.get_opentelemetry_metrics_port(), 8080)
+
+    def test_get_enable_opentelemetry_logs(self):
+        # Test default behavior
+        dec_1 = AKSPreviewManagedClusterCreateDecorator(
+            self.cmd,
+            self.client,
+            {},
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        self.assertFalse(dec_1.get_enable_opentelemetry_logs())
+
+        # Test explicit enable
+        dec_2 = AKSPreviewManagedClusterCreateDecorator(
+            self.cmd,
+            self.client,
+            {"enable_opentelemetry_logs": True},
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        self.assertTrue(dec_2.get_enable_opentelemetry_logs())
+
+    def test_get_disable_opentelemetry_logs(self):
+        # Test default behavior
+        dec_1 = AKSPreviewManagedClusterCreateDecorator(
+            self.cmd,
+            self.client,
+            {},
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        self.assertFalse(dec_1.get_disable_opentelemetry_logs())
+
+        # Test explicit disable
+        dec_2 = AKSPreviewManagedClusterCreateDecorator(
+            self.cmd,
+            self.client,
+            {"disable_opentelemetry_logs": True},
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        self.assertTrue(dec_2.get_disable_opentelemetry_logs())
+
+    def test_get_opentelemetry_logs_port(self):
+        # Test default behavior
+        dec_1 = AKSPreviewManagedClusterCreateDecorator(
+            self.cmd,
+            self.client,
+            {},
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        self.assertIsNone(dec_1.get_opentelemetry_logs_port())
+
+        # Test explicit port
+        dec_2 = AKSPreviewManagedClusterCreateDecorator(
+            self.cmd,
+            self.client,
+            {"opentelemetry_logs_port": 8081},
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        self.assertEqual(dec_2.get_opentelemetry_logs_port(), 8081)
+
+    def test_get_enable_azure_monitor_logs(self):
+        # Test default behavior
+        dec_1 = AKSPreviewManagedClusterCreateDecorator(
+            self.cmd,
+            self.client,
+            {},
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        self.assertFalse(dec_1.get_enable_azure_monitor_logs())
+
+        # Test explicit enable
+        dec_2 = AKSPreviewManagedClusterCreateDecorator(
+            self.cmd,
+            self.client,
+            {"enable_azure_monitor_logs": True},
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        self.assertTrue(dec_2.get_enable_azure_monitor_logs())
+
+    def test_set_up_azure_monitor_profile_with_opentelemetry(self):
+        # Test enabling Azure Monitor metrics with OpenTelemetry metrics
+        dec_1 = AKSPreviewManagedClusterCreateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "enable_azure_monitor_metrics": True,
+                "enable_opentelemetry_metrics": True,
+                "opentelemetry_metrics_port": 8080,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        
+        mc_1 = self.models.ManagedCluster(location="test_location")
+        dec_1.context.attach_mc(mc_1)
+        dec_mc_1 = dec_1.set_up_azure_monitor_profile(mc_1)
+        
+        # Verify Azure Monitor profile is set up
+        self.assertIsNotNone(dec_mc_1.azure_monitor_profile)
+        self.assertIsNotNone(dec_mc_1.azure_monitor_profile.metrics)
+        self.assertTrue(dec_mc_1.azure_monitor_profile.metrics.enabled)
+        
+        # Verify OpenTelemetry metrics configuration
+        opentelemetry_config = dec_mc_1.azure_monitor_profile.metrics.opentelemetry_metrics
+        self.assertIsNotNone(opentelemetry_config)
+        self.assertTrue(opentelemetry_config.enabled)
+        self.assertEqual(opentelemetry_config.port, 8080)
+
+        # Test enabling Azure Monitor logs with OpenTelemetry logs
+        dec_2 = AKSPreviewManagedClusterCreateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "enable_azure_monitor_logs": True,
+                "enable_opentelemetry_logs": True,
+                "opentelemetry_logs_port": 8081,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        
+        mc_2 = self.models.ManagedCluster(location="test_location")
+        dec_2.context.attach_mc(mc_2)
+        dec_mc_2 = dec_2.set_up_azure_monitor_profile(mc_2)
+        
+        # Verify Azure Monitor profile is set up
+        self.assertIsNotNone(dec_mc_2.azure_monitor_profile)
+        self.assertIsNotNone(dec_mc_2.azure_monitor_profile.logs)
+        self.assertTrue(dec_mc_2.azure_monitor_profile.logs.enabled)
+        
+        # Verify OpenTelemetry logs configuration
+        opentelemetry_config = dec_mc_2.azure_monitor_profile.logs.opentelemetry_logs
+        self.assertIsNotNone(opentelemetry_config)
+        self.assertTrue(opentelemetry_config.enabled)
+        self.assertEqual(opentelemetry_config.port, 8081)
+
+    def test_set_up_azure_monitor_profile_disable_opentelemetry(self):
+        # Test disabling OpenTelemetry metrics
+        dec_1 = AKSPreviewManagedClusterCreateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "enable_azure_monitor_metrics": True,
+                "disable_opentelemetry_metrics": True,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        
+        mc_1 = self.models.ManagedCluster(location="test_location")
+        dec_1.context.attach_mc(mc_1)
+        dec_mc_1 = dec_1.set_up_azure_monitor_profile(mc_1)
+        
+        # Verify Azure Monitor profile is set up
+        self.assertIsNotNone(dec_mc_1.azure_monitor_profile)
+        self.assertIsNotNone(dec_mc_1.azure_monitor_profile.metrics)
+        self.assertTrue(dec_mc_1.azure_monitor_profile.metrics.enabled)
+        
+        # Verify OpenTelemetry metrics is disabled
+        opentelemetry_config = dec_mc_1.azure_monitor_profile.metrics.opentelemetry_metrics
+        self.assertIsNotNone(opentelemetry_config)
+        self.assertFalse(opentelemetry_config.enabled)
+
 
 class AKSPreviewManagedClusterUpdateDecoratorTestCase(unittest.TestCase):
     def setUp(self):
@@ -10134,6 +10357,149 @@ class AKSPreviewManagedClusterUpdateDecoratorTestCase(unittest.TestCase):
             ),
         )
         self.assertEqual(dec_mc_5, ground_truth_mc_5)
+
+    def test_update_azure_monitor_profile_with_opentelemetry_metrics(self):
+        # Test enabling OpenTelemetry metrics on update
+        dec_1 = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "enable_opentelemetry_metrics": True,
+                "opentelemetry_metrics_port": 8080,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        
+        # Mock existing cluster with Azure Monitor metrics enabled
+        mc_1 = self.models.ManagedCluster(
+            location="test_location",
+            azure_monitor_profile=self.models.ManagedClusterAzureMonitorProfile(
+                metrics=self.models.ManagedClusterAzureMonitorProfileMetrics(
+                    enabled=True
+                )
+            )
+        )
+        dec_1.context.attach_mc(mc_1)
+        dec_mc_1 = dec_1.update_azure_monitor_profile(mc_1)
+        
+        # Verify OpenTelemetry metrics configuration is updated
+        opentelemetry_config = dec_mc_1.azure_monitor_profile.metrics.opentelemetry_metrics
+        self.assertIsNotNone(opentelemetry_config)
+        self.assertTrue(opentelemetry_config.enabled)
+        self.assertEqual(opentelemetry_config.port, 8080)
+
+        # Test disabling OpenTelemetry metrics on update
+        dec_2 = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "disable_opentelemetry_metrics": True,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        
+        # Mock existing cluster with OpenTelemetry metrics enabled
+        mc_2 = self.models.ManagedCluster(
+            location="test_location",
+            azure_monitor_profile=self.models.ManagedClusterAzureMonitorProfile(
+                metrics=self.models.ManagedClusterAzureMonitorProfileMetrics(
+                    enabled=True,
+                    opentelemetry_metrics=self.models.ManagedClusterAzureMonitorProfileOpenTelemetryMetrics(
+                        enabled=True,
+                        port=8080
+                    )
+                )
+            )
+        )
+        dec_2.context.attach_mc(mc_2)
+        dec_mc_2 = dec_2.update_azure_monitor_profile(mc_2)
+        
+        # Verify OpenTelemetry metrics is disabled
+        opentelemetry_config = dec_mc_2.azure_monitor_profile.metrics.opentelemetry_metrics
+        self.assertIsNotNone(opentelemetry_config)
+        self.assertFalse(opentelemetry_config.enabled)
+
+    def test_update_azure_monitor_profile_with_opentelemetry_logs(self):
+        # Test enabling OpenTelemetry logs on update
+        dec_1 = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "enable_opentelemetry_logs": True,
+                "opentelemetry_logs_port": 8081,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        
+        # Mock existing cluster with Azure Monitor logs enabled
+        mc_1 = self.models.ManagedCluster(
+            location="test_location",
+            azure_monitor_profile=self.models.ManagedClusterAzureMonitorProfile(
+                logs=self.models.ManagedClusterAzureMonitorProfileLogs(
+                    enabled=True
+                )
+            )
+        )
+        dec_1.context.attach_mc(mc_1)
+        dec_mc_1 = dec_1.update_azure_monitor_profile(mc_1)
+        
+        # Verify OpenTelemetry logs configuration is updated
+        opentelemetry_config = dec_mc_1.azure_monitor_profile.logs.opentelemetry_logs
+        self.assertIsNotNone(opentelemetry_config)
+        self.assertTrue(opentelemetry_config.enabled)
+        self.assertEqual(opentelemetry_config.port, 8081)
+
+        # Test disabling OpenTelemetry logs on update
+        dec_2 = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "disable_opentelemetry_logs": True,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        
+        # Mock existing cluster with OpenTelemetry logs enabled
+        mc_2 = self.models.ManagedCluster(
+            location="test_location",
+            azure_monitor_profile=self.models.ManagedClusterAzureMonitorProfile(
+                logs=self.models.ManagedClusterAzureMonitorProfileLogs(
+                    enabled=True,
+                    opentelemetry_logs=self.models.ManagedClusterAzureMonitorProfileOpenTelemetryLogs(
+                        enabled=True,
+                        port=8081
+                    )
+                )
+            )
+        )
+        dec_2.context.attach_mc(mc_2)
+        dec_mc_2 = dec_2.update_azure_monitor_profile(mc_2)
+        
+        # Verify OpenTelemetry logs is disabled
+        opentelemetry_config = dec_mc_2.azure_monitor_profile.logs.opentelemetry_logs
+        self.assertIsNotNone(opentelemetry_config)
+        self.assertFalse(opentelemetry_config.enabled)
+
+    def test_update_azure_monitor_profile_enable_azure_monitor_logs(self):
+        # Test enabling Azure Monitor logs (equivalent to az aks enable-addons --addon monitoring)
+        dec_1 = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "enable_azure_monitor_logs": True,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        
+        # Mock existing cluster without Azure Monitor logs
+        mc_1 = self.models.ManagedCluster(location="test_location")
+        dec_1.context.attach_mc(mc_1)
+        dec_mc_1 = dec_1.update_azure_monitor_profile(mc_1)
+        
+        # Verify Azure Monitor logs is enabled
+        self.assertIsNotNone(dec_mc_1.azure_monitor_profile)
+        self.assertIsNotNone(dec_mc_1.azure_monitor_profile.logs)
+        self.assertTrue(dec_mc_1.azure_monitor_profile.logs.enabled)
 
 
 if __name__ == "__main__":

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_opentelemetry_integration.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_opentelemetry_integration.py
@@ -1,0 +1,364 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import unittest
+from unittest.mock import Mock, patch
+from types import SimpleNamespace
+
+import azext_aks_preview._validators as validators
+from azext_aks_preview.managed_cluster_decorator import (
+    AKSPreviewManagedClusterCreateDecorator,
+    AKSPreviewManagedClusterUpdateDecorator,
+)
+from azext_aks_preview._client_factory import CUSTOM_MGMT_AKS_PREVIEW
+from azext_aks_preview.tests.latest.test_managed_cluster_decorator import (
+    AKSPreviewManagedClusterModels,
+)
+from azure.cli.core.azclierror import (
+    ArgumentUsageError,
+    MutuallyExclusiveArgumentError,
+)
+
+
+class MockCLI:
+    def __init__(self):
+        self.data = {}
+
+
+class MockCmd:
+    def __init__(self, cli_ctx):
+        self.cli_ctx = cli_ctx
+
+
+class MockClient:
+    def __init__(self):
+        pass
+
+
+class OpenTelemetryIntegrationTestCase(unittest.TestCase):
+    def setUp(self):
+        self.cli_ctx = MockCLI()
+        self.cmd = MockCmd(self.cli_ctx)
+        self.models = AKSPreviewManagedClusterModels(self.cmd, CUSTOM_MGMT_AKS_PREVIEW)
+        self.client = MockClient()
+
+    def test_opentelemetry_metrics_end_to_end_create(self):
+        """Test complete OpenTelemetry metrics workflow for cluster creation"""
+        # Test successful creation with OpenTelemetry metrics
+        dec = AKSPreviewManagedClusterCreateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "enable_azure_monitor_metrics": True,
+                "enable_opentelemetry_metrics": True,
+                "opentelemetry_metrics_port": 8080,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        
+        # Verify parameters are parsed correctly
+        self.assertTrue(dec.get_enable_azure_monitor_metrics())
+        self.assertTrue(dec.get_enable_opentelemetry_metrics())
+        self.assertEqual(dec.get_opentelemetry_metrics_port(), 8080)
+        
+        # Verify Azure Monitor profile setup
+        mc = self.models.ManagedCluster(location="test_location")
+        dec.context.attach_mc(mc)
+        result_mc = dec.set_up_azure_monitor_profile(mc)
+        
+        self.assertIsNotNone(result_mc.azure_monitor_profile)
+        self.assertTrue(result_mc.azure_monitor_profile.metrics.enabled)
+        self.assertTrue(result_mc.azure_monitor_profile.metrics.opentelemetry_metrics.enabled)
+        self.assertEqual(result_mc.azure_monitor_profile.metrics.opentelemetry_metrics.port, 8080)
+
+    def test_opentelemetry_logs_end_to_end_create(self):
+        """Test complete OpenTelemetry logs workflow for cluster creation"""
+        # Test successful creation with OpenTelemetry logs
+        dec = AKSPreviewManagedClusterCreateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "enable_azure_monitor_logs": True,
+                "enable_opentelemetry_logs": True,
+                "opentelemetry_logs_port": 8081,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        
+        # Verify parameters are parsed correctly
+        self.assertTrue(dec.get_enable_azure_monitor_logs())
+        self.assertTrue(dec.get_enable_opentelemetry_logs())
+        self.assertEqual(dec.get_opentelemetry_logs_port(), 8081)
+        
+        # Verify Azure Monitor profile setup
+        mc = self.models.ManagedCluster(location="test_location")
+        dec.context.attach_mc(mc)
+        result_mc = dec.set_up_azure_monitor_profile(mc)
+        
+        self.assertIsNotNone(result_mc.azure_monitor_profile)
+        self.assertTrue(result_mc.azure_monitor_profile.logs.enabled)
+        self.assertTrue(result_mc.azure_monitor_profile.logs.opentelemetry_logs.enabled)
+        self.assertEqual(result_mc.azure_monitor_profile.logs.opentelemetry_logs.port, 8081)
+
+    def test_opentelemetry_full_stack_end_to_end_create(self):
+        """Test complete OpenTelemetry workflow for both metrics and logs"""
+        # Test successful creation with both OpenTelemetry metrics and logs
+        dec = AKSPreviewManagedClusterCreateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "enable_azure_monitor_metrics": True,
+                "enable_azure_monitor_logs": True,
+                "enable_opentelemetry_metrics": True,
+                "enable_opentelemetry_logs": True,
+                "opentelemetry_metrics_port": 8080,
+                "opentelemetry_logs_port": 8081,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        
+        # Verify Azure Monitor profile setup
+        mc = self.models.ManagedCluster(location="test_location")
+        dec.context.attach_mc(mc)
+        result_mc = dec.set_up_azure_monitor_profile(mc)
+        
+        # Verify complete configuration
+        self.assertIsNotNone(result_mc.azure_monitor_profile)
+        
+        # Metrics verification
+        self.assertTrue(result_mc.azure_monitor_profile.metrics.enabled)
+        self.assertTrue(result_mc.azure_monitor_profile.metrics.opentelemetry_metrics.enabled)
+        self.assertEqual(result_mc.azure_monitor_profile.metrics.opentelemetry_metrics.port, 8080)
+        
+        # Logs verification
+        self.assertTrue(result_mc.azure_monitor_profile.logs.enabled)
+        self.assertTrue(result_mc.azure_monitor_profile.logs.opentelemetry_logs.enabled)
+        self.assertEqual(result_mc.azure_monitor_profile.logs.opentelemetry_logs.port, 8081)
+
+    def test_opentelemetry_metrics_end_to_end_update(self):
+        """Test complete OpenTelemetry metrics workflow for cluster update"""
+        # Test successful update enabling OpenTelemetry metrics
+        dec = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "enable_opentelemetry_metrics": True,
+                "opentelemetry_metrics_port": 8080,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        
+        # Mock existing cluster with Azure Monitor metrics already enabled
+        mc = self.models.ManagedCluster(
+            location="test_location",
+            azure_monitor_profile=self.models.ManagedClusterAzureMonitorProfile(
+                metrics=self.models.ManagedClusterAzureMonitorProfileMetrics(
+                    enabled=True
+                )
+            )
+        )
+        dec.context.attach_mc(mc)
+        result_mc = dec.update_azure_monitor_profile(mc)
+        
+        # Verify OpenTelemetry metrics is enabled
+        self.assertTrue(result_mc.azure_monitor_profile.metrics.opentelemetry_metrics.enabled)
+        self.assertEqual(result_mc.azure_monitor_profile.metrics.opentelemetry_metrics.port, 8080)
+
+    def test_opentelemetry_disable_workflow_update(self):
+        """Test disabling OpenTelemetry configuration during update"""
+        # Test disabling OpenTelemetry metrics
+        dec = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "disable_opentelemetry_metrics": True,
+                "disable_opentelemetry_logs": True,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        
+        # Mock existing cluster with OpenTelemetry enabled
+        mc = self.models.ManagedCluster(
+            location="test_location",
+            azure_monitor_profile=self.models.ManagedClusterAzureMonitorProfile(
+                metrics=self.models.ManagedClusterAzureMonitorProfileMetrics(
+                    enabled=True,
+                    opentelemetry_metrics=self.models.ManagedClusterAzureMonitorProfileOpenTelemetryMetrics(
+                        enabled=True,
+                        port=8080
+                    )
+                ),
+                logs=self.models.ManagedClusterAzureMonitorProfileLogs(
+                    enabled=True,
+                    opentelemetry_logs=self.models.ManagedClusterAzureMonitorProfileOpenTelemetryLogs(
+                        enabled=True,
+                        port=8081
+                    )
+                )
+            )
+        )
+        dec.context.attach_mc(mc)
+        result_mc = dec.update_azure_monitor_profile(mc)
+        
+        # Verify OpenTelemetry is disabled
+        self.assertFalse(result_mc.azure_monitor_profile.metrics.opentelemetry_metrics.enabled)
+        self.assertFalse(result_mc.azure_monitor_profile.logs.opentelemetry_logs.enabled)
+
+    def test_validation_workflow_integration(self):
+        """Test validation workflow integration with various scenarios"""
+        
+        # Test scenario 1: Valid configuration with all dependencies
+        namespace = SimpleNamespace(
+            enable_opentelemetry_metrics=True,
+            disable_opentelemetry_metrics=False,
+            enable_azure_monitor_metrics=True,
+            enable_azuremonitormetrics=False,
+            enable_opentelemetry_logs=True,
+            disable_opentelemetry_logs=False,
+            enable_azure_monitor_logs=True,
+            opentelemetry_metrics_port=8080,
+            opentelemetry_logs_port=8081
+        )
+        
+        # Should pass all validations
+        validators.validate_azure_monitor_and_opentelemetry_for_create(namespace)
+        
+        # Test scenario 2: Port conflicts should fail
+        conflict_namespace = SimpleNamespace(
+            enable_opentelemetry_metrics=True,
+            disable_opentelemetry_metrics=False,
+            enable_azure_monitor_metrics=True,
+            enable_azuremonitormetrics=False,
+            enable_opentelemetry_logs=True,
+            disable_opentelemetry_logs=False,
+            enable_azure_monitor_logs=True,
+            opentelemetry_metrics_port=8080,
+            opentelemetry_logs_port=8080  # Same port as metrics
+        )
+        
+        with self.assertRaises(ArgumentUsageError) as cm:
+            validators.validate_azure_monitor_and_opentelemetry_for_create(conflict_namespace)
+        self.assertIn("cannot be the same", str(cm.exception))
+        
+        # Test scenario 3: Missing Azure Monitor dependencies should fail
+        missing_deps_namespace = SimpleNamespace(
+            enable_opentelemetry_metrics=True,
+            disable_opentelemetry_metrics=False,
+            enable_azure_monitor_metrics=False,
+            enable_azuremonitormetrics=False,
+            enable_opentelemetry_logs=False,
+            disable_opentelemetry_logs=False,
+            enable_azure_monitor_logs=False,
+            opentelemetry_metrics_port=8080,
+            opentelemetry_logs_port=8081
+        )
+        
+        with self.assertRaises(ArgumentUsageError) as cm:
+            validators.validate_azure_monitor_and_opentelemetry_for_create(missing_deps_namespace)
+        self.assertIn("requires Azure Monitor metrics", str(cm.exception))
+
+    def test_deprecated_flag_compatibility(self):
+        """Test backward compatibility with deprecated flags"""
+        # Test using deprecated enable_azuremonitormetrics flag
+        dec = AKSPreviewManagedClusterCreateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "enable_azuremonitormetrics": True,  # Deprecated flag
+                "enable_opentelemetry_metrics": True,
+                "opentelemetry_metrics_port": 8080,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        
+        # Should work with deprecated flag
+        namespace = SimpleNamespace(
+            enable_opentelemetry_metrics=True,
+            disable_opentelemetry_metrics=False,
+            enable_azure_monitor_metrics=False,
+            enable_azuremonitormetrics=True,  # Deprecated flag
+            enable_opentelemetry_logs=False,
+            disable_opentelemetry_logs=False,
+            enable_azure_monitor_logs=False,
+            opentelemetry_metrics_port=8080,
+            opentelemetry_logs_port=None
+        )
+        
+        # Should pass validation with deprecated flag
+        validators.validate_azure_monitor_and_opentelemetry_for_create(namespace)
+
+    def test_port_validation_edge_cases(self):
+        """Test port validation with edge cases"""
+        # Test boundary values
+        valid_boundary_namespace = SimpleNamespace(
+            enable_opentelemetry_metrics=True,
+            disable_opentelemetry_metrics=False,
+            enable_azure_monitor_metrics=True,
+            enable_azuremonitormetrics=False,
+            enable_opentelemetry_logs=True,
+            disable_opentelemetry_logs=False,
+            enable_azure_monitor_logs=True,
+            opentelemetry_metrics_port=1,      # Minimum valid port
+            opentelemetry_logs_port=65535      # Maximum valid port
+        )
+        
+        validators.validate_azure_monitor_and_opentelemetry_for_create(valid_boundary_namespace)
+        
+        # Test invalid ports
+        invalid_port_namespace = SimpleNamespace(
+            enable_opentelemetry_metrics=True,
+            disable_opentelemetry_metrics=False,
+            enable_azure_monitor_metrics=True,
+            enable_azuremonitormetrics=False,
+            enable_opentelemetry_logs=False,
+            disable_opentelemetry_logs=False,
+            enable_azure_monitor_logs=False,
+            opentelemetry_metrics_port=0,      # Invalid port
+            opentelemetry_logs_port=None
+        )
+        
+        with self.assertRaises(ArgumentUsageError) as cm:
+            validators.validate_azure_monitor_and_opentelemetry_for_create(invalid_port_namespace)
+        self.assertIn("must be between 1 and 65535", str(cm.exception))
+
+    def test_mutually_exclusive_flags(self):
+        """Test mutually exclusive flag validation"""
+        # Test mutually exclusive metrics flags
+        exclusive_metrics_namespace = SimpleNamespace(
+            enable_opentelemetry_metrics=True,
+            disable_opentelemetry_metrics=True,
+            enable_azure_monitor_metrics=True,
+            enable_azuremonitormetrics=False,
+            enable_opentelemetry_logs=False,
+            disable_opentelemetry_logs=False,
+            enable_azure_monitor_logs=False,
+            opentelemetry_metrics_port=8080,
+            opentelemetry_logs_port=None
+        )
+        
+        with self.assertRaises(MutuallyExclusiveArgumentError) as cm:
+            validators.validate_azure_monitor_and_opentelemetry_for_create(exclusive_metrics_namespace)
+        self.assertIn("Cannot specify both", str(cm.exception))
+        
+        # Test mutually exclusive logs flags
+        exclusive_logs_namespace = SimpleNamespace(
+            enable_opentelemetry_metrics=False,
+            disable_opentelemetry_metrics=False,
+            enable_azure_monitor_metrics=False,
+            enable_azuremonitormetrics=False,
+            enable_opentelemetry_logs=True,
+            disable_opentelemetry_logs=True,
+            enable_azure_monitor_logs=True,
+            opentelemetry_metrics_port=None,
+            opentelemetry_logs_port=8081
+        )
+        
+        with self.assertRaises(MutuallyExclusiveArgumentError) as cm:
+            validators.validate_azure_monitor_and_opentelemetry_for_create(exclusive_logs_namespace)
+        self.assertIn("Cannot specify both", str(cm.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/aks-preview/setup.py
+++ b/src/aks-preview/setup.py
@@ -9,7 +9,7 @@ from codecs import open as open1
 
 from setuptools import find_packages, setup
 
-VERSION = "18.0.0b36"
+VERSION = "18.0.0b37"
 
 CLASSIFIERS = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
```
az aks create/update --resource-group={resource_group} --name={name} --enable-azure-monitor-metrics --enable-opentelemetry-metrics [--opentelemetry-metrics-port <port>]
az aks create/update --resource-group={resource_group} --name={name} --disable-opentelemetry-metrics
az aks create/update --resource-group={resource_group} --name={name} --enable-azure-monitor-logs -enable-opentelemetry-logs [--opentelemetry-logs-port <port>]
az aks create/update --resource-group={resource_group} --name={name} --disable-opentelemetry-logs
```

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
