### PR TITLE
[confcom] Fix `--exclude-default-fragments`

### DIFF
--- a/src/confcom/HISTORY.rst
+++ b/src/confcom/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+1.2.9
+++++++
+* bugfix for --exclude-default-fragments flag not working as intended
+
 1.2.8
 ++++++
 * Made the default minimum SVN of the infrastructure fragment 4

--- a/src/confcom/azext_confcom/security_policy.py
+++ b/src/confcom/azext_confcom/security_policy.py
@@ -675,13 +675,13 @@ def load_policy_from_arm_template_str(
         containers = []
         existing_containers = None
         fragments = None
-        exclude_default_fragments = False
+        exclude_default_fragments_this_group = exclude_default_fragments
 
         tags = case_insensitive_dict_get(resource, config.ACI_FIELD_TEMPLATE_TAGS)
         if tags:
-            exclude_default_fragments = case_insensitive_dict_get(tags, config.ACI_FIELD_TEMPLATE_ZERO_SIDECAR)
-            if isinstance(exclude_default_fragments, str):
-                exclude_default_fragments = exclude_default_fragments.lower() == "true"
+            exclude_default_fragments_this_group = case_insensitive_dict_get(tags, config.ACI_FIELD_TEMPLATE_ZERO_SIDECAR)
+            if isinstance(exclude_default_fragments_this_group, str):
+                exclude_default_fragments_this_group = exclude_default_fragments_this_group.lower() == "true"
 
         container_group_properties = case_insensitive_dict_get(
             resource, config.ACI_FIELD_TEMPLATE_PROPERTIES
@@ -725,7 +725,7 @@ def load_policy_from_arm_template_str(
                 # In non-diff mode, we ignore the error and proceed without the policy
                 existing_containers, fragments = ([], [])
 
-        rego_fragments = copy.deepcopy(config.DEFAULT_REGO_FRAGMENTS) if not exclude_default_fragments else []
+        rego_fragments = copy.deepcopy(config.DEFAULT_REGO_FRAGMENTS) if not exclude_default_fragments_this_group else []
         if infrastructure_svn:
             # assumes the first DEFAULT_REGO_FRAGMENT is always the
             # infrastructure fragment

--- a/src/confcom/azext_confcom/security_policy.py
+++ b/src/confcom/azext_confcom/security_policy.py
@@ -679,7 +679,8 @@ def load_policy_from_arm_template_str(
 
         tags = case_insensitive_dict_get(resource, config.ACI_FIELD_TEMPLATE_TAGS)
         if tags:
-            exclude_default_fragments_this_group = case_insensitive_dict_get(tags, config.ACI_FIELD_TEMPLATE_ZERO_SIDECAR)
+            exclude_default_fragments_this_group = \
+                case_insensitive_dict_get(tags, config.ACI_FIELD_TEMPLATE_ZERO_SIDECAR)
             if isinstance(exclude_default_fragments_this_group, str):
                 exclude_default_fragments_this_group = exclude_default_fragments_this_group.lower() == "true"
 
@@ -725,7 +726,10 @@ def load_policy_from_arm_template_str(
                 # In non-diff mode, we ignore the error and proceed without the policy
                 existing_containers, fragments = ([], [])
 
-        rego_fragments = copy.deepcopy(config.DEFAULT_REGO_FRAGMENTS) if not exclude_default_fragments_this_group else []
+        rego_fragments = (
+            copy.deepcopy(config.DEFAULT_REGO_FRAGMENTS)
+            if not exclude_default_fragments_this_group else []
+        )
         if infrastructure_svn:
             # assumes the first DEFAULT_REGO_FRAGMENT is always the
             # infrastructure fragment

--- a/src/confcom/azext_confcom/tests/latest/test_confcom_acipolicygen_arm.py
+++ b/src/confcom/azext_confcom/tests/latest/test_confcom_acipolicygen_arm.py
@@ -44,7 +44,6 @@ def test_acipolicygen(sample_directory, generated_policy_path):
 
     for failing_sample_directory, failing_generated_policy_path in [
         ("multi_container_groups", "policy_fragment.rego"), # TODO: https://github.com/Azure/azure-cli-extensions/issues/9229
-        (None, "policy_exclude_default_fragment.rego"), # TODO: https://github.com/Azure/azure-cli-extensions/issues/9198
     ]:
         if (
             failing_sample_directory in (None, sample_directory)

--- a/src/confcom/setup.py
+++ b/src/confcom/setup.py
@@ -19,7 +19,7 @@ except ImportError:
 
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
 
-VERSION = "1.2.8"
+VERSION = "1.2.9"
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
### Why

Addresses 
- https://github.com/Azure/azure-cli-extensions/issues/9198

### How

- [x] Base the per container group value of `exclude_default_fragment` from the input arg instead of always being False
- [x] Use a new unique value for `exclude_default_fragment` per container group 
- [x] Remove marking of known failure in tests caused by this which skips those tests
- [x] Bump the version and update HISTORY.rst

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)