### PR TITLE
updated the api version to 2025-06-01

### DIFF
--- a/src/workload-orchestration/azext_workload_orchestration/aaz/latest/workload_orchestration/solution_template/_bulk_deploy_solution.py
+++ b/src/workload-orchestration/azext_workload_orchestration/aaz/latest/workload_orchestration/solution_template/_bulk_deploy_solution.py
@@ -21,9 +21,9 @@ class BulkDeploySolution(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2025-08-01",
+        "version": "2025-06-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/Microsoft.Edge/solutiontemplates/{}/versions/{}/bulkdeploysolution", "2025-08-01"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/Microsoft.Edge/solutiontemplates/{}/versions/{}/bulkdeploysolution", "2025-06-01"],
         ]
     }
 
@@ -231,7 +231,7 @@ class BulkDeploySolution(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2025-08-01",
+                    "api-version", "2025-06-01",
                     required=True,
                 ),
             }


### PR DESCRIPTION
Changed the API version for bulk deployment to 2025-06-01 as 2025-08-01 has some blocker and we cannot release this version for upcoming release. Once blocker solved the api version would be updated back to 2025-08-01
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
