### PR TITLE
Update firmwareanalysis to GA status

### DIFF
--- a/src/firmwareanalysis/HISTORY.rst
+++ b/src/firmwareanalysis/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+2.0.1
++++++
+* Fix documentation to reflect GA status
+
 2.0.0
 +++++
 * Updating version for 2025-08-02 swagger release

--- a/src/firmwareanalysis/azext_firmwareanalysis/azext_metadata.json
+++ b/src/firmwareanalysis/azext_firmwareanalysis/azext_metadata.json
@@ -1,4 +1,3 @@
 {
-    "azext.isPreview": true,
     "azext.minCliCoreVersion": "2.75.0"
 }

--- a/src/firmwareanalysis/setup.py
+++ b/src/firmwareanalysis/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 
 
 # HISTORY.rst entry.
-VERSION = '2.0.0'
+VERSION = '2.0.1'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
- remove azext.isPreview configuration so docs reflect GA status instead of Preview
- bump version to 2.0.1 so we can release the fix

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
az firmwareanalysis


### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
