### PR TITLE
[AKS] Fix --aks-mcp flag to accept true/false values

### DIFF
--- a/src/aks-agent/HISTORY.rst
+++ b/src/aks-agent/HISTORY.rst
@@ -11,6 +11,7 @@ To release a new version, please select a new version number (usually plus 1 to 
 
 Pending
 +++++++
+* Fix the --aks-mcp flag to allow true/false values.
 
 1.0.0b3
 +++++++

--- a/src/aks-agent/azext_aks_agent/_params.py
+++ b/src/aks-agent/azext_aks_agent/_params.py
@@ -90,10 +90,7 @@ def load_arguments(self, _):
             "use_aks_mcp",
             options_list=["--aks-mcp"],
             default=False,
-            arg_type=get_three_state_flag(
-                positive_label="Enable AKS MCP integration",
-                negative_label="Disable AKS MCP integration",
-            ),
+            arg_type=get_three_state_flag(),
             help=(
                 "Enable AKS MCP integration for enhanced capabilities. "
                 "Traditional mode is the default. Use --aks-mcp to enable MCP mode, or "


### PR DESCRIPTION
Without this change, the following error would happen:

```sh
# az aks agent --aks-mcp=true --model=azure/gpt-4o
az aks agent: 'true' is not a valid value for '--aks-mcp'. Allowed values: Enable AKS MCP integration, Disable AKS MCP integration.
```

Hence, this PR simplified the aks-mcp parameter by removing custom positive/negative labels and using the default three_state_flag behavior to properly handle true/false values.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
