### PR TITLE
{CI} Add status check for extension release pipeline

### DIFF
--- a/.github/workflows/TestTriggerExtensionRelease.yml
+++ b/.github/workflows/TestTriggerExtensionRelease.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
     build:
-        name: Trigger Extension Release Pipeline
+        name: Test Trigger Extension Release Pipeline
         runs-on: ubuntu-latest
         steps:
         - name: Harden Runner
@@ -26,7 +26,7 @@ jobs:
             client-id: ${{ secrets.ADO_SP_ClientID }}
             tenant-id: ${{ secrets.ADO_SP_TenantID }}
             allow-no-subscriptions: true
-        - name: Trigger ADO Pipeline and Wait for Completion
+        - name: Test Trigger ADO Pipeline and Wait for Completion
           uses: azure/cli@v2
           env:
             ado-org: ${{secrets.ADO_ORGANIZATION}}
@@ -89,7 +89,7 @@ jobs:
                   exit 1
                 fi
                 
-                # Wait 30 seconds before checking again
-                echo "Build still running... waiting 30 seconds"
-                sleep 30
+                # Wait 60 seconds before checking again
+                echo "Build still running... waiting 60 seconds"
+                sleep 60
               done

--- a/.github/workflows/TriggerExtensionRelease.yml
+++ b/.github/workflows/TriggerExtensionRelease.yml
@@ -26,7 +26,7 @@ jobs:
             client-id: ${{ secrets.ADO_SP_ClientID }}
             tenant-id: ${{ secrets.ADO_SP_TenantID }}
             allow-no-subscriptions: true
-        - name: Azure CLI
+        - name: Trigger ADO Pipeline and Wait for Completion
           uses: azure/cli@v2
           env:
             ado-org: ${{secrets.ADO_ORGANIZATION}}
@@ -35,4 +35,61 @@ jobs:
             commit-id: ${{ github.sha }}
           with:
             inlineScript: |
-              az pipelines build queue --definition-id ${{ env.ado-pipeline-id }} --organization ${{ env.ado-org }}  --project ${{ env.ado-project }} --variables commit_id=${{ env.commit-id }}
+              # Trigger the pipeline and capture the build ID
+              echo "Triggering ADO pipeline..."
+              BUILD_RESULT=$(az pipelines build queue \
+                --definition-id ${{ env.ado-pipeline-id }} \
+                --organization ${{ env.ado-org }} \
+                --project ${{ env.ado-project }} \
+                --variables commit_id=${{ env.commit-id }} \
+                --output json)
+              
+              BUILD_ID=$(echo $BUILD_RESULT | jq -r '.id')
+              echo "Pipeline triggered with Build ID: $BUILD_ID"
+              
+              if [ "$BUILD_ID" = "null" ] || [ -z "$BUILD_ID" ]; then
+                echo "Failed to get build ID from pipeline trigger"
+                exit 1
+              fi
+              
+              # Wait for the build to complete
+              echo "Waiting for build $BUILD_ID to complete..."
+              while true; do
+                BUILD_JSON=$(az pipelines build show \
+                  --id $BUILD_ID \
+                  --organization ${{ env.ado-org }} \
+                  --project ${{ env.ado-project }} \
+                  --output json)
+                
+                BUILD_STATUS=$(echo "$BUILD_JSON" | jq -r '.status')
+                BUILD_RESULT_STATUS=$(echo "$BUILD_JSON" | jq -r '.result // "none"')
+                
+                echo "Current status: $BUILD_STATUS, Result: $BUILD_RESULT_STATUS"
+                
+                # Check if build is completed
+                if [ "$BUILD_STATUS" = "completed" ]; then
+                  echo "Build completed with result: $BUILD_RESULT_STATUS"
+                  
+                  # Check if the build was successful
+                  if [ "$BUILD_RESULT_STATUS" = "succeeded" ]; then
+                    echo "✅ ADO pipeline build succeeded!"
+                    exit 0
+                  elif [ "$BUILD_RESULT_STATUS" = "partiallySucceeded" ]; then
+                    echo "⚠️ ADO pipeline build partially succeeded"
+                    exit 1
+                  else
+                    echo "❌ ADO pipeline build failed with result: $BUILD_RESULT_STATUS"
+                    exit 1
+                  fi
+                fi
+                
+                # Check for other terminal states
+                if [ "$BUILD_STATUS" = "cancelling" ] || [ "$BUILD_STATUS" = "cancelled" ]; then
+                  echo "❌ ADO pipeline build was cancelled"
+                  exit 1
+                fi
+                
+                # Wait 60 seconds before checking again
+                echo "Build still running... waiting 60 seconds"
+                sleep 60
+              done


### PR DESCRIPTION
---
This PR adds a status check to the Azure CLI extension release pipeline.
If a release fails, we’ll be able to quickly locate the failing commit directly from the GitHub Actions UI.
<img width="527" height="702" alt="image" src="https://github.com/user-attachments/assets/6195acad-bc10-4091-9398-5733c8f2efc0" />

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
