### PR TITLE
breaking change warning

### DIFF
--- a/src/redisenterprise/_breaking_change.py
+++ b/src/redisenterprise/_breaking_change.py
@@ -1,0 +1,9 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+from azure.cli.core.breaking_change import register_required_flag_breaking_change, register_default_value_breaking_change, register_other_breaking_change
+
+register_required_flag_breaking_change('redisenterprise create', '--public-network-access')
+register_default_value_breaking_change('redisenterprise create', '--access-keys-auth', 'Enabled', 'Disabled')
+register_default_value_breaking_change('redisenterprise create', '--access-keys-authentication', 'Enabled', 'Disabled')


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
Related command
az redisenterprise create

Description
This PR adds a breaking change pre-announcement for az redisenterprise create.

New behavior: 
We are adding a new required property publicNetworkAccess and changing the default value of accessKeysAuthentication to disabled
https://github.com/Azure/azure-rest-api-specs/pull/35872
This pre-announcement ensures customers are warned ahead of time and have the opportunity to adjust their scripts or workflows before the November 2025 breaking change release.


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
