### PR TITLE
Restore the behaviour of `--upload-fragment` for acifragmentgen

### DIFF
--- a/src/confcom/azext_confcom/_params.py
+++ b/src/confcom/azext_confcom/_params.py
@@ -320,6 +320,14 @@ def load_arguments(self, _):
             validator=validate_upload_fragment,
         )
         c.argument(
+            "push_fragment_to",
+            help="The reference to push the fragment to",
+        )
+        c.argument(
+            "attach_fragment_to",
+            help="The image reference to attach the fragment to",
+        )
+        c.argument(
             "no_print",
             options_list=("--no-print",),
             required=False,

--- a/src/confcom/azext_confcom/custom.py
+++ b/src/confcom/azext_confcom/custom.py
@@ -5,6 +5,7 @@
 
 import os
 import sys
+from typing import Optional
 
 from azext_confcom import oras_proxy, os_util, security_policy
 from azext_confcom.config import (
@@ -232,6 +233,8 @@ def acifragmentgen_confcom(
     output_filename: str = "",
     outraw: bool = False,
     upload_fragment: bool = False,
+    push_fragment_to: Optional[str] = None,
+    attach_fragment_to: Optional[str] = None,
     no_print: bool = False,
     fragments_json: str = "",
 ):
@@ -335,10 +338,21 @@ def acifragmentgen_confcom(
         out_path = filename + ".cose"
 
         cose_proxy.cose_sign(filename, key, chain, feed, iss, algo, out_path)
-        if upload_fragment and image_target:
-            oras_proxy.attach_fragment_to_image(image_target, out_path)
-        elif upload_fragment:
-            oras_proxy.push_fragment_to_registry(feed, out_path)
+
+        # Preserve default behaviour established since version 1.1.0 of attaching
+        # the fragment to the first image specified in input
+        # (or --image-target if specified)
+        if upload_fragment:
+            oras_proxy.attach_fragment_to_image(
+                image_name=image_target or policy_images[0].containerImage,
+                filename=out_path,
+            )
+
+        if push_fragment_to:
+            oras_proxy.push_fragment_to_registry(push_fragment_to, out_path)
+
+        if attach_fragment_to:
+            oras_proxy.attach_fragment_to_image(attach_fragment_to, out_path)
 
 
 def katapolicygen_confcom(

--- a/src/confcom/azext_confcom/tests/latest/test_confcom_acifragmentgen.py
+++ b/src/confcom/azext_confcom/tests/latest/test_confcom_acifragmentgen.py
@@ -1,0 +1,205 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from itertools import product
+import json
+import os
+import subprocess
+import tempfile
+import pytest
+import docker
+
+from azext_confcom.custom import acifragmentgen_confcom
+
+TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), ".."))
+SAMPLES_DIR = os.path.abspath(os.path.join(TEST_DIR, "..", "..", "..", "samples"))
+
+
+@pytest.fixture()
+def docker_image():
+
+    client = docker.from_env()
+
+    registry_container = client.containers.run(
+        image="registry:2",
+        detach=True,
+        ports={"5000/tcp": 0},
+    )
+    registry_container.reload()
+    registry_port = registry_container.attrs['NetworkSettings']['Ports']['5000/tcp'][0]['HostPort']
+
+    test_container_ref = f"localhost:{registry_port}/hello-world:latest"
+    client.images.pull("hello-world").tag(test_container_ref)
+    client.images.push(test_container_ref)
+
+    with tempfile.NamedTemporaryFile(mode="w+", encoding="utf-8", delete=True) as temp_file:
+        json.dump({
+            "version": "1.0.0",
+            "containers": [
+                {
+                    "name": "hello-world",
+                    "properties": {
+                        "image": test_container_ref,
+                    },
+                }
+            ]
+        }, temp_file)
+        temp_file.flush()
+
+        yield test_container_ref, temp_file.name
+
+    registry_container.stop()
+    registry_container.remove()
+
+
+@pytest.fixture(scope="session")
+def cert_chain():
+    with tempfile.TemporaryDirectory(delete=True) as temp_dir:
+        subprocess.run(
+            [
+                os.path.join(SAMPLES_DIR, "certs", "create_certchain.sh"),
+                temp_dir
+            ],
+            check=True,
+        )
+        yield temp_dir
+
+
+def test_acifragmentgen_fragment_gen(docker_image):
+
+    image_ref, spec_file_path = docker_image
+
+    with tempfile.TemporaryDirectory(delete=True) as temp_dir: # Prevent test writing files to repo
+        acifragmentgen_confcom(
+            image_name=None,
+            tar_mapping_location=None,
+            key=None,
+            chain=None,
+            minimum_svn=None,
+            input_path=spec_file_path,
+            svn="1",
+            namespace="contoso",
+            feed="test-feed",
+            outraw=True,
+            output_filename=os.path.join(temp_dir, "fragment.rego"),
+        )
+
+    # TODO: Implement a proper validation for the fragment, this is hard
+    # because each test run will have a unique image to have unique local
+    # registries on different ports
+
+
+def test_acifragmentgen_fragment_sign(docker_image, cert_chain):
+
+    image_ref, spec_file_path = docker_image
+
+    with tempfile.TemporaryDirectory(delete=True) as temp_dir: # Prevent test writing files to repo
+        acifragmentgen_confcom(
+            image_name=None,
+            tar_mapping_location=None,
+            key=os.path.join(cert_chain, "intermediateCA", "private", "ec_p384_private.pem"),
+            chain=os.path.join(cert_chain, "intermediateCA", "certs", "www.contoso.com.chain.cert.pem"),
+            minimum_svn=None,
+            input_path=spec_file_path,
+            svn="1",
+            namespace="contoso",
+            feed="test-feed",
+            outraw=True,
+            output_filename=os.path.join(temp_dir, "fragment.rego"),
+        )
+
+    # TODO: Implement a proper validation for the cose document
+
+
+def test_acifragmentgen_fragment_upload_fragment(docker_image, cert_chain):
+
+    image_ref, spec_file_path = docker_image
+
+    with tempfile.TemporaryDirectory(delete=True) as temp_dir: # Prevent test writing files to repo
+        acifragmentgen_confcom(
+            image_name=None,
+            tar_mapping_location=None,
+            key=os.path.join(cert_chain, "intermediateCA", "private", "ec_p384_private.pem"),
+            chain=os.path.join(cert_chain, "intermediateCA", "certs", "www.contoso.com.chain.cert.pem"),
+            minimum_svn=None,
+            input_path=spec_file_path,
+            svn="1",
+            namespace="contoso",
+            feed="test-feed",
+            outraw=True,
+            upload_fragment=True,
+            output_filename=os.path.relpath(os.path.join(temp_dir, "fragment.rego"), os.getcwd()), # Must be relative for oras
+        )
+
+        oras_referrers = subprocess.run(
+            ["oras", "discover", image_ref],
+            stdout=subprocess.PIPE,
+            text=True,
+            check=True
+        ).stdout
+
+        # Confirm the fragment is attached to the image
+        assert "application/x-ms-ccepolicy-frag" in oras_referrers
+
+
+def test_acifragmentgen_fragment_push(docker_image, cert_chain):
+
+    image_ref, spec_file_path = docker_image
+    fragment_ref = image_ref.replace("hello-world", "fragment")
+
+    with tempfile.TemporaryDirectory(delete=True) as temp_dir: # Prevent test writing files to repo
+        acifragmentgen_confcom(
+            image_name=None,
+            tar_mapping_location=None,
+            key=os.path.join(cert_chain, "intermediateCA", "private", "ec_p384_private.pem"),
+            chain=os.path.join(cert_chain, "intermediateCA", "certs", "www.contoso.com.chain.cert.pem"),
+            minimum_svn=None,
+            input_path=spec_file_path,
+            svn="1",
+            namespace="contoso",
+            feed="test-feed",
+            outraw=True,
+            push_fragment_to=fragment_ref,
+            output_filename=os.path.relpath(os.path.join(temp_dir, "fragment.rego"), os.getcwd()), # Must be relative for oras
+        )
+
+    # Confirm the fragment exists in the registry
+    subprocess.run(
+        ["oras", "discover", fragment_ref],
+        stdout=subprocess.PIPE,
+        text=True,
+        check=True,
+    ).stdout
+
+
+def test_acifragmentgen_fragment_attach(docker_image, cert_chain):
+
+    image_ref, spec_file_path = docker_image
+
+    with tempfile.TemporaryDirectory(delete=True) as temp_dir: # Prevent test writing files to repo
+        acifragmentgen_confcom(
+            image_name=None,
+            tar_mapping_location=None,
+            key=os.path.join(cert_chain, "intermediateCA", "private", "ec_p384_private.pem"),
+            chain=os.path.join(cert_chain, "intermediateCA", "certs", "www.contoso.com.chain.cert.pem"),
+            minimum_svn=None,
+            input_path=spec_file_path,
+            svn="1",
+            namespace="contoso",
+            feed="test-feed",
+            outraw=True,
+            attach_fragment_to=image_ref,
+            output_filename=os.path.relpath(os.path.join(temp_dir, "fragment.rego"), os.getcwd()), # Must be relative for oras
+        )
+
+    oras_referrers = subprocess.run(
+        ["oras", "discover", image_ref],
+        stdout=subprocess.PIPE,
+        text=True,
+        check=True
+    ).stdout
+
+    # Confirm the fragment is attached to the image
+    assert "application/x-ms-ccepolicy-frag" in oras_referrers, oras_referrers

--- a/src/confcom/samples/certs/create_certchain.sh
+++ b/src/confcom/samples/certs/create_certchain.sh
@@ -3,87 +3,91 @@
 OriginalPath=`pwd`
 
 RootPath=`realpath $(dirname $0)`
-cd $RootPath
+OutPath=${1:-$RootPath}
+
+mkdir -p $OutPath
+
+cd $OutPath
 
 # create dirs for root CA
-mkdir -p $RootPath/rootCA/{certs,crl,newcerts,private,csr}
-mkdir -p $RootPath/intermediateCA/{certs,crl,newcerts,private,csr}
+mkdir -p $OutPath/rootCA/{certs,crl,newcerts,private,csr}
+mkdir -p $OutPath/intermediateCA/{certs,crl,newcerts,private,csr}
 
 # create index files
-echo 1000 > $RootPath/rootCA/serial
-echo 1000 > $RootPath/intermediateCA/serial
+echo 1000 > $OutPath/rootCA/serial
+echo 1000 > $OutPath/intermediateCA/serial
 
 # create crlnumbers
-echo 0100 > $RootPath/rootCA/crlnumber
-echo 0100 > $RootPath/intermediateCA/crlnumber
+echo 0100 > $OutPath/rootCA/crlnumber
+echo 0100 > $OutPath/intermediateCA/crlnumber
 
 # create index files
-touch $RootPath/rootCA/index.txt
-touch $RootPath/intermediateCA/index.txt
+touch $OutPath/rootCA/index.txt
+touch $OutPath/intermediateCA/index.txt
 # NOTE: needed for testing
-echo "unique_subject = no" >> $RootPath/rootCA/index.txt.attr
-echo "unique_subject = no" >> $RootPath/intermediateCA/index.txt.attr
+echo "unique_subject = no" >> $OutPath/rootCA/index.txt.attr
+echo "unique_subject = no" >> $OutPath/intermediateCA/index.txt.attr
 
 # generate root key
-openssl genrsa -out $RootPath/rootCA/private/ca.key.pem 4096
-chmod 400 $RootPath/rootCA/private/ca.key.pem
+openssl genrsa -out $OutPath/rootCA/private/ca.key.pem 4096
+chmod 400 $OutPath/rootCA/private/ca.key.pem
 
 # view the key
-# openssl rsa -noout -text -in $RootPath/rootCA/private/ca.key.pem
+# openssl rsa -noout -text -in $OutPath/rootCA/private/ca.key.pem
 
 # generate root cert
-openssl req -config openssl_root.cnf -key $RootPath/rootCA/private/ca.key.pem -new -x509 -days 7300 -sha256 -extensions v3_ca -out $RootPath/rootCA/certs/ca.cert.pem -subj "/C=US/ST=Georgia/L=Atlanta/O=Microsoft/OU=ACCCT/CN=Root CA"
+openssl req -config $RootPath/openssl_root.cnf -key $OutPath/rootCA/private/ca.key.pem -new -x509 -days 7300 -sha256 -extensions v3_ca -out $OutPath/rootCA/certs/ca.cert.pem -subj "/C=US/ST=Georgia/L=Atlanta/O=Microsoft/OU=ACCCT/CN=Root CA"
 
 # change permissions on root key so it's not globally readable
-chmod 644 $RootPath/rootCA/certs/ca.cert.pem
+chmod 644 $OutPath/rootCA/certs/ca.cert.pem
 
 # verify root cert
-openssl x509 -noout -text -in $RootPath/rootCA/certs/ca.cert.pem
+openssl x509 -noout -text -in $OutPath/rootCA/certs/ca.cert.pem
 
 # generate intermediate key
-openssl genrsa -out $RootPath/intermediateCA/private/intermediate.key.pem 4096
-chmod 600 $RootPath/intermediateCA/private/intermediate.key.pem
+openssl genrsa -out $OutPath/intermediateCA/private/intermediate.key.pem 4096
+chmod 600 $OutPath/intermediateCA/private/intermediate.key.pem
 
 # make CSR for intermediate
-openssl req -config openssl_intermediate.cnf -key $RootPath/intermediateCA/private/intermediate.key.pem -new -sha256 -out $RootPath/intermediateCA/certs/intermediate.csr.pem -subj "/C=US/ST=Georgia/L=Atlanta/O=Microsoft/OU=ACCCT/CN=Intermediate CA"
+openssl req -config $RootPath/openssl_intermediate.cnf -key $OutPath/intermediateCA/private/intermediate.key.pem -new -sha256 -out $OutPath/intermediateCA/certs/intermediate.csr.pem -subj "/C=US/ST=Georgia/L=Atlanta/O=Microsoft/OU=ACCCT/CN=Intermediate CA"
 
 # sign intermediate cert with root
-openssl ca -config openssl_root.cnf -extensions v3_intermediate_ca -days 3650 -notext -md sha256 -in $RootPath/intermediateCA/certs/intermediate.csr.pem -out $RootPath/intermediateCA/certs/intermediate.cert.pem -batch
+openssl ca -config $RootPath/openssl_root.cnf -extensions v3_intermediate_ca -days 3650 -notext -md sha256 -in $OutPath/intermediateCA/certs/intermediate.csr.pem -out $OutPath/intermediateCA/certs/intermediate.cert.pem -batch
 
 # make it readable by everyone
-chmod 644 $RootPath/intermediateCA/certs/intermediate.cert.pem
+chmod 644 $OutPath/intermediateCA/certs/intermediate.cert.pem
 
 # print the cert
-# openssl x509 -noout -text -in $RootPath/intermediateCA/certs/intermediate.cert.pem
+# openssl x509 -noout -text -in $OutPath/intermediateCA/certs/intermediate.cert.pem
 
 # verify intermediate cert
-openssl verify -CAfile $RootPath/rootCA/certs/ca.cert.pem $RootPath/intermediateCA/certs/intermediate.cert.pem
+openssl verify -CAfile $OutPath/rootCA/certs/ca.cert.pem $OutPath/intermediateCA/certs/intermediate.cert.pem
 
 # create chain file
-cat $RootPath/intermediateCA/certs/intermediate.cert.pem $RootPath/rootCA/certs/ca.cert.pem > $RootPath/intermediateCA/certs/ca-chain.cert.pem
+cat $OutPath/intermediateCA/certs/intermediate.cert.pem $OutPath/rootCA/certs/ca.cert.pem > $OutPath/intermediateCA/certs/ca-chain.cert.pem
 
 # verify chain
-openssl verify -CAfile $RootPath/intermediateCA/certs/ca-chain.cert.pem $RootPath/intermediateCA/certs/intermediate.cert.pem
+openssl verify -CAfile $OutPath/intermediateCA/certs/ca-chain.cert.pem $OutPath/intermediateCA/certs/intermediate.cert.pem
 
 # create server key
-openssl ecparam -out $RootPath/intermediateCA/private/www.contoso.com.key.pem -name secp384r1 -genkey
-openssl pkcs8 -topk8 -nocrypt -in $RootPath/intermediateCA/private/www.contoso.com.key.pem -out $RootPath/intermediateCA/private/ec_p384_private.pem
+openssl ecparam -out $OutPath/intermediateCA/private/www.contoso.com.key.pem -name secp384r1 -genkey
+openssl pkcs8 -topk8 -nocrypt -in $OutPath/intermediateCA/private/www.contoso.com.key.pem -out $OutPath/intermediateCA/private/ec_p384_private.pem
 
-chmod 600 $RootPath/intermediateCA/private/www.contoso.com.key.pem
+chmod 600 $OutPath/intermediateCA/private/www.contoso.com.key.pem
 
 # create csr for server
-openssl req -config openssl_intermediate.cnf -key $RootPath/intermediateCA/private/www.contoso.com.key.pem -new -sha384 -out $RootPath/intermediateCA/csr/www.contoso.com.csr.pem -batch
+openssl req -config $RootPath/openssl_intermediate.cnf -key $OutPath/intermediateCA/private/www.contoso.com.key.pem -new -sha384 -out $OutPath/intermediateCA/csr/www.contoso.com.csr.pem -batch
 
 # sign server cert with intermediate key
-openssl ca -config openssl_intermediate.cnf -extensions server_cert -days 375 -notext -md sha384 -in $RootPath/intermediateCA/csr/www.contoso.com.csr.pem -out $RootPath/intermediateCA/certs/www.contoso.com.cert.pem -batch
+openssl ca -config $RootPath/openssl_intermediate.cnf -extensions server_cert -days 375 -notext -md sha384 -in $OutPath/intermediateCA/csr/www.contoso.com.csr.pem -out $OutPath/intermediateCA/certs/www.contoso.com.cert.pem -batch
 
 # print the cert
-# openssl x509 -noout -text -in $RootPath/intermediateCA/certs/www.contoso.com.cert.pem
+# openssl x509 -noout -text -in $OutPath/intermediateCA/certs/www.contoso.com.cert.pem
 
 # make a public key
-# openssl x509 -pubkey -noout -in $RootPath/intermediateCA/certs/www.contoso.com.cert.pem -out $RootPath/intermediateCA/certs/pubkey.pem
+# openssl x509 -pubkey -noout -in $OutPath/intermediateCA/certs/www.contoso.com.cert.pem -out $OutPath/intermediateCA/certs/pubkey.pem
 
 # create chain file
-cat $RootPath/intermediateCA/certs/www.contoso.com.cert.pem $RootPath/intermediateCA/certs/intermediate.cert.pem $RootPath/rootCA/certs/ca.cert.pem > $RootPath/intermediateCA/certs/www.contoso.com.chain.cert.pem
+cat $OutPath/intermediateCA/certs/www.contoso.com.cert.pem $OutPath/intermediateCA/certs/intermediate.cert.pem $OutPath/rootCA/certs/ca.cert.pem > $OutPath/intermediateCA/certs/www.contoso.com.chain.cert.pem
 
 cd $OriginalPath


### PR DESCRIPTION
### Why

Addresses 
- https://github.com/Azure/azure-cli-extensions/issues/9222

### How

- [x] Update the code to restore the "attach to first image in input" behaviour
- [x] Add two new args: "--push-fragment-to" and "--attach-fragment-to" to allow the user to explicitly do one or the other (or both!)
- [x] Add new tests which run a local docker registry, and test that the fragments are generated, signed, pushed and attached as expected (as well as the default behaviour)

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)
