### PR TITLE
{AuthV2} `az webapp auth update`: Fix `--excluded-paths` logic

### DIFF
--- a/src/authV2/HISTORY.rst
+++ b/src/authV2/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+1.0.1
+++++++
+* Fix excluded paths parsing in `az webapp auth update` command.
+
 1.0.0
 ++++++
 * Update module documentation.

--- a/src/authV2/azext_authV2/custom.py
+++ b/src/authV2/azext_authV2/custom.py
@@ -160,10 +160,11 @@ def update_auth_settings_v2(cmd, resource_group_name, name, set_string=None, ena
         if "globalValidation" not in existing_auth.keys():
             existing_auth["globalValidation"] = {}
         try:
-            if isinstance(json.loads(excluded_paths), list):
-                excluded_paths_list = json.loads(excluded_paths)
+            parsed = json.loads(excluded_paths)
+            if isinstance(parsed, list):
+                excluded_paths_list = parsed
             else:
-                excluded_paths_list = excluded_paths.split(",")
+                excluded_paths_list = [parsed] if parsed else []
         except json.JSONDecodeError:
             excluded_paths_list = excluded_paths.split(",")
 

--- a/src/authV2/azext_authV2/tests/latest/recordings/test_authV2_auth.yaml
+++ b/src/authV2/azext_authV2/tests/latest/recordings/test_authV2_auth.yaml
@@ -1,49 +1,6 @@
 interactions:
 - request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - appservice plan create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --sku
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.10 (Linux-5.15.0-1034-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_261_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_authV2000001?api-version=2022-09-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001","name":"cli_test_authV2000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2023-03-28T11:17:14Z"},"properties":{"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '320'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 28 Mar 2023 11:17:15 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"location": "westus", "sku": {"name": "S1", "tier": "STANDARD", "capacity":
+    body: '{"location": "eastus", "sku": {"name": "S1", "tier": "STANDARD", "capacity":
       1}, "properties": {"perSiteScaling": false, "isXenon": false, "zoneRedundant":
       false}}'
     headers:
@@ -62,43 +19,88 @@ interactions:
       ParameterSetName:
       - -g -n --sku
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-web/7.0.0 Python/3.10.10 (Linux-5.15.0-1034-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_261_0
+      - AZURECLI/2.78.0 azsdk-python-core/1.35.0 Python/3.9.6 (macOS-26.0.1-arm64-arm-64bit)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003?api-version=2023-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003?api-version=2024-11-01
   response:
     body:
+<<<<<<< HEAD
+<<<<<<< HEAD
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003","name":"webapp-authentication-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"westus","properties":{"serverFarmId":9148,"name":"webapp-authentication-plan000003","sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1},"workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"cli_test_authV2000001-WestUSwebspace","subscription":"00000000-0000-0000-0000-000000000000","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":0,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
         US","perSiteScaling":false,"elasticScaleEnabled":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"cli_test_authV2000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-bay-223_9148","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null,"kubeEnvironmentProfile":null,"zoneRedundant":false},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'
+=======
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003","name":"webapp-authentication-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"eastus","properties":{"serverFarmId":118704,"name":"webapp-authentication-plan000003","sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1},"workerSize":"Small","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Small","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"cli_test_authV2000001-EastUSwebspace","subscription":"9e223dbe-3399-4e19-88eb-0975f02ac87f","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":0,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"East
+        US","perSiteScaling":false,"elasticScaleEnabled":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"cli_test_authV2000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-blu-205_118704","targetWorkerCount":0,"targetWorkerSizeId":0,"targetWorkerSku":null,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null,"kubeEnvironmentProfile":null,"zoneRedundant":false,"maximumNumberOfZones":3,"currentNumberOfZonesUtilized":1,"migrateToVMSS":null,"vnetConnectionsUsed":null,"vnetConnectionsMax":null,"createdTime":"2025-10-18T07:45:40.4866667","asyncScalingEnabled":false,"isCustomMode":null,"powerState":null,"eligibleLogCategories":null},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003","name":"webapp-authentication-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"eastus","properties":{"serverFarmId":87821,"name":"webapp-authentication-plan000003","sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1},"workerSize":"Small","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Small","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"cli_test_authV2000001-EastUSwebspace","subscription":"9e223dbe-3399-4e19-88eb-0975f02ac87f","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":0,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"East
+        US","perSiteScaling":false,"elasticScaleEnabled":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"cli_test_authV2000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-blu-259_87821","targetWorkerCount":0,"targetWorkerSizeId":0,"targetWorkerSku":null,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null,"kubeEnvironmentProfile":null,"zoneRedundant":false,"maximumNumberOfZones":3,"currentNumberOfZonesUtilized":1,"migrateToVMSS":null,"vnetConnectionsUsed":null,"vnetConnectionsMax":null,"createdTime":"2025-10-17T10:37:56.6966667","asyncScalingEnabled":false,"isCustomMode":null,"powerState":null,"eligibleLogCategories":null},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
     headers:
       cache-control:
       - no-cache
       content-length:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - '1542'
+=======
+      - '1834'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       content-type:
       - application/json
       date:
-      - Tue, 28 Mar 2023 11:17:22 GMT
+      - Fri, 17 Oct 2025 10:37:57 GMT
       etag:
+<<<<<<< HEAD
       - '"1D96166DD9C3260"'
+=======
+      - '1836'
+      content-type:
+      - application/json
+      date:
+      - Sat, 18 Oct 2025 07:45:43 GMT
+      etag:
+      - '"1DC400333F0BC4B"'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - '"1DC3F521A2B024B"'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
       - no-cache
-      server:
-      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+<<<<<<< HEAD
+<<<<<<< HEAD
       x-ms-ratelimit-remaining-subscription-writes:
       - '1195'
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/australiasoutheast/3ffd6215-f8a3-4929-89d5-db2f6a87729e
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '12000'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '800'
+      x-msedge-ref:
+      - 'Ref A: D1311F6624A8425B9E1B34802D0CBBD3 Ref B: SYD03EDGE1910 Ref C: 2025-10-18T07:45:28Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/10fba60e-8a28-4072-a429-0fbfd44dc58e
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '12000'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '800'
+      x-msedge-ref:
+      - 'Ref A: 8D7794DC3AE54DF190A342F8A237C98E Ref B: SYD03EDGE1317 Ref C: 2025-10-17T10:37:49Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -118,40 +120,77 @@ interactions:
       ParameterSetName:
       - -g -n --plan
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-web/7.0.0 Python/3.10.10 (Linux-5.15.0-1034-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_261_0
+      - AZURECLI/2.78.0 azsdk-python-core/1.35.0 Python/3.9.6 (macOS-26.0.1-arm64-arm-64bit)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003?api-version=2023-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003?api-version=2024-11-01
   response:
     body:
+<<<<<<< HEAD
+<<<<<<< HEAD
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003","name":"webapp-authentication-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
         US","properties":{"serverFarmId":9148,"name":"webapp-authentication-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"cli_test_authV2000001-WestUSwebspace","subscription":"00000000-0000-0000-0000-000000000000","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
         US","perSiteScaling":false,"elasticScaleEnabled":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"cli_test_authV2000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-bay-223_9148","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null,"kubeEnvironmentProfile":null,"zoneRedundant":false},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'
+=======
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003","name":"webapp-authentication-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"East
+        US","properties":{"serverFarmId":118704,"name":"webapp-authentication-plan000003","workerSize":"Small","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Small","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"cli_test_authV2000001-EastUSwebspace","subscription":"9e223dbe-3399-4e19-88eb-0975f02ac87f","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"East
+        US","perSiteScaling":false,"elasticScaleEnabled":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"cli_test_authV2000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-blu-205_118704","targetWorkerCount":0,"targetWorkerSizeId":0,"targetWorkerSku":null,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null,"kubeEnvironmentProfile":null,"zoneRedundant":false,"maximumNumberOfZones":3,"currentNumberOfZonesUtilized":1,"migrateToVMSS":null,"vnetConnectionsUsed":0,"vnetConnectionsMax":2,"createdTime":"2025-10-18T07:45:40.4866667","asyncScalingEnabled":false,"isCustomMode":null,"powerState":null,"eligibleLogCategories":null},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003","name":"webapp-authentication-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"East
+        US","properties":{"serverFarmId":87821,"name":"webapp-authentication-plan000003","workerSize":"Small","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Small","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"cli_test_authV2000001-EastUSwebspace","subscription":"9e223dbe-3399-4e19-88eb-0975f02ac87f","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"East
+        US","perSiteScaling":false,"elasticScaleEnabled":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"cli_test_authV2000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-blu-259_87821","targetWorkerCount":0,"targetWorkerSizeId":0,"targetWorkerSku":null,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null,"kubeEnvironmentProfile":null,"zoneRedundant":false,"maximumNumberOfZones":3,"currentNumberOfZonesUtilized":1,"migrateToVMSS":null,"vnetConnectionsUsed":0,"vnetConnectionsMax":2,"createdTime":"2025-10-17T10:37:56.6966667","asyncScalingEnabled":false,"isCustomMode":null,"powerState":null,"eligibleLogCategories":null},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
     headers:
       cache-control:
       - no-cache
       content-length:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - '1468'
       content-type:
       - application/json
       date:
       - Tue, 28 Mar 2023 11:17:22 GMT
+=======
+      - '1756'
+      content-type:
+      - application/json
+      date:
+      - Sat, 18 Oct 2025 07:45:44 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - '1754'
+      content-type:
+      - application/json
+      date:
+      - Fri, 17 Oct 2025 10:37:59 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
       - no-cache
-      server:
-      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: D8E5808669024324A3BFCC43E2FA9A8F Ref B: SYD03EDGE1917 Ref C: 2025-10-18T07:45:44Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 44D6D572BE48470C99124D7DD8CC1C53 Ref B: SYD03EDGE0815 Ref C: 2025-10-17T10:37:58Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -175,10 +214,9 @@ interactions:
       ParameterSetName:
       - -g -n --plan
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-web/7.0.0 Python/3.10.10 (Linux-5.15.0-1034-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_261_0
+      - AZURECLI/2.78.0 azsdk-python-core/1.35.0 Python/3.9.6 (macOS-26.0.1-arm64-arm-64bit)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/checknameavailability?api-version=2023-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/checknameavailability?api-version=2024-11-01
   response:
     body:
       string: '{"nameAvailable":true,"reason":"","message":""}'
@@ -190,23 +228,45 @@ interactions:
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Tue, 28 Mar 2023 11:17:23 GMT
+=======
+      - Sat, 18 Oct 2025 07:45:45 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:37:59 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
       - no-cache
-      server:
-      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/australiasoutheast/9664038a-458c-436c-9afa-6620c411224d
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: C551873E2894405D87E876244756A543 Ref B: SYD03EDGE2110 Ref C: 2025-10-18T07:45:45Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/7259d4d8-f315-4093-9d8e-d2ea5a71436c
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: E09B1C716B954ED7AB5E78C4D5ECC33A Ref B: SYD03EDGE0907 Ref C: 2025-10-17T10:37:59Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -226,15 +286,18 @@ interactions:
       ParameterSetName:
       - -g -n --plan
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-web/7.0.0 Python/3.10.10 (Linux-5.15.0-1034-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_261_0
+      - AZURECLI/2.78.0 azsdk-python-core/1.35.0 Python/3.9.6 (macOS-26.0.1-arm64-arm-64bit)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.Web/webAppStacks?api-version=2023-01-01
+    uri: https://management.azure.com/providers/Microsoft.Web/webAppStacks?api-version=2024-11-01
   response:
     body:
       string: '{"value":[{"id":null,"name":"dotnet","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":".NET","value":"dotnet","preferredOs":"windows","majorVersions":[{"displayText":".NET
-        7 (STS)","value":"dotnet7","minorVersions":[{"displayText":".NET 7 (STS)","value":"7","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v7.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"7.x"}},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|7.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"7.x"}}}}]},{"displayText":".NET
-        6","value":"dotnet6","minorVersions":[{"displayText":".NET 6 (LTS)","value":"6","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v6.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"6.0.x"}},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|6.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"6.0.x"}}}}]},{"displayText":".NET
+        10 (LTS)","value":"dotnet10","minorVersions":[{"displayText":".NET 10 (LTS)
+        (Preview)","value":"10","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v10.0","remoteDebuggingSupported":false,"isHidden":false,"isPreview":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"10.x"},"endOfLifeDate":"2028-12-01T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|10.0","remoteDebuggingSupported":false,"isHidden":false,"isPreview":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"10.x"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2028-12-01T00:00:00Z"}}}]},{"displayText":".NET
+        9 (STS)","value":"dotnet9","minorVersions":[{"displayText":".NET 9 (STS)","value":"9","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v9.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"9.x"},"endOfLifeDate":"2026-05-12T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|9.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"9.x"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2026-05-12T00:00:00Z"}}}]},{"displayText":".NET
+        8 (LTS)","value":"dotnet8","minorVersions":[{"displayText":".NET 8 (LTS)","value":"8","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v8.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.x"},"endOfLifeDate":"2026-11-10T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|8.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.x"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2026-11-10T00:00:00Z"}}}]},{"displayText":".NET
+        7 (STS)","value":"dotnet7","minorVersions":[{"displayText":".NET 7 (STS)","value":"7","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v7.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"7.x"},"endOfLifeDate":"2024-05-14T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|7.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"7.x"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2024-05-14T00:00:00Z"}}}]},{"displayText":".NET
+        6","value":"dotnet6","minorVersions":[{"displayText":".NET 6 (LTS)","value":"6","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v6.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"6.0.x"},"endOfLifeDate":"2024-11-12T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|6.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"6.0.x"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2024-11-12T00:00:00Z"}}}]},{"displayText":".NET
         5","value":"dotnet5","minorVersions":[{"displayText":".NET 5","value":"5","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v5.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"5.0.x"},"endOfLifeDate":"2022-05-08T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|5.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"5.0.x"},"endOfLifeDate":"2022-05-08T00:00:00Z"}}}]},{"displayText":".NET
         Core 3","value":"dotnetcore3","minorVersions":[{"displayText":".NET Core 3.1
         (LTS)","value":"3.1","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"3.1","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.1.301"},"isDeprecated":true,"endOfLifeDate":"2022-12-03T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|3.1","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.1.301"},"isDeprecated":true,"endOfLifeDate":"2022-12-03T00:00:00Z"}}},{"displayText":".NET
@@ -247,9 +310,11 @@ interactions:
         V4","value":"aspdotnetv4","minorVersions":[{"displayText":"ASP.NET V4.8","value":"v4.8","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v4.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.1"}}}}]},{"displayText":"ASP.NET
         V3","value":"aspdotnetv3","minorVersions":[{"displayText":"ASP.NET V3.5","value":"v3.5","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v2.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"2.1"}}}}]}]}},{"id":null,"name":"node","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"Node","value":"node","preferredOs":"linux","majorVersions":[{"displayText":"Node
         LTS","value":"lts","minorVersions":[{"displayText":"Node LTS","value":"lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|lts","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true}}}}]},{"displayText":"Node
-        18","value":"18","minorVersions":[{"displayText":"Node 18 LTS","value":"18-lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|18-lts","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"18.x"}},"windowsRuntimeSettings":{"runtimeVersion":"~18","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"18.x"}}}}]},{"displayText":"Node
-        16","value":"16","minorVersions":[{"displayText":"Node 16 LTS","value":"16-lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|16-lts","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"16.x"},"endOfLifeDate":"2024-04-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"~16","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"16.x"},"endOfLifeDate":"2024-04-30T00:00:00Z"}}}]},{"displayText":"Node
-        14","value":"14","minorVersions":[{"displayText":"Node 14 LTS","value":"14-lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|14-lts","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"14.x"},"endOfLifeDate":"2023-04-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"~14","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"14.x"},"endOfLifeDate":"2023-04-30T00:00:00Z"}}}]},{"displayText":"Node
+        22","value":"22","minorVersions":[{"displayText":"Node 22 LTS","value":"22-lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|22-lts","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"22.x"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2027-04-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"~22","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"22.x"},"endOfLifeDate":"2027-04-30T00:00:00Z"}}}]},{"displayText":"Node
+        20","value":"20","minorVersions":[{"displayText":"Node 20 LTS","value":"20-lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|20-lts","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"20.x"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2026-04-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"~20","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"20.x"},"endOfLifeDate":"2026-04-30T00:00:00Z"}}}]},{"displayText":"Node
+        18","value":"18","minorVersions":[{"displayText":"Node 18 LTS","value":"18-lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|18-lts","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"18.x"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2025-04-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"~18","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"18.x"},"endOfLifeDate":"2025-04-30T00:00:00Z"}}}]},{"displayText":"Node
+        16","value":"16","minorVersions":[{"displayText":"Node 16 LTS","value":"16-lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|16-lts","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"16.x"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2023-09-11T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"~16","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"16.x"},"endOfLifeDate":"2023-09-11T00:00:00Z"}}}]},{"displayText":"Node
+        14","value":"14","minorVersions":[{"displayText":"Node 14 LTS","value":"14-lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|14-lts","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"14.x"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2023-04-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"~14","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"14.x"},"endOfLifeDate":"2023-04-30T00:00:00Z"}}}]},{"displayText":"Node
         12","value":"12","minorVersions":[{"displayText":"Node 12 LTS","value":"12-lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|12-lts","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"12.x"},"endOfLifeDate":"2022-04-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"12.13.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2022-04-01T00:00:00Z"}}},{"displayText":"Node
         12.9","value":"12.9","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|12.9","isDeprecated":true,"remoteDebuggingSupported":true,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"12.x"},"endOfLifeDate":"2022-04-01T00:00:00Z"}}}]},{"displayText":"Node
         10","value":"10","minorVersions":[{"displayText":"Node 10 LTS","value":"10-LTS","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|10-lts","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"10.x"},"endOfLifeDate":"2021-04-01T00:00:00Z"}}},{"displayText":"Node
@@ -284,23 +349,28 @@ interactions:
         4","value":"4","minorVersions":[{"displayText":"Node 4.8","value":"4.8","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|4.8","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2018-04-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"4.8","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2018-04-30T00:00:00Z"}}},{"displayText":"Node
         4.5","value":"4.5","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|4.5","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2018-04-30T00:00:00Z"}}},{"displayText":"Node
         4.4","value":"4.4","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|4.4","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2018-04-30T00:00:00Z"}}}]}]}},{"id":null,"name":"python","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"Python","value":"python","preferredOs":"linux","majorVersions":[{"displayText":"Python
-        3","value":"3","minorVersions":[{"displayText":"Python 3.11","value":"3.11","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.11","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.11"},"isHidden":false}}},{"displayText":"Python
-        3.10","value":"3.10","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.10","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.10"},"isHidden":false,"isEarlyAccess":false}}},{"displayText":"Python
-        3.9","value":"3.9","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.9","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.9"},"isHidden":false}}},{"displayText":"Python
-        3.8","value":"3.8","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.8","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.8"}}}},{"displayText":"Python
-        3.7","value":"3.7","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.7","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.7"}}}},{"displayText":"Python
-        3.6","value":"3.6","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.6","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.6"}},"windowsRuntimeSettings":{"runtimeVersion":"3.4.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.6"}}}}]},{"displayText":"Python
+        3","value":"3","minorVersions":[{"displayText":"Python 3.14","value":"3.14","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.14","remoteDebuggingSupported":false,"isHidden":true,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.14"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2030-10-31T00:00:00Z"}}},{"displayText":"Python
+        3.13","value":"3.13","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.13","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.13"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2029-10-31T00:00:00Z"}}},{"displayText":"Python
+        3.12","value":"3.12","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.12","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.12"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2028-10-31T00:00:00Z"}}},{"displayText":"Python
+        3.11","value":"3.11","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.11","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.11"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2027-10-31T00:00:00Z","isHidden":false}}},{"displayText":"Python
+        3.10","value":"3.10","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.10","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.10"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2026-10-31T00:00:00Z","isHidden":false,"isEarlyAccess":false}}},{"displayText":"Python
+        3.9","value":"3.9","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.9","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.9"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2025-10-31T00:00:00Z","isHidden":false}}},{"displayText":"Python
+        3.8","value":"3.8","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.8","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.8"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2024-10-07T00:00:00Z"}}},{"displayText":"Python
+        3.7","value":"3.7","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.7","remoteDebuggingSupported":false,"isDeprecated":true,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.7"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2023-06-27T00:00:00Z"}}},{"displayText":"Python
+        3.6","value":"3.6","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.6","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.6"},"endOfLifeDate":"2021-12-23T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"3.4.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.6"}}}}]},{"displayText":"Python
         2","value":"2","minorVersions":[{"displayText":"Python 2.7","value":"2.7","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|2.7","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"2.7"},"endOfLifeDate":"2020-02-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"2.7.3","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"2.7"},"endOfLifeDate":"2020-02-01T00:00:00Z"}}}]}]}},{"id":null,"name":"php","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"PHP","value":"php","preferredOs":"linux","majorVersions":[{"displayText":"PHP
-        8","value":"8","minorVersions":[{"displayText":"PHP 8.2","value":"8.2","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|8.2","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.2"},"endOfLifeDate":"2025-11-30T00:00:00Z"}}},{"displayText":"PHP
-        8.1","value":"8.1","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|8.1","isHidden":false,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.1"},"endOfLifeDate":"2024-11-30T00:00:00Z"}}},{"displayText":"PHP
-        8.0","value":"8.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|8.0","isHidden":false,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.0"},"endOfLifeDate":"2023-11-30T00:00:00Z"}}}]},{"displayText":"PHP
+        8","value":"8","minorVersions":[{"displayText":"PHP 8.4","value":"8.4","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|8.4","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.4"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2028-12-31T00:00:00Z"}}},{"displayText":"PHP
+        8.3","value":"8.3","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|8.3","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.3"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2027-12-31T00:00:00Z"}}},{"displayText":"PHP
+        8.2","value":"8.2","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|8.2","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.2"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2026-12-31T00:00:00Z"}}},{"displayText":"PHP
+        8.1","value":"8.1","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|8.1","isHidden":false,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.1"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2025-12-31T00:00:00Z"}}},{"displayText":"PHP
+        8.0","value":"8.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|8.0","isDeprecated":true,"isHidden":false,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.0"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2023-11-26T00:00:00Z"}}}]},{"displayText":"PHP
         7","value":"7","minorVersions":[{"displayText":"PHP 7.4","value":"7.4","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"7.4","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"7.4","notSupportedInCreates":true},"isDeprecated":true,"endOfLifeDate":"2022-11-30T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"PHP|7.4","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"7.4","notSupportedInCreates":true},"isDeprecated":true,"endOfLifeDate":"2022-11-30T00:00:00Z"}}},{"displayText":"PHP
         7.3","value":"7.3","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|7.3","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"7.3","notSupportedInCreates":true},"endOfLifeDate":"2021-12-06T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"7.3","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"7.3","notSupportedInCreates":true},"endOfLifeDate":"2021-12-06T00:00:00Z"}}},{"displayText":"PHP
         7.2","value":"7.2","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|7.2","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2020-11-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"7.2","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2020-11-30T00:00:00Z"}}},{"displayText":"PHP
         7.1","value":"7.1","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"7.1","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2020-02-01T00:00:00Z"}}},{"displayText":"7.0","value":"7.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|7.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2020-02-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"7.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2020-02-01T00:00:00Z"}}}]},{"displayText":"PHP
         5","value":"5","minorVersions":[{"displayText":"PHP 5.6","value":"5.6","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|5.6","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2021-02-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"5.6","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2021-02-01T00:00:00Z"}}}]}]}},{"id":null,"name":"ruby","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"Ruby","value":"ruby","preferredOs":"linux","majorVersions":[{"displayText":"Ruby
-        2","value":"2","minorVersions":[{"displayText":"Ruby 2.7","value":"2.7","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.7","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2023-03-31T00:00:00Z"}}},{"displayText":"Ruby
-        2.7.3","value":"2.7.3","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.7.3","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"isHidden":true,"endOfLifeDate":"2023-03-31T00:00:00Z"}}},{"displayText":"Ruby
+        2","value":"2","minorVersions":[{"displayText":"Ruby 2.7","value":"2.7","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.7","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2023-03-31T00:00:00Z"}}},{"displayText":"Ruby
+        2.7.3","value":"2.7.3","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.7.3","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"isHidden":true,"endOfLifeDate":"2023-03-31T00:00:00Z"}}},{"displayText":"Ruby
         2.6","value":"2.6","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.6","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2022-03-31T00:00:00Z"}}},{"displayText":"Ruby
         2.6.2","value":"2.6.2","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.6.2","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2022-03-31T00:00:00Z"}}},{"displayText":"Ruby
         2.5","value":"2.5","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.5","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2021-03-31T00:00:00Z"}}},{"displayText":"Ruby
@@ -310,44 +380,70 @@ interactions:
         2.3","value":"2.3","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.3","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2019-03-31T00:00:00Z"}}},{"displayText":"Ruby
         2.3.8","value":"2.3.8","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.3.8","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2019-03-31T00:00:00Z"}}},{"displayText":"Ruby
         2.3.3","value":"2.3.3","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.3.3","remoteDebuggingSupported":false,"isDeprecated":true,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2019-03-31T00:00:00Z"}}}]}]}},{"id":null,"name":"java","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"Java","value":"java","preferredOs":"linux","majorVersions":[{"displayText":"Java
-        17","value":"17","minorVersions":[{"displayText":"Java 17","value":"17.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2031-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2031-09-01T00:00:00Z"}}},{"displayText":"Java
-        17.0.2","value":"17.0.2","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2031-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17.0.2","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2031-09-01T00:00:00Z"}}},{"displayText":"Java
-        17.0.1","value":"17.0.1","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2031-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17.0.1","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2031-09-01T00:00:00Z"}}}]},{"displayText":"Java
-        11","value":"11","minorVersions":[{"displayText":"Java 11","value":"11.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"}}},{"displayText":"Java
-        11.0.14","value":"11.0.14","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.14","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"}}},{"displayText":"Java
-        11.0.13","value":"11.0.13","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.13","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"}}},{"displayText":"Java
-        11.0.12","value":"11.0.12","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.12","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"}}},{"displayText":"Java
-        11.0.11","value":"11.0.11","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.11","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"}}},{"displayText":"Java
-        11.0.9","value":"11.0.9","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.9","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"}}},{"displayText":"Java
-        11.0.8","value":"11.0.8","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"11.0.8","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"}}},{"displayText":"Java
-        11.0.7","value":"11.0.7","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.7","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"}}},{"displayText":"Java
-        11.0.6","value":"11.0.6","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.6","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"}}},{"displayText":"Java
-        11.0.5","value":"11.0.5","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.5_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"}}},{"displayText":"Java
-        11.0.3","value":"11.0.3","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"11.0.3_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"}}},{"displayText":"Java
-        11.0.2","value":"11.0.2","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"11.0.2_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"}}}]},{"displayText":"Java
-        8","value":"8","minorVersions":[{"displayText":"Java 8","value":"8.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"1.8","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
-        1.8.0_332","value":"8.0.332","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_332","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
-        1.8.0_322","value":"8.0.322","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_322","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
-        1.8.0_312","value":"8.0.312","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_312","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
-        1.8.0_302","value":"8.0.302","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_302","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
-        1.8.0_292","value":"8.0.292","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_292","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
-        1.8.0_282","value":"8.0.282","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_282","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
-        1.8.0_275","value":"8.0.275","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
-        1.8.0_265","value":"8.0.265","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_265","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
-        1.8.0_252","value":"8.0.252","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_252","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
-        1.8.0_242","value":"8.0.242","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_242","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
-        1.8.0_232","value":"8.0.232","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_232_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
-        1.8.0_212","value":"8.0.212","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_212_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
-        1.8.0_202","value":"8.0.202","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_202_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
+        21","value":"21","minorVersions":[{"displayText":"Java 21","value":"21.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"21","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"}}},{"displayText":"Java
+        21.0.6","value":"21.0.6","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"21.0.6","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"}}},{"displayText":"Java
+        21.0.5","value":"21.0.5","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"21.0.5","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"}}},{"displayText":"Java
+        21.0.4","value":"21.0.4","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"21.0.4","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"}}},{"displayText":"Java
+        21.0.3","value":"21.0.3","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"21.0.3","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"}}},{"displayText":"Java
+        21.0.1","value":"21.0.1","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"21.0.1","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"}}}]},{"displayText":"Java
+        17","value":"17","minorVersions":[{"displayText":"Java 17","value":"17.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        17.0.14","value":"17.0.14","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17.0.14","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        17.0.13","value":"17.0.13","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17.0.13","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        17.0.12","value":"17.0.12","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17.0.12","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        17.0.11","value":"17.0.11","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17.0.11","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        17.0.9","value":"17.0.9","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17.0.9","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        17.0.4","value":"17.0.4","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17.0.4","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        17.0.3","value":"17.0.3","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17.0.3","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        17.0.2","value":"17.0.2","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17.0.2","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        17.0.1","value":"17.0.1","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17.0.1","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}}]},{"displayText":"Java
+        11","value":"11","minorVersions":[{"displayText":"Java 11","value":"11.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.26","value":"11.0.26","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.26","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.25","value":"11.0.25","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.25","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.24","value":"11.0.24","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.24","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.23","value":"11.0.23","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.23","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.21","value":"11.0.21","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.21","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.16","value":"11.0.16","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.16","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.15","value":"11.0.15","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.15","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.14","value":"11.0.14","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.14","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.13","value":"11.0.13","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.13","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.12","value":"11.0.12","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.12","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.11","value":"11.0.11","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.11","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.9","value":"11.0.9","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.9","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.8","value":"11.0.8","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"11.0.8","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.7","value":"11.0.7","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.7","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.6","value":"11.0.6","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.6","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.5","value":"11.0.5","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.5_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.3","value":"11.0.3","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"11.0.3_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.2","value":"11.0.2","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"11.0.2_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}}]},{"displayText":"Java
+        8","value":"8","minorVersions":[{"displayText":"Java 8","value":"8.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"1.8","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_442","value":"8.0.442","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_442","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_432","value":"8.0.432","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_432","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_422","value":"8.0.422","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_422","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_412","value":"8.0.412","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_412","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_392","value":"8.0.392","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_392","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_345","value":"8.0.345","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_345","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_332","value":"8.0.332","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_332","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_322","value":"8.0.322","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_322","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_312","value":"8.0.312","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_312","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_302","value":"8.0.302","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_302","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_292","value":"8.0.292","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_292","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_282","value":"8.0.282","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_282","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_275","value":"8.0.275","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_265","value":"8.0.265","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_265","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_252","value":"8.0.252","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_252","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_242","value":"8.0.242","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_242","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_232","value":"8.0.232","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_232_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_212","value":"8.0.212","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_212_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_202","value":"8.0.202","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_202_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
         1.8.0_202 (Oracle)","value":"8.0.202 (Oracle)","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_202","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"}}}},{"displayText":"Java
-        1.8.0_181","value":"8.0.181","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_181_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_181","value":"8.0.181","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_181_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
         1.8.0_181 (Oracle)","value":"8.0.181 (Oracle)","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_181","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"}}}},{"displayText":"Java
-        1.8.0_172","value":"8.0.172","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_172_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_172","value":"8.0.172","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_172_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
         1.8.0_172 (Oracle)","value":"8.0.172 (Oracle)","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_172","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"}}}},{"displayText":"Java
-        1.8.0_144","value":"8.0.144","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_144","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_144","value":"8.0.144","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_144","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
         1.8.0_111 (Oracle)","value":"8.0.111 (Oracle)","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_111","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"}}}},{"displayText":"Java
-        1.8.0_102","value":"8.0.102","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_102","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
-        1.8.0_92","value":"8.0.92","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_92","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_102","value":"8.0.102","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_102","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_92","value":"8.0.92","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_92","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
         1.8.0_73 (Oracle)","value":"8.0.73 (Oracle)","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_73","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"}}}},{"displayText":"Java
         1.8.0_60 (Oracle)","value":"8.0.60 (Oracle)","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_60","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"}}}},{"displayText":"Java
         1.8.0_25 (Oracle)","value":"8.0.25 (Oracle)","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_25","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"}}}}]},{"displayText":"Java
@@ -363,135 +459,271 @@ interactions:
         1.7.0_51 (Oracle)","value":"7.0.51 (Oracle)","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.7.0_51","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false}}}}]}]}},{"id":null,"name":"javacontainers","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"Java
         Containers","value":"javacontainers","majorVersions":[{"displayText":"Java
         SE (Embedded Web Server)","value":"javase","minorVersions":[{"displayText":"Java
-        SE (Embedded Web Server)","value":"SE","stackSettings":{"windowsContainerSettings":{"javaContainer":"JAVA","javaContainerVersion":"SE","isAutoUpdate":true},"linuxContainerSettings":{"java17Runtime":"JAVA|17-java17","java11Runtime":"JAVA|11-java11","java8Runtime":"JAVA|8-jre8","isAutoUpdate":true}}},{"displayText":"Java
-        SE 17.0.2","value":"17.0.2","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.2"}}},{"displayText":"Java
-        SE 17.0.1","value":"17.0.1","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.1"}}},{"displayText":"Java
-        SE 11.0.14","value":"11.0.14","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.14"}}},{"displayText":"Java
-        SE 11.0.13","value":"11.0.13","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.13"}}},{"displayText":"Java
-        SE 11.0.12","value":"11.0.12","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.12"}}},{"displayText":"Java
-        SE 11.0.11","value":"11.0.11","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.11"}}},{"displayText":"Java
-        SE 11.0.9","value":"11.0.9","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.9"}}},{"displayText":"Java
-        SE 11.0.7","value":"11.0.7","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.7"}}},{"displayText":"Java
-        SE 11.0.6","value":"11.0.6","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.6"}}},{"displayText":"Java
-        SE 11.0.5","value":"11.0.5","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.5"}}},{"displayText":"Java
-        SE 8u332","value":"1.8.332","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u332"}}},{"displayText":"Java
-        SE 8u322","value":"1.8.322","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u322"}}},{"displayText":"Java
-        SE 8u312","value":"1.8.312","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u312"}}},{"displayText":"Java
-        SE 8u302","value":"1.8.302","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u302"}}},{"displayText":"Java
-        SE 8u292","value":"1.8.292","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u292"}}},{"displayText":"Java
-        SE 8u275","value":"1.8.275","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u275"}}},{"displayText":"Java
-        SE 8u252","value":"1.8.252","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u252"}}},{"displayText":"Java
-        SE 8u242","value":"1.8.242","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u242"}}},{"displayText":"Java
-        SE 8u232","value":"1.8.232","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u232"}}}]},{"displayText":"Red
+        SE (Embedded Web Server)","value":"SE","stackSettings":{"windowsContainerSettings":{"javaContainer":"JAVA","javaContainerVersion":"SE","isAutoUpdate":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java21Runtime":"JAVA|21-java21","java17Runtime":"JAVA|17-java17","java11Runtime":"JAVA|11-java11","java8Runtime":"JAVA|8-jre8","isAutoUpdate":true,"runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8-jre8"},{"runtimeVersion":"11","runtime":"JAVA|11-java11"},{"runtimeVersion":"17","runtime":"JAVA|17-java17"},{"runtimeVersion":"21","runtime":"JAVA|21-java21"}]}}},{"displayText":"Java
+        SE 21.0.7","value":"21.0.7","stackSettings":{"linuxContainerSettings":{"java21Runtime":"JAVA|21.0.7","runtimes":[{"runtimeVersion":"21","runtime":"JAVA|21.0.7"}]}}},{"displayText":"Java
+        SE 21.0.6","value":"21.0.6","stackSettings":{"linuxContainerSettings":{"java21Runtime":"JAVA|21.0.6","runtimes":[{"runtimeVersion":"21","runtime":"JAVA|21.0.6"}]}}},{"displayText":"Java
+        SE 21.0.5","value":"21.0.5","stackSettings":{"linuxContainerSettings":{"java21Runtime":"JAVA|21.0.5","runtimes":[{"runtimeVersion":"21","runtime":"JAVA|21.0.5"}]}}},{"displayText":"Java
+        SE 21.0.4","value":"21.0.4","stackSettings":{"linuxContainerSettings":{"java21Runtime":"JAVA|21.0.4","runtimes":[{"runtimeVersion":"21","runtime":"JAVA|21.0.4"}]}}},{"displayText":"Java
+        SE 21.0.3","value":"21.0.3","stackSettings":{"linuxContainerSettings":{"java21Runtime":"JAVA|21.0.3","runtimes":[{"runtimeVersion":"21","runtime":"JAVA|21.0.3"}]}}},{"displayText":"Java
+        SE 21.0.1","value":"21.0.1","stackSettings":{"linuxContainerSettings":{"java21Runtime":"JAVA|21.0.1","runtimes":[{"runtimeVersion":"21","runtime":"JAVA|21.0.1"}]}}},{"displayText":"Java
+        SE 17.0.15","value":"17.0.15","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.15","runtimes":[{"runtimeVersion":"17","runtime":"JAVA|17.0.15"}]}}},{"displayText":"Java
+        SE 17.0.14","value":"17.0.14","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.14","runtimes":[{"runtimeVersion":"17","runtime":"JAVA|17.0.14"}]}}},{"displayText":"Java
+        SE 17.0.13","value":"17.0.13","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.13","runtimes":[{"runtimeVersion":"17","runtime":"JAVA|17.0.13"}]}}},{"displayText":"Java
+        SE 17.0.12","value":"17.0.12","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.12","runtimes":[{"runtimeVersion":"17","runtime":"JAVA|17.0.12"}]}}},{"displayText":"Java
+        SE 17.0.11","value":"17.0.11","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.11","runtimes":[{"runtimeVersion":"17","runtime":"JAVA|17.0.11"}]}}},{"displayText":"Java
+        SE 17.0.9","value":"17.0.9","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.9","runtimes":[{"runtimeVersion":"17","runtime":"JAVA|17.0.9"}]}}},{"displayText":"Java
+        SE 17.0.4","value":"17.0.4","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.4","runtimes":[{"runtimeVersion":"17","runtime":"JAVA|17.0.4"}]}}},{"displayText":"Java
+        SE 17.0.3","value":"17.0.3","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.3","runtimes":[{"runtimeVersion":"17","runtime":"JAVA|17.0.3"}]}}},{"displayText":"Java
+        SE 17.0.2","value":"17.0.2","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.2","runtimes":[{"runtimeVersion":"17","runtime":"JAVA|17.0.2"}]}}},{"displayText":"Java
+        SE 17.0.1","value":"17.0.1","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.1","runtimes":[{"runtimeVersion":"17","runtime":"JAVA|17.0.1"}]}}},{"displayText":"Java
+        SE 11.0.27","value":"11.0.27","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.27","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.27"}]}}},{"displayText":"Java
+        SE 11.0.26","value":"11.0.26","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.26","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.26"}]}}},{"displayText":"Java
+        SE 11.0.25","value":"11.0.25","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.25","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.25"}]}}},{"displayText":"Java
+        SE 11.0.24","value":"11.0.24","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.24","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.24"}]}}},{"displayText":"Java
+        SE 11.0.23","value":"11.0.23","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.23","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.23"}]}}},{"displayText":"Java
+        SE 11.0.21","value":"11.0.21","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.21","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.21"}]}}},{"displayText":"Java
+        SE 11.0.16","value":"11.0.16","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.16","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.16"}]}}},{"displayText":"Java
+        SE 11.0.15","value":"11.0.15","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.15","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.15"}]}}},{"displayText":"Java
+        SE 11.0.14","value":"11.0.14","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.14","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.14"}]}}},{"displayText":"Java
+        SE 11.0.13","value":"11.0.13","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.13","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.13"}]}}},{"displayText":"Java
+        SE 11.0.12","value":"11.0.12","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.12","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.12"}]}}},{"displayText":"Java
+        SE 11.0.11","value":"11.0.11","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.11","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.11"}]}}},{"displayText":"Java
+        SE 11.0.9","value":"11.0.9","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.9","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.9"}]}}},{"displayText":"Java
+        SE 11.0.7","value":"11.0.7","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.7","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.7"}]}}},{"displayText":"Java
+        SE 11.0.6","value":"11.0.6","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.6","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.6"}]}}},{"displayText":"Java
+        SE 11.0.5","value":"11.0.5","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.5","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.5"}]}}},{"displayText":"Java
+        SE 8u452","value":"1.8.452","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u452","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u452"}]}}},{"displayText":"Java
+        SE 8u442","value":"1.8.442","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u442","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u442"}]}}},{"displayText":"Java
+        SE 8u432","value":"1.8.432","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u432","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u432"}]}}},{"displayText":"Java
+        SE 8u422","value":"1.8.422","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u422","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u422"}]}}},{"displayText":"Java
+        SE 8u412","value":"1.8.412","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u412","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u412"}]}}},{"displayText":"Java
+        SE 8u392","value":"1.8.392","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u392","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u392"}]}}},{"displayText":"Java
+        SE 8u345","value":"1.8.345","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u345","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u345"}]}}},{"displayText":"Java
+        SE 8u332","value":"1.8.332","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u332","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u332"}]}}},{"displayText":"Java
+        SE 8u322","value":"1.8.322","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u322","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u322"}]}}},{"displayText":"Java
+        SE 8u312","value":"1.8.312","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u312","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u312"}]}}},{"displayText":"Java
+        SE 8u302","value":"1.8.302","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u302","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u302"}]}}},{"displayText":"Java
+        SE 8u292","value":"1.8.292","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u292","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u292"}]}}},{"displayText":"Java
+        SE 8u275","value":"1.8.275","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u275","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u275"}]}}},{"displayText":"Java
+        SE 8u252","value":"1.8.252","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u252","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u252"}]}}},{"displayText":"Java
+        SE 8u242","value":"1.8.242","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u242","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u242"}]}}},{"displayText":"Java
+        SE 8u232","value":"1.8.232","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u232","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u232"}]}}}]},{"displayText":"Red
+        Hat JBoss EAP 8","value":"jbosseap8.0","minorVersions":[{"displayText":"Red
+        Hat JBoss EAP 8","value":"8","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8-java11","java17Runtime":"JBOSSEAP|8-java17","java21Runtime":"JBOSSEAP|8-java21","isAutoUpdate":true,"runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8-java17"},{"runtimeVersion":"21","runtime":"JBOSSEAP|8-java21"}]}}},{"displayText":"Red
+        Hat JBoss EAP 8.0 update 8","value":"8.0.8","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.8-java11","java17Runtime":"JBOSSEAP|8.0.8-java17","java21Runtime":"JBOSSEAP|8.0.8-java21","runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8.0.8-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8.0.8-java17"},{"runtimeVersion":"21","runtime":"JBOSSEAP|8.0.8-java21"}]}}},{"displayText":"Red
+        Hat JBoss EAP 8.0 update 7","value":"8.0.7","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.7-java11","java17Runtime":"JBOSSEAP|8.0.7-java17","java21Runtime":"JBOSSEAP|8.0.7-java21","runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8.0.7-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8.0.7-java17"},{"runtimeVersion":"21","runtime":"JBOSSEAP|8.0.7-java21"}]}}},{"displayText":"Red
+        Hat JBoss EAP 8.0 update 5.1","value":"8.0.5.1","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.5.1-java11","java17Runtime":"JBOSSEAP|8.0.5.1-java17","runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8.0.5.1-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8.0.5.1-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 8.0 update 4.1","value":"8.0.4.1","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.4.1-java11","java17Runtime":"JBOSSEAP|8.0.4.1-java17","runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8.0.4.1-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8.0.4.1-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 8.0 update 3","value":"8.0.3","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.3-java11","java17Runtime":"JBOSSEAP|8.0.3-java17","runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8.0.3-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8.0.3-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 8.0 update 2.1","value":"8.0.2.1","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.2.1-java11","java17Runtime":"JBOSSEAP|8.0.2.1-java17","runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8.0.2.1-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8.0.2.1-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 8.0 update 1","value":"8.0.1","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.1-java11","java17Runtime":"JBOSSEAP|8.0.1-java17","runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8.0.1-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8.0.1-java17"}]}}}]},{"displayText":"Red
+        Hat JBoss EAP 8 BYO License","value":"jbosseap8.0_byol","minorVersions":[{"displayText":"Red
+        Hat JBoss EAP 8 BYO License","value":"8","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8-java11_byol","java17Runtime":"JBOSSEAP|8-java17_byol","java21Runtime":"JBOSSEAP|8-java21_byol","isAutoUpdate":true,"runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8-java17_byol"},{"runtimeVersion":"21","runtime":"JBOSSEAP|8-java21_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 8.0 update 7","value":"8.0.7","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.7-java11_byol","java17Runtime":"JBOSSEAP|8.0.7-java17_byol","java21Runtime":"JBOSSEAP|8.0.7-java21_byol","runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8.0.7-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8.0.7-java17_byol"},{"runtimeVersion":"21","runtime":"JBOSSEAP|8.0.7-java21_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 8.0 update 5.1","value":"8.0.5.1","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.5.1-java11_byol","java17Runtime":"JBOSSEAP|8.0.5.1-java17_byol","runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8.0.5.1-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8.0.5.1-java17_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 8.0 update 4.1 BYO License","value":"8.0.4.1","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.4.1-java11_byol","java17Runtime":"JBOSSEAP|8.0.4.1-java17_byol","runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8.0.4.1-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8.0.4.1-java17_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 8 update 3 BYO License","value":"8.0.3","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.3-java11_byol","java17Runtime":"JBOSSEAP|8.0.3-java17_byol","runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8.0.3-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8.0.3-java17_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 8.0 update 2.1 BYO License","value":"8.0.2","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.2-java11_byol","java17Runtime":"JBOSSEAP|8.0.2-java17_byol","runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8.0.2-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8.0.2-java17_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 8 update 1 BYO License","value":"8.0.1","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.1-java11_byol","java17Runtime":"JBOSSEAP|8.0.1-java17_byol","runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8.0.1-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8.0.1-java17_byol"}]}}}]},{"displayText":"Red
         Hat JBoss EAP 7","value":"jbosseap","minorVersions":[{"displayText":"Red Hat
-        JBoss EAP 7","value":"7","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7-java8","java11Runtime":"JBOSSEAP|7-java11","isAutoUpdate":true}}},{"displayText":"Red
-        Hat JBoss EAP 7.4.2","value":"7.4.2","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.2-java8","java11Runtime":"JBOSSEAP|7.4.2-java11"}}},{"displayText":"Red
-        Hat JBoss EAP 7.4.1","value":"7.4.1","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.1-java8","java11Runtime":"JBOSSEAP|7.4.1-java11"}}},{"displayText":"Red
-        Hat JBoss EAP 7.4.0","value":"7.4.0","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.0-java8","java11Runtime":"JBOSSEAP|7.4.0-java11"}}},{"displayText":"Red
-        Hat JBoss EAP 7.3.9","value":"7.3.9","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.3.9-java8","java11Runtime":"JBOSSEAP|7.3.9-java11"}}},{"displayText":"Red
-        Hat JBoss EAP 7.3","value":"7.3","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.3-java8","java11Runtime":"JBOSSEAP|7.3-java11","isAutoUpdate":true,"isHidden":true}}},{"displayText":"Red
-        Hat JBoss EAP 7.4","value":"7.4","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4-java8","java11Runtime":"JBOSSEAP|7.4-java11","isAutoUpdate":true,"isHidden":true}}},{"displayText":"JBoss
-        EAP 7.2","value":"7.2.0","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.2-java8","isDeprecated":true}}}]},{"displayText":"Apache
+        JBoss EAP 7","value":"7","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7-java8","java11Runtime":"JBOSSEAP|7-java11","java17Runtime":"JBOSSEAP|7-java17","isAutoUpdate":true,"runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.22","value":"7.4.22","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.22-java8","java11Runtime":"JBOSSEAP|7.4.22-java11","java17Runtime":"JBOSSEAP|7.4.22-java17","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.22-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.22-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.22-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.21","value":"7.4.21","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.21-java8","java11Runtime":"JBOSSEAP|7.4.21-java11","java17Runtime":"JBOSSEAP|7.4.21-java17","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.21-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.21-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.21-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.20","value":"7.4.20","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.20-java8","java11Runtime":"JBOSSEAP|7.4.20-java11","java17Runtime":"JBOSSEAP|7.4.20-java17","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.20-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.20-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.20-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.18","value":"7.4.18","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.18-java8","java11Runtime":"JBOSSEAP|7.4.18-java11","java17Runtime":"JBOSSEAP|7.4.18-java17","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.18-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.18-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.18-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.17","value":"7.4.17","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.17-java8","java11Runtime":"JBOSSEAP|7.4.17-java11","java17Runtime":"JBOSSEAP|7.4.17-java17","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.17-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.17-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.17-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.16","value":"7.4.16","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.16-java8","java11Runtime":"JBOSSEAP|7.4.16-java11","java17Runtime":"JBOSSEAP|7.4.16-java17","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.16-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.16-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.16-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.13","value":"7.4.13","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.13-java8","java11Runtime":"JBOSSEAP|7.4.13-java11","java17Runtime":"JBOSSEAP|7.4.13-java17","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.13-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.13-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.13-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.7","value":"7.4.7","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.7-java8","java11Runtime":"JBOSSEAP|7.4.7-java11","java17Runtime":"JBOSSEAP|7.4.7-java17","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.7-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.7-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.7-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.5","value":"7.4.5","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.5-java8","java11Runtime":"JBOSSEAP|7.4.5-java11","java17Runtime":"JBOSSEAP|7.4.5-java17","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.5-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.5-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.5-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.2","value":"7.4.2","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.2-java8","java11Runtime":"JBOSSEAP|7.4.2-java11","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.2-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.2-java11"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.1","value":"7.4.1","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.1-java8","java11Runtime":"JBOSSEAP|7.4.1-java11","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.1-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.1-java11"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.0","value":"7.4.0","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.0-java8","java11Runtime":"JBOSSEAP|7.4.0-java11","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.0-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.0-java11"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.3.10","value":"7.3.10","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.3.10-java8","java11Runtime":"JBOSSEAP|7.3.10-java11","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.3.10-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.3.10-java11"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.3.9","value":"7.3.9","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.3.9-java8","java11Runtime":"JBOSSEAP|7.3.9-java11","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.3.9-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.3.9-java11"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.3","value":"7.3","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.3-java8","java11Runtime":"JBOSSEAP|7.3-java11","isAutoUpdate":true,"isHidden":true,"runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.3-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.3-java11"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4","value":"7.4","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4-java8","java11Runtime":"JBOSSEAP|7.4-java11","isAutoUpdate":true,"isHidden":true,"runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4-java11"}]}}},{"displayText":"JBoss
+        EAP 7.2","value":"7.2.0","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.2-java8","isDeprecated":true,"runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.2-java8"}]}}}]},{"displayText":"Red
+        Hat JBoss EAP 7 BYO License","value":"jbosseap7_byol","minorVersions":[{"displayText":"Red
+        Hat JBoss EAP 7 BYO License","value":"7","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7-java8_byol","java11Runtime":"JBOSSEAP|7-java11_byol","java17Runtime":"JBOSSEAP|7-java17_byol","isAutoUpdate":true,"runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7-java8_byol"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7-java17_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.21 BYO License","value":"7.4.21","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.21-java8_byol","java11Runtime":"JBOSSEAP|7.4.21-java11_byol","java17Runtime":"JBOSSEAP|7.4.21-java17_byol","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.21-java8_byol"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.21-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.21-java17_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.20 BYO License","value":"7.4.20","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.20-java8_byol","java11Runtime":"JBOSSEAP|7.4.20-java11_byol","java17Runtime":"JBOSSEAP|7.4.20-java17_byol","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.20-java8_byol"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.20-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.20-java17_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.18 BYO License","value":"7.4.18","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.18-java8_byol","java11Runtime":"JBOSSEAP|7.4.18-java11_byol","java17Runtime":"JBOSSEAP|7.4.18-java17_byol","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.18-java8_byol"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.18-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.18-java17_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.16 BYO License","value":"7.4.16","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.16-java8_byol","java11Runtime":"JBOSSEAP|7.4.16-java11_byol","java17Runtime":"JBOSSEAP|7.4.16-java17_byol","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.16-java8_byol"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.16-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.16-java17_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.13 BYO License","value":"7.4.13","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.13-java8_byol","java11Runtime":"JBOSSEAP|7.4.13-java11_byol","java17Runtime":"JBOSSEAP|7.4.13-java17_byol","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.13-java8_byol"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.13-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.13-java17_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.7 BYO License","value":"7.4.7","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.7-java8_byol","java11Runtime":"JBOSSEAP|7.4.7-java11_byol","java17Runtime":"JBOSSEAP|7.4.7-java17_byol","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.7-java8_byol"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.7-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.7-java17_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.5 BYO License","value":"7.4.5","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.5-java8_byol","java11Runtime":"JBOSSEAP|7.4.5-java11_byol","java17Runtime":"JBOSSEAP|7.4.5-java17_byol","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.5-java8_byol"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.5-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.5-java17_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.2 BYO License","value":"7.4.2","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.2-java8_byol","java11Runtime":"JBOSSEAP|7.4.2-java11_byol","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.2-java8_byol"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.2-java11_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.1 BYO License","value":"7.4.1","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.1-java8_byol","java11Runtime":"JBOSSEAP|7.4.1-java11_byol","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.1-java8_byol"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.1-java11_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.0 BYO License","value":"7.4.0","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.0-java8_byol","java11Runtime":"JBOSSEAP|7.4.0-java11_byol","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.0-java8_byol"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.0-java11_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.3.10 BYO License","value":"7.3.10","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.3.10-java8_byol","java11Runtime":"JBOSSEAP|7.3.10-java11_byol","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.3.10-java8_byol"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.3.10-java11_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.3.9 BYO License","value":"7.3.9","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.3.9-java8_byol","java11Runtime":"JBOSSEAP|7.3.9-java11_byol","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.3.9-java8_byol"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.3.9-java11_byol"}]}}}]},{"displayText":"Apache
+        Tomcat 11.0","value":"tomcat11.0","minorVersions":[{"displayText":"Apache
+        Tomcat 11.0","value":"11.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"11.0","isAutoUpdate":true,"runtimes":[{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java21Runtime":"TOMCAT|11.0-java21","java17Runtime":"TOMCAT|11.0-java17","java11Runtime":"TOMCAT|11.0-java11","isAutoUpdate":true,"runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|11.0-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|11.0-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|11.0-java21"}]}}},{"displayText":"Apache
+        Tomcat 11.0.9","value":"11.0.9","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"11.0.9","isHidden":true,"runtimes":[{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java17Runtime":"TOMCAT|11.0.9-java17","java21Runtime":"TOMCAT|11.0.9-java21","runtimes":[{"runtimeVersion":"17","runtime":"TOMCAT|11.0.9-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|11.0.9-java21"}]}}},{"displayText":"Apache
+        Tomcat 11.0.8","value":"11.0.8","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"11.0.8","isHidden":true,"runtimes":[{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java17Runtime":"TOMCAT|11.0.8-java17","java21Runtime":"TOMCAT|11.0.8-java21","runtimes":[{"runtimeVersion":"17","runtime":"TOMCAT|11.0.8-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|11.0.8-java21"}]}}},{"displayText":"Apache
+        Tomcat 11.0.7","value":"11.0.7","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"11.0.7","runtimes":[{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"isHidden":true,"java17Runtime":"TOMCAT|11.0.7-java17","java21Runtime":"TOMCAT|11.0.7-java21","runtimes":[{"runtimeVersion":"17","runtime":"TOMCAT|11.0.7-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|11.0.7-java21"}]}}},{"displayText":"Apache
+        Tomcat 11.0.6","value":"11.0.6","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"11.0.6","isHidden":true,"runtimes":[{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java17Runtime":"TOMCAT|11.0.6-java17","java21Runtime":"TOMCAT|11.0.6-java21","runtimes":[{"runtimeVersion":"17","runtime":"TOMCAT|11.0.6-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|11.0.6-java21"}]}}},{"displayText":"Apache
+        Tomcat 11.0.5","value":"11.0.5","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"11.0.5","runtimes":[{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java17Runtime":"TOMCAT|11.0.5-java17","java21Runtime":"TOMCAT|11.0.5-java21","runtimes":[{"runtimeVersion":"17","runtime":"TOMCAT|11.0.5-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|11.0.5-java21"}]}}},{"displayText":"Apache
+        Tomcat 11.0.4","value":"11.0.4","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"11.0.4","isHidden":true,"runtimes":[{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java17Runtime":"TOMCAT|11.0.4-java17","java21Runtime":"TOMCAT|11.0.4-java21","runtimes":[{"runtimeVersion":"17","runtime":"TOMCAT|11.0.4-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|11.0.4-java21"}]}}},{"displayText":"Apache
+        Tomcat 11.0.2","value":"11.0.2","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"11.0.2","runtimes":[{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java17Runtime":"TOMCAT|11.0.2-java17","java21Runtime":"TOMCAT|11.0.2-java21","runtimes":[{"runtimeVersion":"17","runtime":"TOMCAT|11.0.2-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|11.0.2-java21"}]}}},{"displayText":"Apache
+        Tomcat 11.0.1","value":"11.0.1","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"11.0.1","isHidden":true,"runtimes":[{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java17Runtime":"TOMCAT|11.0.1-java17","java21Runtime":"TOMCAT|11.0.1-java21","runtimes":[{"runtimeVersion":"17","runtime":"TOMCAT|11.0.1-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|11.0.1-java21"}]}}}]},{"displayText":"Apache
+        Tomcat 10.1","value":"tomcat10.1","minorVersions":[{"displayText":"Apache
+        Tomcat 10.1","value":"10.1","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1","isAutoUpdate":true,"runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java21Runtime":"TOMCAT|10.1-java21","java17Runtime":"TOMCAT|10.1-java17","java11Runtime":"TOMCAT|10.1-java11","isAutoUpdate":true,"runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1-java21"}]}}},{"displayText":"Apache
+        Tomcat 10.1.43","value":"10.1.43","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.43","isHidden":true,"runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.43-java11","java17Runtime":"TOMCAT|10.1.43-java17","java21Runtime":"TOMCAT|10.1.43-java21","runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1.43-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1.43-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1.43-java21"}]}}},{"displayText":"Apache
+        Tomcat 10.1.42","value":"10.1.42","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.42","isHidden":true,"runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.42-java11","java17Runtime":"TOMCAT|10.1.42-java17","java21Runtime":"TOMCAT|10.1.42-java21","runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1.42-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1.42-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1.42-java21"}]}}},{"displayText":"Apache
+        Tomcat 10.1.41","value":"10.1.41","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.41","runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"isHidden":true,"java11Runtime":"TOMCAT|10.1.41-java11","java17Runtime":"TOMCAT|10.1.41-java17","java21Runtime":"TOMCAT|10.1.41-java21","runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1.41-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1.41-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1.41-java21"}]}}},{"displayText":"Apache
+        Tomcat 10.1.40","value":"10.1.40","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.40","isHidden":true,"runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.40-java11","java17Runtime":"TOMCAT|10.1.40-java17","java21Runtime":"TOMCAT|10.1.40-java21","runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1.40-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1.40-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1.40-java21"}]}}},{"displayText":"Apache
+        Tomcat 10.1.39","value":"10.1.39","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.39","runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.39-java11","java17Runtime":"TOMCAT|10.1.39-java17","java21Runtime":"TOMCAT|10.1.39-java21","runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1.39-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1.39-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1.39-java21"}]}}},{"displayText":"Apache
+        Tomcat 10.1.36","value":"10.1.36","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.36","isHidden":true,"runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.36-java11","java17Runtime":"TOMCAT|10.1.36-java17","java21Runtime":"TOMCAT|10.1.36-java21","runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1.36-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1.36-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1.36-java21"}]}}},{"displayText":"Apache
+        Tomcat 10.1.34","value":"10.1.34","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.34","runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.34-java11","java17Runtime":"TOMCAT|10.1.34-java17","java21Runtime":"TOMCAT|10.1.34-java21","runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1.34-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1.34-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1.34-java21"}]}}},{"displayText":"Apache
+        Tomcat 10.1.33","value":"10.1.33","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.33","isHidden":true,"runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.33-java11","java17Runtime":"TOMCAT|10.1.33-java17","java21Runtime":"TOMCAT|10.1.33-java21","runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1.33-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1.33-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1.33-java21"}]}}},{"displayText":"Apache
+        Tomcat 10.1.31","value":"10.1.31","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.31","runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.31-java11","java17Runtime":"TOMCAT|10.1.31-java17","java21Runtime":"TOMCAT|10.1.31-java21","isHidden":true,"runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1.31-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1.31-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1.31-java21"}]}}},{"displayText":"Apache
+        Tomcat 10.1.28","value":"10.1.28","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.28","isHidden":true,"runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.28-java11","java17Runtime":"TOMCAT|10.1.28-java17","java21Runtime":"TOMCAT|10.1.28-java21","runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1.28-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1.28-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1.28-java21"}]}}},{"displayText":"Apache
+        Tomcat 10.1.25","value":"10.1.25","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.25","runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.25-java11","java17Runtime":"TOMCAT|10.1.25-java17","java21Runtime":"TOMCAT|10.1.25-java21","runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1.25-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1.25-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1.25-java21"}]}}},{"displayText":"Apache
+        Tomcat 10.1.23","value":"10.1.23","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.23","isHidden":true,"runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.23-java11","java17Runtime":"TOMCAT|10.1.23-java17","java21Runtime":"TOMCAT|10.1.23-java21","runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1.23-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1.23-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1.23-java21"}]}}},{"displayText":"Apache
+        Tomcat 10.1.16","value":"10.1.16","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.16","runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.16-java11","java17Runtime":"TOMCAT|10.1.16-java17","java21Runtime":"TOMCAT|10.1.16-java21","runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1.16-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1.16-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1.16-java21"}]}}}]},{"displayText":"Apache
         Tomcat 10.0","value":"tomcat10.0","minorVersions":[{"displayText":"Apache
-        Tomcat 10.0","value":"10.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0","isAutoUpdate":true},"linuxContainerSettings":{"java17Runtime":"TOMCAT|10.0-java17","java11Runtime":"TOMCAT|10.0-java11","java8Runtime":"TOMCAT|10.0-jre8","isAutoUpdate":true}}},{"displayText":"Apache
-        Tomcat 10.0.20","value":"10.0.20","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0.20"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|10.0.20-java8","java11Runtime":"TOMCAT|10.0.20-java11","java17Runtime":"TOMCAT|10.0.20-java17"}}},{"displayText":"Apache
-        Tomcat 10.0.12","value":"10.0.12","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0.12"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|10.0.12-java8","java11Runtime":"TOMCAT|10.0.12-java11","java17Runtime":"TOMCAT|10.0.12-java17"}}}]},{"displayText":"Apache
+        Tomcat 10.0","value":"10.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0","isAutoUpdate":true,"endOfLifeDate":"2022-10-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java17Runtime":"TOMCAT|10.0-java17","java11Runtime":"TOMCAT|10.0-java11","java8Runtime":"TOMCAT|10.0-jre8","isAutoUpdate":true,"endOfLifeDate":"2022-10-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|10.0-jre8"},{"runtimeVersion":"11","runtime":"TOMCAT|10.0-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.0-java17"}]}}},{"displayText":"Apache
+        Tomcat 10.0.27","value":"10.0.27","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0.27","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|10.0.27-java8","java11Runtime":"TOMCAT|10.0.27-java11","java17Runtime":"TOMCAT|10.0.27-java17","endOfLifeDate":"2022-10-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|10.0.27-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|10.0.27-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.0.27-java17"}]}}},{"displayText":"Apache
+        Tomcat 10.0.23","value":"10.0.23","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0.23","endOfLifeDate":"2022-10-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|10.0.23-java8","java11Runtime":"TOMCAT|10.0.23-java11","java17Runtime":"TOMCAT|10.0.23-java17","endOfLifeDate":"2022-10-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|10.0.23-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|10.0.23-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.0.23-java17"}]}}},{"displayText":"Apache
+        Tomcat 10.0.21","value":"10.0.21","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0.21","endOfLifeDate":"2022-10-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|10.0.21-java8","java11Runtime":"TOMCAT|10.0.21-java11","java17Runtime":"TOMCAT|10.0.21-java17","endOfLifeDate":"2022-10-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|10.0.21-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|10.0.21-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.0.21-java17"}]}}},{"displayText":"Apache
+        Tomcat 10.0.20","value":"10.0.20","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0.20","endOfLifeDate":"2022-10-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|10.0.20-java8","java11Runtime":"TOMCAT|10.0.20-java11","java17Runtime":"TOMCAT|10.0.20-java17","endOfLifeDate":"2022-10-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|10.0.20-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|10.0.20-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.0.20-java17"}]}}},{"displayText":"Apache
+        Tomcat 10.0.12","value":"10.0.12","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0.12","endOfLifeDate":"2022-10-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|10.0.12-java8","java11Runtime":"TOMCAT|10.0.12-java11","java17Runtime":"TOMCAT|10.0.12-java17","endOfLifeDate":"2022-10-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|10.0.12-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|10.0.12-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.0.12-java17"}]}}}]},{"displayText":"Apache
         Tomcat 9.0","value":"tomcat9.0","minorVersions":[{"displayText":"Apache Tomcat
-        9.0","value":"9.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0","isAutoUpdate":true},"linuxContainerSettings":{"java17Runtime":"TOMCAT|9.0-java17","java11Runtime":"TOMCAT|9.0-java11","java8Runtime":"TOMCAT|9.0-jre8","isAutoUpdate":true}}},{"displayText":"Apache
-        Tomcat 9.0.62","value":"9.0.62","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.62"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.62-java8","java11Runtime":"TOMCAT|9.0.62-java11","java17Runtime":"TOMCAT|9.0.62-java17"}}},{"displayText":"Apache
-        Tomcat 9.0.54","value":"9.0.54","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.54"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.54-java8","java11Runtime":"TOMCAT|9.0.54-java11","java17Runtime":"TOMCAT|9.0.54-java17"}}},{"displayText":"Apache
-        Tomcat 9.0.52","value":"9.0.52","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.52"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.52-java8","java11Runtime":"TOMCAT|9.0.52-java11"}}},{"displayText":"Apache
-        Tomcat 9.0.46","value":"9.0.46","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.46"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.46-java8","java11Runtime":"TOMCAT|9.0.46-java11"}}},{"displayText":"Apache
-        Tomcat 9.0.41","value":"9.0.41","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.41-java8","java11Runtime":"TOMCAT|9.0.41-java11"}}},{"displayText":"Apache
-        Tomcat 9.0.38","value":"9.0.38","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.38"}}},{"displayText":"Apache
-        Tomcat 9.0.37","value":"9.0.37","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.37"},"linuxContainerSettings":{"java11Runtime":"TOMCAT|9.0.37-java11","java8Runtime":"TOMCAT|9.0.37-java8"}}},{"displayText":"Apache
-        Tomcat 9.0.33","value":"9.0.33","stackSettings":{"linuxContainerSettings":{"java11Runtime":"TOMCAT|9.0.33-java11","java8Runtime":"TOMCAT|9.0.33-java8"}}},{"displayText":"Apache
-        Tomcat 9.0.31","value":"9.0.31","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.31"}}},{"displayText":"Apache
-        Tomcat 9.0.27","value":"9.0.27","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.27"}}},{"displayText":"Apache
-        Tomcat 9.0.21","value":"9.0.21","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.21"}}},{"displayText":"Apache
-        Tomcat 9.0.20","value":"9.0.20","stackSettings":{"linuxContainerSettings":{"java11Runtime":"TOMCAT|9.0.20-java11","java8Runtime":"TOMCAT|9.0.20-java8"}}},{"displayText":"Apache
-        Tomcat 9.0.14","value":"9.0.14","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.14"}}},{"displayText":"Apache
-        Tomcat 9.0.12","value":"9.0.12","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.12"}}},{"displayText":"Apache
-        Tomcat 9.0.8","value":"9.0.8","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.8"}}},{"displayText":"Apache
-        Tomcat 9.0.0","value":"9.0.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.0"}}}]},{"displayText":"Apache
+        9.0","value":"9.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0","isAutoUpdate":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java21Runtime":"TOMCAT|9.0-java21","java17Runtime":"TOMCAT|9.0-java17","java11Runtime":"TOMCAT|9.0-java11","java8Runtime":"TOMCAT|9.0-jre8","isAutoUpdate":true,"runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0-jre8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.107","value":"9.0.107","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.107","isHidden":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.107-java8","java11Runtime":"TOMCAT|9.0.107-java11","java17Runtime":"TOMCAT|9.0.107-java17","java21Runtime":"TOMCAT|9.0.107-java21","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.107-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.107-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.107-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.107-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.106","value":"9.0.106","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.106","isHidden":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.106-java8","java11Runtime":"TOMCAT|9.0.106-java11","java17Runtime":"TOMCAT|9.0.106-java17","java21Runtime":"TOMCAT|9.0.106-java21","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.106-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.106-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.106-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.106-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.105","value":"9.0.105","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.105","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"isHidden":true,"java8Runtime":"TOMCAT|9.0.105-java8","java11Runtime":"TOMCAT|9.0.105-java11","java17Runtime":"TOMCAT|9.0.105-java17","java21Runtime":"TOMCAT|9.0.105-java21","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.105-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.105-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.105-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.105-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.104","value":"9.0.104","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.104","isHidden":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.104-java8","java11Runtime":"TOMCAT|9.0.104-java11","java17Runtime":"TOMCAT|9.0.104-java17","java21Runtime":"TOMCAT|9.0.104-java21","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.104-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.104-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.104-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.104-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.102","value":"9.0.102","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.102","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.102-java8","java11Runtime":"TOMCAT|9.0.102-java11","java17Runtime":"TOMCAT|9.0.102-java17","java21Runtime":"TOMCAT|9.0.102-java21","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.102-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.102-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.102-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.102-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.100","value":"9.0.100","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.100","isHidden":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.100-java8","java11Runtime":"TOMCAT|9.0.100-java11","java17Runtime":"TOMCAT|9.0.100-java17","java21Runtime":"TOMCAT|9.0.100-java21","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.100-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.100-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.100-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.100-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.98","value":"9.0.98","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.98","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.98-java8","java11Runtime":"TOMCAT|9.0.98-java11","java17Runtime":"TOMCAT|9.0.98-java17","java21Runtime":"TOMCAT|9.0.98-java21","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.98-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.98-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.98-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.98-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.97","value":"9.0.97","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.97","isHidden":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.97-java8","java11Runtime":"TOMCAT|9.0.97-java11","java17Runtime":"TOMCAT|9.0.97-java17","java21Runtime":"TOMCAT|9.0.97-java21","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.97-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.97-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.97-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.97-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.96","value":"9.0.97","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.96","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.96-java8","java11Runtime":"TOMCAT|9.0.96-java11","java17Runtime":"TOMCAT|9.0.96-java17","java21Runtime":"TOMCAT|9.0.96-java21","isHidden":true,"runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.96-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.96-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.96-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.96-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.93","value":"9.0.93","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.93","isHidden":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.93-java8","java11Runtime":"TOMCAT|9.0.93-java11","java17Runtime":"TOMCAT|9.0.93-java17","java21Runtime":"TOMCAT|9.0.93-java21","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.93-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.93-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.93-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.93-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.91","value":"9.0.91","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.91","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.91-java8","java11Runtime":"TOMCAT|9.0.91-java11","java17Runtime":"TOMCAT|9.0.91-java17","java21Runtime":"TOMCAT|9.0.91-java21","isHidden":true,"runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.91-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.91-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.91-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.91-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.90","value":"9.0.90","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.90","isHidden":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.90-java8","java11Runtime":"TOMCAT|9.0.90-java11","java17Runtime":"TOMCAT|9.0.90-java17","java21Runtime":"TOMCAT|9.0.90-java21","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.90-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.90-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.90-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.90-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.88","value":"9.0.88","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.88","isHidden":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.88-java8","java11Runtime":"TOMCAT|9.0.88-java11","java17Runtime":"TOMCAT|9.0.88-java17","java21Runtime":"TOMCAT|9.0.88-java21","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.88-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.88-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.88-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.88-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.83","value":"9.0.83","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.83","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.83-java8","java11Runtime":"TOMCAT|9.0.83-java11","java17Runtime":"TOMCAT|9.0.83-java17","java21Runtime":"TOMCAT|9.0.83-java21","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.83-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.83-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.83-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.83-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.65","value":"9.0.65","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.65","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.65-java8","java11Runtime":"TOMCAT|9.0.65-java11","java17Runtime":"TOMCAT|9.0.65-java17","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.65-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.65-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.65-java17"}]}}},{"displayText":"Apache
+        Tomcat 9.0.63","value":"9.0.63","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.63","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.63-java8","java11Runtime":"TOMCAT|9.0.63-java11","java17Runtime":"TOMCAT|9.0.63-java17","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.63-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.63-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.63-java17"}]}}},{"displayText":"Apache
+        Tomcat 9.0.62","value":"9.0.62","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.62","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.62-java8","java11Runtime":"TOMCAT|9.0.62-java11","java17Runtime":"TOMCAT|9.0.62-java17","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.62-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.62-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.62-java17"}]}}},{"displayText":"Apache
+        Tomcat 9.0.54","value":"9.0.54","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.54","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.54-java8","java11Runtime":"TOMCAT|9.0.54-java11","java17Runtime":"TOMCAT|9.0.54-java17","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.54-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.54-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.54-java17"}]}}},{"displayText":"Apache
+        Tomcat 9.0.52","value":"9.0.52","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.52","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.52-java8","java11Runtime":"TOMCAT|9.0.52-java11","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.52-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.52-java11"}]}}},{"displayText":"Apache
+        Tomcat 9.0.46","value":"9.0.46","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.46","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.46-java8","java11Runtime":"TOMCAT|9.0.46-java11","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.46-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.46-java11"}]}}},{"displayText":"Apache
+        Tomcat 9.0.41","value":"9.0.41","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.41-java8","java11Runtime":"TOMCAT|9.0.41-java11","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.41-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.41-java11"}]}}},{"displayText":"Apache
+        Tomcat 9.0.38","value":"9.0.38","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.38","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.37","value":"9.0.37","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.37","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|9.0.37-java11","java8Runtime":"TOMCAT|9.0.37-java8","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.37-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.37-java11"}]}}},{"displayText":"Apache
+        Tomcat 9.0.33","value":"9.0.33","stackSettings":{"linuxContainerSettings":{"java11Runtime":"TOMCAT|9.0.33-java11","java8Runtime":"TOMCAT|9.0.33-java8","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.33-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.33-java11"}]}}},{"displayText":"Apache
+        Tomcat 9.0.31","value":"9.0.31","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.31","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.27","value":"9.0.27","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.27","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.21","value":"9.0.21","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.21","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.20","value":"9.0.20","stackSettings":{"linuxContainerSettings":{"java11Runtime":"TOMCAT|9.0.20-java11","java8Runtime":"TOMCAT|9.0.20-java8","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.20-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.20-java11"}]}}},{"displayText":"Apache
+        Tomcat 9.0.14","value":"9.0.14","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.14","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.12","value":"9.0.12","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.12","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.8","value":"9.0.8","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.8","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.0","value":"9.0.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.0","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}}]},{"displayText":"Apache
         Tomcat 8.5","value":"tomcat8.5","minorVersions":[{"displayText":"Apache Tomcat
-        8.5","value":"8.5","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5","isAutoUpdate":true},"linuxContainerSettings":{"java11Runtime":"TOMCAT|8.5-java11","java8Runtime":"TOMCAT|8.5-jre8","isAutoUpdate":true}}},{"displayText":"Apache
-        Tomcat 8.5.78","value":"8.5.78","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.78-java8","java11Runtime":"TOMCAT|8.5.78-java11"},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.78"}}},{"displayText":"Apache
-        Tomcat 8.5.72","value":"8.5.72","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.72-java8","java11Runtime":"TOMCAT|8.5.72-java11"},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.72"}}},{"displayText":"Apache
-        Tomcat 8.5.69","value":"8.5.69","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.69-java8","java11Runtime":"TOMCAT|8.5.69-java11"},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.69"}}},{"displayText":"Apache
-        Tomcat 8.5.66","value":"8.5.66","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.66-java8","java11Runtime":"TOMCAT|8.5.66-java11"},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.66"}}},{"displayText":"Apache
-        Tomcat 8.5.61","value":"8.5.61","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.61-java8","java11Runtime":"TOMCAT|8.5.61-java11"}}},{"displayText":"Apache
-        Tomcat 8.5.58","value":"8.5.58","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.58"}}},{"displayText":"Apache
-        Tomcat 8.5.57","value":"8.5.57","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.57"},"linuxContainerSettings":{"java11Runtime":"TOMCAT|8.5.57-java11","java8Runtime":"TOMCAT|8.5.57-java8"}}},{"displayText":"Apache
-        Tomcat 8.5.53","value":"8.5.53","stackSettings":{"linuxContainerSettings":{"java11Runtime":"TOMCAT|8.5.53-java11","java8Runtime":"TOMCAT|8.5.53-java8"}}},{"displayText":"Apache
-        Tomcat 8.5.51","value":"8.5.51","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.51"}}},{"displayText":"Apache
-        Tomcat 8.5.47","value":"8.5.47","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.47"}}},{"displayText":"Apache
-        Tomcat 8.5.42","value":"8.5.42","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.42"}}},{"displayText":"Apache
-        Tomcat 8.5.41","value":"8.5.41","stackSettings":{"linuxContainerSettings":{"java11Runtime":"TOMCAT|8.5.41-java11","java8Runtime":"TOMCAT|8.5.41-java8"}}},{"displayText":"Apache
-        Tomcat 8.5.37","value":"8.5.37","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.37"}}},{"displayText":"Apache
-        Tomcat 8.5.34","value":"8.5.34","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.34"}}},{"displayText":"Apache
-        Tomcat 8.5.31","value":"8.5.31","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.31"}}},{"displayText":"Apache
-        Tomcat 8.5.20","value":"8.5.20","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.20"}}},{"displayText":"Apache
-        Tomcat 8.5.6","value":"8.5.6","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.6"}}}]},{"displayText":"Apache
+        8.5","value":"8.5","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5","isAutoUpdate":true,"endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|8.5-java11","java8Runtime":"TOMCAT|8.5-jre8","isAutoUpdate":true,"endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|8.5-jre8"},{"runtimeVersion":"11","runtime":"TOMCAT|8.5-java11"}]}}},{"displayText":"Apache
+        Tomcat 8.5.100","value":"8.5.100","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.100-java8","java11Runtime":"TOMCAT|8.5.100-java11","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|8.5.100-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|8.5.100-java11"}]},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.100","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.96","value":"8.5.96","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.96-java8","java11Runtime":"TOMCAT|8.5.96-java11","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|8.5.96-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|8.5.96-java11"}]},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.96","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.82","value":"8.5.82","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.82-java8","java11Runtime":"TOMCAT|8.5.82-java11","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|8.5.82-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|8.5.82-java11"}]},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.82","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.79","value":"8.5.79","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.79-java8","java11Runtime":"TOMCAT|8.5.79-java11","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|8.5.79-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|8.5.79-java11"}]},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.79","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.78","value":"8.5.78","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.78-java8","java11Runtime":"TOMCAT|8.5.78-java11","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|8.5.78-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|8.5.78-java11"}]},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.78","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.72","value":"8.5.72","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.72-java8","java11Runtime":"TOMCAT|8.5.72-java11","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|8.5.72-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|8.5.72-java11"}]},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.72","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.69","value":"8.5.69","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.69-java8","java11Runtime":"TOMCAT|8.5.69-java11","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|8.5.69-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|8.5.69-java11"}]},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.69","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.66","value":"8.5.66","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.66-java8","java11Runtime":"TOMCAT|8.5.66-java11","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|8.5.66-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|8.5.66-java11"}]},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.66","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.61","value":"8.5.61","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.61-java8","java11Runtime":"TOMCAT|8.5.61-java11","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|8.5.61-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|8.5.61-java11"}]}}},{"displayText":"Apache
+        Tomcat 8.5.58","value":"8.5.58","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.58","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.57","value":"8.5.57","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.57","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|8.5.57-java11","java8Runtime":"TOMCAT|8.5.57-java8","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|8.5.57-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|8.5.57-java11"}]}}},{"displayText":"Apache
+        Tomcat 8.5.53","value":"8.5.53","stackSettings":{"linuxContainerSettings":{"java11Runtime":"TOMCAT|8.5.53-java11","java8Runtime":"TOMCAT|8.5.53-java8","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|8.5.53-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|8.5.53-java11"}]}}},{"displayText":"Apache
+        Tomcat 8.5.51","value":"8.5.51","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.51","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.47","value":"8.5.47","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.47","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.42","value":"8.5.42","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.42","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.41","value":"8.5.41","stackSettings":{"linuxContainerSettings":{"java11Runtime":"TOMCAT|8.5.41-java11","java8Runtime":"TOMCAT|8.5.41-java8","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|8.5.41-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|8.5.41-java11"}]}}},{"displayText":"Apache
+        Tomcat 8.5.37","value":"8.5.37","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.37","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.34","value":"8.5.34","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.34","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.31","value":"8.5.31","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.31","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.20","value":"8.5.20","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.20","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.6","value":"8.5.6","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.6","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}}]},{"displayText":"Apache
         Tomcat 8.0","value":"tomcat8.0","minorVersions":[{"displayText":"Apache Tomcat
-        8.0","value":"8.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.0","isAutoUpdate":true,"isDeprecated":true}}},{"displayText":"Apache
-        Tomcat 8.0.53","value":"8.0.53","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.0.53","isDeprecated":true}}},{"displayText":"Apache
-        Tomcat 8.0.46","value":"8.0.46","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.0.46","isDeprecated":true}}},{"displayText":"Apache
-        Tomcat 8.0.23","value":"8.0.23","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.0.23","isDeprecated":true}}}]},{"displayText":"Apache
+        8.0","value":"8.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.0","isAutoUpdate":true,"isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.0.53","value":"8.0.53","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.0.53","isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.0.46","value":"8.0.46","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.0.46","isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.0.23","value":"8.0.23","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.0.23","isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}}]},{"displayText":"Apache
         Tomcat 7.0","value":"tomcat7.0","minorVersions":[{"displayText":"Apache Tomcat
-        7.0","value":"7.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"7.0","isAutoUpdate":true,"isDeprecated":true}}},{"displayText":"Apache
-        Tomcat 7.0.94","value":"7.0.94","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"7.0.94","isDeprecated":true}}},{"displayText":"Apache
-        Tomcat 7.0.81","value":"7.0.81","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"7.0.81","isDeprecated":true}}},{"displayText":"Apache
-        Tomcat 7.0.62","value":"7.0.62","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"7.0.62","isDeprecated":true}}},{"displayText":"Apache
-        Tomcat 7.0.50","value":"7.0.50","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"7.0.50","isDeprecated":true}}}]},{"displayText":"Jetty
-        9.3","value":"jetty9.3","minorVersions":[{"displayText":"Jetty 9.3","value":"9.3","stackSettings":{"windowsContainerSettings":{"javaContainer":"JETTY","javaContainerVersion":"9.3","isAutoUpdate":true,"isDeprecated":true}}},{"displayText":"Jetty
-        9.3.25","value":"9.3.25","stackSettings":{"windowsContainerSettings":{"javaContainer":"JETTY","javaContainerVersion":"9.3.25","isDeprecated":true}}},{"displayText":"Jetty
-        9.3.13","value":"9.3.13","stackSettings":{"windowsContainerSettings":{"javaContainer":"JETTY","javaContainerVersion":"9.3.13","isDeprecated":true}}}]},{"displayText":"Jetty
-        9.1","value":"jetty9.1","minorVersions":[{"displayText":"Jetty 9.1","value":"9.1","stackSettings":{"windowsContainerSettings":{"javaContainer":"JETTY","javaContainerVersion":"9.1","isAutoUpdate":true,"isDeprecated":true}}},{"displayText":"Jetty
-        9.1.0","value":"9.1.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"JETTY","javaContainerVersion":"9.1.0","isDeprecated":true}}}]},{"displayText":"WildFly
-        14","value":"wildfly14","minorVersions":[{"displayText":"WildFly 14","value":"14","stackSettings":{"linuxContainerSettings":{"java8Runtime":"WILDFLY|14-jre8","isDeprecated":true,"isAutoUpdate":true}}},{"displayText":"WildFly
-        14.0.1","value":"14.0.1","stackSettings":{"linuxContainerSettings":{"isDeprecated":true,"java8Runtime":"WILDFLY|14.0.1-java8"}}}]}]}},{"id":null,"name":"staticsite","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"HTML
+        7.0","value":"7.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"7.0","isAutoUpdate":true,"isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 7.0.94","value":"7.0.94","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"7.0.94","isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 7.0.81","value":"7.0.81","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"7.0.81","isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 7.0.62","value":"7.0.62","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"7.0.62","isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 7.0.50","value":"7.0.50","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"7.0.50","isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}}]},{"displayText":"Jetty
+        9.3","value":"jetty9.3","minorVersions":[{"displayText":"Jetty 9.3","value":"9.3","stackSettings":{"windowsContainerSettings":{"javaContainer":"JETTY","javaContainerVersion":"9.3","isAutoUpdate":true,"isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Jetty
+        9.3.25","value":"9.3.25","stackSettings":{"windowsContainerSettings":{"javaContainer":"JETTY","javaContainerVersion":"9.3.25","isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Jetty
+        9.3.13","value":"9.3.13","stackSettings":{"windowsContainerSettings":{"javaContainer":"JETTY","javaContainerVersion":"9.3.13","isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}}]},{"displayText":"Jetty
+        9.1","value":"jetty9.1","minorVersions":[{"displayText":"Jetty 9.1","value":"9.1","stackSettings":{"windowsContainerSettings":{"javaContainer":"JETTY","javaContainerVersion":"9.1","isAutoUpdate":true,"isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Jetty
+        9.1.0","value":"9.1.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"JETTY","javaContainerVersion":"9.1.0","isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}}]},{"displayText":"WildFly
+        14","value":"wildfly14","minorVersions":[{"displayText":"WildFly 14","value":"14","stackSettings":{"linuxContainerSettings":{"java8Runtime":"WILDFLY|14-jre8","isDeprecated":true,"isAutoUpdate":true,"runtimes":[{"runtimeVersion":"8","runtime":"WILDFLY|14-jre8"}]}}},{"displayText":"WildFly
+        14.0.1","value":"14.0.1","stackSettings":{"linuxContainerSettings":{"isDeprecated":true,"java8Runtime":"WILDFLY|14.0.1-java8","runtimes":[{"runtimeVersion":"8","runtime":"WILDFLY|14.0.1-java8"}]}}}]}]}},{"id":null,"name":"staticsite","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"HTML
         (Static Content)","value":"staticsite","preferredOs":"linux","majorVersions":[{"displayText":"HTML
         (Static Content)","value":"1","minorVersions":[{"displayText":"HTML (Static
         Content)","value":"1.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"STATICSITE|1.0","isHidden":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false}}}}]}]}},{"id":null,"name":"go","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"Go","value":"go","preferredOs":"linux","majorVersions":[{"displayText":"Go
-        1","value":"go1","minorVersions":[{"displayText":"Go 1.19 (Experimental)","value":"go1.19","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"GO|1.19","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true},"isHidden":false,"isEarlyAccess":false}}},{"displayText":"Go
-        1.18 (Experimental)","value":"go1.18","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"GO|1.18","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"isHidden":false,"isEarlyAccess":false,"isDeprecated":true}}}]}]}}],"nextLink":null,"id":null}'
+        1","value":"go1","minorVersions":[{"displayText":"Go 1.19 (Experimental)","value":"go1.19","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"GO|1.19","remoteDebuggingSupported":false,"isDeprecated":true,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true},"supportedFeatures":{"disableSsh":true},"isHidden":false,"isEarlyAccess":false}}},{"displayText":"Go
+        1.18 (Experimental)","value":"go1.18","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"GO|1.18","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"supportedFeatures":{"disableSsh":true},"isHidden":false,"isEarlyAccess":false,"isDeprecated":true}}}]}]}}],"nextLink":null,"id":null}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '72306'
+      - '153017'
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Tue, 28 Mar 2023 11:17:23 GMT
+=======
+      - Sat, 18 Oct 2025 07:45:46 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:38:01 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
       - no-cache
-      server:
-      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+      x-ms-operation-identifier:
+      - ''
+      x-msedge-ref:
+      - 'Ref A: 9C574EC65CD04963BD45961842DEAD96 Ref B: SYD03EDGE1118 Ref C: 2025-10-18T07:45:46Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      x-ms-operation-identifier:
+      - ''
+      x-msedge-ref:
+      - 'Ref A: 187FA6583B3D48E6B0C96C141BCBB1A6 Ref B: SYD03EDGE1411 Ref C: 2025-10-17T10:38:00Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
       code: 200
       message: OK
 - request:
-    body: '{"location": "West US", "properties": {"serverFarmId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003",
+    body: '{"location": "East US", "properties": {"serverFarmId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003",
       "reserved": false, "isXenon": false, "hyperV": false, "siteConfig": {"netFrameworkVersion":
-      "v4.6", "appSettings": [{"name": "WEBSITE_NODE_DEFAULT_VERSION", "value": "~14"}],
-      "alwaysOn": true, "localMySqlEnabled": false, "http20Enabled": true}, "scmSiteAlsoStopped":
-      false, "httpsOnly": false}}'
+      "v4.6", "appSettings": [{"name": "WEBSITE_NODE_DEFAULT_VERSION", "value": "~20"}],
+      "alwaysOn": true, "localMySqlEnabled": false, "http20Enabled": true, "http20ProxyFlag":
+      0}, "scmSiteAlsoStopped": false, "httpsOnly": false}}'
     headers:
       Accept:
       - application/json
@@ -502,51 +734,96 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '510'
+      - '532'
       Content-Type:
       - application/json
       ParameterSetName:
       - -g -n --plan
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-web/7.0.0 Python/3.10.10 (Linux-5.15.0-1034-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_261_0
+      - AZURECLI/2.78.0 azsdk-python-core/1.35.0 Python/3.9.6 (macOS-26.0.1-arm64-arm-64bit)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002?api-version=2023-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002?api-version=2024-11-01
   response:
     body:
+<<<<<<< HEAD
+<<<<<<< HEAD
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002","name":"webapp-authentication-test000002","type":"Microsoft.Web/sites","kind":"app","location":"West
         US","properties":{"name":"webapp-authentication-test000002","state":"Running","hostNames":["webapp-authentication-test000002.azurewebsites.net"],"webSpace":"cli_test_authV2000001-WestUSwebspace","selfLink":"https://waws-prod-bay-223.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli_test_authV2000001-WestUSwebspace/sites/webapp-authentication-test000002","repositorySiteName":"webapp-authentication-test000002","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["webapp-authentication-test000002.azurewebsites.net","webapp-authentication-test000002.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-authentication-test000002.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-authentication-test000002.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2023-03-28T11:17:30.6033333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"vnetRouteAllEnabled":false,"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"vnetImagePullEnabled":false,"vnetContentShareEnabled":false,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"","windowsFxVersion":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
         all","description":"Allow all access"}],"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
         all","description":"Allow all access"}],"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":null,"elasticWebAppScaleLimit":0,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null},"deploymentId":"webapp-authentication-test000002","slotName":null,"trafficManagerHostNames":null,"sku":"Standard","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"253001F2FCF5A7B1CD759EB861E9BB1596370BE27E47A991F72184277B3D12F2","kind":"app","inboundIpAddress":"40.112.243.107","possibleInboundIpAddresses":"40.112.243.107","ftpUsername":"webapp-authentication-test000002\\$webapp-authentication-test000002","ftpsHostName":"ftps://waws-prod-bay-223.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"20.66.38.156,20.253.192.150,20.253.192.214,20.253.192.68,20.245.167.222,20.237.236.221,40.112.243.107","possibleOutboundIpAddresses":"20.66.38.156,20.253.192.150,20.253.192.214,20.253.192.68,20.245.167.222,20.237.236.221,20.245.167.166,20.237.238.86,20.237.238.182,20.253.194.143,20.237.199.64,20.253.135.107,20.245.168.61,20.245.171.12,20.253.128.204,20.66.39.179,20.253.128.252,20.253.194.226,20.228.120.185,20.253.194.255,20.253.195.13,20.253.195.67,20.237.239.11,20.237.198.135,20.228.127.198,20.228.127.190,20.237.231.73,20.245.163.76,20.237.158.144,20.66.32.118,40.112.243.107","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-223","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli_test_authV2000001","defaultHostName":"webapp-authentication-test000002.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"publicNetworkAccess":null,"buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs","storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","defaultHostNameScope":"Global","privateLinkIdentifiers":null}}'
+=======
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002","name":"webapp-authentication-test000002","type":"Microsoft.Web/sites","kind":"app","location":"East
+        US","properties":{"name":"webapp-authentication-test000002","state":"Running","hostNames":["webapp-authentication-test000002.azurewebsites.net"],"webSpace":"cli_test_authV2000001-EastUSwebspace","selfLink":"https://waws-prod-blu-205.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli_test_authV2000001-EastUSwebspace/sites/webapp-authentication-test000002","repositorySiteName":"webapp-authentication-test000002","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["webapp-authentication-test000002.azurewebsites.net","webapp-authentication-test000002.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-authentication-test000002.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-authentication-test000002.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003","reserved":false,"isXenon":false,"hyperV":false,"sandboxType":null,"lastModifiedTimeUtc":"2025-10-18T07:45:51.1","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"outboundVnetRouting":{"allTraffic":false,"applicationTraffic":false,"contentShareTraffic":false,"imagePullTraffic":false,"backupRestoreTraffic":false,"managedIdentityTraffic":false},"legacyServiceEndpointTrafficEvaluation":null,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"","windowsFxVersion":null,"sandboxType":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":null,"elasticWebAppScaleLimit":0,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false,"webJobsEnabled":false},"functionAppConfig":null,"daprConfig":null,"deploymentId":"webapp-authentication-test000002","slotName":null,"trafficManagerHostNames":null,"sku":"Standard","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientAffinityProxyEnabled":false,"useQueryStringAffinity":false,"blockPathTraversal":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"clientCertExclusionEndPoints":null,"hostNamesDisabled":false,"ipMode":"IPv4","domainVerificationIdentifiers":null,"customDomainVerificationId":"70240F0BA32B9DD28948DBEC834A732C467825FB279A572BFED6A386F1954E0A","kind":"app","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"20.49.104.11","possibleInboundIpAddresses":"20.49.104.11","inboundIpv6Address":"2603:1030:210:6::37","possibleInboundIpv6Addresses":"2603:1030:210:6::37","ftpUsername":"webapp-authentication-test000002\\$webapp-authentication-test000002","ftpsHostName":"ftps://waws-prod-blu-205.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.146.26.88,52.146.28.45,52.146.28.53,52.146.28.78,52.146.28.108,52.146.28.170,20.49.104.11","possibleOutboundIpAddresses":"52.146.26.88,52.146.28.45,52.146.28.53,52.146.28.78,52.146.28.108,52.146.28.170,57.152.97.248,52.146.28.175,52.146.28.180,52.146.28.221,52.146.28.226,52.146.29.36,52.146.29.124,52.146.29.135,40.76.149.51,52.146.29.193,52.146.29.214,52.146.29.220,52.146.29.239,40.76.150.19,52.146.29.241,52.146.29.248,52.146.30.16,52.146.30.18,52.146.30.20,52.146.30.58,52.146.30.61,52.146.30.90,20.62.245.89,20.62.246.33,20.62.246.112,20.49.104.11","outboundIpv6Addresses":"2603:1030:20c:9::3c,2603:1030:20c:9::ac,2603:1030:20c:9::10a,2603:1030:20c:f::800,2603:1030:20c:f::f7,2603:1030:20c:9::1c2,2603:1030:210:6::37,2603:10e1:100:2::1431:680b","possibleOutboundIpv6Addresses":"2603:1030:20c:9::3c,2603:1030:20c:9::ac,2603:1030:20c:9::10a,2603:1030:20c:f::800,2603:1030:20c:f::f7,2603:1030:20c:9::1c2,2603:1030:20c:f::830,2603:1030:20c:f::83b,2603:1030:20c:f::83c,2603:1030:20c:f::83d,2603:1030:20c:f::83f,2603:1030:20c:f::840,2603:1030:20c:f::841,2603:1030:20c:f::842,2603:1030:20c:f::843,2603:1030:20c:f::844,2603:1030:20c:f::845,2603:1030:20c:f::846,2603:1030:20c:f::847,2603:1030:20c:f::848,2603:1030:20c:f::849,2603:1030:20c:a::15a,2603:1030:20c:a::166,2603:1030:20c:f::84a,2603:1030:20c:f::150,2603:1030:20c:f::206,2603:1030:20c:f::261,2603:1030:20c:f::3dc,2603:1030:20c:f::404,2603:1030:20c:f::812,2603:1030:210:6::37,2603:10e1:100:2::1431:680b","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-blu-205","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli_test_authV2000001","defaultHostName":"webapp-authentication-test000002.azurewebsites.net","slotSwapStatus":null,"httpsOnly":true,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"publicNetworkAccess":"Enabled","buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs,AppServiceAuthenticationLogs","inFlightFeatures":null,"storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"privateLinkIdentifiers":null,"sshEnabled":null}}'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002","name":"webapp-authentication-test000002","type":"Microsoft.Web/sites","kind":"app","location":"East
+        US","properties":{"name":"webapp-authentication-test000002","state":"Running","hostNames":["webapp-authentication-test000002.azurewebsites.net"],"webSpace":"cli_test_authV2000001-EastUSwebspace","selfLink":"https://waws-prod-blu-259.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli_test_authV2000001-EastUSwebspace/sites/webapp-authentication-test000002","repositorySiteName":"webapp-authentication-test000002","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["webapp-authentication-test000002.azurewebsites.net","webapp-authentication-test000002.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-authentication-test000002.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-authentication-test000002.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003","reserved":false,"isXenon":false,"hyperV":false,"sandboxType":null,"lastModifiedTimeUtc":"2025-10-17T10:38:03.8666667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"outboundVnetRouting":{"allTraffic":false,"applicationTraffic":false,"contentShareTraffic":false,"imagePullTraffic":false,"backupRestoreTraffic":false,"managedIdentityTraffic":false},"legacyServiceEndpointTrafficEvaluation":null,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"","windowsFxVersion":null,"sandboxType":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":null,"elasticWebAppScaleLimit":0,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false,"webJobsEnabled":false},"functionAppConfig":null,"daprConfig":null,"deploymentId":"webapp-authentication-test000002","slotName":null,"trafficManagerHostNames":null,"sku":"Standard","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientAffinityProxyEnabled":false,"useQueryStringAffinity":false,"blockPathTraversal":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"clientCertExclusionEndPoints":null,"hostNamesDisabled":false,"ipMode":"IPv4","domainVerificationIdentifiers":null,"customDomainVerificationId":"70240F0BA32B9DD28948DBEC834A732C467825FB279A572BFED6A386F1954E0A","kind":"app","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"20.49.104.39","possibleInboundIpAddresses":"20.49.104.39","inboundIpv6Address":"2603:1030:210:6::2f","possibleInboundIpv6Addresses":"2603:1030:210:6::2f","ftpUsername":"webapp-authentication-test000002\\$webapp-authentication-test000002","ftpsHostName":"ftps://waws-prod-blu-259.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.188.26.154,52.188.26.198,52.188.28.80,52.188.28.96,52.188.29.113,52.188.29.150,20.49.104.39","possibleOutboundIpAddresses":"52.188.26.154,52.188.26.198,52.188.28.80,52.188.28.96,52.188.29.113,52.188.29.150,40.90.240.223,52.188.29.166,52.188.29.191,52.188.29.238,52.191.80.68,52.191.80.135,52.191.81.55,52.191.81.142,52.191.82.33,52.191.82.204,52.191.82.212,104.45.186.174,52.170.172.70,52.170.174.189,52.191.82.238,52.191.83.233,52.191.84.62,52.191.84.69,52.191.84.78,52.191.84.110,52.191.85.208,52.191.86.24,52.191.86.43,52.191.86.88,52.191.86.91,20.49.104.39","outboundIpv6Addresses":"2603:1030:20c:9::f28,2603:1030:20c:9::f2d,2603:1030:20c:9::f34,2603:1030:20c:9::f38,2603:1030:20c:9::f3c,2603:1030:20c:9::f40,2603:1030:210:6::2f,2603:10e1:100:2::1431:6827","possibleOutboundIpv6Addresses":"2603:1030:20c:9::f28,2603:1030:20c:9::f2d,2603:1030:20c:9::f34,2603:1030:20c:9::f38,2603:1030:20c:9::f3c,2603:1030:20c:9::f40,2603:1030:20c:9::f44,2603:1030:20c:9::f49,2603:1030:20c:9::f4d,2603:1030:20c:9::f51,2603:1030:20c:9::f56,2603:1030:20c:9::f5c,2603:1030:20c:9::f63,2603:1030:20c:9::f69,2603:1030:20c:9::f6f,2603:1030:20c:9::f77,2603:1030:20c:9::f7d,2603:1030:20c:9::f84,2603:1030:20c:9::f8d,2603:1030:20c:9::f94,2603:1030:20c:9::f9b,2603:1030:20c:9::fa3,2603:1030:20c:9::fa8,2603:1030:20c:9::fae,2603:1030:20c:9::fb4,2603:1030:20c:9::fbc,2603:1030:20c:9::fc1,2603:1030:20c:9::fc6,2603:1030:20c:9::fcb,2603:1030:20c:9::fd2,2603:1030:210:6::2f,2603:10e1:100:2::1431:6827","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-blu-259","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli_test_authV2000001","defaultHostName":"webapp-authentication-test000002.azurewebsites.net","slotSwapStatus":null,"httpsOnly":true,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"publicNetworkAccess":"Enabled","buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs,AppServiceAuthenticationLogs","inFlightFeatures":null,"storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"privateLinkIdentifiers":null,"sshEnabled":null}}'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
     headers:
       cache-control:
       - no-cache
       content-length:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - '7038'
+=======
+      - '8927'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       content-type:
       - application/json
       date:
-      - Tue, 28 Mar 2023 11:17:48 GMT
+      - Fri, 17 Oct 2025 10:38:23 GMT
       etag:
+<<<<<<< HEAD
       - '"1D96166E33E2700"'
+=======
+      - '8908'
+      content-type:
+      - application/json
+      date:
+      - Sat, 18 Oct 2025 07:46:11 GMT
+      etag:
+      - '"1DC40033A2E54AB"'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - '"1DC3F521E6E8560"'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
       - no-cache
-      server:
-      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+<<<<<<< HEAD
+<<<<<<< HEAD
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '499'
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/australiaeast/6895e4fa-2c63-402d-890b-89cca8e9ed0d
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '800'
+      x-msedge-ref:
+      - 'Ref A: D12EC5AB25434DBFB07D7495B1A5BD30 Ref B: SYD03EDGE1012 Ref C: 2025-10-18T07:45:47Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/43561bcc-3964-4de8-afc9-1a30d577d1b8
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '800'
+      x-msedge-ref:
+      - 'Ref A: 4E0DAE372D68405AA055BEABBAC9B761 Ref B: SYD03EDGE1721 Ref C: 2025-10-17T10:38:02Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -570,54 +847,92 @@ interactions:
       ParameterSetName:
       - -g -n --plan
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-web/7.0.0 Python/3.10.10 (Linux-5.15.0-1034-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_261_0
+      - AZURECLI/2.78.0 azsdk-python-core/1.35.0 Python/3.9.6 (macOS-26.0.1-arm64-arm-64bit)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/publishxml?api-version=2023-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/publishxml?api-version=2024-11-01
   response:
     body:
       string: <publishData><publishProfile profileName="webapp-authentication-test000002
         - Web Deploy" publishMethod="MSDeploy" publishUrl="webapp-authentication-test000002.scm.azurewebsites.net:443"
-        msdeploySite="webapp-authentication-test000002" userName="$webapp-authentication-test000002"
-        userPWD="hlzkQ6lHweqsszrzMaxD4p0HdmC0o1iprqCj8h7wtB5JjpzD7PnvtXCsrTzo" destinationAppUrl="http://webapp-authentication-test000002.azurewebsites.net"
-        SQLServerDBConnectionString="" mySQLDBConnectionString="" hostingProviderForumLink=""
-        controlPanelLink="http://windows.azure.com" webSystem="WebSites"><databases
+        msdeploySite="webapp-authentication-test000002" userName="REDACTED" userPWD="REDACTED"
+        destinationAppUrl="https://webapp-authentication-test000002.azurewebsites.net"
+        SQLServerDBConnectionString="REDACTED" mySQLDBConnectionString="" hostingProviderForumLink=""
+        controlPanelLink="https://portal.azure.com" webSystem="WebSites"><databases
         /></publishProfile><publishProfile profileName="webapp-authentication-test000002
+<<<<<<< HEAD
+<<<<<<< HEAD
         - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-bay-223.ftp.azurewebsites.windows.net/site/wwwroot"
         ftpPassiveMode="True" userName="webapp-authentication-test000002\$webapp-authentication-test000002"
         userPWD="hlzkQ6lHweqsszrzMaxD4p0HdmC0o1iprqCj8h7wtB5JjpzD7PnvtXCsrTzo" destinationAppUrl="http://webapp-authentication-test000002.azurewebsites.net"
         SQLServerDBConnectionString="" mySQLDBConnectionString="" hostingProviderForumLink=""
         controlPanelLink="http://windows.azure.com" webSystem="WebSites"><databases
+=======
+        - FTP" publishMethod="FTP" publishUrl="ftps://waws-prod-blu-205.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="REDACTED" userPWD="REDACTED" destinationAppUrl="https://webapp-authentication-test000002.azurewebsites.net"
+        SQLServerDBConnectionString="REDACTED" mySQLDBConnectionString="" hostingProviderForumLink=""
+        controlPanelLink="https://portal.azure.com" webSystem="WebSites"><databases
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+        - FTP" publishMethod="FTP" publishUrl="ftps://waws-prod-blu-259.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="REDACTED" userPWD="REDACTED" destinationAppUrl="https://webapp-authentication-test000002.azurewebsites.net"
+        SQLServerDBConnectionString="REDACTED" mySQLDBConnectionString="" hostingProviderForumLink=""
+        controlPanelLink="https://portal.azure.com" webSystem="WebSites"><databases
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
         /></publishProfile><publishProfile profileName="webapp-authentication-test000002
         - Zip Deploy" publishMethod="ZipDeploy" publishUrl="webapp-authentication-test000002.scm.azurewebsites.net:443"
-        userName="$webapp-authentication-test000002" userPWD="hlzkQ6lHweqsszrzMaxD4p0HdmC0o1iprqCj8h7wtB5JjpzD7PnvtXCsrTzo"
-        destinationAppUrl="http://webapp-authentication-test000002.azurewebsites.net"
-        SQLServerDBConnectionString="" mySQLDBConnectionString="" hostingProviderForumLink=""
-        controlPanelLink="http://windows.azure.com" webSystem="WebSites"><databases
+        userName="REDACTED" userPWD="REDACTED" destinationAppUrl="https://webapp-authentication-test000002.azurewebsites.net"
+        SQLServerDBConnectionString="REDACTED" mySQLDBConnectionString="" hostingProviderForumLink=""
+        controlPanelLink="https://portal.azure.com" webSystem="WebSites"><databases
         /></publishProfile></publishData>
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1771'
+      - '1535'
       content-type:
       - application/xml
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Tue, 28 Mar 2023 11:17:58 GMT
+=======
+      - Sat, 18 Oct 2025 07:46:12 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:38:24 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
       - no-cache
-      server:
-      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+<<<<<<< HEAD
+<<<<<<< HEAD
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '11999'
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/9d1f7520-8e3d-4969-afa1-628e16ce14bc
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: B5703332C5B846EA800A48FD88A5BC35 Ref B: SYD03EDGE1916 Ref C: 2025-10-18T07:46:12Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/abe78e9d-b3f2-432e-8665-cf65adc9da5d
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: ACF12D52CFAB4994961DB7FE0F0AE9D5 Ref B: SYD03EDGE2118 Ref C: 2025-10-17T10:38:24Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -639,13 +954,12 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - python/3.10.10 (Linux-5.15.0-1034-azure-x86_64-with-glibc2.31) AZURECLI/2.46.0
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_261_0
+      - python/3.9.6 (macOS-26.0.1-arm64-arm-64bit) AZURECLI/2.78.0
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authSettings/list?api-version=2020-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettings","name":"authsettings","type":"Microsoft.Web/sites/config","location":"West
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettings","name":"authsettings","type":"Microsoft.Web/sites/config","location":"East
         US","properties":{"enabled":false,"unauthenticatedClientAction":null,"tokenStoreEnabled":null,"allowedExternalRedirectUrls":null,"defaultProvider":null,"clientId":null,"clientSecret":null,"clientSecretSettingName":null,"clientSecretCertificateThumbprint":null,"issuer":null,"allowedAudiences":null,"additionalLoginParams":null,"isAadAutoProvisioned":false,"aadClaimsAuthorization":null,"googleClientId":null,"googleClientSecret":null,"googleClientSecretSettingName":null,"googleOAuthScopes":null,"facebookAppId":null,"facebookAppSecret":null,"facebookAppSecretSettingName":null,"facebookOAuthScopes":null,"gitHubClientId":null,"gitHubClientSecret":null,"gitHubClientSecretSettingName":null,"gitHubOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"twitterConsumerSecretSettingName":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountClientSecretSettingName":null,"microsoftAccountOAuthScopes":null,"configVersion":"v1"}}'
     headers:
       cache-control:
@@ -655,25 +969,47 @@ interactions:
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Tue, 28 Mar 2023 11:18:00 GMT
+=======
+      - Sat, 18 Oct 2025 07:46:14 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:38:24 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
       - no-cache
-      server:
-      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+<<<<<<< HEAD
+<<<<<<< HEAD
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '11999'
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/australiaeast/a2523d06-93e4-4846-b97e-77d4f9ac4d12
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: 850F2F2544E8494EA947C621A81F6531 Ref B: SYD03EDGE1319 Ref C: 2025-10-18T07:46:13Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/a702a9dd-f09e-4e04-8100-af239c341539
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: C853CD852F91456EBBDDBC6ED0655B2F Ref B: SYD03EDGE1906 Ref C: 2025-10-17T10:38:25Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -693,35 +1029,390 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - python/3.10.10 (Linux-5.15.0-1034-azure-x86_64-with-glibc2.31) AZURECLI/2.46.0
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_261_0
+      - python/3.9.6 (macOS-26.0.1-arm64-arm-64bit) AZURECLI/2.78.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authSettingsV2/list?api-version=2020-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettingsV2","name":"authsettingsV2","type":"Microsoft.Web/sites/config","location":"West
-        US","properties":{}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettingsV2","name":"authsettingsV2","type":"Microsoft.Web/sites/config","location":"East
+        US","properties":{"platform":{"enabled":false}}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '279'
+      - '307'
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Tue, 28 Mar 2023 11:18:01 GMT
+=======
+      - Sat, 18 Oct 2025 07:46:14 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:38:25 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
       - no-cache
-      server:
-      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/5aeccc38-1001-46ae-a4a3-f4d8717f8a49
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: D554F328CB9C4D62AAD73F2C1C9FF43E Ref B: SYD03EDGE0907 Ref C: 2025-10-18T07:46:15Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/9d1727ab-e1da-4618-9537-29f06c1560df
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 96931DE086D2475EB4FE4B745DCE48DC Ref B: SYD03EDGE1906 Ref C: 2025-10-17T10:38:26Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp auth config-version upgrade
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.9.6 (macOS-26.0.1-arm64-arm-64bit) AZURECLI/2.78.0
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authSettings/list?api-version=2020-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettings","name":"authsettings","type":"Microsoft.Web/sites/config","location":"East
+        US","properties":{"enabled":false,"unauthenticatedClientAction":null,"tokenStoreEnabled":null,"allowedExternalRedirectUrls":null,"defaultProvider":null,"clientId":null,"clientSecret":null,"clientSecretSettingName":null,"clientSecretCertificateThumbprint":null,"issuer":null,"allowedAudiences":null,"additionalLoginParams":null,"isAadAutoProvisioned":false,"aadClaimsAuthorization":null,"googleClientId":null,"googleClientSecret":null,"googleClientSecretSettingName":null,"googleOAuthScopes":null,"facebookAppId":null,"facebookAppSecret":null,"facebookAppSecretSettingName":null,"facebookOAuthScopes":null,"gitHubClientId":null,"gitHubClientSecret":null,"gitHubClientSecretSettingName":null,"gitHubOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"twitterConsumerSecretSettingName":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountClientSecretSettingName":null,"microsoftAccountOAuthScopes":null,"configVersion":"v1"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1237'
+      content-type:
+      - application/json
+      date:
+      - Fri, 17 Oct 2025 10:38:26 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/c4d15244-2e70-4991-8d47-6f9554f5ca0c
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: AA9D85D4768F4888AF953596E24FBCF0 Ref B: SYD03EDGE2115 Ref C: 2025-10-17T10:38:26Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp auth config-version upgrade
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - AZURECLI/2.78.0 azsdk-python-core/1.35.0 Python/3.9.6 (macOS-26.0.1-arm64-arm-64bit)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettings/list?api-version=2024-11-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettings","name":"authsettings","type":"Microsoft.Web/sites/config","location":"East
+        US","properties":{"enabled":false,"unauthenticatedClientAction":null,"tokenStoreEnabled":null,"allowedExternalRedirectUrls":null,"defaultProvider":null,"clientId":null,"clientSecret":null,"clientSecretSettingName":null,"clientSecretCertificateThumbprint":null,"issuer":null,"allowedAudiences":null,"additionalLoginParams":null,"isAadAutoProvisioned":false,"aadClaimsAuthorization":null,"googleClientId":null,"googleClientSecret":null,"googleClientSecretSettingName":null,"googleOAuthScopes":null,"facebookAppId":null,"facebookAppSecret":null,"facebookAppSecretSettingName":null,"facebookOAuthScopes":null,"gitHubClientId":null,"gitHubClientSecret":null,"gitHubClientSecretSettingName":null,"gitHubOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"twitterConsumerSecretSettingName":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountClientSecretSettingName":null,"microsoftAccountOAuthScopes":null,"configVersion":"v1"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1237'
+      content-type:
+      - application/json
+      date:
+      - Fri, 17 Oct 2025 10:38:29 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/australiasoutheast/219476dc-ae35-4231-a4a8-2e7a2ba1fff7
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: AC2437D2548F47DEA6B34BCE5918E5B8 Ref B: SYD03EDGE0916 Ref C: 2025-10-17T10:38:27Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp auth config-version upgrade
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.9.6 (macOS-26.0.1-arm64-arm-64bit) AZURECLI/2.78.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authSettingsV2/list?api-version=2020-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettingsV2","name":"authsettingsV2","type":"Microsoft.Web/sites/config","location":"East
+        US","properties":{"platform":{"enabled":false}}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '307'
+      content-type:
+      - application/json
+      date:
+      - Fri, 17 Oct 2025 10:38:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/australiaeast/88cd84a1-3246-4134-b3b0-2e9ded6a94eb
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 099F0C8F515F4CC4A38DD1EC47880841 Ref B: SYD03EDGE1321 Ref C: 2025-10-17T10:38:29Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp auth config-version upgrade
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.9.6 (macOS-26.0.1-arm64-arm-64bit) AZURECLI/2.78.0
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authSettings/list?api-version=2020-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettings","name":"authsettings","type":"Microsoft.Web/sites/config","location":"East
+        US","properties":{"enabled":false,"unauthenticatedClientAction":null,"tokenStoreEnabled":null,"allowedExternalRedirectUrls":null,"defaultProvider":null,"clientId":null,"clientSecret":null,"clientSecretSettingName":null,"clientSecretCertificateThumbprint":null,"issuer":null,"allowedAudiences":null,"additionalLoginParams":null,"isAadAutoProvisioned":false,"aadClaimsAuthorization":null,"googleClientId":null,"googleClientSecret":null,"googleClientSecretSettingName":null,"googleOAuthScopes":null,"facebookAppId":null,"facebookAppSecret":null,"facebookAppSecretSettingName":null,"facebookOAuthScopes":null,"gitHubClientId":null,"gitHubClientSecret":null,"gitHubClientSecretSettingName":null,"gitHubOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"twitterConsumerSecretSettingName":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountClientSecretSettingName":null,"microsoftAccountOAuthScopes":null,"configVersion":"v1"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1237'
+      content-type:
+      - application/json
+      date:
+      - Fri, 17 Oct 2025 10:38:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/8f3945dc-79f1-476d-9c37-41dc376ee618
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: 27B41F1CBBC8491EBCFEF61C6CCEB4F5 Ref B: SYD03EDGE1712 Ref C: 2025-10-17T10:38:30Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp auth config-version upgrade
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.9.6 (macOS-26.0.1-arm64-arm-64bit) AZURECLI/2.78.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authSettingsV2/list?api-version=2020-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettingsV2","name":"authsettingsV2","type":"Microsoft.Web/sites/config","location":"East
+        US","properties":{"platform":{"enabled":false}}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '307'
+      content-type:
+      - application/json
+      date:
+      - Fri, 17 Oct 2025 10:38:31 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/4cb69c7e-ca41-4944-ab2f-59d2d8644132
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: DF64F81C902448F7927E23B171FA0E41 Ref B: SYD03EDGE1313 Ref C: 2025-10-17T10:38:31Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"platform": {"enabled": false}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp auth config-version upgrade
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.9.6 (macOS-26.0.1-arm64-arm-64bit) AZURECLI/2.78.0
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authSettingsV2?api-version=2020-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettingsV2","name":"authsettingsV2","type":"Microsoft.Web/sites/config","location":"East
+        US","properties":{"platform":{"enabled":false,"runtimeVersion":"~1"},"globalValidation":{"requireAuthentication":true,"unauthenticatedClientAction":"RedirectToLoginPage"},"identityProviders":{"azureActiveDirectory":{"enabled":true,"registration":{},"login":{"disableWWWAuthenticate":false},"validation":{"jwtClaimChecks":{},"defaultAuthorizationPolicy":{"allowedPrincipals":{}}}},"facebook":{"enabled":true,"registration":{},"login":{}},"gitHub":{"enabled":true,"registration":{},"login":{}},"google":{"enabled":true,"registration":{},"login":{},"validation":{}},"twitter":{"enabled":true,"registration":{}},"legacyMicrosoftAccount":{"enabled":true,"registration":{},"login":{},"validation":{}},"apple":{"enabled":true,"registration":{},"login":{}}},"login":{"routes":{},"tokenStore":{"enabled":false,"tokenRefreshExtensionHours":72.0,"fileSystem":{},"azureBlobStorage":{}},"preserveUrlFragmentsForLogins":false,"cookieExpiration":{"convention":"FixedTime","timeToExpiration":"08:00:00"},"nonce":{"validateNonce":true,"nonceExpirationInterval":"00:05:00"}},"httpSettings":{"requireHttps":true,"routes":{"apiPrefix":"/.auth"},"forwardProxy":{"convention":"NoProxy"}},"clearInboundClaimsMapping":"false"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1462'
+      content-type:
+      - application/json
+      date:
+      - Fri, 17 Oct 2025 10:38:32 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/dfb86deb-ed87-41ef-86ad-a1be1b9dd41a
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '11999'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: D6AAA7D4B4D543DB9ACCCE891AF8DC2E Ref B: SYD03EDGE1913 Ref C: 2025-10-17T10:38:31Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -741,39 +1432,40 @@ interactions:
       ParameterSetName:
       - -g -n --enabled --runtime-version
       User-Agent:
-      - python/3.10.10 (Linux-5.15.0-1034-azure-x86_64-with-glibc2.31) AZURECLI/2.46.0
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_261_0
+      - python/3.9.6 (macOS-26.0.1-arm64-arm-64bit) AZURECLI/2.78.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authSettingsV2/list?api-version=2020-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettingsV2","name":"authsettingsV2","type":"Microsoft.Web/sites/config","location":"West
-        US","properties":{}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettingsV2","name":"authsettingsV2","type":"Microsoft.Web/sites/config","location":"East
+        US","properties":{"platform":{"enabled":false,"runtimeVersion":"~1"},"globalValidation":{"requireAuthentication":true,"unauthenticatedClientAction":"RedirectToLoginPage"},"identityProviders":{"azureActiveDirectory":{"enabled":true,"registration":{},"login":{"disableWWWAuthenticate":false},"validation":{"jwtClaimChecks":{},"defaultAuthorizationPolicy":{"allowedPrincipals":{}}}},"facebook":{"enabled":true,"registration":{},"login":{}},"gitHub":{"enabled":true,"registration":{},"login":{}},"google":{"enabled":true,"registration":{},"login":{},"validation":{}},"twitter":{"enabled":true,"registration":{}},"legacyMicrosoftAccount":{"enabled":true,"registration":{},"login":{},"validation":{}},"apple":{"enabled":true,"registration":{},"login":{}}},"login":{"routes":{},"tokenStore":{"enabled":false,"tokenRefreshExtensionHours":72.0,"fileSystem":{},"azureBlobStorage":{}},"preserveUrlFragmentsForLogins":false,"cookieExpiration":{"convention":"FixedTime","timeToExpiration":"08:00:00"},"nonce":{"validateNonce":true,"nonceExpirationInterval":"00:05:00"}},"httpSettings":{"requireHttps":true,"routes":{"apiPrefix":"/.auth"},"forwardProxy":{"convention":"NoProxy"}},"clearInboundClaimsMapping":"false"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '279'
+      - '1462'
       content-type:
       - application/json
       date:
-      - Tue, 28 Mar 2023 11:18:04 GMT
+      - Fri, 17 Oct 2025 10:38:33 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
-      server:
-      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/677395ed-c8d8-4738-a85b-38f3f7830aec
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 8066404DBE3A4ED7A01BD869208EDA9B Ref B: SYD03EDGE0720 Ref C: 2025-10-17T10:38:33Z'
       x-powered-by:
       - ASP.NET
     status:
@@ -795,13 +1487,80 @@ interactions:
       ParameterSetName:
       - -g -n --enabled --runtime-version
       User-Agent:
-      - python/3.10.10 (Linux-5.15.0-1034-azure-x86_64-with-glibc2.31) AZURECLI/2.46.0
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_261_0
+      - python/3.9.6 (macOS-26.0.1-arm64-arm-64bit) AZURECLI/2.78.0
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authSettings/list?api-version=2020-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettings","name":"authsettings","type":"Microsoft.Web/sites/config","location":"West
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettings","name":"authsettings","type":"Microsoft.Web/sites/config","location":"East
+        US","properties":{"enabled":false,"unauthenticatedClientAction":null,"tokenStoreEnabled":null,"allowedExternalRedirectUrls":null,"defaultProvider":null,"clientId":null,"clientSecret":null,"clientSecretSettingName":null,"clientSecretCertificateThumbprint":null,"issuer":null,"allowedAudiences":null,"additionalLoginParams":null,"isAadAutoProvisioned":false,"aadClaimsAuthorization":null,"googleClientId":null,"googleClientSecret":null,"googleClientSecretSettingName":null,"googleOAuthScopes":null,"facebookAppId":null,"facebookAppSecret":null,"facebookAppSecretSettingName":null,"facebookOAuthScopes":null,"gitHubClientId":null,"gitHubClientSecret":null,"gitHubClientSecretSettingName":null,"gitHubOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"twitterConsumerSecretSettingName":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountClientSecretSettingName":null,"microsoftAccountOAuthScopes":null,"isAuthFromFile":"False","configVersion":"v2"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1262'
+      content-type:
+      - application/json
+      date:
+<<<<<<< HEAD
+<<<<<<< HEAD
+      - Tue, 28 Mar 2023 11:18:05 GMT
+=======
+      - Sat, 18 Oct 2025 07:46:16 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:38:33 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+<<<<<<< HEAD
+<<<<<<< HEAD
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/4cc6c4aa-a805-485a-a120-4b74faf37e6f
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: 9D7B99AEDD2B491E92D5C5DD794F7E1D Ref B: SYD03EDGE1014 Ref C: 2025-10-18T07:46:16Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp auth config-version upgrade
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - AZURECLI/2.78.0 azsdk-python-core/1.35.0 Python/3.9.6 (macOS-26.0.1-arm64-arm-64bit)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettings/list?api-version=2024-11-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettings","name":"authsettings","type":"Microsoft.Web/sites/config","location":"East
         US","properties":{"enabled":false,"unauthenticatedClientAction":null,"tokenStoreEnabled":null,"allowedExternalRedirectUrls":null,"defaultProvider":null,"clientId":null,"clientSecret":null,"clientSecretSettingName":null,"clientSecretCertificateThumbprint":null,"issuer":null,"allowedAudiences":null,"additionalLoginParams":null,"isAadAutoProvisioned":false,"aadClaimsAuthorization":null,"googleClientId":null,"googleClientSecret":null,"googleClientSecretSettingName":null,"googleOAuthScopes":null,"facebookAppId":null,"facebookAppSecret":null,"facebookAppSecretSettingName":null,"facebookOAuthScopes":null,"gitHubClientId":null,"gitHubClientSecret":null,"gitHubClientSecretSettingName":null,"gitHubOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"twitterConsumerSecretSettingName":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountClientSecretSettingName":null,"microsoftAccountOAuthScopes":null,"configVersion":"v1"}}'
     headers:
       cache-control:
@@ -811,25 +1570,254 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 28 Mar 2023 11:18:05 GMT
+      - Sat, 18 Oct 2025 07:46:18 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
-      server:
-      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/australiaeast/cbb30336-f1d0-4c64-9ff9-1ad07cee1f7b
       x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: 3A028609429044DB90458EF599ED9804 Ref B: SYD03EDGE2122 Ref C: 2025-10-18T07:46:17Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp auth config-version upgrade
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.9.6 (macOS-26.0.1-arm64-arm-64bit) AZURECLI/2.78.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authSettingsV2/list?api-version=2020-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettingsV2","name":"authsettingsV2","type":"Microsoft.Web/sites/config","location":"East
+        US","properties":{"platform":{"enabled":false}}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '307'
+      content-type:
+      - application/json
+      date:
+      - Sat, 18 Oct 2025 07:46:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/771a3396-9a61-45a7-ae2f-d5c960602a6a
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: EEA3A3106F944E68A98AE56B7ED3F38B Ref B: SYD03EDGE1920 Ref C: 2025-10-18T07:46:19Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp auth config-version upgrade
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.9.6 (macOS-26.0.1-arm64-arm-64bit) AZURECLI/2.78.0
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authSettings/list?api-version=2020-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettings","name":"authsettings","type":"Microsoft.Web/sites/config","location":"East
+        US","properties":{"enabled":false,"unauthenticatedClientAction":null,"tokenStoreEnabled":null,"allowedExternalRedirectUrls":null,"defaultProvider":null,"clientId":null,"clientSecret":null,"clientSecretSettingName":null,"clientSecretCertificateThumbprint":null,"issuer":null,"allowedAudiences":null,"additionalLoginParams":null,"isAadAutoProvisioned":false,"aadClaimsAuthorization":null,"googleClientId":null,"googleClientSecret":null,"googleClientSecretSettingName":null,"googleOAuthScopes":null,"facebookAppId":null,"facebookAppSecret":null,"facebookAppSecretSettingName":null,"facebookOAuthScopes":null,"gitHubClientId":null,"gitHubClientSecret":null,"gitHubClientSecretSettingName":null,"gitHubOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"twitterConsumerSecretSettingName":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountClientSecretSettingName":null,"microsoftAccountOAuthScopes":null,"configVersion":"v1"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1237'
+      content-type:
+      - application/json
+      date:
+      - Sat, 18 Oct 2025 07:46:20 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/80143565-ad32-4267-ab82-bd1fbb97253b
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: CB3696F771034D9D92C519A3D3DEE34C Ref B: SYD03EDGE1005 Ref C: 2025-10-18T07:46:19Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp auth config-version upgrade
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.9.6 (macOS-26.0.1-arm64-arm-64bit) AZURECLI/2.78.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authSettingsV2/list?api-version=2020-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettingsV2","name":"authsettingsV2","type":"Microsoft.Web/sites/config","location":"East
+        US","properties":{"platform":{"enabled":false}}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '307'
+      content-type:
+      - application/json
+      date:
+      - Sat, 18 Oct 2025 07:46:20 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/36ac5358-094d-48b7-88a6-f056cac94d6b
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 3F3696C5CFBC4206886266B2AA5A8111 Ref B: SYD03EDGE0715 Ref C: 2025-10-18T07:46:20Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"platform": {"enabled": false}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp auth config-version upgrade
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.9.6 (macOS-26.0.1-arm64-arm-64bit) AZURECLI/2.78.0
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authSettingsV2?api-version=2020-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettingsV2","name":"authsettingsV2","type":"Microsoft.Web/sites/config","location":"East
+        US","properties":{"platform":{"enabled":false,"runtimeVersion":"~1"},"globalValidation":{"requireAuthentication":true,"unauthenticatedClientAction":"RedirectToLoginPage"},"identityProviders":{"azureActiveDirectory":{"enabled":true,"registration":{},"login":{"disableWWWAuthenticate":false},"validation":{"jwtClaimChecks":{},"defaultAuthorizationPolicy":{"allowedPrincipals":{}}}},"facebook":{"enabled":true,"registration":{},"login":{}},"gitHub":{"enabled":true,"registration":{},"login":{}},"google":{"enabled":true,"registration":{},"login":{},"validation":{}},"twitter":{"enabled":true,"registration":{}},"legacyMicrosoftAccount":{"enabled":true,"registration":{},"login":{},"validation":{}},"apple":{"enabled":true,"registration":{},"login":{}}},"login":{"routes":{},"tokenStore":{"enabled":false,"tokenRefreshExtensionHours":72.0,"fileSystem":{},"azureBlobStorage":{}},"preserveUrlFragmentsForLogins":false,"cookieExpiration":{"convention":"FixedTime","timeToExpiration":"08:00:00"},"nonce":{"validateNonce":true,"nonceExpirationInterval":"00:05:00"}},"httpSettings":{"requireHttps":true,"routes":{"apiPrefix":"/.auth"},"forwardProxy":{"convention":"NoProxy"}},"clearInboundClaimsMapping":"false"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1462'
+      content-type:
+      - application/json
+      date:
+      - Sat, 18 Oct 2025 07:46:22 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/f4d06da7-5104-45cb-837c-f6a43307f807
+      x-ms-ratelimit-remaining-subscription-global-writes:
       - '11999'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: 1C7C0FDEE72249029F80EA871C7B3E13 Ref B: SYD03EDGE1013 Ref C: 2025-10-18T07:46:21Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/ad6c98cd-4e0a-4e38-a23f-9089cde8ce99
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: C513CE76197B494B9AD985240F09655C Ref B: SYD03EDGE0906 Ref C: 2025-10-17T10:38:33Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -849,47 +1837,58 @@ interactions:
       ParameterSetName:
       - -g -n --enabled --runtime-version
       User-Agent:
-      - python/3.10.10 (Linux-5.15.0-1034-azure-x86_64-with-glibc2.31) AZURECLI/2.46.0
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_261_0
+      - python/3.9.6 (macOS-26.0.1-arm64-arm-64bit) AZURECLI/2.78.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authSettingsV2/list?api-version=2020-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettingsV2","name":"authsettingsV2","type":"Microsoft.Web/sites/config","location":"West
-        US","properties":{}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettingsV2","name":"authsettingsV2","type":"Microsoft.Web/sites/config","location":"East
+        US","properties":{"platform":{"enabled":false,"runtimeVersion":"~1"},"globalValidation":{"requireAuthentication":true,"unauthenticatedClientAction":"RedirectToLoginPage"},"identityProviders":{"azureActiveDirectory":{"enabled":true,"registration":{},"login":{"disableWWWAuthenticate":false},"validation":{"jwtClaimChecks":{},"defaultAuthorizationPolicy":{"allowedPrincipals":{}}}},"facebook":{"enabled":true,"registration":{},"login":{}},"gitHub":{"enabled":true,"registration":{},"login":{}},"google":{"enabled":true,"registration":{},"login":{},"validation":{}},"twitter":{"enabled":true,"registration":{}},"legacyMicrosoftAccount":{"enabled":true,"registration":{},"login":{},"validation":{}},"apple":{"enabled":true,"registration":{},"login":{}}},"login":{"routes":{},"tokenStore":{"enabled":false,"tokenRefreshExtensionHours":72.0,"fileSystem":{},"azureBlobStorage":{}},"preserveUrlFragmentsForLogins":false,"cookieExpiration":{"convention":"FixedTime","timeToExpiration":"08:00:00"},"nonce":{"validateNonce":true,"nonceExpirationInterval":"00:05:00"}},"httpSettings":{"requireHttps":true,"routes":{"apiPrefix":"/.auth"},"forwardProxy":{"convention":"NoProxy"}},"clearInboundClaimsMapping":"false"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '279'
+      - '1462'
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Tue, 28 Mar 2023 11:18:05 GMT
+=======
+      - Sat, 18 Oct 2025 07:46:23 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:38:34 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
       - no-cache
-      server:
-      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/9915ccd9-3e5d-433a-aab8-5599dfc0d512
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: E149F8C94A574D8FA6E4B46BD98B82D8 Ref B: SYD03EDGE0708 Ref C: 2025-10-18T07:46:23Z'
       x-powered-by:
       - ASP.NET
     status:
       code: 200
       message: OK
 - request:
-    body: '{"properties": {"platform": {"enabled": "true", "runtimeVersion": "1.2.8"},
-      "login": {"tokenStore": {"enabled": true}}}}'
+    body: null
     headers:
       Accept:
       - '*/*'
@@ -900,49 +1899,206 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '120'
+      - '0'
+      ParameterSetName:
+      - -g -n --enabled --runtime-version
+      User-Agent:
+      - python/3.9.6 (macOS-26.0.1-arm64-arm-64bit) AZURECLI/2.78.0
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authSettings/list?api-version=2020-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettings","name":"authsettings","type":"Microsoft.Web/sites/config","location":"East
+        US","properties":{"enabled":false,"unauthenticatedClientAction":null,"tokenStoreEnabled":null,"allowedExternalRedirectUrls":null,"defaultProvider":null,"clientId":null,"clientSecret":null,"clientSecretSettingName":null,"clientSecretCertificateThumbprint":null,"issuer":null,"allowedAudiences":null,"additionalLoginParams":null,"isAadAutoProvisioned":false,"aadClaimsAuthorization":null,"googleClientId":null,"googleClientSecret":null,"googleClientSecretSettingName":null,"googleOAuthScopes":null,"facebookAppId":null,"facebookAppSecret":null,"facebookAppSecretSettingName":null,"facebookOAuthScopes":null,"gitHubClientId":null,"gitHubClientSecret":null,"gitHubClientSecretSettingName":null,"gitHubOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"twitterConsumerSecretSettingName":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountClientSecretSettingName":null,"microsoftAccountOAuthScopes":null,"isAuthFromFile":"False","configVersion":"v2"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1262'
+      content-type:
+      - application/json
+      date:
+      - Sat, 18 Oct 2025 07:46:23 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/5c429891-0fdf-4898-b6d3-ef12b4c19751
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: 9E0960B767D346DFA47629388A7A38D6 Ref B: SYD03EDGE1314 Ref C: 2025-10-18T07:46:23Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp auth update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --enabled --runtime-version
+      User-Agent:
+      - python/3.9.6 (macOS-26.0.1-arm64-arm-64bit) AZURECLI/2.78.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authSettingsV2/list?api-version=2020-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettingsV2","name":"authsettingsV2","type":"Microsoft.Web/sites/config","location":"East
+        US","properties":{"platform":{"enabled":false,"runtimeVersion":"~1"},"globalValidation":{"requireAuthentication":true,"unauthenticatedClientAction":"RedirectToLoginPage"},"identityProviders":{"azureActiveDirectory":{"enabled":true,"registration":{},"login":{"disableWWWAuthenticate":false},"validation":{"jwtClaimChecks":{},"defaultAuthorizationPolicy":{"allowedPrincipals":{}}}},"facebook":{"enabled":true,"registration":{},"login":{}},"gitHub":{"enabled":true,"registration":{},"login":{}},"google":{"enabled":true,"registration":{},"login":{},"validation":{}},"twitter":{"enabled":true,"registration":{}},"legacyMicrosoftAccount":{"enabled":true,"registration":{},"login":{},"validation":{}},"apple":{"enabled":true,"registration":{},"login":{}}},"login":{"routes":{},"tokenStore":{"enabled":false,"tokenRefreshExtensionHours":72.0,"fileSystem":{},"azureBlobStorage":{}},"preserveUrlFragmentsForLogins":false,"cookieExpiration":{"convention":"FixedTime","timeToExpiration":"08:00:00"},"nonce":{"validateNonce":true,"nonceExpirationInterval":"00:05:00"}},"httpSettings":{"requireHttps":true,"routes":{"apiPrefix":"/.auth"},"forwardProxy":{"convention":"NoProxy"}},"clearInboundClaimsMapping":"false"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1462'
+      content-type:
+      - application/json
+      date:
+      - Sat, 18 Oct 2025 07:46:24 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/139c0ce5-5646-4d7a-9eaa-c0b2af963529
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: C8B6A76F9A804F2D90F97E68DC5B6EC9 Ref B: SYD03EDGE1914 Ref C: 2025-10-18T07:46:24Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/95febbfa-a009-4482-997d-9394da3f5cf2
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 7201A510E763437381FFCCACE0A06E28 Ref B: SYD03EDGE2119 Ref C: 2025-10-17T10:38:34Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"platform": {"enabled": "true", "runtimeVersion": "1.2.8"},
+      "globalValidation": {"requireAuthentication": true, "unauthenticatedClientAction":
+      "RedirectToLoginPage"}, "identityProviders": {"azureActiveDirectory": {"enabled":
+      true, "registration": {}, "login": {"disableWWWAuthenticate": false}, "validation":
+      {"jwtClaimChecks": {}, "defaultAuthorizationPolicy": {"allowedPrincipals": {}}}},
+      "facebook": {"enabled": true, "registration": {}, "login": {}}, "gitHub": {"enabled":
+      true, "registration": {}, "login": {}}, "google": {"enabled": true, "registration":
+      {}, "login": {}, "validation": {}}, "twitter": {"enabled": true, "registration":
+      {}}, "legacyMicrosoftAccount": {"enabled": true, "registration": {}, "login":
+      {}, "validation": {}}, "apple": {"enabled": true, "registration": {}, "login":
+      {}}}, "login": {"routes": {}, "tokenStore": {"enabled": false, "tokenRefreshExtensionHours":
+      72.0, "fileSystem": {}, "azureBlobStorage": {}}, "preserveUrlFragmentsForLogins":
+      false, "cookieExpiration": {"convention": "FixedTime", "timeToExpiration": "08:00:00"},
+      "nonce": {"validateNonce": true, "nonceExpirationInterval": "00:05:00"}}, "httpSettings":
+      {"requireHttps": true, "routes": {"apiPrefix": "/.auth"}, "forwardProxy": {"convention":
+      "NoProxy"}}, "clearInboundClaimsMapping": "false"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp auth update
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1308'
       Content-Type:
       - application/json
       ParameterSetName:
       - -g -n --enabled --runtime-version
       User-Agent:
-      - python/3.10.10 (Linux-5.15.0-1034-azure-x86_64-with-glibc2.31) AZURECLI/2.46.0
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_261_0
+      - python/3.9.6 (macOS-26.0.1-arm64-arm-64bit) AZURECLI/2.78.0
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authSettingsV2?api-version=2020-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettingsV2","name":"authsettingsV2","type":"Microsoft.Web/sites/config","location":"West
-        US","properties":{"platform":{"enabled":true,"runtimeVersion":"1.2.8"},"globalValidation":{"requireAuthentication":true,"unauthenticatedClientAction":"RedirectToLoginPage"},"identityProviders":{"azureActiveDirectory":{"enabled":true,"registration":{},"login":{"disableWWWAuthenticate":false},"validation":{"jwtClaimChecks":{},"defaultAuthorizationPolicy":{"allowedPrincipals":{}}}},"facebook":{"enabled":true,"registration":{},"login":{}},"gitHub":{"enabled":true,"registration":{},"login":{}},"google":{"enabled":true,"registration":{},"login":{},"validation":{}},"twitter":{"enabled":true,"registration":{}},"legacyMicrosoftAccount":{"enabled":true,"registration":{},"login":{},"validation":{}},"apple":{"enabled":true,"registration":{},"login":{}}},"login":{"routes":{},"tokenStore":{"enabled":true,"tokenRefreshExtensionHours":72.0,"fileSystem":{},"azureBlobStorage":{}},"preserveUrlFragmentsForLogins":false,"cookieExpiration":{"convention":"FixedTime","timeToExpiration":"08:00:00"},"nonce":{"validateNonce":true,"nonceExpirationInterval":"00:05:00"}},"httpSettings":{"requireHttps":true,"routes":{"apiPrefix":"/.auth"},"forwardProxy":{"convention":"NoProxy"}}}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettingsV2","name":"authsettingsV2","type":"Microsoft.Web/sites/config","location":"East
+        US","properties":{"platform":{"enabled":true,"runtimeVersion":"1.2.8"},"globalValidation":{"requireAuthentication":true,"unauthenticatedClientAction":"RedirectToLoginPage"},"identityProviders":{"azureActiveDirectory":{"enabled":true,"registration":{},"login":{"disableWWWAuthenticate":false},"validation":{"jwtClaimChecks":{},"defaultAuthorizationPolicy":{"allowedPrincipals":{},"allowedApplications":[]}}},"facebook":{"enabled":true,"registration":{},"login":{}},"gitHub":{"enabled":true,"registration":{},"login":{}},"google":{"enabled":true,"registration":{},"login":{},"validation":{}},"twitter":{"enabled":true,"registration":{}},"legacyMicrosoftAccount":{"enabled":true,"registration":{},"login":{},"validation":{}},"apple":{"enabled":true,"registration":{},"login":{}}},"login":{"routes":{},"tokenStore":{"enabled":false,"tokenRefreshExtensionHours":72.0,"fileSystem":{},"azureBlobStorage":{}},"preserveUrlFragmentsForLogins":false,"cookieExpiration":{"convention":"FixedTime","timeToExpiration":"08:00:00"},"nonce":{"validateNonce":true,"nonceExpirationInterval":"00:05:00"}},"httpSettings":{"requireHttps":true,"routes":{"apiPrefix":"/.auth"},"forwardProxy":{"convention":"NoProxy"}},"clearInboundClaimsMapping":"false"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1427'
+      - '1489'
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Tue, 28 Mar 2023 11:18:27 GMT
       etag:
       - '"1D96166F84D1520"'
+=======
+      - Sat, 18 Oct 2025 07:46:25 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:38:36 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
       - no-cache
-      server:
-      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+<<<<<<< HEAD
+<<<<<<< HEAD
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/0e5f230c-59b3-435a-a6ef-31194dd62da8
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '11999'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: 23DEF3DED493462ABFE2FCDF89D09C09 Ref B: SYD03EDGE1714 Ref C: 2025-10-18T07:46:25Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/5569d45e-1163-4bc8-a91a-edbf30f37830
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '11999'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: A17D71BC5016403B8F9A60AD93DAF01E Ref B: SYD03EDGE2015 Ref C: 2025-10-17T10:38:35Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:

--- a/src/authV2/azext_authV2/tests/latest/recordings/test_authV2_authclassic.yaml
+++ b/src/authV2/azext_authV2/tests/latest/recordings/test_authV2_authclassic.yaml
@@ -1,52 +1,6 @@
 interactions:
 - request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - appservice plan create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --sku
-      User-Agent:
-      - AZURECLI/2.67.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_authV2000001?api-version=2022-09-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001","name":"cli_test_authV2000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_authV2_authclassic","date":"2024-12-05T03:37:51Z","module":"authV2"},"properties":{"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '371'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 05 Dec 2024 03:38:02 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-cache:
-      - CONFIG_NOCACHE
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-global-reads:
-      - '3749'
-      x-msedge-ref:
-      - 'Ref A: A2D7B5D938104D569979D2973F8F3561 Ref B: MAA201060514033 Ref C: 2024-12-05T03:38:02Z'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"location": "westus", "sku": {"name": "S1", "tier": "STANDARD", "capacity":
+    body: '{"location": "eastus", "sku": {"name": "S1", "tier": "STANDARD", "capacity":
       1}, "properties": {"perSiteScaling": false, "isXenon": false, "zoneRedundant":
       false}}'
     headers:
@@ -65,24 +19,52 @@ interactions:
       ParameterSetName:
       - -g -n --sku
       User-Agent:
-      - AZURECLI/2.67.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.78.0 azsdk-python-core/1.35.0 Python/3.9.6 (macOS-26.0.1-arm64-arm-64bit)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003?api-version=2023-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003?api-version=2024-11-01
   response:
     body:
+<<<<<<< HEAD
+<<<<<<< HEAD
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003","name":"webapp-authentication-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"westus","properties":{"serverFarmId":62125,"name":"webapp-authentication-plan000003","sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1},"workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"cli_test_authV2000001-WestUSwebspace","subscription":"00000000-0000-0000-0000-000000000000","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":0,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
         US","perSiteScaling":false,"elasticScaleEnabled":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"cli_test_authV2000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-bay-137_62125","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null,"kubeEnvironmentProfile":null,"zoneRedundant":false,"migrateToVMSS":null,"vnetConnectionsUsed":null,"vnetConnectionsMax":null,"createdTime":"2024-12-05T03:38:08.6366667"},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'
+=======
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003","name":"webapp-authentication-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"eastus","properties":{"serverFarmId":63732,"name":"webapp-authentication-plan000003","sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1},"workerSize":"Small","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Small","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"cli_test_authV2000001-EastUSwebspace","subscription":"9e223dbe-3399-4e19-88eb-0975f02ac87f","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":0,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"East
+        US","perSiteScaling":false,"elasticScaleEnabled":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"cli_test_authV2000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-blu-511_63732","targetWorkerCount":0,"targetWorkerSizeId":0,"targetWorkerSku":null,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null,"kubeEnvironmentProfile":null,"zoneRedundant":false,"maximumNumberOfZones":3,"currentNumberOfZonesUtilized":1,"migrateToVMSS":null,"vnetConnectionsUsed":null,"vnetConnectionsMax":null,"createdTime":"2025-10-18T07:46:37.07","asyncScalingEnabled":false,"isCustomMode":null,"powerState":null,"eligibleLogCategories":null},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003","name":"webapp-authentication-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"eastus","properties":{"serverFarmId":66639,"name":"webapp-authentication-plan000003","sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1},"workerSize":"Small","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Small","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"cli_test_authV2000001-EastUSwebspace","subscription":"9e223dbe-3399-4e19-88eb-0975f02ac87f","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":0,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"East
+        US","perSiteScaling":false,"elasticScaleEnabled":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"cli_test_authV2000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-blu-497_66639","targetWorkerCount":0,"targetWorkerSizeId":0,"targetWorkerSku":null,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null,"kubeEnvironmentProfile":null,"zoneRedundant":false,"maximumNumberOfZones":3,"currentNumberOfZonesUtilized":1,"migrateToVMSS":null,"vnetConnectionsUsed":null,"vnetConnectionsMax":null,"createdTime":"2025-10-17T10:38:45.7866667","asyncScalingEnabled":false,"isCustomMode":null,"powerState":null,"eligibleLogCategories":null},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
     headers:
       cache-control:
       - no-cache
       content-length:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - '1662'
+=======
+      - '1834'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       content-type:
       - application/json
       date:
-      - Thu, 05 Dec 2024 03:38:12 GMT
+      - Fri, 17 Oct 2025 10:38:47 GMT
       etag:
+<<<<<<< HEAD
       - '"1DB46C71A5F07B5"'
+=======
+      - '1829'
+      content-type:
+      - application/json
+      date:
+      - Sat, 18 Oct 2025 07:46:40 GMT
+      etag:
+      - '"1DC400355868DF5"'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - '"1DC3F523768F88B"'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -95,12 +77,30 @@ interactions:
       - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/95c8e0b6-6fb2-4a50-b83a-aa8d913b5d39
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/700240ec-bcec-4966-af6f-05bd59e64938
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-ms-ratelimit-remaining-subscription-global-writes:
-      - '2999'
+      - '12000'
       x-ms-ratelimit-remaining-subscription-writes:
-      - '199'
+      - '800'
       x-msedge-ref:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - 'Ref A: 5FC5AE35DE024A9593A5BF461DB6164F Ref B: MAA201060515019 Ref C: 2024-12-05T03:38:03Z'
+=======
+      - 'Ref A: B815168EF0E94EC1BCA071D4A9546590 Ref B: SYD03EDGE2110 Ref C: 2025-10-18T07:46:29Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - 'Ref A: 5CE2B399D4164F739512237ACF5F9DB5 Ref B: SYD03EDGE0917 Ref C: 2025-10-17T10:38:38Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -120,23 +120,51 @@ interactions:
       ParameterSetName:
       - -g -n --plan
       User-Agent:
-      - AZURECLI/2.67.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.78.0 azsdk-python-core/1.35.0 Python/3.9.6 (macOS-26.0.1-arm64-arm-64bit)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003?api-version=2023-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003?api-version=2024-11-01
   response:
     body:
+<<<<<<< HEAD
+<<<<<<< HEAD
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003","name":"webapp-authentication-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
         US","properties":{"serverFarmId":62125,"name":"webapp-authentication-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"cli_test_authV2000001-WestUSwebspace","subscription":"00000000-0000-0000-0000-000000000000","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
         US","perSiteScaling":false,"elasticScaleEnabled":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"cli_test_authV2000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-bay-137_62125","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null,"kubeEnvironmentProfile":null,"zoneRedundant":false,"migrateToVMSS":null,"vnetConnectionsUsed":0,"vnetConnectionsMax":2,"createdTime":"2024-12-05T03:38:08.6366667"},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'
+=======
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003","name":"webapp-authentication-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"East
+        US","properties":{"serverFarmId":63732,"name":"webapp-authentication-plan000003","workerSize":"Small","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Small","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"cli_test_authV2000001-EastUSwebspace","subscription":"9e223dbe-3399-4e19-88eb-0975f02ac87f","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"East
+        US","perSiteScaling":false,"elasticScaleEnabled":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"cli_test_authV2000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-blu-511_63732","targetWorkerCount":0,"targetWorkerSizeId":0,"targetWorkerSku":null,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null,"kubeEnvironmentProfile":null,"zoneRedundant":false,"maximumNumberOfZones":3,"currentNumberOfZonesUtilized":1,"migrateToVMSS":null,"vnetConnectionsUsed":0,"vnetConnectionsMax":2,"createdTime":"2025-10-18T07:46:37.07","asyncScalingEnabled":false,"isCustomMode":null,"powerState":null,"eligibleLogCategories":null},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003","name":"webapp-authentication-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"East
+        US","properties":{"serverFarmId":66639,"name":"webapp-authentication-plan000003","workerSize":"Small","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Small","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"cli_test_authV2000001-EastUSwebspace","subscription":"9e223dbe-3399-4e19-88eb-0975f02ac87f","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"East
+        US","perSiteScaling":false,"elasticScaleEnabled":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"cli_test_authV2000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-blu-497_66639","targetWorkerCount":0,"targetWorkerSizeId":0,"targetWorkerSku":null,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null,"kubeEnvironmentProfile":null,"zoneRedundant":false,"maximumNumberOfZones":3,"currentNumberOfZonesUtilized":1,"migrateToVMSS":null,"vnetConnectionsUsed":0,"vnetConnectionsMax":2,"createdTime":"2025-10-17T10:38:45.7866667","asyncScalingEnabled":false,"isCustomMode":null,"powerState":null,"eligibleLogCategories":null},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
     headers:
       cache-control:
       - no-cache
       content-length:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - '1582'
       content-type:
       - application/json
       date:
       - Thu, 05 Dec 2024 03:38:16 GMT
+=======
+      - '1749'
+      content-type:
+      - application/json
+      date:
+      - Sat, 18 Oct 2025 07:46:41 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - '1754'
+      content-type:
+      - application/json
+      date:
+      - Fri, 17 Oct 2025 10:38:48 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -150,9 +178,17 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-global-reads:
-      - '3749'
+      - '16499'
       x-msedge-ref:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - 'Ref A: 6645377FB0444EB8B91843AB5B22693B Ref B: MAA201060514019 Ref C: 2024-12-05T03:38:16Z'
+=======
+      - 'Ref A: 7C24977A5C1A44F1AFA22D25659DD825 Ref B: SYD03EDGE1113 Ref C: 2025-10-18T07:46:41Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - 'Ref A: 429CFB8485434F11916884D07CF152D6 Ref B: SYD03EDGE0917 Ref C: 2025-10-17T10:38:48Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -176,9 +212,9 @@ interactions:
       ParameterSetName:
       - -g -n --plan
       User-Agent:
-      - AZURECLI/2.67.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.78.0 azsdk-python-core/1.35.0 Python/3.9.6 (macOS-26.0.1-arm64-arm-64bit)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/checknameavailability?api-version=2023-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/checknameavailability?api-version=2024-11-01
   response:
     body:
       string: '{"nameAvailable":true,"reason":"","message":""}'
@@ -190,7 +226,15 @@ interactions:
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Thu, 05 Dec 2024 03:38:17 GMT
+=======
+      - Sat, 18 Oct 2025 07:46:42 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:38:50 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -203,10 +247,28 @@ interactions:
       - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/4a946c77-2fb9-4425-b4a2-d935142608ae
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/2a5e7274-6e5e-4310-86a3-d97bfd242dec
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-ms-ratelimit-remaining-subscription-global-reads:
-      - '3749'
+      - '16499'
       x-msedge-ref:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - 'Ref A: 6BEF6D59848840178FC7D01C4F24AAAC Ref B: MAA201060515045 Ref C: 2024-12-05T03:38:17Z'
+=======
+      - 'Ref A: F38B1483EBA8483984AD77CCBD6AA8B8 Ref B: SYD03EDGE1707 Ref C: 2025-10-18T07:46:42Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - 'Ref A: 7055521C40944B1EA8CABC55DE68C277 Ref B: SYD03EDGE1409 Ref C: 2025-10-17T10:38:49Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -226,16 +288,18 @@ interactions:
       ParameterSetName:
       - -g -n --plan
       User-Agent:
-      - AZURECLI/2.67.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.78.0 azsdk-python-core/1.35.0 Python/3.9.6 (macOS-26.0.1-arm64-arm-64bit)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.Web/webAppStacks?api-version=2023-01-01
+    uri: https://management.azure.com/providers/Microsoft.Web/webAppStacks?api-version=2024-11-01
   response:
     body:
       string: '{"value":[{"id":null,"name":"dotnet","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":".NET","value":"dotnet","preferredOs":"windows","majorVersions":[{"displayText":".NET
-        9 (STS)","value":"dotnet9","minorVersions":[{"displayText":".NET 9 (STS)","value":"9","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v9.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"9.x"}},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|9.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"9.x"},"supportedFeatures":{"disableSsh":true}}}}]},{"displayText":".NET
-        8 (LTS)","value":"dotnet8","minorVersions":[{"displayText":".NET 8 (LTS)","value":"8","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v8.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.x"}},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|8.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.x"},"supportedFeatures":{"disableSsh":true}}}}]},{"displayText":".NET
-        7 (STS)","value":"dotnet7","minorVersions":[{"displayText":".NET 7 (STS)","value":"7","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v7.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"7.x"},"endOfLifeDate":"2024-05-14T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|7.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"7.x"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2024-05-14T00:00:00Z"}}}]},{"displayText":".NET
-        6","value":"dotnet6","minorVersions":[{"displayText":".NET 6 (LTS)","value":"6","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v6.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"6.0.x"}},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|6.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"6.0.x"},"supportedFeatures":{"disableSsh":true}}}}]},{"displayText":".NET
+        10 (LTS)","value":"dotnet10","minorVersions":[{"displayText":".NET 10 (LTS)
+        (Preview)","value":"10","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v10.0","remoteDebuggingSupported":false,"isHidden":false,"isPreview":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"10.x"},"endOfLifeDate":"2028-12-01T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|10.0","remoteDebuggingSupported":false,"isHidden":false,"isPreview":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"10.x"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2028-12-01T00:00:00Z"}}}]},{"displayText":".NET
+        9 (STS)","value":"dotnet9","minorVersions":[{"displayText":".NET 9 (STS)","value":"9","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v9.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"9.x"},"endOfLifeDate":"2026-05-12T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|9.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"9.x"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2026-05-12T00:00:00Z"}}}]},{"displayText":".NET
+        8 (LTS)","value":"dotnet8","minorVersions":[{"displayText":".NET 8 (LTS)","value":"8","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v8.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.x"},"endOfLifeDate":"2026-11-10T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|8.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.x"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2026-11-10T00:00:00Z"}}}]},{"displayText":".NET
+        7 (STS)","value":"dotnet7","minorVersions":[{"displayText":".NET 7 (STS)","value":"7","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v7.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"7.x"},"endOfLifeDate":"2024-05-14T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|7.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"7.x"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2024-05-14T00:00:00Z"}}}]},{"displayText":".NET
+        6","value":"dotnet6","minorVersions":[{"displayText":".NET 6 (LTS)","value":"6","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v6.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"6.0.x"},"endOfLifeDate":"2024-11-12T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|6.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"6.0.x"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2024-11-12T00:00:00Z"}}}]},{"displayText":".NET
         5","value":"dotnet5","minorVersions":[{"displayText":".NET 5","value":"5","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v5.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"5.0.x"},"endOfLifeDate":"2022-05-08T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|5.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"5.0.x"},"endOfLifeDate":"2022-05-08T00:00:00Z"}}}]},{"displayText":".NET
         Core 3","value":"dotnetcore3","minorVersions":[{"displayText":".NET Core 3.1
         (LTS)","value":"3.1","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"3.1","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.1.301"},"isDeprecated":true,"endOfLifeDate":"2022-12-03T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|3.1","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.1.301"},"isDeprecated":true,"endOfLifeDate":"2022-12-03T00:00:00Z"}}},{"displayText":".NET
@@ -248,9 +312,10 @@ interactions:
         V4","value":"aspdotnetv4","minorVersions":[{"displayText":"ASP.NET V4.8","value":"v4.8","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v4.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.1"}}}}]},{"displayText":"ASP.NET
         V3","value":"aspdotnetv3","minorVersions":[{"displayText":"ASP.NET V3.5","value":"v3.5","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v2.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"2.1"}}}}]}]}},{"id":null,"name":"node","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"Node","value":"node","preferredOs":"linux","majorVersions":[{"displayText":"Node
         LTS","value":"lts","minorVersions":[{"displayText":"Node LTS","value":"lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|lts","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true}}}}]},{"displayText":"Node
-        20","value":"20","minorVersions":[{"displayText":"Node 20 LTS","value":"20-lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|20-lts","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"20.x"},"supportedFeatures":{"disableSsh":true}},"windowsRuntimeSettings":{"runtimeVersion":"~20","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"20.x"}}}}]},{"displayText":"Node
-        18","value":"18","minorVersions":[{"displayText":"Node 18 LTS","value":"18-lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|18-lts","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"18.x"},"supportedFeatures":{"disableSsh":true}},"windowsRuntimeSettings":{"runtimeVersion":"~18","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"18.x"}}}}]},{"displayText":"Node
-        16","value":"16","minorVersions":[{"displayText":"Node 16 LTS","value":"16-lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|16-lts","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"16.x"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2023-09-11T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"~16","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"16.x"},"endOfLifeDate":"2023-09-11T00:00:00Z"}}}]},{"displayText":"Node
+        22","value":"22","minorVersions":[{"displayText":"Node 22 LTS","value":"22-lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|22-lts","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"22.x"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2027-04-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"~22","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"22.x"},"endOfLifeDate":"2027-04-30T00:00:00Z"}}}]},{"displayText":"Node
+        20","value":"20","minorVersions":[{"displayText":"Node 20 LTS","value":"20-lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|20-lts","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"20.x"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2026-04-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"~20","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"20.x"},"endOfLifeDate":"2026-04-30T00:00:00Z"}}}]},{"displayText":"Node
+        18","value":"18","minorVersions":[{"displayText":"Node 18 LTS","value":"18-lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|18-lts","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"18.x"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2025-04-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"~18","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"18.x"},"endOfLifeDate":"2025-04-30T00:00:00Z"}}}]},{"displayText":"Node
+        16","value":"16","minorVersions":[{"displayText":"Node 16 LTS","value":"16-lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|16-lts","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"16.x"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2023-09-11T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"~16","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"16.x"},"endOfLifeDate":"2023-09-11T00:00:00Z"}}}]},{"displayText":"Node
         14","value":"14","minorVersions":[{"displayText":"Node 14 LTS","value":"14-lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|14-lts","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"14.x"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2023-04-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"~14","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"14.x"},"endOfLifeDate":"2023-04-30T00:00:00Z"}}}]},{"displayText":"Node
         12","value":"12","minorVersions":[{"displayText":"Node 12 LTS","value":"12-lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|12-lts","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"12.x"},"endOfLifeDate":"2022-04-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"12.13.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2022-04-01T00:00:00Z"}}},{"displayText":"Node
         12.9","value":"12.9","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|12.9","isDeprecated":true,"remoteDebuggingSupported":true,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"12.x"},"endOfLifeDate":"2022-04-01T00:00:00Z"}}}]},{"displayText":"Node
@@ -286,18 +351,21 @@ interactions:
         4","value":"4","minorVersions":[{"displayText":"Node 4.8","value":"4.8","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|4.8","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2018-04-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"4.8","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2018-04-30T00:00:00Z"}}},{"displayText":"Node
         4.5","value":"4.5","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|4.5","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2018-04-30T00:00:00Z"}}},{"displayText":"Node
         4.4","value":"4.4","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|4.4","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2018-04-30T00:00:00Z"}}}]}]}},{"id":null,"name":"python","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"Python","value":"python","preferredOs":"linux","majorVersions":[{"displayText":"Python
-        3","value":"3","minorVersions":[{"displayText":"Python 3.12","value":"3.12","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.12","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.12"},"supportedFeatures":{"disableSsh":true}}}},{"displayText":"Python
-        3.11","value":"3.11","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.11","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.11"},"supportedFeatures":{"disableSsh":true},"isHidden":false}}},{"displayText":"Python
-        3.10","value":"3.10","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.10","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.10"},"supportedFeatures":{"disableSsh":true},"isHidden":false,"isEarlyAccess":false}}},{"displayText":"Python
-        3.9","value":"3.9","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.9","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.9"},"supportedFeatures":{"disableSsh":true},"isHidden":false}}},{"displayText":"Python
-        3.8","value":"3.8","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.8","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.8"},"supportedFeatures":{"disableSsh":true}}}},{"displayText":"Python
-        3.7","value":"3.7","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.7","remoteDebuggingSupported":false,"isDeprecated":true,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.7"},"supportedFeatures":{"disableSsh":true}}}},{"displayText":"Python
-        3.6","value":"3.6","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.6","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.6"}},"windowsRuntimeSettings":{"runtimeVersion":"3.4.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.6"}}}}]},{"displayText":"Python
+        3","value":"3","minorVersions":[{"displayText":"Python 3.14","value":"3.14","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.14","remoteDebuggingSupported":false,"isHidden":true,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.14"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2030-10-31T00:00:00Z"}}},{"displayText":"Python
+        3.13","value":"3.13","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.13","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.13"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2029-10-31T00:00:00Z"}}},{"displayText":"Python
+        3.12","value":"3.12","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.12","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.12"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2028-10-31T00:00:00Z"}}},{"displayText":"Python
+        3.11","value":"3.11","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.11","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.11"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2027-10-31T00:00:00Z","isHidden":false}}},{"displayText":"Python
+        3.10","value":"3.10","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.10","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.10"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2026-10-31T00:00:00Z","isHidden":false,"isEarlyAccess":false}}},{"displayText":"Python
+        3.9","value":"3.9","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.9","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.9"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2025-10-31T00:00:00Z","isHidden":false}}},{"displayText":"Python
+        3.8","value":"3.8","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.8","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.8"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2024-10-07T00:00:00Z"}}},{"displayText":"Python
+        3.7","value":"3.7","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.7","remoteDebuggingSupported":false,"isDeprecated":true,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.7"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2023-06-27T00:00:00Z"}}},{"displayText":"Python
+        3.6","value":"3.6","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.6","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.6"},"endOfLifeDate":"2021-12-23T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"3.4.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.6"}}}}]},{"displayText":"Python
         2","value":"2","minorVersions":[{"displayText":"Python 2.7","value":"2.7","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|2.7","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"2.7"},"endOfLifeDate":"2020-02-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"2.7.3","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"2.7"},"endOfLifeDate":"2020-02-01T00:00:00Z"}}}]}]}},{"id":null,"name":"php","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"PHP","value":"php","preferredOs":"linux","majorVersions":[{"displayText":"PHP
-        8","value":"8","minorVersions":[{"displayText":"PHP 8.3","value":"8.3","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|8.3","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.3"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2026-11-23T00:00:00Z"}}},{"displayText":"PHP
-        8.2","value":"8.2","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|8.2","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.2"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2025-12-08T00:00:00Z"}}},{"displayText":"PHP
-        8.1","value":"8.1","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|8.1","isHidden":false,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.1"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2023-11-26T00:00:00Z"}}},{"displayText":"PHP
-        8.0","value":"8.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|8.0","isHidden":false,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.0"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2023-11-26T00:00:00Z"}}}]},{"displayText":"PHP
+        8","value":"8","minorVersions":[{"displayText":"PHP 8.4","value":"8.4","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|8.4","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.4"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2028-12-31T00:00:00Z"}}},{"displayText":"PHP
+        8.3","value":"8.3","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|8.3","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.3"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2027-12-31T00:00:00Z"}}},{"displayText":"PHP
+        8.2","value":"8.2","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|8.2","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.2"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2026-12-31T00:00:00Z"}}},{"displayText":"PHP
+        8.1","value":"8.1","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|8.1","isHidden":false,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.1"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2025-12-31T00:00:00Z"}}},{"displayText":"PHP
+        8.0","value":"8.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|8.0","isDeprecated":true,"isHidden":false,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.0"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2023-11-26T00:00:00Z"}}}]},{"displayText":"PHP
         7","value":"7","minorVersions":[{"displayText":"PHP 7.4","value":"7.4","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"7.4","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"7.4","notSupportedInCreates":true},"isDeprecated":true,"endOfLifeDate":"2022-11-30T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"PHP|7.4","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"7.4","notSupportedInCreates":true},"isDeprecated":true,"endOfLifeDate":"2022-11-30T00:00:00Z"}}},{"displayText":"PHP
         7.3","value":"7.3","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|7.3","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"7.3","notSupportedInCreates":true},"endOfLifeDate":"2021-12-06T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"7.3","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"7.3","notSupportedInCreates":true},"endOfLifeDate":"2021-12-06T00:00:00Z"}}},{"displayText":"PHP
         7.2","value":"7.2","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|7.2","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2020-11-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"7.2","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2020-11-30T00:00:00Z"}}},{"displayText":"PHP
@@ -315,20 +383,26 @@ interactions:
         2.3.8","value":"2.3.8","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.3.8","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2019-03-31T00:00:00Z"}}},{"displayText":"Ruby
         2.3.3","value":"2.3.3","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.3.3","remoteDebuggingSupported":false,"isDeprecated":true,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2019-03-31T00:00:00Z"}}}]}]}},{"id":null,"name":"java","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"Java","value":"java","preferredOs":"linux","majorVersions":[{"displayText":"Java
         21","value":"21","minorVersions":[{"displayText":"Java 21","value":"21.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"21","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"}}},{"displayText":"Java
-        21.0.4","value":"21.0.4","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"}}},{"displayText":"Java
-        21.0.3","value":"21.0.3","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"}}},{"displayText":"Java
+        21.0.6","value":"21.0.6","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"21.0.6","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"}}},{"displayText":"Java
+        21.0.5","value":"21.0.5","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"21.0.5","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"}}},{"displayText":"Java
+        21.0.4","value":"21.0.4","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"21.0.4","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"}}},{"displayText":"Java
+        21.0.3","value":"21.0.3","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"21.0.3","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"}}},{"displayText":"Java
         21.0.1","value":"21.0.1","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"21.0.1","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"}}}]},{"displayText":"Java
         17","value":"17","minorVersions":[{"displayText":"Java 17","value":"17.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
-        17.0.12","value":"17.0.12","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
-        17.0.11","value":"17.0.11","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        17.0.14","value":"17.0.14","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17.0.14","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        17.0.13","value":"17.0.13","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17.0.13","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        17.0.12","value":"17.0.12","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17.0.12","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        17.0.11","value":"17.0.11","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17.0.11","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
         17.0.9","value":"17.0.9","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17.0.9","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
         17.0.4","value":"17.0.4","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17.0.4","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
         17.0.3","value":"17.0.3","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17.0.3","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
         17.0.2","value":"17.0.2","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17.0.2","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
         17.0.1","value":"17.0.1","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17.0.1","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}}]},{"displayText":"Java
         11","value":"11","minorVersions":[{"displayText":"Java 11","value":"11.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
-        11.0.24","value":"11.0.21","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
-        11.0.23","value":"11.0.21","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.26","value":"11.0.26","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.26","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.25","value":"11.0.25","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.25","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.24","value":"11.0.24","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.24","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.23","value":"11.0.23","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.23","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
         11.0.21","value":"11.0.21","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.21","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
         11.0.16","value":"11.0.16","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.16","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
         11.0.15","value":"11.0.15","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.15","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
@@ -344,7 +418,10 @@ interactions:
         11.0.3","value":"11.0.3","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"11.0.3_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
         11.0.2","value":"11.0.2","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"11.0.2_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}}]},{"displayText":"Java
         8","value":"8","minorVersions":[{"displayText":"Java 8","value":"8.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"1.8","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
-        1.8.0_422","value":"8.0.422","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_442","value":"8.0.442","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_442","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_432","value":"8.0.432","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_432","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_422","value":"8.0.422","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_422","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_412","value":"8.0.412","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_412","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
         1.8.0_392","value":"8.0.392","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_392","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
         1.8.0_345","value":"8.0.345","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_345","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
         1.8.0_332","value":"8.0.332","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_332","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
@@ -384,155 +461,212 @@ interactions:
         1.7.0_51 (Oracle)","value":"7.0.51 (Oracle)","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.7.0_51","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false}}}}]}]}},{"id":null,"name":"javacontainers","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"Java
         Containers","value":"javacontainers","majorVersions":[{"displayText":"Java
         SE (Embedded Web Server)","value":"javase","minorVersions":[{"displayText":"Java
-        SE (Embedded Web Server)","value":"SE","stackSettings":{"windowsContainerSettings":{"javaContainer":"JAVA","javaContainerVersion":"SE","isAutoUpdate":true},"linuxContainerSettings":{"java21Runtime":"JAVA|21-java21","java17Runtime":"JAVA|17-java17","java11Runtime":"JAVA|11-java11","java8Runtime":"JAVA|8-jre8","isAutoUpdate":true}}},{"displayText":"Java
-        SE 21.0.4","value":"21.0.4","stackSettings":{"linuxContainerSettings":{"java21Runtime":"JAVA|21.0.4"}}},{"displayText":"Java
-        SE 21.0.3","value":"21.0.3","stackSettings":{"linuxContainerSettings":{"java21Runtime":"JAVA|21.0.3"}}},{"displayText":"Java
-        SE 21.0.1","value":"21.0.1","stackSettings":{"linuxContainerSettings":{"java21Runtime":"JAVA|21.0.1"}}},{"displayText":"Java
-        SE 17.0.12","value":"17.0.12","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.12"}}},{"displayText":"Java
-        SE 17.0.11","value":"17.0.11","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.11"}}},{"displayText":"Java
-        SE 17.0.9","value":"17.0.9","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.9"}}},{"displayText":"Java
-        SE 17.0.4","value":"17.0.4","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.4"}}},{"displayText":"Java
-        SE 17.0.3","value":"17.0.3","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.3"}}},{"displayText":"Java
-        SE 17.0.2","value":"17.0.2","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.2"}}},{"displayText":"Java
-        SE 17.0.1","value":"17.0.1","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.1"}}},{"displayText":"Java
-        SE 11.0.24","value":"11.0.24","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.24"}}},{"displayText":"Java
-        SE 11.0.23","value":"11.0.23","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.23"}}},{"displayText":"Java
-        SE 11.0.21","value":"11.0.21","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.21"}}},{"displayText":"Java
-        SE 11.0.16","value":"11.0.16","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.16"}}},{"displayText":"Java
-        SE 11.0.15","value":"11.0.15","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.15"}}},{"displayText":"Java
-        SE 11.0.14","value":"11.0.14","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.14"}}},{"displayText":"Java
-        SE 11.0.13","value":"11.0.13","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.13"}}},{"displayText":"Java
-        SE 11.0.12","value":"11.0.12","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.12"}}},{"displayText":"Java
-        SE 11.0.11","value":"11.0.11","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.11"}}},{"displayText":"Java
-        SE 11.0.9","value":"11.0.9","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.9"}}},{"displayText":"Java
-        SE 11.0.7","value":"11.0.7","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.7"}}},{"displayText":"Java
-        SE 11.0.6","value":"11.0.6","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.6"}}},{"displayText":"Java
-        SE 11.0.5","value":"11.0.5","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.5"}}},{"displayText":"Java
-        SE 8u422","value":"1.8.422","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u422"}}},{"displayText":"Java
-        SE 8u412","value":"1.8.412","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u412"}}},{"displayText":"Java
-        SE 8u392","value":"1.8.392","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u392"}}},{"displayText":"Java
-        SE 8u345","value":"1.8.345","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u345"}}},{"displayText":"Java
-        SE 8u332","value":"1.8.332","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u332"}}},{"displayText":"Java
-        SE 8u322","value":"1.8.322","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u322"}}},{"displayText":"Java
-        SE 8u312","value":"1.8.312","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u312"}}},{"displayText":"Java
-        SE 8u302","value":"1.8.302","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u302"}}},{"displayText":"Java
-        SE 8u292","value":"1.8.292","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u292"}}},{"displayText":"Java
-        SE 8u275","value":"1.8.275","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u275"}}},{"displayText":"Java
-        SE 8u252","value":"1.8.252","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u252"}}},{"displayText":"Java
-        SE 8u242","value":"1.8.242","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u242"}}},{"displayText":"Java
-        SE 8u232","value":"1.8.232","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u232"}}}]},{"displayText":"Red
+        SE (Embedded Web Server)","value":"SE","stackSettings":{"windowsContainerSettings":{"javaContainer":"JAVA","javaContainerVersion":"SE","isAutoUpdate":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java21Runtime":"JAVA|21-java21","java17Runtime":"JAVA|17-java17","java11Runtime":"JAVA|11-java11","java8Runtime":"JAVA|8-jre8","isAutoUpdate":true,"runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8-jre8"},{"runtimeVersion":"11","runtime":"JAVA|11-java11"},{"runtimeVersion":"17","runtime":"JAVA|17-java17"},{"runtimeVersion":"21","runtime":"JAVA|21-java21"}]}}},{"displayText":"Java
+        SE 21.0.7","value":"21.0.7","stackSettings":{"linuxContainerSettings":{"java21Runtime":"JAVA|21.0.7","runtimes":[{"runtimeVersion":"21","runtime":"JAVA|21.0.7"}]}}},{"displayText":"Java
+        SE 21.0.6","value":"21.0.6","stackSettings":{"linuxContainerSettings":{"java21Runtime":"JAVA|21.0.6","runtimes":[{"runtimeVersion":"21","runtime":"JAVA|21.0.6"}]}}},{"displayText":"Java
+        SE 21.0.5","value":"21.0.5","stackSettings":{"linuxContainerSettings":{"java21Runtime":"JAVA|21.0.5","runtimes":[{"runtimeVersion":"21","runtime":"JAVA|21.0.5"}]}}},{"displayText":"Java
+        SE 21.0.4","value":"21.0.4","stackSettings":{"linuxContainerSettings":{"java21Runtime":"JAVA|21.0.4","runtimes":[{"runtimeVersion":"21","runtime":"JAVA|21.0.4"}]}}},{"displayText":"Java
+        SE 21.0.3","value":"21.0.3","stackSettings":{"linuxContainerSettings":{"java21Runtime":"JAVA|21.0.3","runtimes":[{"runtimeVersion":"21","runtime":"JAVA|21.0.3"}]}}},{"displayText":"Java
+        SE 21.0.1","value":"21.0.1","stackSettings":{"linuxContainerSettings":{"java21Runtime":"JAVA|21.0.1","runtimes":[{"runtimeVersion":"21","runtime":"JAVA|21.0.1"}]}}},{"displayText":"Java
+        SE 17.0.15","value":"17.0.15","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.15","runtimes":[{"runtimeVersion":"17","runtime":"JAVA|17.0.15"}]}}},{"displayText":"Java
+        SE 17.0.14","value":"17.0.14","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.14","runtimes":[{"runtimeVersion":"17","runtime":"JAVA|17.0.14"}]}}},{"displayText":"Java
+        SE 17.0.13","value":"17.0.13","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.13","runtimes":[{"runtimeVersion":"17","runtime":"JAVA|17.0.13"}]}}},{"displayText":"Java
+        SE 17.0.12","value":"17.0.12","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.12","runtimes":[{"runtimeVersion":"17","runtime":"JAVA|17.0.12"}]}}},{"displayText":"Java
+        SE 17.0.11","value":"17.0.11","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.11","runtimes":[{"runtimeVersion":"17","runtime":"JAVA|17.0.11"}]}}},{"displayText":"Java
+        SE 17.0.9","value":"17.0.9","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.9","runtimes":[{"runtimeVersion":"17","runtime":"JAVA|17.0.9"}]}}},{"displayText":"Java
+        SE 17.0.4","value":"17.0.4","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.4","runtimes":[{"runtimeVersion":"17","runtime":"JAVA|17.0.4"}]}}},{"displayText":"Java
+        SE 17.0.3","value":"17.0.3","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.3","runtimes":[{"runtimeVersion":"17","runtime":"JAVA|17.0.3"}]}}},{"displayText":"Java
+        SE 17.0.2","value":"17.0.2","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.2","runtimes":[{"runtimeVersion":"17","runtime":"JAVA|17.0.2"}]}}},{"displayText":"Java
+        SE 17.0.1","value":"17.0.1","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.1","runtimes":[{"runtimeVersion":"17","runtime":"JAVA|17.0.1"}]}}},{"displayText":"Java
+        SE 11.0.27","value":"11.0.27","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.27","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.27"}]}}},{"displayText":"Java
+        SE 11.0.26","value":"11.0.26","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.26","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.26"}]}}},{"displayText":"Java
+        SE 11.0.25","value":"11.0.25","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.25","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.25"}]}}},{"displayText":"Java
+        SE 11.0.24","value":"11.0.24","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.24","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.24"}]}}},{"displayText":"Java
+        SE 11.0.23","value":"11.0.23","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.23","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.23"}]}}},{"displayText":"Java
+        SE 11.0.21","value":"11.0.21","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.21","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.21"}]}}},{"displayText":"Java
+        SE 11.0.16","value":"11.0.16","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.16","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.16"}]}}},{"displayText":"Java
+        SE 11.0.15","value":"11.0.15","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.15","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.15"}]}}},{"displayText":"Java
+        SE 11.0.14","value":"11.0.14","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.14","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.14"}]}}},{"displayText":"Java
+        SE 11.0.13","value":"11.0.13","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.13","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.13"}]}}},{"displayText":"Java
+        SE 11.0.12","value":"11.0.12","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.12","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.12"}]}}},{"displayText":"Java
+        SE 11.0.11","value":"11.0.11","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.11","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.11"}]}}},{"displayText":"Java
+        SE 11.0.9","value":"11.0.9","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.9","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.9"}]}}},{"displayText":"Java
+        SE 11.0.7","value":"11.0.7","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.7","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.7"}]}}},{"displayText":"Java
+        SE 11.0.6","value":"11.0.6","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.6","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.6"}]}}},{"displayText":"Java
+        SE 11.0.5","value":"11.0.5","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.5","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.5"}]}}},{"displayText":"Java
+        SE 8u452","value":"1.8.452","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u452","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u452"}]}}},{"displayText":"Java
+        SE 8u442","value":"1.8.442","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u442","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u442"}]}}},{"displayText":"Java
+        SE 8u432","value":"1.8.432","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u432","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u432"}]}}},{"displayText":"Java
+        SE 8u422","value":"1.8.422","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u422","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u422"}]}}},{"displayText":"Java
+        SE 8u412","value":"1.8.412","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u412","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u412"}]}}},{"displayText":"Java
+        SE 8u392","value":"1.8.392","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u392","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u392"}]}}},{"displayText":"Java
+        SE 8u345","value":"1.8.345","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u345","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u345"}]}}},{"displayText":"Java
+        SE 8u332","value":"1.8.332","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u332","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u332"}]}}},{"displayText":"Java
+        SE 8u322","value":"1.8.322","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u322","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u322"}]}}},{"displayText":"Java
+        SE 8u312","value":"1.8.312","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u312","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u312"}]}}},{"displayText":"Java
+        SE 8u302","value":"1.8.302","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u302","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u302"}]}}},{"displayText":"Java
+        SE 8u292","value":"1.8.292","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u292","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u292"}]}}},{"displayText":"Java
+        SE 8u275","value":"1.8.275","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u275","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u275"}]}}},{"displayText":"Java
+        SE 8u252","value":"1.8.252","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u252","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u252"}]}}},{"displayText":"Java
+        SE 8u242","value":"1.8.242","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u242","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u242"}]}}},{"displayText":"Java
+        SE 8u232","value":"1.8.232","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u232","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u232"}]}}}]},{"displayText":"Red
         Hat JBoss EAP 8","value":"jbosseap8.0","minorVersions":[{"displayText":"Red
-        Hat JBoss EAP 8","value":"8","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8-java11","java17Runtime":"JBOSSEAP|8-java17","isAutoUpdate":true}}},{"displayText":"Red
-        Hat JBoss EAP 8.0 update 2.1","value":"8.0.2.1","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.2.1-java11","java17Runtime":"JBOSSEAP|8.0.2.1-java17"}}},{"displayText":"Red
-        Hat JBoss EAP 8.0 update 1","value":"8.0.1","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.1-java11","java17Runtime":"JBOSSEAP|8.0.1-java17"}}}]},{"displayText":"Red
+        Hat JBoss EAP 8","value":"8","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8-java11","java17Runtime":"JBOSSEAP|8-java17","java21Runtime":"JBOSSEAP|8-java21","isAutoUpdate":true,"runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8-java17"},{"runtimeVersion":"21","runtime":"JBOSSEAP|8-java21"}]}}},{"displayText":"Red
+        Hat JBoss EAP 8.0 update 8","value":"8.0.8","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.8-java11","java17Runtime":"JBOSSEAP|8.0.8-java17","java21Runtime":"JBOSSEAP|8.0.8-java21","runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8.0.8-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8.0.8-java17"},{"runtimeVersion":"21","runtime":"JBOSSEAP|8.0.8-java21"}]}}},{"displayText":"Red
+        Hat JBoss EAP 8.0 update 7","value":"8.0.7","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.7-java11","java17Runtime":"JBOSSEAP|8.0.7-java17","java21Runtime":"JBOSSEAP|8.0.7-java21","runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8.0.7-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8.0.7-java17"},{"runtimeVersion":"21","runtime":"JBOSSEAP|8.0.7-java21"}]}}},{"displayText":"Red
+        Hat JBoss EAP 8.0 update 5.1","value":"8.0.5.1","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.5.1-java11","java17Runtime":"JBOSSEAP|8.0.5.1-java17","runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8.0.5.1-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8.0.5.1-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 8.0 update 4.1","value":"8.0.4.1","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.4.1-java11","java17Runtime":"JBOSSEAP|8.0.4.1-java17","runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8.0.4.1-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8.0.4.1-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 8.0 update 3","value":"8.0.3","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.3-java11","java17Runtime":"JBOSSEAP|8.0.3-java17","runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8.0.3-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8.0.3-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 8.0 update 2.1","value":"8.0.2.1","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.2.1-java11","java17Runtime":"JBOSSEAP|8.0.2.1-java17","runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8.0.2.1-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8.0.2.1-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 8.0 update 1","value":"8.0.1","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.1-java11","java17Runtime":"JBOSSEAP|8.0.1-java17","runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8.0.1-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8.0.1-java17"}]}}}]},{"displayText":"Red
         Hat JBoss EAP 8 BYO License","value":"jbosseap8.0_byol","minorVersions":[{"displayText":"Red
-        Hat JBoss EAP 8 BYO License","value":"8","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8-java11_byol","java17Runtime":"JBOSSEAP|8-java17_byol","isAutoUpdate":true}}},{"displayText":"Red
-        Hat JBoss EAP 8 update 1 BYO License","value":"8.0.1","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.1-java11_byol","java17Runtime":"JBOSSEAP|8.0.1-java17_byol"}}},{"displayText":"Red
-        Hat JBoss EAP 8.0 update 2.1 BYO License","value":"8.0.2","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.2-java11_byol","java17Runtime":"JBOSSEAP|8.0.2-java17_byol"}}}]},{"displayText":"Red
+        Hat JBoss EAP 8 BYO License","value":"8","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8-java11_byol","java17Runtime":"JBOSSEAP|8-java17_byol","java21Runtime":"JBOSSEAP|8-java21_byol","isAutoUpdate":true,"runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8-java17_byol"},{"runtimeVersion":"21","runtime":"JBOSSEAP|8-java21_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 8.0 update 7","value":"8.0.7","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.7-java11_byol","java17Runtime":"JBOSSEAP|8.0.7-java17_byol","java21Runtime":"JBOSSEAP|8.0.7-java21_byol","runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8.0.7-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8.0.7-java17_byol"},{"runtimeVersion":"21","runtime":"JBOSSEAP|8.0.7-java21_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 8.0 update 5.1","value":"8.0.5.1","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.5.1-java11_byol","java17Runtime":"JBOSSEAP|8.0.5.1-java17_byol","runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8.0.5.1-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8.0.5.1-java17_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 8.0 update 4.1 BYO License","value":"8.0.4.1","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.4.1-java11_byol","java17Runtime":"JBOSSEAP|8.0.4.1-java17_byol","runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8.0.4.1-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8.0.4.1-java17_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 8 update 3 BYO License","value":"8.0.3","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.3-java11_byol","java17Runtime":"JBOSSEAP|8.0.3-java17_byol","runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8.0.3-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8.0.3-java17_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 8.0 update 2.1 BYO License","value":"8.0.2","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.2-java11_byol","java17Runtime":"JBOSSEAP|8.0.2-java17_byol","runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8.0.2-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8.0.2-java17_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 8 update 1 BYO License","value":"8.0.1","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.1-java11_byol","java17Runtime":"JBOSSEAP|8.0.1-java17_byol","runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8.0.1-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8.0.1-java17_byol"}]}}}]},{"displayText":"Red
         Hat JBoss EAP 7","value":"jbosseap","minorVersions":[{"displayText":"Red Hat
-        JBoss EAP 7","value":"7","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7-java8","java11Runtime":"JBOSSEAP|7-java11","java17Runtime":"JBOSSEAP|7-java17","isAutoUpdate":true}}},{"displayText":"Red
-        Hat JBoss EAP 7.4.18","value":"7.4.18","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.18-java8","java11Runtime":"JBOSSEAP|7.4.18-java11","java17Runtime":"JBOSSEAP|7.4.18-java17"}}},{"displayText":"Red
-        Hat JBoss EAP 7.4.17","value":"7.4.17","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.17-java8","java11Runtime":"JBOSSEAP|7.4.17-java11","java17Runtime":"JBOSSEAP|7.4.17-java17"}}},{"displayText":"Red
-        Hat JBoss EAP 7.4.16","value":"7.4.16","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.16-java8","java11Runtime":"JBOSSEAP|7.4.16-java11","java17Runtime":"JBOSSEAP|7.4.16-java17"}}},{"displayText":"Red
-        Hat JBoss EAP 7.4.13","value":"7.4.13","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.13-java8","java11Runtime":"JBOSSEAP|7.4.13-java11","java17Runtime":"JBOSSEAP|7.4.13-java17"}}},{"displayText":"Red
-        Hat JBoss EAP 7.4.7","value":"7.4.7","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.7-java8","java11Runtime":"JBOSSEAP|7.4.7-java11","java17Runtime":"JBOSSEAP|7.4.7-java17"}}},{"displayText":"Red
-        Hat JBoss EAP 7.4.5","value":"7.4.5","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.5-java8","java11Runtime":"JBOSSEAP|7.4.5-java11","java17Runtime":"JBOSSEAP|7.4.5-java17"}}},{"displayText":"Red
-        Hat JBoss EAP 7.4.2","value":"7.4.2","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.2-java8","java11Runtime":"JBOSSEAP|7.4.2-java11"}}},{"displayText":"Red
-        Hat JBoss EAP 7.4.1","value":"7.4.1","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.1-java8","java11Runtime":"JBOSSEAP|7.4.1-java11"}}},{"displayText":"Red
-        Hat JBoss EAP 7.4.0","value":"7.4.0","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.0-java8","java11Runtime":"JBOSSEAP|7.4.0-java11"}}},{"displayText":"Red
-        Hat JBoss EAP 7.3.10","value":"7.3.10","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.3.10-java8","java11Runtime":"JBOSSEAP|7.3.10-java11"}}},{"displayText":"Red
-        Hat JBoss EAP 7.3.9","value":"7.3.9","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.3.9-java8","java11Runtime":"JBOSSEAP|7.3.9-java11"}}},{"displayText":"Red
-        Hat JBoss EAP 7.3","value":"7.3","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.3-java8","java11Runtime":"JBOSSEAP|7.3-java11","isAutoUpdate":true,"isHidden":true}}},{"displayText":"Red
-        Hat JBoss EAP 7.4","value":"7.4","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4-java8","java11Runtime":"JBOSSEAP|7.4-java11","isAutoUpdate":true,"isHidden":true}}},{"displayText":"JBoss
-        EAP 7.2","value":"7.2.0","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.2-java8","isDeprecated":true}}}]},{"displayText":"Red
+        JBoss EAP 7","value":"7","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7-java8","java11Runtime":"JBOSSEAP|7-java11","java17Runtime":"JBOSSEAP|7-java17","isAutoUpdate":true,"runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.22","value":"7.4.22","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.22-java8","java11Runtime":"JBOSSEAP|7.4.22-java11","java17Runtime":"JBOSSEAP|7.4.22-java17","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.22-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.22-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.22-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.21","value":"7.4.21","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.21-java8","java11Runtime":"JBOSSEAP|7.4.21-java11","java17Runtime":"JBOSSEAP|7.4.21-java17","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.21-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.21-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.21-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.20","value":"7.4.20","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.20-java8","java11Runtime":"JBOSSEAP|7.4.20-java11","java17Runtime":"JBOSSEAP|7.4.20-java17","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.20-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.20-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.20-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.18","value":"7.4.18","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.18-java8","java11Runtime":"JBOSSEAP|7.4.18-java11","java17Runtime":"JBOSSEAP|7.4.18-java17","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.18-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.18-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.18-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.17","value":"7.4.17","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.17-java8","java11Runtime":"JBOSSEAP|7.4.17-java11","java17Runtime":"JBOSSEAP|7.4.17-java17","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.17-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.17-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.17-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.16","value":"7.4.16","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.16-java8","java11Runtime":"JBOSSEAP|7.4.16-java11","java17Runtime":"JBOSSEAP|7.4.16-java17","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.16-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.16-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.16-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.13","value":"7.4.13","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.13-java8","java11Runtime":"JBOSSEAP|7.4.13-java11","java17Runtime":"JBOSSEAP|7.4.13-java17","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.13-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.13-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.13-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.7","value":"7.4.7","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.7-java8","java11Runtime":"JBOSSEAP|7.4.7-java11","java17Runtime":"JBOSSEAP|7.4.7-java17","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.7-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.7-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.7-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.5","value":"7.4.5","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.5-java8","java11Runtime":"JBOSSEAP|7.4.5-java11","java17Runtime":"JBOSSEAP|7.4.5-java17","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.5-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.5-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.5-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.2","value":"7.4.2","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.2-java8","java11Runtime":"JBOSSEAP|7.4.2-java11","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.2-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.2-java11"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.1","value":"7.4.1","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.1-java8","java11Runtime":"JBOSSEAP|7.4.1-java11","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.1-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.1-java11"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.0","value":"7.4.0","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.0-java8","java11Runtime":"JBOSSEAP|7.4.0-java11","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.0-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.0-java11"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.3.10","value":"7.3.10","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.3.10-java8","java11Runtime":"JBOSSEAP|7.3.10-java11","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.3.10-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.3.10-java11"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.3.9","value":"7.3.9","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.3.9-java8","java11Runtime":"JBOSSEAP|7.3.9-java11","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.3.9-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.3.9-java11"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.3","value":"7.3","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.3-java8","java11Runtime":"JBOSSEAP|7.3-java11","isAutoUpdate":true,"isHidden":true,"runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.3-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.3-java11"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4","value":"7.4","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4-java8","java11Runtime":"JBOSSEAP|7.4-java11","isAutoUpdate":true,"isHidden":true,"runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4-java11"}]}}},{"displayText":"JBoss
+        EAP 7.2","value":"7.2.0","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.2-java8","isDeprecated":true,"runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.2-java8"}]}}}]},{"displayText":"Red
         Hat JBoss EAP 7 BYO License","value":"jbosseap7_byol","minorVersions":[{"displayText":"Red
-        Hat JBoss EAP 7 BYO License","value":"7","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7-java8_byol","java11Runtime":"JBOSSEAP|7-java11_byol","java17Runtime":"JBOSSEAP|7-java17_byol","isAutoUpdate":true}}},{"displayText":"Red
-        Hat JBoss EAP 7.4.13 BYO License","value":"7.4.13","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.13-java8_byol","java11Runtime":"JBOSSEAP|7.4.13-java11_byol","java17Runtime":"JBOSSEAP|7.4.13-java17_byol"}}},{"displayText":"Red
-        Hat JBoss EAP 7.4.7 BYO License","value":"7.4.7","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.7-java8_byol","java11Runtime":"JBOSSEAP|7.4.7-java11_byol","java17Runtime":"JBOSSEAP|7.4.7-java17_byol"}}},{"displayText":"Red
-        Hat JBoss EAP 7.4.5 BYO License","value":"7.4.5","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.5-java8_byol","java11Runtime":"JBOSSEAP|7.4.5-java11_byol","java17Runtime":"JBOSSEAP|7.4.5-java17_byol"}}},{"displayText":"Red
-        Hat JBoss EAP 7.4.2 BYO License","value":"7.4.2","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.2-java8_byol","java11Runtime":"JBOSSEAP|7.4.2-java11_byol"}}},{"displayText":"Red
-        Hat JBoss EAP 7.4.1 BYO License","value":"7.4.1","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.1-java8_byol","java11Runtime":"JBOSSEAP|7.4.1-java11_byol"}}},{"displayText":"Red
-        Hat JBoss EAP 7.4.0 BYO License","value":"7.4.0","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.0-java8_byol","java11Runtime":"JBOSSEAP|7.4.0-java11_byol"}}},{"displayText":"Red
-        Hat JBoss EAP 7.3.10 BYO License","value":"7.3.10","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.3.10-java8_byol","java11Runtime":"JBOSSEAP|7.3.10-java11_byol"}}},{"displayText":"Red
-        Hat JBoss EAP 7.3.9 BYO License","value":"7.3.9","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.3.9-java8_byol","java11Runtime":"JBOSSEAP|7.3.9-java11_byol"}}}]},{"displayText":"Apache
+        Hat JBoss EAP 7 BYO License","value":"7","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7-java8_byol","java11Runtime":"JBOSSEAP|7-java11_byol","java17Runtime":"JBOSSEAP|7-java17_byol","isAutoUpdate":true,"runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7-java8_byol"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7-java17_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.21 BYO License","value":"7.4.21","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.21-java8_byol","java11Runtime":"JBOSSEAP|7.4.21-java11_byol","java17Runtime":"JBOSSEAP|7.4.21-java17_byol","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.21-java8_byol"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.21-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.21-java17_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.20 BYO License","value":"7.4.20","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.20-java8_byol","java11Runtime":"JBOSSEAP|7.4.20-java11_byol","java17Runtime":"JBOSSEAP|7.4.20-java17_byol","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.20-java8_byol"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.20-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.20-java17_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.18 BYO License","value":"7.4.18","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.18-java8_byol","java11Runtime":"JBOSSEAP|7.4.18-java11_byol","java17Runtime":"JBOSSEAP|7.4.18-java17_byol","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.18-java8_byol"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.18-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.18-java17_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.16 BYO License","value":"7.4.16","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.16-java8_byol","java11Runtime":"JBOSSEAP|7.4.16-java11_byol","java17Runtime":"JBOSSEAP|7.4.16-java17_byol","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.16-java8_byol"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.16-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.16-java17_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.13 BYO License","value":"7.4.13","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.13-java8_byol","java11Runtime":"JBOSSEAP|7.4.13-java11_byol","java17Runtime":"JBOSSEAP|7.4.13-java17_byol","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.13-java8_byol"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.13-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.13-java17_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.7 BYO License","value":"7.4.7","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.7-java8_byol","java11Runtime":"JBOSSEAP|7.4.7-java11_byol","java17Runtime":"JBOSSEAP|7.4.7-java17_byol","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.7-java8_byol"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.7-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.7-java17_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.5 BYO License","value":"7.4.5","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.5-java8_byol","java11Runtime":"JBOSSEAP|7.4.5-java11_byol","java17Runtime":"JBOSSEAP|7.4.5-java17_byol","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.5-java8_byol"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.5-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.5-java17_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.2 BYO License","value":"7.4.2","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.2-java8_byol","java11Runtime":"JBOSSEAP|7.4.2-java11_byol","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.2-java8_byol"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.2-java11_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.1 BYO License","value":"7.4.1","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.1-java8_byol","java11Runtime":"JBOSSEAP|7.4.1-java11_byol","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.1-java8_byol"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.1-java11_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.0 BYO License","value":"7.4.0","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.0-java8_byol","java11Runtime":"JBOSSEAP|7.4.0-java11_byol","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.0-java8_byol"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.0-java11_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.3.10 BYO License","value":"7.3.10","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.3.10-java8_byol","java11Runtime":"JBOSSEAP|7.3.10-java11_byol","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.3.10-java8_byol"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.3.10-java11_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.3.9 BYO License","value":"7.3.9","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.3.9-java8_byol","java11Runtime":"JBOSSEAP|7.3.9-java11_byol","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.3.9-java8_byol"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.3.9-java11_byol"}]}}}]},{"displayText":"Apache
+        Tomcat 11.0","value":"tomcat11.0","minorVersions":[{"displayText":"Apache
+        Tomcat 11.0","value":"11.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"11.0","isAutoUpdate":true,"runtimes":[{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java21Runtime":"TOMCAT|11.0-java21","java17Runtime":"TOMCAT|11.0-java17","java11Runtime":"TOMCAT|11.0-java11","isAutoUpdate":true,"runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|11.0-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|11.0-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|11.0-java21"}]}}},{"displayText":"Apache
+        Tomcat 11.0.9","value":"11.0.9","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"11.0.9","isHidden":true,"runtimes":[{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java17Runtime":"TOMCAT|11.0.9-java17","java21Runtime":"TOMCAT|11.0.9-java21","runtimes":[{"runtimeVersion":"17","runtime":"TOMCAT|11.0.9-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|11.0.9-java21"}]}}},{"displayText":"Apache
+        Tomcat 11.0.8","value":"11.0.8","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"11.0.8","isHidden":true,"runtimes":[{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java17Runtime":"TOMCAT|11.0.8-java17","java21Runtime":"TOMCAT|11.0.8-java21","runtimes":[{"runtimeVersion":"17","runtime":"TOMCAT|11.0.8-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|11.0.8-java21"}]}}},{"displayText":"Apache
+        Tomcat 11.0.7","value":"11.0.7","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"11.0.7","runtimes":[{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"isHidden":true,"java17Runtime":"TOMCAT|11.0.7-java17","java21Runtime":"TOMCAT|11.0.7-java21","runtimes":[{"runtimeVersion":"17","runtime":"TOMCAT|11.0.7-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|11.0.7-java21"}]}}},{"displayText":"Apache
+        Tomcat 11.0.6","value":"11.0.6","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"11.0.6","isHidden":true,"runtimes":[{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java17Runtime":"TOMCAT|11.0.6-java17","java21Runtime":"TOMCAT|11.0.6-java21","runtimes":[{"runtimeVersion":"17","runtime":"TOMCAT|11.0.6-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|11.0.6-java21"}]}}},{"displayText":"Apache
+        Tomcat 11.0.5","value":"11.0.5","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"11.0.5","runtimes":[{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java17Runtime":"TOMCAT|11.0.5-java17","java21Runtime":"TOMCAT|11.0.5-java21","runtimes":[{"runtimeVersion":"17","runtime":"TOMCAT|11.0.5-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|11.0.5-java21"}]}}},{"displayText":"Apache
+        Tomcat 11.0.4","value":"11.0.4","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"11.0.4","isHidden":true,"runtimes":[{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java17Runtime":"TOMCAT|11.0.4-java17","java21Runtime":"TOMCAT|11.0.4-java21","runtimes":[{"runtimeVersion":"17","runtime":"TOMCAT|11.0.4-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|11.0.4-java21"}]}}},{"displayText":"Apache
+        Tomcat 11.0.2","value":"11.0.2","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"11.0.2","runtimes":[{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java17Runtime":"TOMCAT|11.0.2-java17","java21Runtime":"TOMCAT|11.0.2-java21","runtimes":[{"runtimeVersion":"17","runtime":"TOMCAT|11.0.2-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|11.0.2-java21"}]}}},{"displayText":"Apache
+        Tomcat 11.0.1","value":"11.0.1","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"11.0.1","isHidden":true,"runtimes":[{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java17Runtime":"TOMCAT|11.0.1-java17","java21Runtime":"TOMCAT|11.0.1-java21","runtimes":[{"runtimeVersion":"17","runtime":"TOMCAT|11.0.1-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|11.0.1-java21"}]}}}]},{"displayText":"Apache
         Tomcat 10.1","value":"tomcat10.1","minorVersions":[{"displayText":"Apache
-        Tomcat 10.1","value":"10.1","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1","isAutoUpdate":true},"linuxContainerSettings":{"java21Runtime":"TOMCAT|10.1-java21","java17Runtime":"TOMCAT|10.1-java17","java11Runtime":"TOMCAT|10.1-java11","isAutoUpdate":true}}},{"displayText":"Apache
-        Tomcat 10.1.28","value":"10.1.28","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.28"},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.28-java11","java17Runtime":"TOMCAT|10.1.28-java17","java21Runtime":"TOMCAT|10.1.28-java21"}}},{"displayText":"Apache
-        Tomcat 10.1.25","value":"10.1.25","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.25"},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.25-java11","java17Runtime":"TOMCAT|10.1.25-java17","java21Runtime":"TOMCAT|10.1.25-java21"}}},{"displayText":"Apache
-        Tomcat 10.1.23","value":"10.1.23","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.23"},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.23-java11","java17Runtime":"TOMCAT|10.1.23-java17","java21Runtime":"TOMCAT|10.1.23-java21"}}},{"displayText":"Apache
-        Tomcat 10.1.16","value":"10.1.16","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.16"},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.16-java11","java17Runtime":"TOMCAT|10.1.16-java17","java21Runtime":"TOMCAT|10.1.16-java21"}}}]},{"displayText":"Apache
+        Tomcat 10.1","value":"10.1","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1","isAutoUpdate":true,"runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java21Runtime":"TOMCAT|10.1-java21","java17Runtime":"TOMCAT|10.1-java17","java11Runtime":"TOMCAT|10.1-java11","isAutoUpdate":true,"runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1-java21"}]}}},{"displayText":"Apache
+        Tomcat 10.1.43","value":"10.1.43","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.43","isHidden":true,"runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.43-java11","java17Runtime":"TOMCAT|10.1.43-java17","java21Runtime":"TOMCAT|10.1.43-java21","runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1.43-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1.43-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1.43-java21"}]}}},{"displayText":"Apache
+        Tomcat 10.1.42","value":"10.1.42","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.42","isHidden":true,"runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.42-java11","java17Runtime":"TOMCAT|10.1.42-java17","java21Runtime":"TOMCAT|10.1.42-java21","runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1.42-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1.42-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1.42-java21"}]}}},{"displayText":"Apache
+        Tomcat 10.1.41","value":"10.1.41","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.41","runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"isHidden":true,"java11Runtime":"TOMCAT|10.1.41-java11","java17Runtime":"TOMCAT|10.1.41-java17","java21Runtime":"TOMCAT|10.1.41-java21","runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1.41-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1.41-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1.41-java21"}]}}},{"displayText":"Apache
+        Tomcat 10.1.40","value":"10.1.40","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.40","isHidden":true,"runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.40-java11","java17Runtime":"TOMCAT|10.1.40-java17","java21Runtime":"TOMCAT|10.1.40-java21","runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1.40-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1.40-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1.40-java21"}]}}},{"displayText":"Apache
+        Tomcat 10.1.39","value":"10.1.39","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.39","runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.39-java11","java17Runtime":"TOMCAT|10.1.39-java17","java21Runtime":"TOMCAT|10.1.39-java21","runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1.39-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1.39-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1.39-java21"}]}}},{"displayText":"Apache
+        Tomcat 10.1.36","value":"10.1.36","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.36","isHidden":true,"runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.36-java11","java17Runtime":"TOMCAT|10.1.36-java17","java21Runtime":"TOMCAT|10.1.36-java21","runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1.36-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1.36-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1.36-java21"}]}}},{"displayText":"Apache
+        Tomcat 10.1.34","value":"10.1.34","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.34","runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.34-java11","java17Runtime":"TOMCAT|10.1.34-java17","java21Runtime":"TOMCAT|10.1.34-java21","runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1.34-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1.34-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1.34-java21"}]}}},{"displayText":"Apache
+        Tomcat 10.1.33","value":"10.1.33","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.33","isHidden":true,"runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.33-java11","java17Runtime":"TOMCAT|10.1.33-java17","java21Runtime":"TOMCAT|10.1.33-java21","runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1.33-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1.33-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1.33-java21"}]}}},{"displayText":"Apache
+        Tomcat 10.1.31","value":"10.1.31","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.31","runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.31-java11","java17Runtime":"TOMCAT|10.1.31-java17","java21Runtime":"TOMCAT|10.1.31-java21","isHidden":true,"runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1.31-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1.31-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1.31-java21"}]}}},{"displayText":"Apache
+        Tomcat 10.1.28","value":"10.1.28","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.28","isHidden":true,"runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.28-java11","java17Runtime":"TOMCAT|10.1.28-java17","java21Runtime":"TOMCAT|10.1.28-java21","runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1.28-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1.28-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1.28-java21"}]}}},{"displayText":"Apache
+        Tomcat 10.1.25","value":"10.1.25","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.25","runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.25-java11","java17Runtime":"TOMCAT|10.1.25-java17","java21Runtime":"TOMCAT|10.1.25-java21","runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1.25-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1.25-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1.25-java21"}]}}},{"displayText":"Apache
+        Tomcat 10.1.23","value":"10.1.23","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.23","isHidden":true,"runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.23-java11","java17Runtime":"TOMCAT|10.1.23-java17","java21Runtime":"TOMCAT|10.1.23-java21","runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1.23-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1.23-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1.23-java21"}]}}},{"displayText":"Apache
+        Tomcat 10.1.16","value":"10.1.16","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.16","runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.16-java11","java17Runtime":"TOMCAT|10.1.16-java17","java21Runtime":"TOMCAT|10.1.16-java21","runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1.16-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1.16-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1.16-java21"}]}}}]},{"displayText":"Apache
         Tomcat 10.0","value":"tomcat10.0","minorVersions":[{"displayText":"Apache
-        Tomcat 10.0","value":"10.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0","isAutoUpdate":true,"endOfLifeDate":"2022-10-31T00:00:00Z"},"linuxContainerSettings":{"java17Runtime":"TOMCAT|10.0-java17","java11Runtime":"TOMCAT|10.0-java11","java8Runtime":"TOMCAT|10.0-jre8","isAutoUpdate":true,"endOfLifeDate":"2022-10-31T00:00:00Z"}}},{"displayText":"Apache
-        Tomcat 10.0.27","value":"10.0.27","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0.27"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|10.0.27-java8","java11Runtime":"TOMCAT|10.0.27-java11","java17Runtime":"TOMCAT|10.0.27-java17","endOfLifeDate":"2022-10-31T00:00:00Z"}}},{"displayText":"Apache
-        Tomcat 10.0.23","value":"10.0.23","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0.23","endOfLifeDate":"2022-10-31T00:00:00Z"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|10.0.23-java8","java11Runtime":"TOMCAT|10.0.23-java11","java17Runtime":"TOMCAT|10.0.23-java17","endOfLifeDate":"2022-10-31T00:00:00Z"}}},{"displayText":"Apache
-        Tomcat 10.0.21","value":"10.0.21","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0.21","endOfLifeDate":"2022-10-31T00:00:00Z"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|10.0.21-java8","java11Runtime":"TOMCAT|10.0.21-java11","java17Runtime":"TOMCAT|10.0.21-java17","endOfLifeDate":"2022-10-31T00:00:00Z"}}},{"displayText":"Apache
-        Tomcat 10.0.20","value":"10.0.20","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0.20","endOfLifeDate":"2022-10-31T00:00:00Z"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|10.0.20-java8","java11Runtime":"TOMCAT|10.0.20-java11","java17Runtime":"TOMCAT|10.0.20-java17","endOfLifeDate":"2022-10-31T00:00:00Z"}}},{"displayText":"Apache
-        Tomcat 10.0.12","value":"10.0.12","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0.12","endOfLifeDate":"2022-10-31T00:00:00Z"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|10.0.12-java8","java11Runtime":"TOMCAT|10.0.12-java11","java17Runtime":"TOMCAT|10.0.12-java17","endOfLifeDate":"2022-10-31T00:00:00Z"}}}]},{"displayText":"Apache
+        Tomcat 10.0","value":"10.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0","isAutoUpdate":true,"endOfLifeDate":"2022-10-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java17Runtime":"TOMCAT|10.0-java17","java11Runtime":"TOMCAT|10.0-java11","java8Runtime":"TOMCAT|10.0-jre8","isAutoUpdate":true,"endOfLifeDate":"2022-10-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|10.0-jre8"},{"runtimeVersion":"11","runtime":"TOMCAT|10.0-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.0-java17"}]}}},{"displayText":"Apache
+        Tomcat 10.0.27","value":"10.0.27","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0.27","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|10.0.27-java8","java11Runtime":"TOMCAT|10.0.27-java11","java17Runtime":"TOMCAT|10.0.27-java17","endOfLifeDate":"2022-10-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|10.0.27-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|10.0.27-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.0.27-java17"}]}}},{"displayText":"Apache
+        Tomcat 10.0.23","value":"10.0.23","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0.23","endOfLifeDate":"2022-10-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|10.0.23-java8","java11Runtime":"TOMCAT|10.0.23-java11","java17Runtime":"TOMCAT|10.0.23-java17","endOfLifeDate":"2022-10-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|10.0.23-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|10.0.23-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.0.23-java17"}]}}},{"displayText":"Apache
+        Tomcat 10.0.21","value":"10.0.21","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0.21","endOfLifeDate":"2022-10-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|10.0.21-java8","java11Runtime":"TOMCAT|10.0.21-java11","java17Runtime":"TOMCAT|10.0.21-java17","endOfLifeDate":"2022-10-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|10.0.21-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|10.0.21-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.0.21-java17"}]}}},{"displayText":"Apache
+        Tomcat 10.0.20","value":"10.0.20","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0.20","endOfLifeDate":"2022-10-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|10.0.20-java8","java11Runtime":"TOMCAT|10.0.20-java11","java17Runtime":"TOMCAT|10.0.20-java17","endOfLifeDate":"2022-10-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|10.0.20-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|10.0.20-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.0.20-java17"}]}}},{"displayText":"Apache
+        Tomcat 10.0.12","value":"10.0.12","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0.12","endOfLifeDate":"2022-10-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|10.0.12-java8","java11Runtime":"TOMCAT|10.0.12-java11","java17Runtime":"TOMCAT|10.0.12-java17","endOfLifeDate":"2022-10-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|10.0.12-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|10.0.12-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.0.12-java17"}]}}}]},{"displayText":"Apache
         Tomcat 9.0","value":"tomcat9.0","minorVersions":[{"displayText":"Apache Tomcat
-        9.0","value":"9.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0","isAutoUpdate":true},"linuxContainerSettings":{"java21Runtime":"TOMCAT|9.0-java21","java17Runtime":"TOMCAT|9.0-java17","java11Runtime":"TOMCAT|9.0-java11","java8Runtime":"TOMCAT|9.0-jre8","isAutoUpdate":true}}},{"displayText":"Apache
-        Tomcat 9.0.93","value":"9.0.93","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.93"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.93-java8","java11Runtime":"TOMCAT|9.0.93-java11","java17Runtime":"TOMCAT|9.0.93-java17","java21Runtime":"TOMCAT|9.0.93-java21"}}},{"displayText":"Apache
-        Tomcat 9.0.90","value":"9.0.90","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.90"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.90-java8","java11Runtime":"TOMCAT|9.0.90-java11","java17Runtime":"TOMCAT|9.0.90-java17","java21Runtime":"TOMCAT|9.0.90-java21"}}},{"displayText":"Apache
-        Tomcat 9.0.88","value":"9.0.88","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.88"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.88-java8","java11Runtime":"TOMCAT|9.0.88-java11","java17Runtime":"TOMCAT|9.0.88-java17","java21Runtime":"TOMCAT|9.0.88-java21"}}},{"displayText":"Apache
-        Tomcat 9.0.83","value":"9.0.83","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.83"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.83-java8","java11Runtime":"TOMCAT|9.0.83-java11","java17Runtime":"TOMCAT|9.0.83-java17","java21Runtime":"TOMCAT|9.0.83-java21"}}},{"displayText":"Apache
-        Tomcat 9.0.65","value":"9.0.65","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.65"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.65-java8","java11Runtime":"TOMCAT|9.0.65-java11","java17Runtime":"TOMCAT|9.0.65-java17"}}},{"displayText":"Apache
-        Tomcat 9.0.63","value":"9.0.63","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.63"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.63-java8","java11Runtime":"TOMCAT|9.0.63-java11","java17Runtime":"TOMCAT|9.0.63-java17"}}},{"displayText":"Apache
-        Tomcat 9.0.62","value":"9.0.62","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.62"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.62-java8","java11Runtime":"TOMCAT|9.0.62-java11","java17Runtime":"TOMCAT|9.0.62-java17"}}},{"displayText":"Apache
-        Tomcat 9.0.54","value":"9.0.54","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.54"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.54-java8","java11Runtime":"TOMCAT|9.0.54-java11","java17Runtime":"TOMCAT|9.0.54-java17"}}},{"displayText":"Apache
-        Tomcat 9.0.52","value":"9.0.52","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.52"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.52-java8","java11Runtime":"TOMCAT|9.0.52-java11"}}},{"displayText":"Apache
-        Tomcat 9.0.46","value":"9.0.46","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.46"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.46-java8","java11Runtime":"TOMCAT|9.0.46-java11"}}},{"displayText":"Apache
-        Tomcat 9.0.41","value":"9.0.41","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.41-java8","java11Runtime":"TOMCAT|9.0.41-java11"}}},{"displayText":"Apache
-        Tomcat 9.0.38","value":"9.0.38","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.38"}}},{"displayText":"Apache
-        Tomcat 9.0.37","value":"9.0.37","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.37"},"linuxContainerSettings":{"java11Runtime":"TOMCAT|9.0.37-java11","java8Runtime":"TOMCAT|9.0.37-java8"}}},{"displayText":"Apache
-        Tomcat 9.0.33","value":"9.0.33","stackSettings":{"linuxContainerSettings":{"java11Runtime":"TOMCAT|9.0.33-java11","java8Runtime":"TOMCAT|9.0.33-java8"}}},{"displayText":"Apache
-        Tomcat 9.0.31","value":"9.0.31","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.31"}}},{"displayText":"Apache
-        Tomcat 9.0.27","value":"9.0.27","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.27"}}},{"displayText":"Apache
-        Tomcat 9.0.21","value":"9.0.21","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.21"}}},{"displayText":"Apache
-        Tomcat 9.0.20","value":"9.0.20","stackSettings":{"linuxContainerSettings":{"java11Runtime":"TOMCAT|9.0.20-java11","java8Runtime":"TOMCAT|9.0.20-java8"}}},{"displayText":"Apache
-        Tomcat 9.0.14","value":"9.0.14","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.14"}}},{"displayText":"Apache
-        Tomcat 9.0.12","value":"9.0.12","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.12"}}},{"displayText":"Apache
-        Tomcat 9.0.8","value":"9.0.8","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.8"}}},{"displayText":"Apache
-        Tomcat 9.0.0","value":"9.0.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.0"}}}]},{"displayText":"Apache
+        9.0","value":"9.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0","isAutoUpdate":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java21Runtime":"TOMCAT|9.0-java21","java17Runtime":"TOMCAT|9.0-java17","java11Runtime":"TOMCAT|9.0-java11","java8Runtime":"TOMCAT|9.0-jre8","isAutoUpdate":true,"runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0-jre8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.107","value":"9.0.107","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.107","isHidden":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.107-java8","java11Runtime":"TOMCAT|9.0.107-java11","java17Runtime":"TOMCAT|9.0.107-java17","java21Runtime":"TOMCAT|9.0.107-java21","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.107-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.107-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.107-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.107-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.106","value":"9.0.106","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.106","isHidden":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.106-java8","java11Runtime":"TOMCAT|9.0.106-java11","java17Runtime":"TOMCAT|9.0.106-java17","java21Runtime":"TOMCAT|9.0.106-java21","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.106-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.106-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.106-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.106-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.105","value":"9.0.105","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.105","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"isHidden":true,"java8Runtime":"TOMCAT|9.0.105-java8","java11Runtime":"TOMCAT|9.0.105-java11","java17Runtime":"TOMCAT|9.0.105-java17","java21Runtime":"TOMCAT|9.0.105-java21","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.105-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.105-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.105-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.105-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.104","value":"9.0.104","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.104","isHidden":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.104-java8","java11Runtime":"TOMCAT|9.0.104-java11","java17Runtime":"TOMCAT|9.0.104-java17","java21Runtime":"TOMCAT|9.0.104-java21","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.104-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.104-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.104-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.104-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.102","value":"9.0.102","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.102","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.102-java8","java11Runtime":"TOMCAT|9.0.102-java11","java17Runtime":"TOMCAT|9.0.102-java17","java21Runtime":"TOMCAT|9.0.102-java21","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.102-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.102-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.102-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.102-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.100","value":"9.0.100","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.100","isHidden":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.100-java8","java11Runtime":"TOMCAT|9.0.100-java11","java17Runtime":"TOMCAT|9.0.100-java17","java21Runtime":"TOMCAT|9.0.100-java21","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.100-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.100-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.100-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.100-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.98","value":"9.0.98","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.98","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.98-java8","java11Runtime":"TOMCAT|9.0.98-java11","java17Runtime":"TOMCAT|9.0.98-java17","java21Runtime":"TOMCAT|9.0.98-java21","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.98-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.98-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.98-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.98-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.97","value":"9.0.97","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.97","isHidden":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.97-java8","java11Runtime":"TOMCAT|9.0.97-java11","java17Runtime":"TOMCAT|9.0.97-java17","java21Runtime":"TOMCAT|9.0.97-java21","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.97-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.97-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.97-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.97-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.96","value":"9.0.97","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.96","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.96-java8","java11Runtime":"TOMCAT|9.0.96-java11","java17Runtime":"TOMCAT|9.0.96-java17","java21Runtime":"TOMCAT|9.0.96-java21","isHidden":true,"runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.96-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.96-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.96-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.96-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.93","value":"9.0.93","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.93","isHidden":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.93-java8","java11Runtime":"TOMCAT|9.0.93-java11","java17Runtime":"TOMCAT|9.0.93-java17","java21Runtime":"TOMCAT|9.0.93-java21","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.93-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.93-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.93-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.93-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.91","value":"9.0.91","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.91","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.91-java8","java11Runtime":"TOMCAT|9.0.91-java11","java17Runtime":"TOMCAT|9.0.91-java17","java21Runtime":"TOMCAT|9.0.91-java21","isHidden":true,"runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.91-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.91-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.91-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.91-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.90","value":"9.0.90","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.90","isHidden":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.90-java8","java11Runtime":"TOMCAT|9.0.90-java11","java17Runtime":"TOMCAT|9.0.90-java17","java21Runtime":"TOMCAT|9.0.90-java21","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.90-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.90-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.90-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.90-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.88","value":"9.0.88","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.88","isHidden":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.88-java8","java11Runtime":"TOMCAT|9.0.88-java11","java17Runtime":"TOMCAT|9.0.88-java17","java21Runtime":"TOMCAT|9.0.88-java21","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.88-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.88-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.88-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.88-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.83","value":"9.0.83","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.83","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.83-java8","java11Runtime":"TOMCAT|9.0.83-java11","java17Runtime":"TOMCAT|9.0.83-java17","java21Runtime":"TOMCAT|9.0.83-java21","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.83-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.83-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.83-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.83-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.65","value":"9.0.65","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.65","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.65-java8","java11Runtime":"TOMCAT|9.0.65-java11","java17Runtime":"TOMCAT|9.0.65-java17","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.65-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.65-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.65-java17"}]}}},{"displayText":"Apache
+        Tomcat 9.0.63","value":"9.0.63","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.63","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.63-java8","java11Runtime":"TOMCAT|9.0.63-java11","java17Runtime":"TOMCAT|9.0.63-java17","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.63-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.63-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.63-java17"}]}}},{"displayText":"Apache
+        Tomcat 9.0.62","value":"9.0.62","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.62","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.62-java8","java11Runtime":"TOMCAT|9.0.62-java11","java17Runtime":"TOMCAT|9.0.62-java17","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.62-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.62-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.62-java17"}]}}},{"displayText":"Apache
+        Tomcat 9.0.54","value":"9.0.54","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.54","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.54-java8","java11Runtime":"TOMCAT|9.0.54-java11","java17Runtime":"TOMCAT|9.0.54-java17","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.54-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.54-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.54-java17"}]}}},{"displayText":"Apache
+        Tomcat 9.0.52","value":"9.0.52","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.52","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.52-java8","java11Runtime":"TOMCAT|9.0.52-java11","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.52-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.52-java11"}]}}},{"displayText":"Apache
+        Tomcat 9.0.46","value":"9.0.46","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.46","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.46-java8","java11Runtime":"TOMCAT|9.0.46-java11","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.46-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.46-java11"}]}}},{"displayText":"Apache
+        Tomcat 9.0.41","value":"9.0.41","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.41-java8","java11Runtime":"TOMCAT|9.0.41-java11","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.41-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.41-java11"}]}}},{"displayText":"Apache
+        Tomcat 9.0.38","value":"9.0.38","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.38","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.37","value":"9.0.37","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.37","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|9.0.37-java11","java8Runtime":"TOMCAT|9.0.37-java8","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.37-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.37-java11"}]}}},{"displayText":"Apache
+        Tomcat 9.0.33","value":"9.0.33","stackSettings":{"linuxContainerSettings":{"java11Runtime":"TOMCAT|9.0.33-java11","java8Runtime":"TOMCAT|9.0.33-java8","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.33-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.33-java11"}]}}},{"displayText":"Apache
+        Tomcat 9.0.31","value":"9.0.31","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.31","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.27","value":"9.0.27","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.27","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.21","value":"9.0.21","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.21","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.20","value":"9.0.20","stackSettings":{"linuxContainerSettings":{"java11Runtime":"TOMCAT|9.0.20-java11","java8Runtime":"TOMCAT|9.0.20-java8","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.20-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.20-java11"}]}}},{"displayText":"Apache
+        Tomcat 9.0.14","value":"9.0.14","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.14","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.12","value":"9.0.12","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.12","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.8","value":"9.0.8","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.8","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.0","value":"9.0.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.0","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}}]},{"displayText":"Apache
         Tomcat 8.5","value":"tomcat8.5","minorVersions":[{"displayText":"Apache Tomcat
-        8.5","value":"8.5","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5","isAutoUpdate":true,"endOfLifeDate":"2024-03-31T00:00:00Z"},"linuxContainerSettings":{"java11Runtime":"TOMCAT|8.5-java11","java8Runtime":"TOMCAT|8.5-jre8","isAutoUpdate":true,"endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
-        Tomcat 8.5.100","value":"8.5.100","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.100-java8","java11Runtime":"TOMCAT|8.5.100-java11","endOfLifeDate":"2024-03-31T00:00:00Z"},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.100","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
-        Tomcat 8.5.96","value":"8.5.96","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.96-java8","java11Runtime":"TOMCAT|8.5.96-java11","endOfLifeDate":"2024-03-31T00:00:00Z"},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.96","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
-        Tomcat 8.5.82","value":"8.5.82","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.82-java8","java11Runtime":"TOMCAT|8.5.82-java11","endOfLifeDate":"2024-03-31T00:00:00Z"},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.82","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
-        Tomcat 8.5.79","value":"8.5.79","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.79-java8","java11Runtime":"TOMCAT|8.5.79-java11","endOfLifeDate":"2024-03-31T00:00:00Z"},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.79","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
-        Tomcat 8.5.78","value":"8.5.78","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.78-java8","java11Runtime":"TOMCAT|8.5.78-java11","endOfLifeDate":"2024-03-31T00:00:00Z"},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.78","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
-        Tomcat 8.5.72","value":"8.5.72","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.72-java8","java11Runtime":"TOMCAT|8.5.72-java11","endOfLifeDate":"2024-03-31T00:00:00Z"},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.72","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
-        Tomcat 8.5.69","value":"8.5.69","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.69-java8","java11Runtime":"TOMCAT|8.5.69-java11","endOfLifeDate":"2024-03-31T00:00:00Z"},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.69","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
-        Tomcat 8.5.66","value":"8.5.66","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.66-java8","java11Runtime":"TOMCAT|8.5.66-java11","endOfLifeDate":"2024-03-31T00:00:00Z"},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.66","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
-        Tomcat 8.5.61","value":"8.5.61","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.61-java8","java11Runtime":"TOMCAT|8.5.61-java11","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
-        Tomcat 8.5.58","value":"8.5.58","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.58","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
-        Tomcat 8.5.57","value":"8.5.57","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.57","endOfLifeDate":"2024-03-31T00:00:00Z"},"linuxContainerSettings":{"java11Runtime":"TOMCAT|8.5.57-java11","java8Runtime":"TOMCAT|8.5.57-java8","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
-        Tomcat 8.5.53","value":"8.5.53","stackSettings":{"linuxContainerSettings":{"java11Runtime":"TOMCAT|8.5.53-java11","java8Runtime":"TOMCAT|8.5.53-java8","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
-        Tomcat 8.5.51","value":"8.5.51","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.51","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
-        Tomcat 8.5.47","value":"8.5.47","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.47","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
-        Tomcat 8.5.42","value":"8.5.42","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.42","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
-        Tomcat 8.5.41","value":"8.5.41","stackSettings":{"linuxContainerSettings":{"java11Runtime":"TOMCAT|8.5.41-java11","java8Runtime":"TOMCAT|8.5.41-java8","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
-        Tomcat 8.5.37","value":"8.5.37","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.37","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
-        Tomcat 8.5.34","value":"8.5.34","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.34","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
-        Tomcat 8.5.31","value":"8.5.31","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.31","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
-        Tomcat 8.5.20","value":"8.5.20","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.20","endOfLifeDate":"2024-03-31T00:00:00Z"}}},{"displayText":"Apache
-        Tomcat 8.5.6","value":"8.5.6","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.6","endOfLifeDate":"2024-03-31T00:00:00Z"}}}]},{"displayText":"Apache
+        8.5","value":"8.5","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5","isAutoUpdate":true,"endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|8.5-java11","java8Runtime":"TOMCAT|8.5-jre8","isAutoUpdate":true,"endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|8.5-jre8"},{"runtimeVersion":"11","runtime":"TOMCAT|8.5-java11"}]}}},{"displayText":"Apache
+        Tomcat 8.5.100","value":"8.5.100","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.100-java8","java11Runtime":"TOMCAT|8.5.100-java11","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|8.5.100-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|8.5.100-java11"}]},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.100","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.96","value":"8.5.96","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.96-java8","java11Runtime":"TOMCAT|8.5.96-java11","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|8.5.96-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|8.5.96-java11"}]},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.96","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.82","value":"8.5.82","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.82-java8","java11Runtime":"TOMCAT|8.5.82-java11","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|8.5.82-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|8.5.82-java11"}]},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.82","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.79","value":"8.5.79","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.79-java8","java11Runtime":"TOMCAT|8.5.79-java11","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|8.5.79-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|8.5.79-java11"}]},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.79","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.78","value":"8.5.78","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.78-java8","java11Runtime":"TOMCAT|8.5.78-java11","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|8.5.78-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|8.5.78-java11"}]},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.78","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.72","value":"8.5.72","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.72-java8","java11Runtime":"TOMCAT|8.5.72-java11","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|8.5.72-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|8.5.72-java11"}]},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.72","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.69","value":"8.5.69","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.69-java8","java11Runtime":"TOMCAT|8.5.69-java11","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|8.5.69-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|8.5.69-java11"}]},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.69","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.66","value":"8.5.66","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.66-java8","java11Runtime":"TOMCAT|8.5.66-java11","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|8.5.66-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|8.5.66-java11"}]},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.66","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.61","value":"8.5.61","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.61-java8","java11Runtime":"TOMCAT|8.5.61-java11","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|8.5.61-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|8.5.61-java11"}]}}},{"displayText":"Apache
+        Tomcat 8.5.58","value":"8.5.58","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.58","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.57","value":"8.5.57","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.57","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|8.5.57-java11","java8Runtime":"TOMCAT|8.5.57-java8","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|8.5.57-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|8.5.57-java11"}]}}},{"displayText":"Apache
+        Tomcat 8.5.53","value":"8.5.53","stackSettings":{"linuxContainerSettings":{"java11Runtime":"TOMCAT|8.5.53-java11","java8Runtime":"TOMCAT|8.5.53-java8","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|8.5.53-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|8.5.53-java11"}]}}},{"displayText":"Apache
+        Tomcat 8.5.51","value":"8.5.51","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.51","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.47","value":"8.5.47","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.47","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.42","value":"8.5.42","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.42","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.41","value":"8.5.41","stackSettings":{"linuxContainerSettings":{"java11Runtime":"TOMCAT|8.5.41-java11","java8Runtime":"TOMCAT|8.5.41-java8","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|8.5.41-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|8.5.41-java11"}]}}},{"displayText":"Apache
+        Tomcat 8.5.37","value":"8.5.37","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.37","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.34","value":"8.5.34","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.34","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.31","value":"8.5.31","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.31","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.20","value":"8.5.20","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.20","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.6","value":"8.5.6","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.6","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}}]},{"displayText":"Apache
         Tomcat 8.0","value":"tomcat8.0","minorVersions":[{"displayText":"Apache Tomcat
-        8.0","value":"8.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.0","isAutoUpdate":true,"isDeprecated":true}}},{"displayText":"Apache
-        Tomcat 8.0.53","value":"8.0.53","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.0.53","isDeprecated":true}}},{"displayText":"Apache
-        Tomcat 8.0.46","value":"8.0.46","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.0.46","isDeprecated":true}}},{"displayText":"Apache
-        Tomcat 8.0.23","value":"8.0.23","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.0.23","isDeprecated":true}}}]},{"displayText":"Apache
+        8.0","value":"8.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.0","isAutoUpdate":true,"isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.0.53","value":"8.0.53","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.0.53","isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.0.46","value":"8.0.46","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.0.46","isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.0.23","value":"8.0.23","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.0.23","isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}}]},{"displayText":"Apache
         Tomcat 7.0","value":"tomcat7.0","minorVersions":[{"displayText":"Apache Tomcat
-        7.0","value":"7.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"7.0","isAutoUpdate":true,"isDeprecated":true}}},{"displayText":"Apache
-        Tomcat 7.0.94","value":"7.0.94","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"7.0.94","isDeprecated":true}}},{"displayText":"Apache
-        Tomcat 7.0.81","value":"7.0.81","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"7.0.81","isDeprecated":true}}},{"displayText":"Apache
-        Tomcat 7.0.62","value":"7.0.62","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"7.0.62","isDeprecated":true}}},{"displayText":"Apache
-        Tomcat 7.0.50","value":"7.0.50","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"7.0.50","isDeprecated":true}}}]},{"displayText":"Jetty
-        9.3","value":"jetty9.3","minorVersions":[{"displayText":"Jetty 9.3","value":"9.3","stackSettings":{"windowsContainerSettings":{"javaContainer":"JETTY","javaContainerVersion":"9.3","isAutoUpdate":true,"isDeprecated":true}}},{"displayText":"Jetty
-        9.3.25","value":"9.3.25","stackSettings":{"windowsContainerSettings":{"javaContainer":"JETTY","javaContainerVersion":"9.3.25","isDeprecated":true}}},{"displayText":"Jetty
-        9.3.13","value":"9.3.13","stackSettings":{"windowsContainerSettings":{"javaContainer":"JETTY","javaContainerVersion":"9.3.13","isDeprecated":true}}}]},{"displayText":"Jetty
-        9.1","value":"jetty9.1","minorVersions":[{"displayText":"Jetty 9.1","value":"9.1","stackSettings":{"windowsContainerSettings":{"javaContainer":"JETTY","javaContainerVersion":"9.1","isAutoUpdate":true,"isDeprecated":true}}},{"displayText":"Jetty
-        9.1.0","value":"9.1.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"JETTY","javaContainerVersion":"9.1.0","isDeprecated":true}}}]},{"displayText":"WildFly
-        14","value":"wildfly14","minorVersions":[{"displayText":"WildFly 14","value":"14","stackSettings":{"linuxContainerSettings":{"java8Runtime":"WILDFLY|14-jre8","isDeprecated":true,"isAutoUpdate":true}}},{"displayText":"WildFly
-        14.0.1","value":"14.0.1","stackSettings":{"linuxContainerSettings":{"isDeprecated":true,"java8Runtime":"WILDFLY|14.0.1-java8"}}}]}]}},{"id":null,"name":"staticsite","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"HTML
+        7.0","value":"7.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"7.0","isAutoUpdate":true,"isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 7.0.94","value":"7.0.94","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"7.0.94","isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 7.0.81","value":"7.0.81","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"7.0.81","isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 7.0.62","value":"7.0.62","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"7.0.62","isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 7.0.50","value":"7.0.50","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"7.0.50","isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}}]},{"displayText":"Jetty
+        9.3","value":"jetty9.3","minorVersions":[{"displayText":"Jetty 9.3","value":"9.3","stackSettings":{"windowsContainerSettings":{"javaContainer":"JETTY","javaContainerVersion":"9.3","isAutoUpdate":true,"isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Jetty
+        9.3.25","value":"9.3.25","stackSettings":{"windowsContainerSettings":{"javaContainer":"JETTY","javaContainerVersion":"9.3.25","isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Jetty
+        9.3.13","value":"9.3.13","stackSettings":{"windowsContainerSettings":{"javaContainer":"JETTY","javaContainerVersion":"9.3.13","isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}}]},{"displayText":"Jetty
+        9.1","value":"jetty9.1","minorVersions":[{"displayText":"Jetty 9.1","value":"9.1","stackSettings":{"windowsContainerSettings":{"javaContainer":"JETTY","javaContainerVersion":"9.1","isAutoUpdate":true,"isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Jetty
+        9.1.0","value":"9.1.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"JETTY","javaContainerVersion":"9.1.0","isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}}]},{"displayText":"WildFly
+        14","value":"wildfly14","minorVersions":[{"displayText":"WildFly 14","value":"14","stackSettings":{"linuxContainerSettings":{"java8Runtime":"WILDFLY|14-jre8","isDeprecated":true,"isAutoUpdate":true,"runtimes":[{"runtimeVersion":"8","runtime":"WILDFLY|14-jre8"}]}}},{"displayText":"WildFly
+        14.0.1","value":"14.0.1","stackSettings":{"linuxContainerSettings":{"isDeprecated":true,"java8Runtime":"WILDFLY|14.0.1-java8","runtimes":[{"runtimeVersion":"8","runtime":"WILDFLY|14.0.1-java8"}]}}}]}]}},{"id":null,"name":"staticsite","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"HTML
         (Static Content)","value":"staticsite","preferredOs":"linux","majorVersions":[{"displayText":"HTML
         (Static Content)","value":"1","minorVersions":[{"displayText":"HTML (Static
         Content)","value":"1.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"STATICSITE|1.0","isHidden":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false}}}}]}]}},{"id":null,"name":"go","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"Go","value":"go","preferredOs":"linux","majorVersions":[{"displayText":"Go
@@ -542,11 +676,19 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '97731'
+      - '153017'
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Thu, 05 Dec 2024 03:38:18 GMT
+=======
+      - Sat, 18 Oct 2025 07:46:43 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:38:51 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -559,19 +701,29 @@ interactions:
       - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-ms-operation-identifier:
+      - ''
       x-msedge-ref:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - 'Ref A: 33611FC38E2E480BA54C99A4B27D08D7 Ref B: MAA201060514037 Ref C: 2024-12-05T03:38:19Z'
+=======
+      - 'Ref A: D429223E4F494657B6AE8127EB6026DA Ref B: SYD03EDGE1409 Ref C: 2025-10-18T07:46:42Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - 'Ref A: E36A1AB75FD44818ADC793FEC389AA9B Ref B: SYD03EDGE1314 Ref C: 2025-10-17T10:38:50Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
       code: 200
       message: OK
 - request:
-    body: '{"location": "West US", "properties": {"serverFarmId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003",
+    body: '{"location": "East US", "properties": {"serverFarmId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003",
       "reserved": false, "isXenon": false, "hyperV": false, "siteConfig": {"netFrameworkVersion":
-      "v4.6", "appSettings": [{"name": "WEBSITE_NODE_DEFAULT_VERSION", "value": "~16"}],
-      "alwaysOn": true, "localMySqlEnabled": false, "http20Enabled": true}, "scmSiteAlsoStopped":
-      false, "httpsOnly": false}}'
+      "v4.6", "appSettings": [{"name": "WEBSITE_NODE_DEFAULT_VERSION", "value": "~20"}],
+      "alwaysOn": true, "localMySqlEnabled": false, "http20Enabled": true, "http20ProxyFlag":
+      0}, "scmSiteAlsoStopped": false, "httpsOnly": false}}'
     headers:
       Accept:
       - application/json
@@ -582,32 +734,64 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '510'
+      - '532'
       Content-Type:
       - application/json
       ParameterSetName:
       - -g -n --plan
       User-Agent:
-      - AZURECLI/2.67.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.78.0 azsdk-python-core/1.35.0 Python/3.9.6 (macOS-26.0.1-arm64-arm-64bit)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002?api-version=2023-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002?api-version=2024-11-01
   response:
     body:
+<<<<<<< HEAD
+<<<<<<< HEAD
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002","name":"webapp-authentication-test000002","type":"Microsoft.Web/sites","kind":"app","location":"West
         US","properties":{"name":"webapp-authentication-test000002","state":"Running","hostNames":["webapp-authentication-test000002.azurewebsites.net"],"webSpace":"cli_test_authV2000001-WestUSwebspace","selfLink":"https://waws-prod-bay-137.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli_test_authV2000001-WestUSwebspace/sites/webapp-authentication-test000002","repositorySiteName":"webapp-authentication-test000002","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["webapp-authentication-test000002.azurewebsites.net","webapp-authentication-test000002.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-authentication-test000002.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-authentication-test000002.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2024-12-05T03:38:23.5866667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"vnetRouteAllEnabled":false,"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"vnetImagePullEnabled":false,"vnetContentShareEnabled":false,"outboundVnetRouting":{"allTraffic":false,"applicationTraffic":false,"contentShareTraffic":false,"imagePullTraffic":false,"backupRestoreTraffic":false},"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"","windowsFxVersion":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
         all","description":"Allow all access"}],"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
         all","description":"Allow all access"}],"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":null,"elasticWebAppScaleLimit":0,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false},"functionAppConfig":null,"daprConfig":null,"deploymentId":"webapp-authentication-test000002","slotName":null,"trafficManagerHostNames":null,"sku":"Standard","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientAffinityProxyEnabled":false,"blockPathTraversal":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"ipMode":"IPv4","vnetBackupRestoreEnabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"253001F2FCF5A7B1CD759EB861E9BB1596370BE27E47A991F72184277B3D12F2","kind":"app","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"40.112.243.6","possibleInboundIpAddresses":"40.112.243.6","ftpUsername":"webapp-authentication-test000002\\$webapp-authentication-test000002","ftpsHostName":"ftps://waws-prod-bay-137.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"13.93.220.248,13.93.221.96,13.93.221.41,13.93.220.182,40.112.243.6","possibleOutboundIpAddresses":"13.93.220.248,13.93.221.96,13.93.221.41,13.93.220.182,13.93.221.147,13.93.220.112,13.91.111.88,13.93.220.5,13.93.220.231,137.135.38.26,104.40.66.154,104.40.65.169,104.40.68.108,104.40.78.107,104.40.76.238,137.117.12.208,137.117.13.228,168.61.73.157,23.101.192.144,23.99.71.166,23.99.71.188,40.112.243.6","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-137","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli_test_authV2000001","defaultHostName":"webapp-authentication-test000002.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"publicNetworkAccess":null,"buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs,AppServiceAuthenticationLogs","inFlightFeatures":null,"storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"defaultHostNameScope":"Global","privateLinkIdentifiers":null,"sshEnabled":null}}'
+=======
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002","name":"webapp-authentication-test000002","type":"Microsoft.Web/sites","kind":"app","location":"East
+        US","properties":{"name":"webapp-authentication-test000002","state":"Running","hostNames":["webapp-authentication-test000002.azurewebsites.net"],"webSpace":"cli_test_authV2000001-EastUSwebspace","selfLink":"https://waws-prod-blu-511.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli_test_authV2000001-EastUSwebspace/sites/webapp-authentication-test000002","repositorySiteName":"webapp-authentication-test000002","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["webapp-authentication-test000002.azurewebsites.net","webapp-authentication-test000002.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-authentication-test000002.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-authentication-test000002.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003","reserved":false,"isXenon":false,"hyperV":false,"sandboxType":null,"lastModifiedTimeUtc":"2025-10-18T07:46:48.8033333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"outboundVnetRouting":{"allTraffic":false,"applicationTraffic":false,"contentShareTraffic":false,"imagePullTraffic":false,"backupRestoreTraffic":false,"managedIdentityTraffic":false},"legacyServiceEndpointTrafficEvaluation":null,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"","windowsFxVersion":null,"sandboxType":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":null,"elasticWebAppScaleLimit":0,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false,"webJobsEnabled":false},"functionAppConfig":null,"daprConfig":null,"deploymentId":"webapp-authentication-test000002","slotName":null,"trafficManagerHostNames":null,"sku":"Standard","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientAffinityProxyEnabled":false,"useQueryStringAffinity":false,"blockPathTraversal":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"clientCertExclusionEndPoints":null,"hostNamesDisabled":false,"ipMode":"IPv4","domainVerificationIdentifiers":null,"customDomainVerificationId":"70240F0BA32B9DD28948DBEC834A732C467825FB279A572BFED6A386F1954E0A","kind":"app","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"20.119.8.47","possibleInboundIpAddresses":"20.119.8.47","inboundIpv6Address":"2603:1030:210:8::35","possibleInboundIpv6Addresses":"2603:1030:210:8::35","ftpUsername":"webapp-authentication-test000002\\$webapp-authentication-test000002","ftpsHostName":"ftps://waws-prod-blu-511.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"20.102.2.120,20.253.36.200,20.253.36.51,20.253.36.60,20.253.36.61,20.253.36.82,20.253.37.37,20.253.37.41,20.253.37.52,20.253.37.53,20.253.36.4,20.253.37.60,20.253.37.61,20.253.37.106,20.253.37.107,20.253.37.108,20.253.37.109,20.253.37.112,20.119.8.47","possibleOutboundIpAddresses":"20.102.2.120,20.253.36.200,20.253.36.51,20.253.36.60,20.253.36.61,20.253.36.82,20.253.37.37,20.253.37.41,20.253.37.52,20.253.37.53,20.253.36.4,20.253.37.60,20.253.37.61,20.253.37.106,20.253.37.107,20.253.37.108,20.253.37.109,20.253.37.112,57.152.67.243,20.253.36.83,20.253.36.98,20.253.36.99,20.253.36.209,20.253.36.212,20.253.36.213,20.253.36.226,20.253.36.230,20.253.36.231,20.253.36.250,20.253.36.251,20.253.37.4,20.253.37.5,20.253.37.8,20.253.37.9,20.253.37.22,20.253.37.23,20.253.37.36,20.253.37.113,20.253.36.24,20.253.37.118,20.253.37.119,20.253.37.124,20.253.37.181,20.119.8.47","outboundIpv6Addresses":"2603:1030:20c:f::9ac,2603:1030:20c:f::9ad,2603:1030:20c:a::51,2603:1030:20c:a::58d,2603:1030:20c:f::9ae,2603:1030:20e:3::3b3,2603:1030:20e:3::710,2603:1030:20c:f::9b7,2603:1030:20c:f::9b8,2603:1030:20c:f::9b9,2603:1030:20c:f::9ba,2603:1030:20c:f::9bb,2603:1030:20c:f::9c2,2603:1030:20c:f::9c3,2603:1030:20c:f::9c4,2603:1030:20c:f::9c5,2603:1030:20c:f::9c6,2603:1030:20c:f::9c7,2603:1030:210:8::35,2603:10e1:100:2::1477:82f","possibleOutboundIpv6Addresses":"2603:1030:20c:f::9ac,2603:1030:20c:f::9ad,2603:1030:20c:a::51,2603:1030:20c:a::58d,2603:1030:20c:f::9ae,2603:1030:20e:3::3b3,2603:1030:20e:3::710,2603:1030:20c:f::9b7,2603:1030:20c:f::9b8,2603:1030:20c:f::9b9,2603:1030:20c:f::9ba,2603:1030:20c:f::9bb,2603:1030:20c:f::9c2,2603:1030:20c:f::9c3,2603:1030:20c:f::9c4,2603:1030:20c:f::9c5,2603:1030:20c:f::9c6,2603:1030:20c:f::9c7,2603:1030:20c:f::9b3,2603:1030:20e:3::467,2603:1030:20e:3::47e,2603:1030:20c:f::9b4,2603:1030:20c:f::9b5,2603:1030:20c:f::9b6,2603:1030:20c:f::9bc,2603:1030:20c:f::9bd,2603:1030:20c:f::9be,2603:1030:20c:f::9bf,2603:1030:20c:f::9c0,2603:1030:20c:f::9c1,2603:1030:20c:f::9c8,2603:1030:20c:f::9c9,2603:1030:20c:f::9ca,2603:1030:20c:f::9cb,2603:1030:20e:3::7d,2603:1030:20c:f::9cc,2603:1030:20c:f::9af,2603:1030:20e:3::411,2603:1030:20c:f::9b0,2603:1030:20e:3::458,2603:1030:20c:f::9b1,2603:1030:20c:f::9b2,2603:1030:210:8::35,2603:10e1:100:2::1477:82f","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-blu-511","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli_test_authV2000001","defaultHostName":"webapp-authentication-test000002.azurewebsites.net","slotSwapStatus":null,"httpsOnly":true,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"publicNetworkAccess":"Enabled","buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs,AppServiceAuthenticationLogs","inFlightFeatures":null,"storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"privateLinkIdentifiers":null,"sshEnabled":null}}'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002","name":"webapp-authentication-test000002","type":"Microsoft.Web/sites","kind":"app","location":"East
+        US","properties":{"name":"webapp-authentication-test000002","state":"Running","hostNames":["webapp-authentication-test000002.azurewebsites.net"],"webSpace":"cli_test_authV2000001-EastUSwebspace","selfLink":"https://waws-prod-blu-497.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli_test_authV2000001-EastUSwebspace/sites/webapp-authentication-test000002","repositorySiteName":"webapp-authentication-test000002","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["webapp-authentication-test000002.azurewebsites.net","webapp-authentication-test000002.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-authentication-test000002.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-authentication-test000002.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003","reserved":false,"isXenon":false,"hyperV":false,"sandboxType":null,"lastModifiedTimeUtc":"2025-10-17T10:38:53.75","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"outboundVnetRouting":{"allTraffic":false,"applicationTraffic":false,"contentShareTraffic":false,"imagePullTraffic":false,"backupRestoreTraffic":false,"managedIdentityTraffic":false},"legacyServiceEndpointTrafficEvaluation":null,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"","windowsFxVersion":null,"sandboxType":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":null,"elasticWebAppScaleLimit":0,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false,"webJobsEnabled":false},"functionAppConfig":null,"daprConfig":null,"deploymentId":"webapp-authentication-test000002","slotName":null,"trafficManagerHostNames":null,"sku":"Standard","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientAffinityProxyEnabled":false,"useQueryStringAffinity":false,"blockPathTraversal":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"clientCertExclusionEndPoints":null,"hostNamesDisabled":false,"ipMode":"IPv4","domainVerificationIdentifiers":null,"customDomainVerificationId":"70240F0BA32B9DD28948DBEC834A732C467825FB279A572BFED6A386F1954E0A","kind":"app","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"20.119.8.55","possibleInboundIpAddresses":"20.119.8.55","inboundIpv6Address":"2603:1030:210:8::5","possibleInboundIpv6Addresses":"2603:1030:210:8::5","ftpUsername":"webapp-authentication-test000002\\$webapp-authentication-test000002","ftpsHostName":"ftps://waws-prod-blu-497.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.224.92.164,52.224.92.249,52.191.88.59,52.224.92.251,52.224.93.18,52.224.93.20,52.224.94.22,52.224.94.39,52.224.94.68,52.224.94.73,52.224.94.91,52.224.94.104,52.142.33.139,52.224.94.129,52.224.94.131,52.224.94.139,52.149.242.38,52.224.94.157,20.119.8.55","possibleOutboundIpAddresses":"52.224.92.164,52.224.92.249,52.191.88.59,52.224.92.251,52.224.93.18,52.224.93.20,52.224.94.22,52.224.94.39,52.224.94.68,52.224.94.73,52.224.94.91,52.224.94.104,52.142.33.139,52.224.94.129,52.224.94.131,52.224.94.139,52.149.242.38,52.224.94.157,57.152.8.147,52.224.93.31,52.224.93.34,52.224.93.44,52.224.93.53,52.142.39.142,52.224.93.69,52.224.93.72,52.224.93.81,52.224.92.122,52.224.93.112,52.224.93.117,52.224.93.141,52.224.93.157,52.224.93.164,52.224.93.184,52.224.93.202,52.224.93.237,52.224.94.3,52.224.93.56,52.149.173.196,52.224.94.171,52.224.94.176,52.224.94.181,52.142.39.101,20.119.8.55","outboundIpv6Addresses":"2603:1030:20c:f::6e6,2603:1030:20c:9::6dd,2603:1030:20e:3::63d,2603:1030:20c:f::6ea,2603:1030:20c:9::6e2,2603:1030:20c:f::6ee,2603:1030:20c:f::707,2603:1030:20e:3::666,2603:1030:20c:9::700,2603:1030:20c:9::704,2603:1030:20e:3::66c,2603:1030:20c:f::70a,2603:1030:20e:3::671,2603:1030:20c:f::70b,2603:1030:20c:f::70c,2603:1030:20c:f::70f,2603:1030:20e:3::676,2603:1030:20c:9::70e,2603:1030:210:8::5,2603:10e1:100:2::1477:837","possibleOutboundIpv6Addresses":"2603:1030:20c:f::6e6,2603:1030:20c:9::6dd,2603:1030:20e:3::63d,2603:1030:20c:f::6ea,2603:1030:20c:9::6e2,2603:1030:20c:f::6ee,2603:1030:20c:f::707,2603:1030:20e:3::666,2603:1030:20c:9::700,2603:1030:20c:9::704,2603:1030:20e:3::66c,2603:1030:20c:f::70a,2603:1030:20e:3::671,2603:1030:20c:f::70b,2603:1030:20c:f::70c,2603:1030:20c:f::70f,2603:1030:20e:3::676,2603:1030:20c:9::70e,2603:1030:20c:f::6ef,2603:1030:20c:f::6f0,2603:1030:20c:f::6f2,2603:1030:20c:f::6f3,2603:1030:20e:3::64a,2603:1030:20e:3::64c,2603:1030:20c:9::6ec,2603:1030:20e:3::652,2603:1030:20c:9::6ef,2603:1030:20c:9::6f1,2603:1030:20c:9::6f3,2603:1030:20c:f::6fd,2603:1030:20c:f::6ff,2603:1030:20e:3::65d,2603:1030:20e:3::65f,2603:1030:20c:9::6fa,2603:1030:20e:3::662,2603:1030:20c:9::6fd,2603:1030:20e:3::678,2603:1030:20c:f::713,2603:1030:20c:9::70f,2603:1030:20e:3::67a,2603:1030:20c:f::716,2603:1030:20c:9::711,2603:1030:210:8::5,2603:10e1:100:2::1477:837","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-blu-497","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli_test_authV2000001","defaultHostName":"webapp-authentication-test000002.azurewebsites.net","slotSwapStatus":null,"httpsOnly":true,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"publicNetworkAccess":"Enabled","buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs,AppServiceAuthenticationLogs","inFlightFeatures":null,"storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"privateLinkIdentifiers":null,"sshEnabled":null}}'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
     headers:
       cache-control:
       - no-cache
       content-length:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - '7704'
+=======
+      - '9738'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       content-type:
       - application/json
       date:
-      - Thu, 05 Dec 2024 03:38:40 GMT
+      - Fri, 17 Oct 2025 10:39:14 GMT
       etag:
+<<<<<<< HEAD
       - '"1DB46C7232CC0D5"'
+=======
+      - '9729'
+      content-type:
+      - application/json
+      date:
+      - Sat, 18 Oct 2025 07:47:10 GMT
+      etag:
+      - '"1DC40035C87F88B"'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - '"1DC3F523C5F84F5"'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -620,10 +804,28 @@ interactions:
       - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/australiaeast/4148971f-c220-4510-8e43-79f5b57f8fcf
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/9d264e28-340c-44fa-91b8-6a66cfa663d1
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '499'
+      - '800'
       x-msedge-ref:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - 'Ref A: 74978D31A02C43A9A98A3BA3ED0F76CB Ref B: MAA201060514019 Ref C: 2024-12-05T03:38:19Z'
+=======
+      - 'Ref A: E9CC8EBE44B34768A772DEAE24F73310 Ref B: SYD03EDGE1421 Ref C: 2025-10-18T07:46:44Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - 'Ref A: 788A95AFA28C4A84806A2A8CC6FA2FA4 Ref B: SYD03EDGE1920 Ref C: 2025-10-17T10:38:52Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -647,30 +849,35 @@ interactions:
       ParameterSetName:
       - -g -n --plan
       User-Agent:
-      - AZURECLI/2.67.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.78.0 azsdk-python-core/1.35.0 Python/3.9.6 (macOS-26.0.1-arm64-arm-64bit)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/publishxml?api-version=2023-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/publishxml?api-version=2024-11-01
   response:
     body:
       string: <publishData><publishProfile profileName="webapp-authentication-test000002
         - Web Deploy" publishMethod="MSDeploy" publishUrl="webapp-authentication-test000002.scm.azurewebsites.net:443"
         msdeploySite="webapp-authentication-test000002" userName="REDACTED" userPWD="REDACTED"
-        destinationAppUrl="http://webapp-authentication-test000002.azurewebsites.net"
+        destinationAppUrl="https://webapp-authentication-test000002.azurewebsites.net"
         SQLServerDBConnectionString="REDACTED" mySQLDBConnectionString="" hostingProviderForumLink=""
         controlPanelLink="https://portal.azure.com" webSystem="WebSites"><databases
         /></publishProfile><publishProfile profileName="webapp-authentication-test000002
+<<<<<<< HEAD
+<<<<<<< HEAD
         - FTP" publishMethod="FTP" publishUrl="ftps://waws-prod-bay-137.ftp.azurewebsites.windows.net/site/wwwroot"
         ftpPassiveMode="True" userName="REDACTED" userPWD="REDACTED" destinationAppUrl="http://webapp-authentication-test000002.azurewebsites.net"
+=======
+        - FTP" publishMethod="FTP" publishUrl="ftps://waws-prod-blu-511.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="REDACTED" userPWD="REDACTED" destinationAppUrl="https://webapp-authentication-test000002.azurewebsites.net"
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+        - FTP" publishMethod="FTP" publishUrl="ftps://waws-prod-blu-497.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="REDACTED" userPWD="REDACTED" destinationAppUrl="https://webapp-authentication-test000002.azurewebsites.net"
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
         SQLServerDBConnectionString="REDACTED" mySQLDBConnectionString="" hostingProviderForumLink=""
         controlPanelLink="https://portal.azure.com" webSystem="WebSites"><databases
         /></publishProfile><publishProfile profileName="webapp-authentication-test000002
         - Zip Deploy" publishMethod="ZipDeploy" publishUrl="webapp-authentication-test000002.scm.azurewebsites.net:443"
-        userName="REDACTED" userPWD="REDACTED" destinationAppUrl="http://webapp-authentication-test000002.azurewebsites.net"
-        SQLServerDBConnectionString="REDACTED" mySQLDBConnectionString="" hostingProviderForumLink=""
-        controlPanelLink="https://portal.azure.com" webSystem="WebSites"><databases
-        /></publishProfile><publishProfile profileName="webapp-authentication-test000002
-        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftps://waws-prod-bay-137dr.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="REDACTED" userPWD="REDACTED" destinationAppUrl="http://webapp-authentication-test000002.azurewebsites.net"
+        userName="REDACTED" userPWD="REDACTED" destinationAppUrl="https://webapp-authentication-test000002.azurewebsites.net"
         SQLServerDBConnectionString="REDACTED" mySQLDBConnectionString="" hostingProviderForumLink=""
         controlPanelLink="https://portal.azure.com" webSystem="WebSites"><databases
         /></publishProfile></publishData>
@@ -678,11 +885,19 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '2043'
+      - '1535'
       content-type:
       - application/xml
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Thu, 05 Dec 2024 03:38:42 GMT
+=======
+      - Sat, 18 Oct 2025 07:47:11 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:39:14 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -695,10 +910,28 @@ interactions:
       - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/australiaeast/90bc6ce4-925b-47a1-8b77-d75f6161a338
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/d70fae15-e493-4cd7-8fc2-1b8ad44fc6fd
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '799'
       x-msedge-ref:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - 'Ref A: 18526B4587F147B685C312AA525F2E9E Ref B: MAA201060515047 Ref C: 2024-12-05T03:38:41Z'
+=======
+      - 'Ref A: E9E99E89324B47A29E761C145E9F0F3B Ref B: SYD03EDGE2109 Ref C: 2025-10-18T07:47:10Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - 'Ref A: 35F540D829BD485EB184180F803C7BB6 Ref B: SYD03EDGE1109 Ref C: 2025-10-17T10:39:14Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -720,12 +953,12 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - python/3.11.9 (Windows-10-10.0.26100-SP0) AZURECLI/2.67.0
+      - python/3.9.6 (macOS-26.0.1-arm64-arm-64bit) AZURECLI/2.78.0
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authSettings/list?api-version=2020-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettings","name":"authsettings","type":"Microsoft.Web/sites/config","location":"West
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettings","name":"authsettings","type":"Microsoft.Web/sites/config","location":"East
         US","properties":{"enabled":false,"unauthenticatedClientAction":null,"tokenStoreEnabled":null,"allowedExternalRedirectUrls":null,"defaultProvider":null,"clientId":null,"clientSecret":null,"clientSecretSettingName":null,"clientSecretCertificateThumbprint":null,"issuer":null,"allowedAudiences":null,"additionalLoginParams":null,"isAadAutoProvisioned":false,"aadClaimsAuthorization":null,"googleClientId":null,"googleClientSecret":null,"googleClientSecretSettingName":null,"googleOAuthScopes":null,"facebookAppId":null,"facebookAppSecret":null,"facebookAppSecretSettingName":null,"facebookOAuthScopes":null,"gitHubClientId":null,"gitHubClientSecret":null,"gitHubClientSecretSettingName":null,"gitHubOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"twitterConsumerSecretSettingName":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountClientSecretSettingName":null,"microsoftAccountOAuthScopes":null,"configVersion":"v1"}}'
     headers:
       cache-control:
@@ -735,7 +968,15 @@ interactions:
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Thu, 05 Dec 2024 03:38:45 GMT
+=======
+      - Sat, 18 Oct 2025 07:47:11 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:39:15 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -748,10 +989,28 @@ interactions:
       - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/ed95b8e6-e78d-4315-9f7b-41e969992501
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/54826852-681a-4b8c-b72f-6b93982b4ac0
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '799'
       x-msedge-ref:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - 'Ref A: F23E058CA79F4AB2BA0B8F946827B1E1 Ref B: MAA201060516049 Ref C: 2024-12-05T03:38:44Z'
+=======
+      - 'Ref A: 7112C99394764FB89061A7D6879B89E8 Ref B: SYD03EDGE2016 Ref C: 2025-10-18T07:47:12Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - 'Ref A: 13A05A3084C84F12A4A69FD4AB85EE4E Ref B: SYD03EDGE2017 Ref C: 2025-10-17T10:39:15Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -773,12 +1032,12 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.67.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.78.0 azsdk-python-core/1.35.0 Python/3.9.6 (macOS-26.0.1-arm64-arm-64bit)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettings/list?api-version=2023-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettings/list?api-version=2024-11-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettings","name":"authsettings","type":"Microsoft.Web/sites/config","location":"West
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettings","name":"authsettings","type":"Microsoft.Web/sites/config","location":"East
         US","properties":{"enabled":false,"unauthenticatedClientAction":null,"tokenStoreEnabled":null,"allowedExternalRedirectUrls":null,"defaultProvider":null,"clientId":null,"clientSecret":null,"clientSecretSettingName":null,"clientSecretCertificateThumbprint":null,"issuer":null,"allowedAudiences":null,"additionalLoginParams":null,"isAadAutoProvisioned":false,"aadClaimsAuthorization":null,"googleClientId":null,"googleClientSecret":null,"googleClientSecretSettingName":null,"googleOAuthScopes":null,"facebookAppId":null,"facebookAppSecret":null,"facebookAppSecretSettingName":null,"facebookOAuthScopes":null,"gitHubClientId":null,"gitHubClientSecret":null,"gitHubClientSecretSettingName":null,"gitHubOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"twitterConsumerSecretSettingName":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountClientSecretSettingName":null,"microsoftAccountOAuthScopes":null,"configVersion":"v1"}}'
     headers:
       cache-control:
@@ -788,7 +1047,15 @@ interactions:
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Thu, 05 Dec 2024 03:38:53 GMT
+=======
+      - Sat, 18 Oct 2025 07:47:13 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:39:16 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -801,10 +1068,28 @@ interactions:
       - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/a0fe01b9-de35-4116-b16a-e20f2b98ef96
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/6faf2bd7-d6a5-4d47-80c1-bf0e8059d3ef
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '799'
       x-msedge-ref:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - 'Ref A: 163F5E0C8A324D72B7DD664C3B4F3412 Ref B: MAA201060514045 Ref C: 2024-12-05T03:38:52Z'
+=======
+      - 'Ref A: 90617B058C8643C78F9FE18DCD7896EF Ref B: SYD03EDGE2009 Ref C: 2025-10-18T07:47:13Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - 'Ref A: 8BB0D1CFFBB14A9E8ED0ACFB08D88946 Ref B: SYD03EDGE0714 Ref C: 2025-10-17T10:39:16Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -828,12 +1113,12 @@ interactions:
         --aad-client-id --aad-client-secret-certificate-thumbprint --aad-allowed-token-audiences
         --aad-token-issuer-url --facebook-app-id --facebook-oauth-scopes
       User-Agent:
-      - python/3.11.9 (Windows-10-10.0.26100-SP0) AZURECLI/2.67.0
+      - python/3.9.6 (macOS-26.0.1-arm64-arm-64bit) AZURECLI/2.78.0
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authSettings/list?api-version=2020-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettings","name":"authsettings","type":"Microsoft.Web/sites/config","location":"West
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettings","name":"authsettings","type":"Microsoft.Web/sites/config","location":"East
         US","properties":{"enabled":false,"unauthenticatedClientAction":null,"tokenStoreEnabled":null,"allowedExternalRedirectUrls":null,"defaultProvider":null,"clientId":null,"clientSecret":null,"clientSecretSettingName":null,"clientSecretCertificateThumbprint":null,"issuer":null,"allowedAudiences":null,"additionalLoginParams":null,"isAadAutoProvisioned":false,"aadClaimsAuthorization":null,"googleClientId":null,"googleClientSecret":null,"googleClientSecretSettingName":null,"googleOAuthScopes":null,"facebookAppId":null,"facebookAppSecret":null,"facebookAppSecretSettingName":null,"facebookOAuthScopes":null,"gitHubClientId":null,"gitHubClientSecret":null,"gitHubClientSecretSettingName":null,"gitHubOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"twitterConsumerSecretSettingName":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountClientSecretSettingName":null,"microsoftAccountOAuthScopes":null,"configVersion":"v1"}}'
     headers:
       cache-control:
@@ -843,7 +1128,15 @@ interactions:
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Thu, 05 Dec 2024 03:38:56 GMT
+=======
+      - Sat, 18 Oct 2025 07:47:14 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:39:20 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -856,10 +1149,28 @@ interactions:
       - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/95af9461-107a-43cc-ae06-3183593c1811
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/australiasoutheast/ee7d76cc-3017-4e83-9597-525fd1e965fc
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '799'
       x-msedge-ref:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - 'Ref A: D606D5D515194442B8684D2FA23CF689 Ref B: MAA201060515037 Ref C: 2024-12-05T03:38:55Z'
+=======
+      - 'Ref A: 30F3585AAED0469B9BC9866B57C1DD53 Ref B: SYD03EDGE0706 Ref C: 2025-10-18T07:47:14Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - 'Ref A: EE8A604FAE964DCE8E6FF6440200E712 Ref B: SYD03EDGE1321 Ref C: 2025-10-17T10:39:17Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -883,12 +1194,12 @@ interactions:
         --aad-client-id --aad-client-secret-certificate-thumbprint --aad-allowed-token-audiences
         --aad-token-issuer-url --facebook-app-id --facebook-oauth-scopes
       User-Agent:
-      - AZURECLI/2.67.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.78.0 azsdk-python-core/1.35.0 Python/3.9.6 (macOS-26.0.1-arm64-arm-64bit)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettings/list?api-version=2023-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettings/list?api-version=2024-11-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettings","name":"authsettings","type":"Microsoft.Web/sites/config","location":"West
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettings","name":"authsettings","type":"Microsoft.Web/sites/config","location":"East
         US","properties":{"enabled":false,"unauthenticatedClientAction":null,"tokenStoreEnabled":null,"allowedExternalRedirectUrls":null,"defaultProvider":null,"clientId":null,"clientSecret":null,"clientSecretSettingName":null,"clientSecretCertificateThumbprint":null,"issuer":null,"allowedAudiences":null,"additionalLoginParams":null,"isAadAutoProvisioned":false,"aadClaimsAuthorization":null,"googleClientId":null,"googleClientSecret":null,"googleClientSecretSettingName":null,"googleOAuthScopes":null,"facebookAppId":null,"facebookAppSecret":null,"facebookAppSecretSettingName":null,"facebookOAuthScopes":null,"gitHubClientId":null,"gitHubClientSecret":null,"gitHubClientSecretSettingName":null,"gitHubOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"twitterConsumerSecretSettingName":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountClientSecretSettingName":null,"microsoftAccountOAuthScopes":null,"configVersion":"v1"}}'
     headers:
       cache-control:
@@ -898,7 +1209,15 @@ interactions:
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Thu, 05 Dec 2024 03:38:58 GMT
+=======
+      - Sat, 18 Oct 2025 07:47:14 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:39:21 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -911,10 +1230,28 @@ interactions:
       - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/351e0cf2-c10c-4b5f-90b5-97b4dd46d8fe
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/461a8706-870f-45f5-8b55-741fdfd16917
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '799'
       x-msedge-ref:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - 'Ref A: 4F7D3990E9FB492891BF86E406C6F31D Ref B: MAA201060515019 Ref C: 2024-12-05T03:38:56Z'
+=======
+      - 'Ref A: 8DD522A41BDB432FB50845D9528D454B Ref B: SYD03EDGE1309 Ref C: 2025-10-18T07:47:15Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - 'Ref A: 559BD33331234B5B874230F0DF93EA3C Ref B: SYD03EDGE1016 Ref C: 2025-10-17T10:39:21Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -944,12 +1281,12 @@ interactions:
         --aad-client-id --aad-client-secret-certificate-thumbprint --aad-allowed-token-audiences
         --aad-token-issuer-url --facebook-app-id --facebook-oauth-scopes
       User-Agent:
-      - AZURECLI/2.67.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.78.0 azsdk-python-core/1.35.0 Python/3.9.6 (macOS-26.0.1-arm64-arm-64bit)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettings?api-version=2023-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettings?api-version=2024-11-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettings","name":"authsettings","type":"Microsoft.Web/sites/config","location":"West
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettings","name":"authsettings","type":"Microsoft.Web/sites/config","location":"East
         US","properties":{"enabled":true,"runtimeVersion":"1.2.8","unauthenticatedClientAction":"RedirectToLoginPage","tokenStoreEnabled":false,"allowedExternalRedirectUrls":null,"defaultProvider":"Facebook","tokenRefreshExtensionHours":7.2,"clientId":"aad_client_id","clientSecret":null,"clientSecretSettingName":null,"clientSecretCertificateThumbprint":"aad_thumbprint","issuer":"https://issuer_url","allowedAudiences":["https://audience1"],"additionalLoginParams":null,"isAadAutoProvisioned":false,"aadClaimsAuthorization":"{\"allowed_groups\":null,\"allowed_client_applications\":[]}","googleClientId":null,"googleClientSecret":null,"googleClientSecretSettingName":null,"googleOAuthScopes":null,"facebookAppId":"facebook_id","facebookAppSecret":null,"facebookAppSecretSettingName":null,"facebookOAuthScopes":null,"gitHubClientId":null,"gitHubClientSecret":null,"gitHubClientSecretSettingName":null,"gitHubOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"twitterConsumerSecretSettingName":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountClientSecretSettingName":null,"microsoftAccountOAuthScopes":null,"configVersion":"v1"}}'
     headers:
       cache-control:
@@ -959,7 +1296,15 @@ interactions:
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Thu, 05 Dec 2024 03:39:00 GMT
+=======
+      - Sat, 18 Oct 2025 07:47:16 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:39:23 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -972,12 +1317,30 @@ interactions:
       - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/c87a4306-d4a7-4de2-b697-22f8a1506d39
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/784c570a-ca21-4cef-9291-0ca629a2b0aa
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-ms-ratelimit-remaining-subscription-global-writes:
-      - '2999'
+      - '11999'
       x-ms-ratelimit-remaining-subscription-writes:
-      - '199'
+      - '799'
       x-msedge-ref:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - 'Ref A: C6D05050613641F780FF8C4ECD1FDCFD Ref B: MAA201060513017 Ref C: 2024-12-05T03:38:59Z'
+=======
+      - 'Ref A: 2603703480C5442CAABA7E5213E19BF0 Ref B: SYD03EDGE1718 Ref C: 2025-10-18T07:47:16Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - 'Ref A: FA8C6576282F41018F59F07A7A6A81C6 Ref B: SYD03EDGE2021 Ref C: 2025-10-17T10:39:22Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -999,12 +1362,12 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.67.0 azsdk-python-core/1.31.0 Python/3.11.9 (Windows-10-10.0.26100-SP0)
+      - AZURECLI/2.78.0 azsdk-python-core/1.35.0 Python/3.9.6 (macOS-26.0.1-arm64-arm-64bit)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettings/list?api-version=2023-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettings/list?api-version=2024-11-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettings","name":"authsettings","type":"Microsoft.Web/sites/config","location":"West
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettings","name":"authsettings","type":"Microsoft.Web/sites/config","location":"East
         US","properties":{"enabled":true,"runtimeVersion":"1.2.8","unauthenticatedClientAction":"RedirectToLoginPage","tokenStoreEnabled":false,"allowedExternalRedirectUrls":null,"defaultProvider":"Facebook","tokenRefreshExtensionHours":7.2,"clientId":"aad_client_id","clientSecret":null,"clientSecretSettingName":null,"clientSecretCertificateThumbprint":"aad_thumbprint","issuer":"https://issuer_url","allowedAudiences":["https://audience1"],"additionalLoginParams":null,"isAadAutoProvisioned":false,"aadClaimsAuthorization":"{\"allowed_groups\":null,\"allowed_client_applications\":[]}","googleClientId":null,"googleClientSecret":null,"googleClientSecretSettingName":null,"googleOAuthScopes":null,"facebookAppId":"facebook_id","facebookAppSecret":null,"facebookAppSecretSettingName":null,"facebookOAuthScopes":null,"gitHubClientId":null,"gitHubClientSecret":null,"gitHubClientSecretSettingName":null,"gitHubOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"twitterConsumerSecretSettingName":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountClientSecretSettingName":null,"microsoftAccountOAuthScopes":null,"configVersion":"v1"}}'
     headers:
       cache-control:
@@ -1014,7 +1377,15 @@ interactions:
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Thu, 05 Dec 2024 03:39:03 GMT
+=======
+      - Sat, 18 Oct 2025 07:47:18 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:39:23 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -1027,10 +1398,28 @@ interactions:
       - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/7aaa47e7-c7c6-4d36-a9ef-4d3137019eeb
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/448e6dd3-a5ae-4c78-bed9-1586c7115471
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '799'
       x-msedge-ref:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - 'Ref A: 6B406183E6DB4689A01E0B3F81BA95F7 Ref B: MAA201060516045 Ref C: 2024-12-05T03:39:03Z'
+=======
+      - 'Ref A: 3A5C3B7A20E74459AA8BD49AD6ED26A7 Ref B: SYD03EDGE1019 Ref C: 2025-10-18T07:47:18Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - 'Ref A: 32403DB2C0BD49C4A76E062487D279A9 Ref B: SYD03EDGE1310 Ref C: 2025-10-17T10:39:23Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:

--- a/src/authV2/azext_authV2/tests/latest/recordings/test_authV2_clientsecret_param_combinations.yaml
+++ b/src/authV2/azext_authV2/tests/latest/recordings/test_authV2_clientsecret_param_combinations.yaml
@@ -1,49 +1,6 @@
 interactions:
 - request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - appservice plan create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --sku
-      User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.10 (Linux-5.15.0-1034-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_261_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_authV2000001?api-version=2022-09-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001","name":"cli_test_authV2000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2023-03-28T11:19:25Z"},"properties":{"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '320'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 28 Mar 2023 11:19:26 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"location": "westus", "sku": {"name": "S1", "tier": "STANDARD", "capacity":
+    body: '{"location": "eastus", "sku": {"name": "S1", "tier": "STANDARD", "capacity":
       1}, "properties": {"perSiteScaling": false, "isXenon": false, "zoneRedundant":
       false}}'
     headers:
@@ -62,43 +19,82 @@ interactions:
       ParameterSetName:
       - -g -n --sku
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-web/7.0.0 Python/3.10.10 (Linux-5.15.0-1034-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_261_0
+      - AZURECLI/2.78.0 azsdk-python-core/1.35.0 Python/3.9.6 (macOS-26.0.1-arm64-arm-64bit)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003?api-version=2023-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003?api-version=2024-11-01
   response:
     body:
+<<<<<<< HEAD
+<<<<<<< HEAD
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003","name":"webapp-authentication-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"westus","properties":{"serverFarmId":34142,"name":"webapp-authentication-plan000003","sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1},"workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"cli_test_authV2000001-WestUSwebspace","subscription":"00000000-0000-0000-0000-000000000000","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":0,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
         US","perSiteScaling":false,"elasticScaleEnabled":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"cli_test_authV2000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-bay-177_34142","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null,"kubeEnvironmentProfile":null,"zoneRedundant":false},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'
+=======
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003","name":"webapp-authentication-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"eastus","properties":{"serverFarmId":97621,"name":"webapp-authentication-plan000003","sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1},"workerSize":"Small","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Small","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"cli_test_authV2000001-EastUSwebspace","subscription":"9e223dbe-3399-4e19-88eb-0975f02ac87f","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":0,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"East
+        US","perSiteScaling":false,"elasticScaleEnabled":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"cli_test_authV2000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-blu-301_97621","targetWorkerCount":0,"targetWorkerSizeId":0,"targetWorkerSku":null,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null,"kubeEnvironmentProfile":null,"zoneRedundant":false,"maximumNumberOfZones":3,"currentNumberOfZonesUtilized":1,"migrateToVMSS":null,"vnetConnectionsUsed":null,"vnetConnectionsMax":null,"createdTime":"2025-10-18T07:47:29.71","asyncScalingEnabled":false,"isCustomMode":null,"powerState":null,"eligibleLogCategories":null},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003","name":"webapp-authentication-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"eastus","properties":{"serverFarmId":80605,"name":"webapp-authentication-plan000003","sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1},"workerSize":"Small","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Small","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"cli_test_authV2000001-EastUSwebspace","subscription":"9e223dbe-3399-4e19-88eb-0975f02ac87f","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":0,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"East
+        US","perSiteScaling":false,"elasticScaleEnabled":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"cli_test_authV2000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-blu-315_80605","targetWorkerCount":0,"targetWorkerSizeId":0,"targetWorkerSku":null,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null,"kubeEnvironmentProfile":null,"zoneRedundant":false,"maximumNumberOfZones":3,"currentNumberOfZonesUtilized":1,"migrateToVMSS":null,"vnetConnectionsUsed":null,"vnetConnectionsMax":null,"createdTime":"2025-10-17T10:39:35.52","asyncScalingEnabled":false,"isCustomMode":null,"powerState":null,"eligibleLogCategories":null},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1544'
+      - '1829'
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Tue, 28 Mar 2023 11:19:49 GMT
       etag:
       - '"1D96167359E4EB5"'
+=======
+      - Sat, 18 Oct 2025 07:47:31 GMT
+      etag:
+      - '"1DC400374F58800"'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:39:37 GMT
+      etag:
+      - '"1DC3F5255050755"'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
       - no-cache
-      server:
-      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+<<<<<<< HEAD
+<<<<<<< HEAD
       x-ms-ratelimit-remaining-subscription-writes:
       - '1196'
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/e46045ed-2832-4c30-adad-8d148b7c7245
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '12000'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '800'
+      x-msedge-ref:
+      - 'Ref A: A63D270F171740E797E2A0D5C067F62E Ref B: SYD03EDGE1311 Ref C: 2025-10-18T07:47:22Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/e76639fc-9c7d-4925-8204-e78a014ad64f
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '12000'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '800'
+      x-msedge-ref:
+      - 'Ref A: 444175B2CA9E4E7996ECDAFD1FF06712 Ref B: SYD03EDGE1308 Ref C: 2025-10-17T10:39:27Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -118,40 +114,69 @@ interactions:
       ParameterSetName:
       - -g -n --plan
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-web/7.0.0 Python/3.10.10 (Linux-5.15.0-1034-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_261_0
+      - AZURECLI/2.78.0 azsdk-python-core/1.35.0 Python/3.9.6 (macOS-26.0.1-arm64-arm-64bit)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003?api-version=2023-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003?api-version=2024-11-01
   response:
     body:
+<<<<<<< HEAD
+<<<<<<< HEAD
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003","name":"webapp-authentication-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
         US","properties":{"serverFarmId":34142,"name":"webapp-authentication-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"cli_test_authV2000001-WestUSwebspace","subscription":"00000000-0000-0000-0000-000000000000","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
         US","perSiteScaling":false,"elasticScaleEnabled":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"cli_test_authV2000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-bay-177_34142","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null,"kubeEnvironmentProfile":null,"zoneRedundant":false},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'
+=======
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003","name":"webapp-authentication-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"East
+        US","properties":{"serverFarmId":97621,"name":"webapp-authentication-plan000003","workerSize":"Small","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Small","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"cli_test_authV2000001-EastUSwebspace","subscription":"9e223dbe-3399-4e19-88eb-0975f02ac87f","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"East
+        US","perSiteScaling":false,"elasticScaleEnabled":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"cli_test_authV2000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-blu-301_97621","targetWorkerCount":0,"targetWorkerSizeId":0,"targetWorkerSku":null,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null,"kubeEnvironmentProfile":null,"zoneRedundant":false,"maximumNumberOfZones":3,"currentNumberOfZonesUtilized":1,"migrateToVMSS":null,"vnetConnectionsUsed":0,"vnetConnectionsMax":2,"createdTime":"2025-10-18T07:47:29.71","asyncScalingEnabled":false,"isCustomMode":null,"powerState":null,"eligibleLogCategories":null},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003","name":"webapp-authentication-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"East
+        US","properties":{"serverFarmId":80605,"name":"webapp-authentication-plan000003","workerSize":"Small","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Small","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"cli_test_authV2000001-EastUSwebspace","subscription":"9e223dbe-3399-4e19-88eb-0975f02ac87f","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"East
+        US","perSiteScaling":false,"elasticScaleEnabled":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"cli_test_authV2000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-blu-315_80605","targetWorkerCount":0,"targetWorkerSizeId":0,"targetWorkerSku":null,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null,"kubeEnvironmentProfile":null,"zoneRedundant":false,"maximumNumberOfZones":3,"currentNumberOfZonesUtilized":1,"migrateToVMSS":null,"vnetConnectionsUsed":0,"vnetConnectionsMax":2,"createdTime":"2025-10-17T10:39:35.52","asyncScalingEnabled":false,"isCustomMode":null,"powerState":null,"eligibleLogCategories":null},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1470'
+      - '1749'
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Tue, 28 Mar 2023 11:19:50 GMT
+=======
+      - Sat, 18 Oct 2025 07:47:32 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:39:39 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
       - no-cache
-      server:
-      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 11FD36ED83DC4DC7B6E0299B5D12957C Ref B: SYD03EDGE1910 Ref C: 2025-10-18T07:47:32Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 36C78468DB6642ACB303CF9031E32FD0 Ref B: SYD03EDGE0915 Ref C: 2025-10-17T10:39:37Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -175,10 +200,9 @@ interactions:
       ParameterSetName:
       - -g -n --plan
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-web/7.0.0 Python/3.10.10 (Linux-5.15.0-1034-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_261_0
+      - AZURECLI/2.78.0 azsdk-python-core/1.35.0 Python/3.9.6 (macOS-26.0.1-arm64-arm-64bit)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/checknameavailability?api-version=2023-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/checknameavailability?api-version=2024-11-01
   response:
     body:
       string: '{"nameAvailable":true,"reason":"","message":""}'
@@ -190,23 +214,45 @@ interactions:
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Tue, 28 Mar 2023 11:19:51 GMT
+=======
+      - Sat, 18 Oct 2025 07:47:33 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:39:40 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
       - no-cache
-      server:
-      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/9df3c38d-5e04-46df-bffc-d6b4f05fc73a
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 8C3D7037FB8B484EAC6201593BF300F8 Ref B: SYD03EDGE1714 Ref C: 2025-10-18T07:47:33Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/651f6b36-819b-427d-8a57-f50eacf0228b
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 210E23C8786A4900B702FB90A59549FA Ref B: SYD03EDGE1316 Ref C: 2025-10-17T10:39:39Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -226,15 +272,18 @@ interactions:
       ParameterSetName:
       - -g -n --plan
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-web/7.0.0 Python/3.10.10 (Linux-5.15.0-1034-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_261_0
+      - AZURECLI/2.78.0 azsdk-python-core/1.35.0 Python/3.9.6 (macOS-26.0.1-arm64-arm-64bit)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.Web/webAppStacks?api-version=2023-01-01
+    uri: https://management.azure.com/providers/Microsoft.Web/webAppStacks?api-version=2024-11-01
   response:
     body:
       string: '{"value":[{"id":null,"name":"dotnet","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":".NET","value":"dotnet","preferredOs":"windows","majorVersions":[{"displayText":".NET
-        7 (STS)","value":"dotnet7","minorVersions":[{"displayText":".NET 7 (STS)","value":"7","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v7.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"7.x"}},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|7.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"7.x"}}}}]},{"displayText":".NET
-        6","value":"dotnet6","minorVersions":[{"displayText":".NET 6 (LTS)","value":"6","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v6.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"6.0.x"}},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|6.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"6.0.x"}}}}]},{"displayText":".NET
+        10 (LTS)","value":"dotnet10","minorVersions":[{"displayText":".NET 10 (LTS)
+        (Preview)","value":"10","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v10.0","remoteDebuggingSupported":false,"isHidden":false,"isPreview":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"10.x"},"endOfLifeDate":"2028-12-01T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|10.0","remoteDebuggingSupported":false,"isHidden":false,"isPreview":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"10.x"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2028-12-01T00:00:00Z"}}}]},{"displayText":".NET
+        9 (STS)","value":"dotnet9","minorVersions":[{"displayText":".NET 9 (STS)","value":"9","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v9.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"9.x"},"endOfLifeDate":"2026-05-12T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|9.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"9.x"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2026-05-12T00:00:00Z"}}}]},{"displayText":".NET
+        8 (LTS)","value":"dotnet8","minorVersions":[{"displayText":".NET 8 (LTS)","value":"8","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v8.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.x"},"endOfLifeDate":"2026-11-10T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|8.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.x"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2026-11-10T00:00:00Z"}}}]},{"displayText":".NET
+        7 (STS)","value":"dotnet7","minorVersions":[{"displayText":".NET 7 (STS)","value":"7","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v7.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"7.x"},"endOfLifeDate":"2024-05-14T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|7.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"7.x"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2024-05-14T00:00:00Z"}}}]},{"displayText":".NET
+        6","value":"dotnet6","minorVersions":[{"displayText":".NET 6 (LTS)","value":"6","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v6.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"6.0.x"},"endOfLifeDate":"2024-11-12T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|6.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"6.0.x"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2024-11-12T00:00:00Z"}}}]},{"displayText":".NET
         5","value":"dotnet5","minorVersions":[{"displayText":".NET 5","value":"5","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v5.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"5.0.x"},"endOfLifeDate":"2022-05-08T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|5.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"5.0.x"},"endOfLifeDate":"2022-05-08T00:00:00Z"}}}]},{"displayText":".NET
         Core 3","value":"dotnetcore3","minorVersions":[{"displayText":".NET Core 3.1
         (LTS)","value":"3.1","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"3.1","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.1.301"},"isDeprecated":true,"endOfLifeDate":"2022-12-03T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"DOTNETCORE|3.1","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.1.301"},"isDeprecated":true,"endOfLifeDate":"2022-12-03T00:00:00Z"}}},{"displayText":".NET
@@ -247,9 +296,11 @@ interactions:
         V4","value":"aspdotnetv4","minorVersions":[{"displayText":"ASP.NET V4.8","value":"v4.8","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v4.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.1"}}}}]},{"displayText":"ASP.NET
         V3","value":"aspdotnetv3","minorVersions":[{"displayText":"ASP.NET V3.5","value":"v3.5","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v2.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"2.1"}}}}]}]}},{"id":null,"name":"node","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"Node","value":"node","preferredOs":"linux","majorVersions":[{"displayText":"Node
         LTS","value":"lts","minorVersions":[{"displayText":"Node LTS","value":"lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|lts","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true}}}}]},{"displayText":"Node
-        18","value":"18","minorVersions":[{"displayText":"Node 18 LTS","value":"18-lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|18-lts","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"18.x"}},"windowsRuntimeSettings":{"runtimeVersion":"~18","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"18.x"}}}}]},{"displayText":"Node
-        16","value":"16","minorVersions":[{"displayText":"Node 16 LTS","value":"16-lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|16-lts","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"16.x"},"endOfLifeDate":"2024-04-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"~16","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"16.x"},"endOfLifeDate":"2024-04-30T00:00:00Z"}}}]},{"displayText":"Node
-        14","value":"14","minorVersions":[{"displayText":"Node 14 LTS","value":"14-lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|14-lts","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"14.x"},"endOfLifeDate":"2023-04-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"~14","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"14.x"},"endOfLifeDate":"2023-04-30T00:00:00Z"}}}]},{"displayText":"Node
+        22","value":"22","minorVersions":[{"displayText":"Node 22 LTS","value":"22-lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|22-lts","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"22.x"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2027-04-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"~22","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"22.x"},"endOfLifeDate":"2027-04-30T00:00:00Z"}}}]},{"displayText":"Node
+        20","value":"20","minorVersions":[{"displayText":"Node 20 LTS","value":"20-lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|20-lts","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"20.x"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2026-04-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"~20","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"20.x"},"endOfLifeDate":"2026-04-30T00:00:00Z"}}}]},{"displayText":"Node
+        18","value":"18","minorVersions":[{"displayText":"Node 18 LTS","value":"18-lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|18-lts","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"18.x"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2025-04-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"~18","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"18.x"},"endOfLifeDate":"2025-04-30T00:00:00Z"}}}]},{"displayText":"Node
+        16","value":"16","minorVersions":[{"displayText":"Node 16 LTS","value":"16-lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|16-lts","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"16.x"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2023-09-11T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"~16","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"16.x"},"endOfLifeDate":"2023-09-11T00:00:00Z"}}}]},{"displayText":"Node
+        14","value":"14","minorVersions":[{"displayText":"Node 14 LTS","value":"14-lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|14-lts","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"14.x"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2023-04-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"~14","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"14.x"},"endOfLifeDate":"2023-04-30T00:00:00Z"}}}]},{"displayText":"Node
         12","value":"12","minorVersions":[{"displayText":"Node 12 LTS","value":"12-lts","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|12-lts","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"12.x"},"endOfLifeDate":"2022-04-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"12.13.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2022-04-01T00:00:00Z"}}},{"displayText":"Node
         12.9","value":"12.9","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|12.9","isDeprecated":true,"remoteDebuggingSupported":true,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"12.x"},"endOfLifeDate":"2022-04-01T00:00:00Z"}}}]},{"displayText":"Node
         10","value":"10","minorVersions":[{"displayText":"Node 10 LTS","value":"10-LTS","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|10-lts","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"10.x"},"endOfLifeDate":"2021-04-01T00:00:00Z"}}},{"displayText":"Node
@@ -284,23 +335,28 @@ interactions:
         4","value":"4","minorVersions":[{"displayText":"Node 4.8","value":"4.8","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|4.8","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2018-04-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"4.8","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2018-04-30T00:00:00Z"}}},{"displayText":"Node
         4.5","value":"4.5","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|4.5","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2018-04-30T00:00:00Z"}}},{"displayText":"Node
         4.4","value":"4.4","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"NODE|4.4","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2018-04-30T00:00:00Z"}}}]}]}},{"id":null,"name":"python","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"Python","value":"python","preferredOs":"linux","majorVersions":[{"displayText":"Python
-        3","value":"3","minorVersions":[{"displayText":"Python 3.11","value":"3.11","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.11","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.11"},"isHidden":false}}},{"displayText":"Python
-        3.10","value":"3.10","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.10","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.10"},"isHidden":false,"isEarlyAccess":false}}},{"displayText":"Python
-        3.9","value":"3.9","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.9","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.9"},"isHidden":false}}},{"displayText":"Python
-        3.8","value":"3.8","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.8","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.8"}}}},{"displayText":"Python
-        3.7","value":"3.7","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.7","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.7"}}}},{"displayText":"Python
-        3.6","value":"3.6","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.6","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.6"}},"windowsRuntimeSettings":{"runtimeVersion":"3.4.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.6"}}}}]},{"displayText":"Python
+        3","value":"3","minorVersions":[{"displayText":"Python 3.14","value":"3.14","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.14","remoteDebuggingSupported":false,"isHidden":true,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.14"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2030-10-31T00:00:00Z"}}},{"displayText":"Python
+        3.13","value":"3.13","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.13","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.13"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2029-10-31T00:00:00Z"}}},{"displayText":"Python
+        3.12","value":"3.12","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.12","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.12"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2028-10-31T00:00:00Z"}}},{"displayText":"Python
+        3.11","value":"3.11","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.11","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.11"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2027-10-31T00:00:00Z","isHidden":false}}},{"displayText":"Python
+        3.10","value":"3.10","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.10","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.10"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2026-10-31T00:00:00Z","isHidden":false,"isEarlyAccess":false}}},{"displayText":"Python
+        3.9","value":"3.9","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.9","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.9"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2025-10-31T00:00:00Z","isHidden":false}}},{"displayText":"Python
+        3.8","value":"3.8","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.8","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.8"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2024-10-07T00:00:00Z"}}},{"displayText":"Python
+        3.7","value":"3.7","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.7","remoteDebuggingSupported":false,"isDeprecated":true,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.7"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2023-06-27T00:00:00Z"}}},{"displayText":"Python
+        3.6","value":"3.6","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|3.6","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.6"},"endOfLifeDate":"2021-12-23T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"3.4.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.6"}}}}]},{"displayText":"Python
         2","value":"2","minorVersions":[{"displayText":"Python 2.7","value":"2.7","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PYTHON|2.7","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"2.7"},"endOfLifeDate":"2020-02-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"2.7.3","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"2.7"},"endOfLifeDate":"2020-02-01T00:00:00Z"}}}]}]}},{"id":null,"name":"php","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"PHP","value":"php","preferredOs":"linux","majorVersions":[{"displayText":"PHP
-        8","value":"8","minorVersions":[{"displayText":"PHP 8.2","value":"8.2","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|8.2","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.2"},"endOfLifeDate":"2025-11-30T00:00:00Z"}}},{"displayText":"PHP
-        8.1","value":"8.1","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|8.1","isHidden":false,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.1"},"endOfLifeDate":"2024-11-30T00:00:00Z"}}},{"displayText":"PHP
-        8.0","value":"8.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|8.0","isHidden":false,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.0"},"endOfLifeDate":"2023-11-30T00:00:00Z"}}}]},{"displayText":"PHP
+        8","value":"8","minorVersions":[{"displayText":"PHP 8.4","value":"8.4","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|8.4","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.4"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2028-12-31T00:00:00Z"}}},{"displayText":"PHP
+        8.3","value":"8.3","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|8.3","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.3"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2027-12-31T00:00:00Z"}}},{"displayText":"PHP
+        8.2","value":"8.2","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|8.2","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.2"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2026-12-31T00:00:00Z"}}},{"displayText":"PHP
+        8.1","value":"8.1","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|8.1","isHidden":false,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.1"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2025-12-31T00:00:00Z"}}},{"displayText":"PHP
+        8.0","value":"8.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|8.0","isDeprecated":true,"isHidden":false,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.0"},"supportedFeatures":{"disableSsh":true},"endOfLifeDate":"2023-11-26T00:00:00Z"}}}]},{"displayText":"PHP
         7","value":"7","minorVersions":[{"displayText":"PHP 7.4","value":"7.4","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"7.4","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"7.4","notSupportedInCreates":true},"isDeprecated":true,"endOfLifeDate":"2022-11-30T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"PHP|7.4","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"7.4","notSupportedInCreates":true},"isDeprecated":true,"endOfLifeDate":"2022-11-30T00:00:00Z"}}},{"displayText":"PHP
         7.3","value":"7.3","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|7.3","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"7.3","notSupportedInCreates":true},"endOfLifeDate":"2021-12-06T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"7.3","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"7.3","notSupportedInCreates":true},"endOfLifeDate":"2021-12-06T00:00:00Z"}}},{"displayText":"PHP
         7.2","value":"7.2","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|7.2","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2020-11-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"7.2","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true},"endOfLifeDate":"2020-11-30T00:00:00Z"}}},{"displayText":"PHP
         7.1","value":"7.1","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"7.1","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2020-02-01T00:00:00Z"}}},{"displayText":"7.0","value":"7.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|7.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2020-02-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"7.0","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2020-02-01T00:00:00Z"}}}]},{"displayText":"PHP
         5","value":"5","minorVersions":[{"displayText":"PHP 5.6","value":"5.6","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"PHP|5.6","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2021-02-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"5.6","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2021-02-01T00:00:00Z"}}}]}]}},{"id":null,"name":"ruby","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"Ruby","value":"ruby","preferredOs":"linux","majorVersions":[{"displayText":"Ruby
-        2","value":"2","minorVersions":[{"displayText":"Ruby 2.7","value":"2.7","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.7","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2023-03-31T00:00:00Z"}}},{"displayText":"Ruby
-        2.7.3","value":"2.7.3","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.7.3","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"isHidden":true,"endOfLifeDate":"2023-03-31T00:00:00Z"}}},{"displayText":"Ruby
+        2","value":"2","minorVersions":[{"displayText":"Ruby 2.7","value":"2.7","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.7","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2023-03-31T00:00:00Z"}}},{"displayText":"Ruby
+        2.7.3","value":"2.7.3","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.7.3","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"isHidden":true,"endOfLifeDate":"2023-03-31T00:00:00Z"}}},{"displayText":"Ruby
         2.6","value":"2.6","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.6","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2022-03-31T00:00:00Z"}}},{"displayText":"Ruby
         2.6.2","value":"2.6.2","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.6.2","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2022-03-31T00:00:00Z"}}},{"displayText":"Ruby
         2.5","value":"2.5","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.5","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2021-03-31T00:00:00Z"}}},{"displayText":"Ruby
@@ -310,44 +366,70 @@ interactions:
         2.3","value":"2.3","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.3","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2019-03-31T00:00:00Z"}}},{"displayText":"Ruby
         2.3.8","value":"2.3.8","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.3.8","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2019-03-31T00:00:00Z"}}},{"displayText":"Ruby
         2.3.3","value":"2.3.3","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"RUBY|2.3.3","remoteDebuggingSupported":false,"isDeprecated":true,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"endOfLifeDate":"2019-03-31T00:00:00Z"}}}]}]}},{"id":null,"name":"java","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"Java","value":"java","preferredOs":"linux","majorVersions":[{"displayText":"Java
-        17","value":"17","minorVersions":[{"displayText":"Java 17","value":"17.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2031-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2031-09-01T00:00:00Z"}}},{"displayText":"Java
-        17.0.2","value":"17.0.2","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2031-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17.0.2","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2031-09-01T00:00:00Z"}}},{"displayText":"Java
-        17.0.1","value":"17.0.1","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2031-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17.0.1","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2031-09-01T00:00:00Z"}}}]},{"displayText":"Java
-        11","value":"11","minorVersions":[{"displayText":"Java 11","value":"11.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"}}},{"displayText":"Java
-        11.0.14","value":"11.0.14","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.14","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"}}},{"displayText":"Java
-        11.0.13","value":"11.0.13","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.13","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"}}},{"displayText":"Java
-        11.0.12","value":"11.0.12","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.12","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"}}},{"displayText":"Java
-        11.0.11","value":"11.0.11","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.11","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"}}},{"displayText":"Java
-        11.0.9","value":"11.0.9","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.9","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"}}},{"displayText":"Java
-        11.0.8","value":"11.0.8","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"11.0.8","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"}}},{"displayText":"Java
-        11.0.7","value":"11.0.7","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.7","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"}}},{"displayText":"Java
-        11.0.6","value":"11.0.6","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.6","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"}}},{"displayText":"Java
-        11.0.5","value":"11.0.5","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.5_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"}}},{"displayText":"Java
-        11.0.3","value":"11.0.3","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"11.0.3_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"}}},{"displayText":"Java
-        11.0.2","value":"11.0.2","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"11.0.2_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2026-09-01T00:00:00Z"}}}]},{"displayText":"Java
-        8","value":"8","minorVersions":[{"displayText":"Java 8","value":"8.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"1.8","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
-        1.8.0_332","value":"8.0.332","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_332","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
-        1.8.0_322","value":"8.0.322","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_322","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
-        1.8.0_312","value":"8.0.312","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_312","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
-        1.8.0_302","value":"8.0.302","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_302","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
-        1.8.0_292","value":"8.0.292","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_292","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
-        1.8.0_282","value":"8.0.282","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_282","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
-        1.8.0_275","value":"8.0.275","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
-        1.8.0_265","value":"8.0.265","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_265","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
-        1.8.0_252","value":"8.0.252","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_252","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
-        1.8.0_242","value":"8.0.242","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_242","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
-        1.8.0_232","value":"8.0.232","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_232_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
-        1.8.0_212","value":"8.0.212","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_212_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
-        1.8.0_202","value":"8.0.202","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_202_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
+        21","value":"21","minorVersions":[{"displayText":"Java 21","value":"21.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"21","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"}}},{"displayText":"Java
+        21.0.6","value":"21.0.6","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"21.0.6","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"}}},{"displayText":"Java
+        21.0.5","value":"21.0.5","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"21.0.5","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"}}},{"displayText":"Java
+        21.0.4","value":"21.0.4","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"21.0.4","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"}}},{"displayText":"Java
+        21.0.3","value":"21.0.3","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"21.0.3","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"}}},{"displayText":"Java
+        21.0.1","value":"21.0.1","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"21.0.1","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"21"},"endOfLifeDate":"2028-09-01T00:00:00Z"}}}]},{"displayText":"Java
+        17","value":"17","minorVersions":[{"displayText":"Java 17","value":"17.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        17.0.14","value":"17.0.14","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17.0.14","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        17.0.13","value":"17.0.13","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17.0.13","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        17.0.12","value":"17.0.12","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17.0.12","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        17.0.11","value":"17.0.11","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17.0.11","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        17.0.9","value":"17.0.9","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17.0.9","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        17.0.4","value":"17.0.4","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17.0.4","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        17.0.3","value":"17.0.3","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17.0.3","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        17.0.2","value":"17.0.2","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17.0.2","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        17.0.1","value":"17.0.1","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"17.0.1","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}}]},{"displayText":"Java
+        11","value":"11","minorVersions":[{"displayText":"Java 11","value":"11.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.26","value":"11.0.26","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.26","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.25","value":"11.0.25","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.25","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.24","value":"11.0.24","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.24","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.23","value":"11.0.23","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.23","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.21","value":"11.0.21","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.21","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.16","value":"11.0.16","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.16","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.15","value":"11.0.15","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.15","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.14","value":"11.0.14","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.14","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.13","value":"11.0.13","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.13","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.12","value":"11.0.12","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.12","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.11","value":"11.0.11","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.11","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.9","value":"11.0.9","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.9","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.8","value":"11.0.8","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"11.0.8","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.7","value":"11.0.7","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.7","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.6","value":"11.0.6","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.6","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.5","value":"11.0.5","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"11.0.5_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.3","value":"11.0.3","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"11.0.3_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}},{"displayText":"Java
+        11.0.2","value":"11.0.2","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"11.0.2_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"endOfLifeDate":"2027-09-01T00:00:00Z"}}}]},{"displayText":"Java
+        8","value":"8","minorVersions":[{"displayText":"Java 8","value":"8.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"1.8","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_442","value":"8.0.442","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_442","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_432","value":"8.0.432","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_432","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_422","value":"8.0.422","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_422","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_412","value":"8.0.412","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_412","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_392","value":"8.0.392","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_392","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_345","value":"8.0.345","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_345","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_332","value":"8.0.332","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_332","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_322","value":"8.0.322","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_322","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_312","value":"8.0.312","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_312","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_302","value":"8.0.302","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_302","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_292","value":"8.0.292","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_292","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_282","value":"8.0.282","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_282","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_275","value":"8.0.275","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_265","value":"8.0.265","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_265","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_252","value":"8.0.252","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_252","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_242","value":"8.0.242","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_242","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_232","value":"8.0.232","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"},"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_232_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_212","value":"8.0.212","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_212_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_202","value":"8.0.202","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_202_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
         1.8.0_202 (Oracle)","value":"8.0.202 (Oracle)","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_202","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"}}}},{"displayText":"Java
-        1.8.0_181","value":"8.0.181","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_181_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_181","value":"8.0.181","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_181_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
         1.8.0_181 (Oracle)","value":"8.0.181 (Oracle)","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_181","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"}}}},{"displayText":"Java
-        1.8.0_172","value":"8.0.172","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_172_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_172","value":"8.0.172","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_172_ZULU","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":false},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
         1.8.0_172 (Oracle)","value":"8.0.172 (Oracle)","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_172","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"}}}},{"displayText":"Java
-        1.8.0_144","value":"8.0.144","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_144","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_144","value":"8.0.144","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_144","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
         1.8.0_111 (Oracle)","value":"8.0.111 (Oracle)","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_111","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"}}}},{"displayText":"Java
-        1.8.0_102","value":"8.0.102","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_102","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
-        1.8.0_92","value":"8.0.92","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_92","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2025-03-01T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_102","value":"8.0.102","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_102","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
+        1.8.0_92","value":"8.0.92","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_92","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"endOfLifeDate":"2026-11-30T00:00:00Z"}}},{"displayText":"Java
         1.8.0_73 (Oracle)","value":"8.0.73 (Oracle)","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_73","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"}}}},{"displayText":"Java
         1.8.0_60 (Oracle)","value":"8.0.60 (Oracle)","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_60","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"}}}},{"displayText":"Java
         1.8.0_25 (Oracle)","value":"8.0.25 (Oracle)","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8.0_25","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"}}}}]},{"displayText":"Java
@@ -363,131 +445,271 @@ interactions:
         1.7.0_51 (Oracle)","value":"7.0.51 (Oracle)","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.7.0_51","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false,"isDefaultOff":true},"gitHubActionSettings":{"isSupported":false}}}}]}]}},{"id":null,"name":"javacontainers","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"Java
         Containers","value":"javacontainers","majorVersions":[{"displayText":"Java
         SE (Embedded Web Server)","value":"javase","minorVersions":[{"displayText":"Java
-        SE (Embedded Web Server)","value":"SE","stackSettings":{"windowsContainerSettings":{"javaContainer":"JAVA","javaContainerVersion":"SE","isAutoUpdate":true},"linuxContainerSettings":{"java17Runtime":"JAVA|17-java17","java11Runtime":"JAVA|11-java11","java8Runtime":"JAVA|8-jre8","isAutoUpdate":true}}},{"displayText":"Java
-        SE 17.0.2","value":"17.0.2","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.2"}}},{"displayText":"Java
-        SE 17.0.1","value":"17.0.1","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.1"}}},{"displayText":"Java
-        SE 11.0.14","value":"11.0.14","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.14"}}},{"displayText":"Java
-        SE 11.0.13","value":"11.0.13","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.13"}}},{"displayText":"Java
-        SE 11.0.12","value":"11.0.12","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.12"}}},{"displayText":"Java
-        SE 11.0.11","value":"11.0.11","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.11"}}},{"displayText":"Java
-        SE 11.0.9","value":"11.0.9","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.9"}}},{"displayText":"Java
-        SE 11.0.7","value":"11.0.7","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.7"}}},{"displayText":"Java
-        SE 11.0.6","value":"11.0.6","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.6"}}},{"displayText":"Java
-        SE 11.0.5","value":"11.0.5","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.5"}}},{"displayText":"Java
-        SE 8u332","value":"1.8.332","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u332"}}},{"displayText":"Java
-        SE 8u322","value":"1.8.322","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u322"}}},{"displayText":"Java
-        SE 8u312","value":"1.8.312","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u312"}}},{"displayText":"Java
-        SE 8u302","value":"1.8.302","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u302"}}},{"displayText":"Java
-        SE 8u292","value":"1.8.292","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u292"}}},{"displayText":"Java
-        SE 8u275","value":"1.8.275","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u275"}}},{"displayText":"Java
-        SE 8u252","value":"1.8.252","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u252"}}},{"displayText":"Java
-        SE 8u242","value":"1.8.242","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u242"}}},{"displayText":"Java
-        SE 8u232","value":"1.8.232","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u232"}}}]},{"displayText":"Red
+        SE (Embedded Web Server)","value":"SE","stackSettings":{"windowsContainerSettings":{"javaContainer":"JAVA","javaContainerVersion":"SE","isAutoUpdate":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java21Runtime":"JAVA|21-java21","java17Runtime":"JAVA|17-java17","java11Runtime":"JAVA|11-java11","java8Runtime":"JAVA|8-jre8","isAutoUpdate":true,"runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8-jre8"},{"runtimeVersion":"11","runtime":"JAVA|11-java11"},{"runtimeVersion":"17","runtime":"JAVA|17-java17"},{"runtimeVersion":"21","runtime":"JAVA|21-java21"}]}}},{"displayText":"Java
+        SE 21.0.7","value":"21.0.7","stackSettings":{"linuxContainerSettings":{"java21Runtime":"JAVA|21.0.7","runtimes":[{"runtimeVersion":"21","runtime":"JAVA|21.0.7"}]}}},{"displayText":"Java
+        SE 21.0.6","value":"21.0.6","stackSettings":{"linuxContainerSettings":{"java21Runtime":"JAVA|21.0.6","runtimes":[{"runtimeVersion":"21","runtime":"JAVA|21.0.6"}]}}},{"displayText":"Java
+        SE 21.0.5","value":"21.0.5","stackSettings":{"linuxContainerSettings":{"java21Runtime":"JAVA|21.0.5","runtimes":[{"runtimeVersion":"21","runtime":"JAVA|21.0.5"}]}}},{"displayText":"Java
+        SE 21.0.4","value":"21.0.4","stackSettings":{"linuxContainerSettings":{"java21Runtime":"JAVA|21.0.4","runtimes":[{"runtimeVersion":"21","runtime":"JAVA|21.0.4"}]}}},{"displayText":"Java
+        SE 21.0.3","value":"21.0.3","stackSettings":{"linuxContainerSettings":{"java21Runtime":"JAVA|21.0.3","runtimes":[{"runtimeVersion":"21","runtime":"JAVA|21.0.3"}]}}},{"displayText":"Java
+        SE 21.0.1","value":"21.0.1","stackSettings":{"linuxContainerSettings":{"java21Runtime":"JAVA|21.0.1","runtimes":[{"runtimeVersion":"21","runtime":"JAVA|21.0.1"}]}}},{"displayText":"Java
+        SE 17.0.15","value":"17.0.15","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.15","runtimes":[{"runtimeVersion":"17","runtime":"JAVA|17.0.15"}]}}},{"displayText":"Java
+        SE 17.0.14","value":"17.0.14","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.14","runtimes":[{"runtimeVersion":"17","runtime":"JAVA|17.0.14"}]}}},{"displayText":"Java
+        SE 17.0.13","value":"17.0.13","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.13","runtimes":[{"runtimeVersion":"17","runtime":"JAVA|17.0.13"}]}}},{"displayText":"Java
+        SE 17.0.12","value":"17.0.12","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.12","runtimes":[{"runtimeVersion":"17","runtime":"JAVA|17.0.12"}]}}},{"displayText":"Java
+        SE 17.0.11","value":"17.0.11","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.11","runtimes":[{"runtimeVersion":"17","runtime":"JAVA|17.0.11"}]}}},{"displayText":"Java
+        SE 17.0.9","value":"17.0.9","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.9","runtimes":[{"runtimeVersion":"17","runtime":"JAVA|17.0.9"}]}}},{"displayText":"Java
+        SE 17.0.4","value":"17.0.4","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.4","runtimes":[{"runtimeVersion":"17","runtime":"JAVA|17.0.4"}]}}},{"displayText":"Java
+        SE 17.0.3","value":"17.0.3","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.3","runtimes":[{"runtimeVersion":"17","runtime":"JAVA|17.0.3"}]}}},{"displayText":"Java
+        SE 17.0.2","value":"17.0.2","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.2","runtimes":[{"runtimeVersion":"17","runtime":"JAVA|17.0.2"}]}}},{"displayText":"Java
+        SE 17.0.1","value":"17.0.1","stackSettings":{"linuxContainerSettings":{"java17Runtime":"JAVA|17.0.1","runtimes":[{"runtimeVersion":"17","runtime":"JAVA|17.0.1"}]}}},{"displayText":"Java
+        SE 11.0.27","value":"11.0.27","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.27","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.27"}]}}},{"displayText":"Java
+        SE 11.0.26","value":"11.0.26","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.26","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.26"}]}}},{"displayText":"Java
+        SE 11.0.25","value":"11.0.25","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.25","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.25"}]}}},{"displayText":"Java
+        SE 11.0.24","value":"11.0.24","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.24","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.24"}]}}},{"displayText":"Java
+        SE 11.0.23","value":"11.0.23","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.23","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.23"}]}}},{"displayText":"Java
+        SE 11.0.21","value":"11.0.21","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.21","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.21"}]}}},{"displayText":"Java
+        SE 11.0.16","value":"11.0.16","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.16","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.16"}]}}},{"displayText":"Java
+        SE 11.0.15","value":"11.0.15","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.15","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.15"}]}}},{"displayText":"Java
+        SE 11.0.14","value":"11.0.14","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.14","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.14"}]}}},{"displayText":"Java
+        SE 11.0.13","value":"11.0.13","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.13","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.13"}]}}},{"displayText":"Java
+        SE 11.0.12","value":"11.0.12","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.12","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.12"}]}}},{"displayText":"Java
+        SE 11.0.11","value":"11.0.11","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.11","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.11"}]}}},{"displayText":"Java
+        SE 11.0.9","value":"11.0.9","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.9","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.9"}]}}},{"displayText":"Java
+        SE 11.0.7","value":"11.0.7","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.7","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.7"}]}}},{"displayText":"Java
+        SE 11.0.6","value":"11.0.6","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.6","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.6"}]}}},{"displayText":"Java
+        SE 11.0.5","value":"11.0.5","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JAVA|11.0.5","runtimes":[{"runtimeVersion":"11","runtime":"JAVA|11.0.5"}]}}},{"displayText":"Java
+        SE 8u452","value":"1.8.452","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u452","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u452"}]}}},{"displayText":"Java
+        SE 8u442","value":"1.8.442","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u442","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u442"}]}}},{"displayText":"Java
+        SE 8u432","value":"1.8.432","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u432","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u432"}]}}},{"displayText":"Java
+        SE 8u422","value":"1.8.422","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u422","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u422"}]}}},{"displayText":"Java
+        SE 8u412","value":"1.8.412","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u412","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u412"}]}}},{"displayText":"Java
+        SE 8u392","value":"1.8.392","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u392","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u392"}]}}},{"displayText":"Java
+        SE 8u345","value":"1.8.345","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u345","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u345"}]}}},{"displayText":"Java
+        SE 8u332","value":"1.8.332","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u332","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u332"}]}}},{"displayText":"Java
+        SE 8u322","value":"1.8.322","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u322","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u322"}]}}},{"displayText":"Java
+        SE 8u312","value":"1.8.312","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u312","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u312"}]}}},{"displayText":"Java
+        SE 8u302","value":"1.8.302","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u302","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u302"}]}}},{"displayText":"Java
+        SE 8u292","value":"1.8.292","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u292","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u292"}]}}},{"displayText":"Java
+        SE 8u275","value":"1.8.275","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u275","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u275"}]}}},{"displayText":"Java
+        SE 8u252","value":"1.8.252","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u252","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u252"}]}}},{"displayText":"Java
+        SE 8u242","value":"1.8.242","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u242","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u242"}]}}},{"displayText":"Java
+        SE 8u232","value":"1.8.232","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JAVA|8u232","runtimes":[{"runtimeVersion":"8","runtime":"JAVA|8u232"}]}}}]},{"displayText":"Red
+        Hat JBoss EAP 8","value":"jbosseap8.0","minorVersions":[{"displayText":"Red
+        Hat JBoss EAP 8","value":"8","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8-java11","java17Runtime":"JBOSSEAP|8-java17","java21Runtime":"JBOSSEAP|8-java21","isAutoUpdate":true,"runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8-java17"},{"runtimeVersion":"21","runtime":"JBOSSEAP|8-java21"}]}}},{"displayText":"Red
+        Hat JBoss EAP 8.0 update 8","value":"8.0.8","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.8-java11","java17Runtime":"JBOSSEAP|8.0.8-java17","java21Runtime":"JBOSSEAP|8.0.8-java21","runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8.0.8-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8.0.8-java17"},{"runtimeVersion":"21","runtime":"JBOSSEAP|8.0.8-java21"}]}}},{"displayText":"Red
+        Hat JBoss EAP 8.0 update 7","value":"8.0.7","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.7-java11","java17Runtime":"JBOSSEAP|8.0.7-java17","java21Runtime":"JBOSSEAP|8.0.7-java21","runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8.0.7-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8.0.7-java17"},{"runtimeVersion":"21","runtime":"JBOSSEAP|8.0.7-java21"}]}}},{"displayText":"Red
+        Hat JBoss EAP 8.0 update 5.1","value":"8.0.5.1","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.5.1-java11","java17Runtime":"JBOSSEAP|8.0.5.1-java17","runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8.0.5.1-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8.0.5.1-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 8.0 update 4.1","value":"8.0.4.1","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.4.1-java11","java17Runtime":"JBOSSEAP|8.0.4.1-java17","runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8.0.4.1-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8.0.4.1-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 8.0 update 3","value":"8.0.3","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.3-java11","java17Runtime":"JBOSSEAP|8.0.3-java17","runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8.0.3-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8.0.3-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 8.0 update 2.1","value":"8.0.2.1","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.2.1-java11","java17Runtime":"JBOSSEAP|8.0.2.1-java17","runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8.0.2.1-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8.0.2.1-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 8.0 update 1","value":"8.0.1","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.1-java11","java17Runtime":"JBOSSEAP|8.0.1-java17","runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8.0.1-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8.0.1-java17"}]}}}]},{"displayText":"Red
+        Hat JBoss EAP 8 BYO License","value":"jbosseap8.0_byol","minorVersions":[{"displayText":"Red
+        Hat JBoss EAP 8 BYO License","value":"8","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8-java11_byol","java17Runtime":"JBOSSEAP|8-java17_byol","java21Runtime":"JBOSSEAP|8-java21_byol","isAutoUpdate":true,"runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8-java17_byol"},{"runtimeVersion":"21","runtime":"JBOSSEAP|8-java21_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 8.0 update 7","value":"8.0.7","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.7-java11_byol","java17Runtime":"JBOSSEAP|8.0.7-java17_byol","java21Runtime":"JBOSSEAP|8.0.7-java21_byol","runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8.0.7-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8.0.7-java17_byol"},{"runtimeVersion":"21","runtime":"JBOSSEAP|8.0.7-java21_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 8.0 update 5.1","value":"8.0.5.1","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.5.1-java11_byol","java17Runtime":"JBOSSEAP|8.0.5.1-java17_byol","runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8.0.5.1-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8.0.5.1-java17_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 8.0 update 4.1 BYO License","value":"8.0.4.1","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.4.1-java11_byol","java17Runtime":"JBOSSEAP|8.0.4.1-java17_byol","runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8.0.4.1-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8.0.4.1-java17_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 8 update 3 BYO License","value":"8.0.3","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.3-java11_byol","java17Runtime":"JBOSSEAP|8.0.3-java17_byol","runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8.0.3-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8.0.3-java17_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 8.0 update 2.1 BYO License","value":"8.0.2","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.2-java11_byol","java17Runtime":"JBOSSEAP|8.0.2-java17_byol","runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8.0.2-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8.0.2-java17_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 8 update 1 BYO License","value":"8.0.1","stackSettings":{"linuxContainerSettings":{"java11Runtime":"JBOSSEAP|8.0.1-java11_byol","java17Runtime":"JBOSSEAP|8.0.1-java17_byol","runtimes":[{"runtimeVersion":"11","runtime":"JBOSSEAP|8.0.1-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|8.0.1-java17_byol"}]}}}]},{"displayText":"Red
         Hat JBoss EAP 7","value":"jbosseap","minorVersions":[{"displayText":"Red Hat
-        JBoss EAP 7","value":"7","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7-java8","java11Runtime":"JBOSSEAP|7-java11","isAutoUpdate":true}}},{"displayText":"Red
-        Hat JBoss EAP 7.4.2","value":"7.4.2","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.2-java8","java11Runtime":"JBOSSEAP|7.4.2-java11"}}},{"displayText":"Red
-        Hat JBoss EAP 7.4.1","value":"7.4.1","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.1-java8","java11Runtime":"JBOSSEAP|7.4.1-java11"}}},{"displayText":"Red
-        Hat JBoss EAP 7.4.0","value":"7.4.0","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.0-java8","java11Runtime":"JBOSSEAP|7.4.0-java11"}}},{"displayText":"Red
-        Hat JBoss EAP 7.3.9","value":"7.3.9","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.3.9-java8","java11Runtime":"JBOSSEAP|7.3.9-java11"}}},{"displayText":"Red
-        Hat JBoss EAP 7.3","value":"7.3","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.3-java8","java11Runtime":"JBOSSEAP|7.3-java11","isAutoUpdate":true,"isHidden":true}}},{"displayText":"Red
-        Hat JBoss EAP 7.4","value":"7.4","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4-java8","java11Runtime":"JBOSSEAP|7.4-java11","isAutoUpdate":true,"isHidden":true}}},{"displayText":"JBoss
-        EAP 7.2","value":"7.2.0","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.2-java8","isDeprecated":true}}}]},{"displayText":"Apache
+        JBoss EAP 7","value":"7","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7-java8","java11Runtime":"JBOSSEAP|7-java11","java17Runtime":"JBOSSEAP|7-java17","isAutoUpdate":true,"runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.22","value":"7.4.22","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.22-java8","java11Runtime":"JBOSSEAP|7.4.22-java11","java17Runtime":"JBOSSEAP|7.4.22-java17","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.22-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.22-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.22-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.21","value":"7.4.21","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.21-java8","java11Runtime":"JBOSSEAP|7.4.21-java11","java17Runtime":"JBOSSEAP|7.4.21-java17","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.21-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.21-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.21-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.20","value":"7.4.20","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.20-java8","java11Runtime":"JBOSSEAP|7.4.20-java11","java17Runtime":"JBOSSEAP|7.4.20-java17","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.20-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.20-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.20-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.18","value":"7.4.18","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.18-java8","java11Runtime":"JBOSSEAP|7.4.18-java11","java17Runtime":"JBOSSEAP|7.4.18-java17","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.18-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.18-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.18-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.17","value":"7.4.17","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.17-java8","java11Runtime":"JBOSSEAP|7.4.17-java11","java17Runtime":"JBOSSEAP|7.4.17-java17","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.17-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.17-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.17-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.16","value":"7.4.16","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.16-java8","java11Runtime":"JBOSSEAP|7.4.16-java11","java17Runtime":"JBOSSEAP|7.4.16-java17","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.16-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.16-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.16-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.13","value":"7.4.13","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.13-java8","java11Runtime":"JBOSSEAP|7.4.13-java11","java17Runtime":"JBOSSEAP|7.4.13-java17","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.13-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.13-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.13-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.7","value":"7.4.7","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.7-java8","java11Runtime":"JBOSSEAP|7.4.7-java11","java17Runtime":"JBOSSEAP|7.4.7-java17","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.7-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.7-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.7-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.5","value":"7.4.5","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.5-java8","java11Runtime":"JBOSSEAP|7.4.5-java11","java17Runtime":"JBOSSEAP|7.4.5-java17","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.5-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.5-java11"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.5-java17"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.2","value":"7.4.2","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.2-java8","java11Runtime":"JBOSSEAP|7.4.2-java11","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.2-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.2-java11"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.1","value":"7.4.1","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.1-java8","java11Runtime":"JBOSSEAP|7.4.1-java11","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.1-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.1-java11"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.0","value":"7.4.0","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.0-java8","java11Runtime":"JBOSSEAP|7.4.0-java11","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.0-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.0-java11"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.3.10","value":"7.3.10","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.3.10-java8","java11Runtime":"JBOSSEAP|7.3.10-java11","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.3.10-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.3.10-java11"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.3.9","value":"7.3.9","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.3.9-java8","java11Runtime":"JBOSSEAP|7.3.9-java11","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.3.9-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.3.9-java11"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.3","value":"7.3","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.3-java8","java11Runtime":"JBOSSEAP|7.3-java11","isAutoUpdate":true,"isHidden":true,"runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.3-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.3-java11"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4","value":"7.4","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4-java8","java11Runtime":"JBOSSEAP|7.4-java11","isAutoUpdate":true,"isHidden":true,"runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4-java8"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4-java11"}]}}},{"displayText":"JBoss
+        EAP 7.2","value":"7.2.0","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.2-java8","isDeprecated":true,"runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.2-java8"}]}}}]},{"displayText":"Red
+        Hat JBoss EAP 7 BYO License","value":"jbosseap7_byol","minorVersions":[{"displayText":"Red
+        Hat JBoss EAP 7 BYO License","value":"7","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7-java8_byol","java11Runtime":"JBOSSEAP|7-java11_byol","java17Runtime":"JBOSSEAP|7-java17_byol","isAutoUpdate":true,"runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7-java8_byol"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7-java17_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.21 BYO License","value":"7.4.21","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.21-java8_byol","java11Runtime":"JBOSSEAP|7.4.21-java11_byol","java17Runtime":"JBOSSEAP|7.4.21-java17_byol","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.21-java8_byol"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.21-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.21-java17_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.20 BYO License","value":"7.4.20","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.20-java8_byol","java11Runtime":"JBOSSEAP|7.4.20-java11_byol","java17Runtime":"JBOSSEAP|7.4.20-java17_byol","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.20-java8_byol"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.20-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.20-java17_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.18 BYO License","value":"7.4.18","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.18-java8_byol","java11Runtime":"JBOSSEAP|7.4.18-java11_byol","java17Runtime":"JBOSSEAP|7.4.18-java17_byol","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.18-java8_byol"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.18-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.18-java17_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.16 BYO License","value":"7.4.16","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.16-java8_byol","java11Runtime":"JBOSSEAP|7.4.16-java11_byol","java17Runtime":"JBOSSEAP|7.4.16-java17_byol","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.16-java8_byol"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.16-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.16-java17_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.13 BYO License","value":"7.4.13","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.13-java8_byol","java11Runtime":"JBOSSEAP|7.4.13-java11_byol","java17Runtime":"JBOSSEAP|7.4.13-java17_byol","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.13-java8_byol"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.13-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.13-java17_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.7 BYO License","value":"7.4.7","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.7-java8_byol","java11Runtime":"JBOSSEAP|7.4.7-java11_byol","java17Runtime":"JBOSSEAP|7.4.7-java17_byol","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.7-java8_byol"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.7-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.7-java17_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.5 BYO License","value":"7.4.5","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.5-java8_byol","java11Runtime":"JBOSSEAP|7.4.5-java11_byol","java17Runtime":"JBOSSEAP|7.4.5-java17_byol","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.5-java8_byol"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.5-java11_byol"},{"runtimeVersion":"17","runtime":"JBOSSEAP|7.4.5-java17_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.2 BYO License","value":"7.4.2","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.2-java8_byol","java11Runtime":"JBOSSEAP|7.4.2-java11_byol","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.2-java8_byol"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.2-java11_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.1 BYO License","value":"7.4.1","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.1-java8_byol","java11Runtime":"JBOSSEAP|7.4.1-java11_byol","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.1-java8_byol"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.1-java11_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.4.0 BYO License","value":"7.4.0","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.4.0-java8_byol","java11Runtime":"JBOSSEAP|7.4.0-java11_byol","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.4.0-java8_byol"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.4.0-java11_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.3.10 BYO License","value":"7.3.10","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.3.10-java8_byol","java11Runtime":"JBOSSEAP|7.3.10-java11_byol","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.3.10-java8_byol"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.3.10-java11_byol"}]}}},{"displayText":"Red
+        Hat JBoss EAP 7.3.9 BYO License","value":"7.3.9","stackSettings":{"linuxContainerSettings":{"java8Runtime":"JBOSSEAP|7.3.9-java8_byol","java11Runtime":"JBOSSEAP|7.3.9-java11_byol","runtimes":[{"runtimeVersion":"8","runtime":"JBOSSEAP|7.3.9-java8_byol"},{"runtimeVersion":"11","runtime":"JBOSSEAP|7.3.9-java11_byol"}]}}}]},{"displayText":"Apache
+        Tomcat 11.0","value":"tomcat11.0","minorVersions":[{"displayText":"Apache
+        Tomcat 11.0","value":"11.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"11.0","isAutoUpdate":true,"runtimes":[{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java21Runtime":"TOMCAT|11.0-java21","java17Runtime":"TOMCAT|11.0-java17","java11Runtime":"TOMCAT|11.0-java11","isAutoUpdate":true,"runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|11.0-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|11.0-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|11.0-java21"}]}}},{"displayText":"Apache
+        Tomcat 11.0.9","value":"11.0.9","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"11.0.9","isHidden":true,"runtimes":[{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java17Runtime":"TOMCAT|11.0.9-java17","java21Runtime":"TOMCAT|11.0.9-java21","runtimes":[{"runtimeVersion":"17","runtime":"TOMCAT|11.0.9-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|11.0.9-java21"}]}}},{"displayText":"Apache
+        Tomcat 11.0.8","value":"11.0.8","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"11.0.8","isHidden":true,"runtimes":[{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java17Runtime":"TOMCAT|11.0.8-java17","java21Runtime":"TOMCAT|11.0.8-java21","runtimes":[{"runtimeVersion":"17","runtime":"TOMCAT|11.0.8-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|11.0.8-java21"}]}}},{"displayText":"Apache
+        Tomcat 11.0.7","value":"11.0.7","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"11.0.7","runtimes":[{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"isHidden":true,"java17Runtime":"TOMCAT|11.0.7-java17","java21Runtime":"TOMCAT|11.0.7-java21","runtimes":[{"runtimeVersion":"17","runtime":"TOMCAT|11.0.7-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|11.0.7-java21"}]}}},{"displayText":"Apache
+        Tomcat 11.0.6","value":"11.0.6","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"11.0.6","isHidden":true,"runtimes":[{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java17Runtime":"TOMCAT|11.0.6-java17","java21Runtime":"TOMCAT|11.0.6-java21","runtimes":[{"runtimeVersion":"17","runtime":"TOMCAT|11.0.6-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|11.0.6-java21"}]}}},{"displayText":"Apache
+        Tomcat 11.0.5","value":"11.0.5","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"11.0.5","runtimes":[{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java17Runtime":"TOMCAT|11.0.5-java17","java21Runtime":"TOMCAT|11.0.5-java21","runtimes":[{"runtimeVersion":"17","runtime":"TOMCAT|11.0.5-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|11.0.5-java21"}]}}},{"displayText":"Apache
+        Tomcat 11.0.4","value":"11.0.4","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"11.0.4","isHidden":true,"runtimes":[{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java17Runtime":"TOMCAT|11.0.4-java17","java21Runtime":"TOMCAT|11.0.4-java21","runtimes":[{"runtimeVersion":"17","runtime":"TOMCAT|11.0.4-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|11.0.4-java21"}]}}},{"displayText":"Apache
+        Tomcat 11.0.2","value":"11.0.2","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"11.0.2","runtimes":[{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java17Runtime":"TOMCAT|11.0.2-java17","java21Runtime":"TOMCAT|11.0.2-java21","runtimes":[{"runtimeVersion":"17","runtime":"TOMCAT|11.0.2-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|11.0.2-java21"}]}}},{"displayText":"Apache
+        Tomcat 11.0.1","value":"11.0.1","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"11.0.1","isHidden":true,"runtimes":[{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java17Runtime":"TOMCAT|11.0.1-java17","java21Runtime":"TOMCAT|11.0.1-java21","runtimes":[{"runtimeVersion":"17","runtime":"TOMCAT|11.0.1-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|11.0.1-java21"}]}}}]},{"displayText":"Apache
+        Tomcat 10.1","value":"tomcat10.1","minorVersions":[{"displayText":"Apache
+        Tomcat 10.1","value":"10.1","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1","isAutoUpdate":true,"runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java21Runtime":"TOMCAT|10.1-java21","java17Runtime":"TOMCAT|10.1-java17","java11Runtime":"TOMCAT|10.1-java11","isAutoUpdate":true,"runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1-java21"}]}}},{"displayText":"Apache
+        Tomcat 10.1.43","value":"10.1.43","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.43","isHidden":true,"runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.43-java11","java17Runtime":"TOMCAT|10.1.43-java17","java21Runtime":"TOMCAT|10.1.43-java21","runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1.43-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1.43-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1.43-java21"}]}}},{"displayText":"Apache
+        Tomcat 10.1.42","value":"10.1.42","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.42","isHidden":true,"runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.42-java11","java17Runtime":"TOMCAT|10.1.42-java17","java21Runtime":"TOMCAT|10.1.42-java21","runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1.42-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1.42-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1.42-java21"}]}}},{"displayText":"Apache
+        Tomcat 10.1.41","value":"10.1.41","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.41","runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"isHidden":true,"java11Runtime":"TOMCAT|10.1.41-java11","java17Runtime":"TOMCAT|10.1.41-java17","java21Runtime":"TOMCAT|10.1.41-java21","runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1.41-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1.41-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1.41-java21"}]}}},{"displayText":"Apache
+        Tomcat 10.1.40","value":"10.1.40","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.40","isHidden":true,"runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.40-java11","java17Runtime":"TOMCAT|10.1.40-java17","java21Runtime":"TOMCAT|10.1.40-java21","runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1.40-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1.40-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1.40-java21"}]}}},{"displayText":"Apache
+        Tomcat 10.1.39","value":"10.1.39","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.39","runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.39-java11","java17Runtime":"TOMCAT|10.1.39-java17","java21Runtime":"TOMCAT|10.1.39-java21","runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1.39-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1.39-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1.39-java21"}]}}},{"displayText":"Apache
+        Tomcat 10.1.36","value":"10.1.36","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.36","isHidden":true,"runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.36-java11","java17Runtime":"TOMCAT|10.1.36-java17","java21Runtime":"TOMCAT|10.1.36-java21","runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1.36-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1.36-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1.36-java21"}]}}},{"displayText":"Apache
+        Tomcat 10.1.34","value":"10.1.34","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.34","runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.34-java11","java17Runtime":"TOMCAT|10.1.34-java17","java21Runtime":"TOMCAT|10.1.34-java21","runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1.34-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1.34-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1.34-java21"}]}}},{"displayText":"Apache
+        Tomcat 10.1.33","value":"10.1.33","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.33","isHidden":true,"runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.33-java11","java17Runtime":"TOMCAT|10.1.33-java17","java21Runtime":"TOMCAT|10.1.33-java21","runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1.33-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1.33-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1.33-java21"}]}}},{"displayText":"Apache
+        Tomcat 10.1.31","value":"10.1.31","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.31","runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.31-java11","java17Runtime":"TOMCAT|10.1.31-java17","java21Runtime":"TOMCAT|10.1.31-java21","isHidden":true,"runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1.31-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1.31-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1.31-java21"}]}}},{"displayText":"Apache
+        Tomcat 10.1.28","value":"10.1.28","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.28","isHidden":true,"runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.28-java11","java17Runtime":"TOMCAT|10.1.28-java17","java21Runtime":"TOMCAT|10.1.28-java21","runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1.28-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1.28-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1.28-java21"}]}}},{"displayText":"Apache
+        Tomcat 10.1.25","value":"10.1.25","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.25","runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.25-java11","java17Runtime":"TOMCAT|10.1.25-java17","java21Runtime":"TOMCAT|10.1.25-java21","runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1.25-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1.25-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1.25-java21"}]}}},{"displayText":"Apache
+        Tomcat 10.1.23","value":"10.1.23","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.23","isHidden":true,"runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.23-java11","java17Runtime":"TOMCAT|10.1.23-java17","java21Runtime":"TOMCAT|10.1.23-java21","runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1.23-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1.23-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1.23-java21"}]}}},{"displayText":"Apache
+        Tomcat 10.1.16","value":"10.1.16","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.1.16","runtimes":[{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|10.1.16-java11","java17Runtime":"TOMCAT|10.1.16-java17","java21Runtime":"TOMCAT|10.1.16-java21","runtimes":[{"runtimeVersion":"11","runtime":"TOMCAT|10.1.16-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.1.16-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|10.1.16-java21"}]}}}]},{"displayText":"Apache
         Tomcat 10.0","value":"tomcat10.0","minorVersions":[{"displayText":"Apache
-        Tomcat 10.0","value":"10.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0","isAutoUpdate":true},"linuxContainerSettings":{"java17Runtime":"TOMCAT|10.0-java17","java11Runtime":"TOMCAT|10.0-java11","java8Runtime":"TOMCAT|10.0-jre8","isAutoUpdate":true}}},{"displayText":"Apache
-        Tomcat 10.0.20","value":"10.0.20","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0.20"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|10.0.20-java8","java11Runtime":"TOMCAT|10.0.20-java11","java17Runtime":"TOMCAT|10.0.20-java17"}}},{"displayText":"Apache
-        Tomcat 10.0.12","value":"10.0.12","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0.12"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|10.0.12-java8","java11Runtime":"TOMCAT|10.0.12-java11","java17Runtime":"TOMCAT|10.0.12-java17"}}}]},{"displayText":"Apache
+        Tomcat 10.0","value":"10.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0","isAutoUpdate":true,"endOfLifeDate":"2022-10-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java17Runtime":"TOMCAT|10.0-java17","java11Runtime":"TOMCAT|10.0-java11","java8Runtime":"TOMCAT|10.0-jre8","isAutoUpdate":true,"endOfLifeDate":"2022-10-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|10.0-jre8"},{"runtimeVersion":"11","runtime":"TOMCAT|10.0-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.0-java17"}]}}},{"displayText":"Apache
+        Tomcat 10.0.27","value":"10.0.27","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0.27","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|10.0.27-java8","java11Runtime":"TOMCAT|10.0.27-java11","java17Runtime":"TOMCAT|10.0.27-java17","endOfLifeDate":"2022-10-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|10.0.27-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|10.0.27-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.0.27-java17"}]}}},{"displayText":"Apache
+        Tomcat 10.0.23","value":"10.0.23","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0.23","endOfLifeDate":"2022-10-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|10.0.23-java8","java11Runtime":"TOMCAT|10.0.23-java11","java17Runtime":"TOMCAT|10.0.23-java17","endOfLifeDate":"2022-10-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|10.0.23-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|10.0.23-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.0.23-java17"}]}}},{"displayText":"Apache
+        Tomcat 10.0.21","value":"10.0.21","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0.21","endOfLifeDate":"2022-10-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|10.0.21-java8","java11Runtime":"TOMCAT|10.0.21-java11","java17Runtime":"TOMCAT|10.0.21-java17","endOfLifeDate":"2022-10-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|10.0.21-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|10.0.21-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.0.21-java17"}]}}},{"displayText":"Apache
+        Tomcat 10.0.20","value":"10.0.20","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0.20","endOfLifeDate":"2022-10-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|10.0.20-java8","java11Runtime":"TOMCAT|10.0.20-java11","java17Runtime":"TOMCAT|10.0.20-java17","endOfLifeDate":"2022-10-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|10.0.20-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|10.0.20-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.0.20-java17"}]}}},{"displayText":"Apache
+        Tomcat 10.0.12","value":"10.0.12","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"10.0.12","endOfLifeDate":"2022-10-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|10.0.12-java8","java11Runtime":"TOMCAT|10.0.12-java11","java17Runtime":"TOMCAT|10.0.12-java17","endOfLifeDate":"2022-10-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|10.0.12-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|10.0.12-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|10.0.12-java17"}]}}}]},{"displayText":"Apache
         Tomcat 9.0","value":"tomcat9.0","minorVersions":[{"displayText":"Apache Tomcat
-        9.0","value":"9.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0","isAutoUpdate":true},"linuxContainerSettings":{"java17Runtime":"TOMCAT|9.0-java17","java11Runtime":"TOMCAT|9.0-java11","java8Runtime":"TOMCAT|9.0-jre8","isAutoUpdate":true}}},{"displayText":"Apache
-        Tomcat 9.0.62","value":"9.0.62","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.62"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.62-java8","java11Runtime":"TOMCAT|9.0.62-java11","java17Runtime":"TOMCAT|9.0.62-java17"}}},{"displayText":"Apache
-        Tomcat 9.0.54","value":"9.0.54","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.54"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.54-java8","java11Runtime":"TOMCAT|9.0.54-java11","java17Runtime":"TOMCAT|9.0.54-java17"}}},{"displayText":"Apache
-        Tomcat 9.0.52","value":"9.0.52","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.52"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.52-java8","java11Runtime":"TOMCAT|9.0.52-java11"}}},{"displayText":"Apache
-        Tomcat 9.0.46","value":"9.0.46","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.46"},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.46-java8","java11Runtime":"TOMCAT|9.0.46-java11"}}},{"displayText":"Apache
-        Tomcat 9.0.41","value":"9.0.41","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.41-java8","java11Runtime":"TOMCAT|9.0.41-java11"}}},{"displayText":"Apache
-        Tomcat 9.0.38","value":"9.0.38","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.38"}}},{"displayText":"Apache
-        Tomcat 9.0.37","value":"9.0.37","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.37"},"linuxContainerSettings":{"java11Runtime":"TOMCAT|9.0.37-java11","java8Runtime":"TOMCAT|9.0.37-java8"}}},{"displayText":"Apache
-        Tomcat 9.0.33","value":"9.0.33","stackSettings":{"linuxContainerSettings":{"java11Runtime":"TOMCAT|9.0.33-java11","java8Runtime":"TOMCAT|9.0.33-java8"}}},{"displayText":"Apache
-        Tomcat 9.0.31","value":"9.0.31","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.31"}}},{"displayText":"Apache
-        Tomcat 9.0.27","value":"9.0.27","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.27"}}},{"displayText":"Apache
-        Tomcat 9.0.21","value":"9.0.21","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.21"}}},{"displayText":"Apache
-        Tomcat 9.0.20","value":"9.0.20","stackSettings":{"linuxContainerSettings":{"java11Runtime":"TOMCAT|9.0.20-java11","java8Runtime":"TOMCAT|9.0.20-java8"}}},{"displayText":"Apache
-        Tomcat 9.0.14","value":"9.0.14","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.14"}}},{"displayText":"Apache
-        Tomcat 9.0.12","value":"9.0.12","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.12"}}},{"displayText":"Apache
-        Tomcat 9.0.8","value":"9.0.8","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.8"}}},{"displayText":"Apache
-        Tomcat 9.0.0","value":"9.0.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.0"}}}]},{"displayText":"Apache
+        9.0","value":"9.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0","isAutoUpdate":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java21Runtime":"TOMCAT|9.0-java21","java17Runtime":"TOMCAT|9.0-java17","java11Runtime":"TOMCAT|9.0-java11","java8Runtime":"TOMCAT|9.0-jre8","isAutoUpdate":true,"runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0-jre8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.107","value":"9.0.107","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.107","isHidden":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.107-java8","java11Runtime":"TOMCAT|9.0.107-java11","java17Runtime":"TOMCAT|9.0.107-java17","java21Runtime":"TOMCAT|9.0.107-java21","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.107-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.107-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.107-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.107-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.106","value":"9.0.106","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.106","isHidden":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.106-java8","java11Runtime":"TOMCAT|9.0.106-java11","java17Runtime":"TOMCAT|9.0.106-java17","java21Runtime":"TOMCAT|9.0.106-java21","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.106-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.106-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.106-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.106-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.105","value":"9.0.105","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.105","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"isHidden":true,"java8Runtime":"TOMCAT|9.0.105-java8","java11Runtime":"TOMCAT|9.0.105-java11","java17Runtime":"TOMCAT|9.0.105-java17","java21Runtime":"TOMCAT|9.0.105-java21","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.105-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.105-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.105-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.105-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.104","value":"9.0.104","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.104","isHidden":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.104-java8","java11Runtime":"TOMCAT|9.0.104-java11","java17Runtime":"TOMCAT|9.0.104-java17","java21Runtime":"TOMCAT|9.0.104-java21","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.104-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.104-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.104-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.104-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.102","value":"9.0.102","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.102","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.102-java8","java11Runtime":"TOMCAT|9.0.102-java11","java17Runtime":"TOMCAT|9.0.102-java17","java21Runtime":"TOMCAT|9.0.102-java21","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.102-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.102-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.102-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.102-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.100","value":"9.0.100","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.100","isHidden":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.100-java8","java11Runtime":"TOMCAT|9.0.100-java11","java17Runtime":"TOMCAT|9.0.100-java17","java21Runtime":"TOMCAT|9.0.100-java21","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.100-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.100-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.100-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.100-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.98","value":"9.0.98","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.98","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.98-java8","java11Runtime":"TOMCAT|9.0.98-java11","java17Runtime":"TOMCAT|9.0.98-java17","java21Runtime":"TOMCAT|9.0.98-java21","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.98-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.98-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.98-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.98-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.97","value":"9.0.97","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.97","isHidden":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.97-java8","java11Runtime":"TOMCAT|9.0.97-java11","java17Runtime":"TOMCAT|9.0.97-java17","java21Runtime":"TOMCAT|9.0.97-java21","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.97-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.97-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.97-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.97-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.96","value":"9.0.97","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.96","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.96-java8","java11Runtime":"TOMCAT|9.0.96-java11","java17Runtime":"TOMCAT|9.0.96-java17","java21Runtime":"TOMCAT|9.0.96-java21","isHidden":true,"runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.96-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.96-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.96-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.96-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.93","value":"9.0.93","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.93","isHidden":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.93-java8","java11Runtime":"TOMCAT|9.0.93-java11","java17Runtime":"TOMCAT|9.0.93-java17","java21Runtime":"TOMCAT|9.0.93-java21","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.93-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.93-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.93-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.93-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.91","value":"9.0.91","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.91","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.91-java8","java11Runtime":"TOMCAT|9.0.91-java11","java17Runtime":"TOMCAT|9.0.91-java17","java21Runtime":"TOMCAT|9.0.91-java21","isHidden":true,"runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.91-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.91-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.91-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.91-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.90","value":"9.0.90","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.90","isHidden":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.90-java8","java11Runtime":"TOMCAT|9.0.90-java11","java17Runtime":"TOMCAT|9.0.90-java17","java21Runtime":"TOMCAT|9.0.90-java21","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.90-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.90-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.90-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.90-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.88","value":"9.0.88","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.88","isHidden":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.88-java8","java11Runtime":"TOMCAT|9.0.88-java11","java17Runtime":"TOMCAT|9.0.88-java17","java21Runtime":"TOMCAT|9.0.88-java21","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.88-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.88-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.88-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.88-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.83","value":"9.0.83","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.83","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.83-java8","java11Runtime":"TOMCAT|9.0.83-java11","java17Runtime":"TOMCAT|9.0.83-java17","java21Runtime":"TOMCAT|9.0.83-java21","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.83-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.83-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.83-java17"},{"runtimeVersion":"21","runtime":"TOMCAT|9.0.83-java21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.65","value":"9.0.65","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.65","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.65-java8","java11Runtime":"TOMCAT|9.0.65-java11","java17Runtime":"TOMCAT|9.0.65-java17","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.65-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.65-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.65-java17"}]}}},{"displayText":"Apache
+        Tomcat 9.0.63","value":"9.0.63","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.63","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.63-java8","java11Runtime":"TOMCAT|9.0.63-java11","java17Runtime":"TOMCAT|9.0.63-java17","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.63-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.63-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.63-java17"}]}}},{"displayText":"Apache
+        Tomcat 9.0.62","value":"9.0.62","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.62","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.62-java8","java11Runtime":"TOMCAT|9.0.62-java11","java17Runtime":"TOMCAT|9.0.62-java17","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.62-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.62-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.62-java17"}]}}},{"displayText":"Apache
+        Tomcat 9.0.54","value":"9.0.54","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.54","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.54-java8","java11Runtime":"TOMCAT|9.0.54-java11","java17Runtime":"TOMCAT|9.0.54-java17","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.54-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.54-java11"},{"runtimeVersion":"17","runtime":"TOMCAT|9.0.54-java17"}]}}},{"displayText":"Apache
+        Tomcat 9.0.52","value":"9.0.52","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.52","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.52-java8","java11Runtime":"TOMCAT|9.0.52-java11","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.52-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.52-java11"}]}}},{"displayText":"Apache
+        Tomcat 9.0.46","value":"9.0.46","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.46","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.46-java8","java11Runtime":"TOMCAT|9.0.46-java11","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.46-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.46-java11"}]}}},{"displayText":"Apache
+        Tomcat 9.0.41","value":"9.0.41","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|9.0.41-java8","java11Runtime":"TOMCAT|9.0.41-java11","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.41-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.41-java11"}]}}},{"displayText":"Apache
+        Tomcat 9.0.38","value":"9.0.38","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.38","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.37","value":"9.0.37","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.37","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|9.0.37-java11","java8Runtime":"TOMCAT|9.0.37-java8","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.37-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.37-java11"}]}}},{"displayText":"Apache
+        Tomcat 9.0.33","value":"9.0.33","stackSettings":{"linuxContainerSettings":{"java11Runtime":"TOMCAT|9.0.33-java11","java8Runtime":"TOMCAT|9.0.33-java8","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.33-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.33-java11"}]}}},{"displayText":"Apache
+        Tomcat 9.0.31","value":"9.0.31","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.31","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.27","value":"9.0.27","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.27","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.21","value":"9.0.21","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.21","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.20","value":"9.0.20","stackSettings":{"linuxContainerSettings":{"java11Runtime":"TOMCAT|9.0.20-java11","java8Runtime":"TOMCAT|9.0.20-java8","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|9.0.20-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|9.0.20-java11"}]}}},{"displayText":"Apache
+        Tomcat 9.0.14","value":"9.0.14","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.14","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.12","value":"9.0.12","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.12","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.8","value":"9.0.8","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.8","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 9.0.0","value":"9.0.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"9.0.0","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}}]},{"displayText":"Apache
         Tomcat 8.5","value":"tomcat8.5","minorVersions":[{"displayText":"Apache Tomcat
-        8.5","value":"8.5","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5","isAutoUpdate":true},"linuxContainerSettings":{"java11Runtime":"TOMCAT|8.5-java11","java8Runtime":"TOMCAT|8.5-jre8","isAutoUpdate":true}}},{"displayText":"Apache
-        Tomcat 8.5.78","value":"8.5.78","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.78-java8","java11Runtime":"TOMCAT|8.5.78-java11"},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.78"}}},{"displayText":"Apache
-        Tomcat 8.5.72","value":"8.5.72","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.72-java8","java11Runtime":"TOMCAT|8.5.72-java11"},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.72"}}},{"displayText":"Apache
-        Tomcat 8.5.69","value":"8.5.69","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.69-java8","java11Runtime":"TOMCAT|8.5.69-java11"},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.69"}}},{"displayText":"Apache
-        Tomcat 8.5.66","value":"8.5.66","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.66-java8","java11Runtime":"TOMCAT|8.5.66-java11"},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.66"}}},{"displayText":"Apache
-        Tomcat 8.5.61","value":"8.5.61","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.61-java8","java11Runtime":"TOMCAT|8.5.61-java11"}}},{"displayText":"Apache
-        Tomcat 8.5.58","value":"8.5.58","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.58"}}},{"displayText":"Apache
-        Tomcat 8.5.57","value":"8.5.57","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.57"},"linuxContainerSettings":{"java11Runtime":"TOMCAT|8.5.57-java11","java8Runtime":"TOMCAT|8.5.57-java8"}}},{"displayText":"Apache
-        Tomcat 8.5.53","value":"8.5.53","stackSettings":{"linuxContainerSettings":{"java11Runtime":"TOMCAT|8.5.53-java11","java8Runtime":"TOMCAT|8.5.53-java8"}}},{"displayText":"Apache
-        Tomcat 8.5.51","value":"8.5.51","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.51"}}},{"displayText":"Apache
-        Tomcat 8.5.47","value":"8.5.47","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.47"}}},{"displayText":"Apache
-        Tomcat 8.5.42","value":"8.5.42","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.42"}}},{"displayText":"Apache
-        Tomcat 8.5.41","value":"8.5.41","stackSettings":{"linuxContainerSettings":{"java11Runtime":"TOMCAT|8.5.41-java11","java8Runtime":"TOMCAT|8.5.41-java8"}}},{"displayText":"Apache
-        Tomcat 8.5.37","value":"8.5.37","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.37"}}},{"displayText":"Apache
-        Tomcat 8.5.34","value":"8.5.34","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.34"}}},{"displayText":"Apache
-        Tomcat 8.5.31","value":"8.5.31","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.31"}}},{"displayText":"Apache
-        Tomcat 8.5.20","value":"8.5.20","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.20"}}},{"displayText":"Apache
-        Tomcat 8.5.6","value":"8.5.6","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.6"}}}]},{"displayText":"Apache
+        8.5","value":"8.5","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5","isAutoUpdate":true,"endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|8.5-java11","java8Runtime":"TOMCAT|8.5-jre8","isAutoUpdate":true,"endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|8.5-jre8"},{"runtimeVersion":"11","runtime":"TOMCAT|8.5-java11"}]}}},{"displayText":"Apache
+        Tomcat 8.5.100","value":"8.5.100","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.100-java8","java11Runtime":"TOMCAT|8.5.100-java11","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|8.5.100-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|8.5.100-java11"}]},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.100","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.96","value":"8.5.96","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.96-java8","java11Runtime":"TOMCAT|8.5.96-java11","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|8.5.96-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|8.5.96-java11"}]},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.96","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.82","value":"8.5.82","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.82-java8","java11Runtime":"TOMCAT|8.5.82-java11","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|8.5.82-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|8.5.82-java11"}]},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.82","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.79","value":"8.5.79","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.79-java8","java11Runtime":"TOMCAT|8.5.79-java11","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|8.5.79-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|8.5.79-java11"}]},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.79","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.78","value":"8.5.78","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.78-java8","java11Runtime":"TOMCAT|8.5.78-java11","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|8.5.78-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|8.5.78-java11"}]},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.78","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.72","value":"8.5.72","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.72-java8","java11Runtime":"TOMCAT|8.5.72-java11","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|8.5.72-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|8.5.72-java11"}]},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.72","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.69","value":"8.5.69","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.69-java8","java11Runtime":"TOMCAT|8.5.69-java11","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|8.5.69-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|8.5.69-java11"}]},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.69","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.66","value":"8.5.66","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.66-java8","java11Runtime":"TOMCAT|8.5.66-java11","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|8.5.66-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|8.5.66-java11"}]},"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.66","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.61","value":"8.5.61","stackSettings":{"linuxContainerSettings":{"java8Runtime":"TOMCAT|8.5.61-java8","java11Runtime":"TOMCAT|8.5.61-java11","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|8.5.61-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|8.5.61-java11"}]}}},{"displayText":"Apache
+        Tomcat 8.5.58","value":"8.5.58","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.58","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.57","value":"8.5.57","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.57","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]},"linuxContainerSettings":{"java11Runtime":"TOMCAT|8.5.57-java11","java8Runtime":"TOMCAT|8.5.57-java8","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|8.5.57-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|8.5.57-java11"}]}}},{"displayText":"Apache
+        Tomcat 8.5.53","value":"8.5.53","stackSettings":{"linuxContainerSettings":{"java11Runtime":"TOMCAT|8.5.53-java11","java8Runtime":"TOMCAT|8.5.53-java8","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|8.5.53-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|8.5.53-java11"}]}}},{"displayText":"Apache
+        Tomcat 8.5.51","value":"8.5.51","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.51","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.47","value":"8.5.47","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.47","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.42","value":"8.5.42","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.42","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.41","value":"8.5.41","stackSettings":{"linuxContainerSettings":{"java11Runtime":"TOMCAT|8.5.41-java11","java8Runtime":"TOMCAT|8.5.41-java8","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8","runtime":"TOMCAT|8.5.41-java8"},{"runtimeVersion":"11","runtime":"TOMCAT|8.5.41-java11"}]}}},{"displayText":"Apache
+        Tomcat 8.5.37","value":"8.5.37","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.37","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.34","value":"8.5.34","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.34","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.31","value":"8.5.31","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.31","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.20","value":"8.5.20","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.20","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.5.6","value":"8.5.6","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.5.6","endOfLifeDate":"2024-03-31T00:00:00Z","runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}}]},{"displayText":"Apache
         Tomcat 8.0","value":"tomcat8.0","minorVersions":[{"displayText":"Apache Tomcat
-        8.0","value":"8.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.0","isAutoUpdate":true,"isDeprecated":true}}},{"displayText":"Apache
-        Tomcat 8.0.53","value":"8.0.53","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.0.53","isDeprecated":true}}},{"displayText":"Apache
-        Tomcat 8.0.46","value":"8.0.46","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.0.46","isDeprecated":true}}},{"displayText":"Apache
-        Tomcat 8.0.23","value":"8.0.23","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.0.23","isDeprecated":true}}}]},{"displayText":"Apache
+        8.0","value":"8.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.0","isAutoUpdate":true,"isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.0.53","value":"8.0.53","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.0.53","isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.0.46","value":"8.0.46","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.0.46","isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 8.0.23","value":"8.0.23","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"8.0.23","isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}}]},{"displayText":"Apache
         Tomcat 7.0","value":"tomcat7.0","minorVersions":[{"displayText":"Apache Tomcat
-        7.0","value":"7.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"7.0","isAutoUpdate":true,"isDeprecated":true}}},{"displayText":"Apache
-        Tomcat 7.0.94","value":"7.0.94","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"7.0.94","isDeprecated":true}}},{"displayText":"Apache
-        Tomcat 7.0.81","value":"7.0.81","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"7.0.81","isDeprecated":true}}},{"displayText":"Apache
-        Tomcat 7.0.62","value":"7.0.62","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"7.0.62","isDeprecated":true}}},{"displayText":"Apache
-        Tomcat 7.0.50","value":"7.0.50","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"7.0.50","isDeprecated":true}}}]},{"displayText":"Jetty
-        9.3","value":"jetty9.3","minorVersions":[{"displayText":"Jetty 9.3","value":"9.3","stackSettings":{"windowsContainerSettings":{"javaContainer":"JETTY","javaContainerVersion":"9.3","isAutoUpdate":true,"isDeprecated":true}}},{"displayText":"Jetty
-        9.3.25","value":"9.3.25","stackSettings":{"windowsContainerSettings":{"javaContainer":"JETTY","javaContainerVersion":"9.3.25","isDeprecated":true}}},{"displayText":"Jetty
-        9.3.13","value":"9.3.13","stackSettings":{"windowsContainerSettings":{"javaContainer":"JETTY","javaContainerVersion":"9.3.13","isDeprecated":true}}}]},{"displayText":"Jetty
-        9.1","value":"jetty9.1","minorVersions":[{"displayText":"Jetty 9.1","value":"9.1","stackSettings":{"windowsContainerSettings":{"javaContainer":"JETTY","javaContainerVersion":"9.1","isAutoUpdate":true,"isDeprecated":true}}},{"displayText":"Jetty
-        9.1.0","value":"9.1.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"JETTY","javaContainerVersion":"9.1.0","isDeprecated":true}}}]},{"displayText":"WildFly
-        14","value":"wildfly14","minorVersions":[{"displayText":"WildFly 14","value":"14","stackSettings":{"linuxContainerSettings":{"java8Runtime":"WILDFLY|14-jre8","isDeprecated":true,"isAutoUpdate":true}}},{"displayText":"WildFly
-        14.0.1","value":"14.0.1","stackSettings":{"linuxContainerSettings":{"isDeprecated":true,"java8Runtime":"WILDFLY|14.0.1-java8"}}}]}]}},{"id":null,"name":"staticsite","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"HTML
+        7.0","value":"7.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"7.0","isAutoUpdate":true,"isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 7.0.94","value":"7.0.94","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"7.0.94","isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 7.0.81","value":"7.0.81","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"7.0.81","isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 7.0.62","value":"7.0.62","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"7.0.62","isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Apache
+        Tomcat 7.0.50","value":"7.0.50","stackSettings":{"windowsContainerSettings":{"javaContainer":"TOMCAT","javaContainerVersion":"7.0.50","isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}}]},{"displayText":"Jetty
+        9.3","value":"jetty9.3","minorVersions":[{"displayText":"Jetty 9.3","value":"9.3","stackSettings":{"windowsContainerSettings":{"javaContainer":"JETTY","javaContainerVersion":"9.3","isAutoUpdate":true,"isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Jetty
+        9.3.25","value":"9.3.25","stackSettings":{"windowsContainerSettings":{"javaContainer":"JETTY","javaContainerVersion":"9.3.25","isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Jetty
+        9.3.13","value":"9.3.13","stackSettings":{"windowsContainerSettings":{"javaContainer":"JETTY","javaContainerVersion":"9.3.13","isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}}]},{"displayText":"Jetty
+        9.1","value":"jetty9.1","minorVersions":[{"displayText":"Jetty 9.1","value":"9.1","stackSettings":{"windowsContainerSettings":{"javaContainer":"JETTY","javaContainerVersion":"9.1","isAutoUpdate":true,"isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}},{"displayText":"Jetty
+        9.1.0","value":"9.1.0","stackSettings":{"windowsContainerSettings":{"javaContainer":"JETTY","javaContainerVersion":"9.1.0","isDeprecated":true,"runtimes":[{"runtimeVersion":"8"},{"runtimeVersion":"11"},{"runtimeVersion":"17"},{"runtimeVersion":"21"}]}}}]},{"displayText":"WildFly
+        14","value":"wildfly14","minorVersions":[{"displayText":"WildFly 14","value":"14","stackSettings":{"linuxContainerSettings":{"java8Runtime":"WILDFLY|14-jre8","isDeprecated":true,"isAutoUpdate":true,"runtimes":[{"runtimeVersion":"8","runtime":"WILDFLY|14-jre8"}]}}},{"displayText":"WildFly
+        14.0.1","value":"14.0.1","stackSettings":{"linuxContainerSettings":{"isDeprecated":true,"java8Runtime":"WILDFLY|14.0.1-java8","runtimes":[{"runtimeVersion":"8","runtime":"WILDFLY|14.0.1-java8"}]}}}]}]}},{"id":null,"name":"staticsite","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"HTML
         (Static Content)","value":"staticsite","preferredOs":"linux","majorVersions":[{"displayText":"HTML
         (Static Content)","value":"1","minorVersions":[{"displayText":"HTML (Static
         Content)","value":"1.0","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"STATICSITE|1.0","isHidden":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false}}}}]}]}},{"id":null,"name":"go","type":"Microsoft.Web/webAppStacks?stackOsType=All","properties":{"displayText":"Go","value":"go","preferredOs":"linux","majorVersions":[{"displayText":"Go
-        1","value":"go1","minorVersions":[{"displayText":"Go 1.19 (Experimental)","value":"go1.19","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"GO|1.19","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true},"isHidden":false,"isEarlyAccess":false}}},{"displayText":"Go
-        1.18 (Experimental)","value":"go1.18","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"GO|1.18","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"isHidden":false,"isEarlyAccess":false,"isDeprecated":true}}}]}]}}],"nextLink":null,"id":null}'
+        1","value":"go1","minorVersions":[{"displayText":"Go 1.19 (Experimental)","value":"go1.19","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"GO|1.19","remoteDebuggingSupported":false,"isDeprecated":true,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":true},"supportedFeatures":{"disableSsh":true},"isHidden":false,"isEarlyAccess":false}}},{"displayText":"Go
+        1.18 (Experimental)","value":"go1.18","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"GO|1.18","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":false},"gitHubActionSettings":{"isSupported":false},"supportedFeatures":{"disableSsh":true},"isHidden":false,"isEarlyAccess":false,"isDeprecated":true}}}]}]}}],"nextLink":null,"id":null}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '72306'
+      - '153017'
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Tue, 28 Mar 2023 11:19:51 GMT
+=======
+      - Sat, 18 Oct 2025 07:47:34 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:39:40 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
       - no-cache
-      server:
-      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+      x-ms-operation-identifier:
+      - ''
+      x-msedge-ref:
+      - 'Ref A: D72D663EF6F945B7B542188342EC21F1 Ref B: SYD03EDGE0921 Ref C: 2025-10-18T07:47:34Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      x-ms-operation-identifier:
+      - ''
+      x-msedge-ref:
+      - 'Ref A: 4DF7A359A83A42C1BB1C47E0209ACC89 Ref B: SYD03EDGE1010 Ref C: 2025-10-17T10:39:40Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
       code: 200
       message: OK
 - request:
-    body: '{"location": "West US", "properties": {"serverFarmId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003",
+    body: '{"location": "East US", "properties": {"serverFarmId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003",
       "reserved": false, "isXenon": false, "hyperV": false, "siteConfig": {"netFrameworkVersion":
-      "v4.6", "appSettings": [{"name": "WEBSITE_NODE_DEFAULT_VERSION", "value": "~14"}],
-      "alwaysOn": true, "localMySqlEnabled": false, "http20Enabled": true}, "scmSiteAlsoStopped":
-      false, "httpsOnly": false}}'
+      "v4.6", "appSettings": [{"name": "WEBSITE_NODE_DEFAULT_VERSION", "value": "~20"}],
+      "alwaysOn": true, "localMySqlEnabled": false, "http20Enabled": true, "http20ProxyFlag":
+      0}, "scmSiteAlsoStopped": false, "httpsOnly": false}}'
     headers:
       Accept:
       - application/json
@@ -498,51 +720,96 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '510'
+      - '532'
       Content-Type:
       - application/json
       ParameterSetName:
       - -g -n --plan
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-web/7.0.0 Python/3.10.10 (Linux-5.15.0-1034-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_261_0
+      - AZURECLI/2.78.0 azsdk-python-core/1.35.0 Python/3.9.6 (macOS-26.0.1-arm64-arm-64bit)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002?api-version=2023-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002?api-version=2024-11-01
   response:
     body:
+<<<<<<< HEAD
+<<<<<<< HEAD
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002","name":"webapp-authentication-test000002","type":"Microsoft.Web/sites","kind":"app","location":"West
         US","properties":{"name":"webapp-authentication-test000002","state":"Running","hostNames":["webapp-authentication-test000002.azurewebsites.net"],"webSpace":"cli_test_authV2000001-WestUSwebspace","selfLink":"https://waws-prod-bay-177.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli_test_authV2000001-WestUSwebspace/sites/webapp-authentication-test000002","repositorySiteName":"webapp-authentication-test000002","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["webapp-authentication-test000002.azurewebsites.net","webapp-authentication-test000002.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-authentication-test000002.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-authentication-test000002.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2023-03-28T11:20:00.1066667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"vnetRouteAllEnabled":false,"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"vnetImagePullEnabled":false,"vnetContentShareEnabled":false,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"","windowsFxVersion":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
         all","description":"Allow all access"}],"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
         all","description":"Allow all access"}],"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":null,"elasticWebAppScaleLimit":0,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null},"deploymentId":"webapp-authentication-test000002","slotName":null,"trafficManagerHostNames":null,"sku":"Standard","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"253001F2FCF5A7B1CD759EB861E9BB1596370BE27E47A991F72184277B3D12F2","kind":"app","inboundIpAddress":"40.112.243.56","possibleInboundIpAddresses":"40.112.243.56","ftpUsername":"webapp-authentication-test000002\\$webapp-authentication-test000002","ftpsHostName":"ftps://waws-prod-bay-177.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.78.93.74,40.78.93.119,40.78.94.159,13.64.195.155,13.64.195.223,13.64.193.139,40.112.243.56","possibleOutboundIpAddresses":"40.78.93.74,40.78.93.119,40.78.94.159,13.64.195.155,13.64.195.223,13.64.193.139,13.64.193.199,13.64.49.75,13.64.62.100,13.64.196.69,13.64.196.89,40.85.153.50,13.64.196.174,13.64.197.23,13.64.199.205,13.83.47.153,13.83.46.13,13.64.62.232,13.83.46.112,13.83.46.127,13.83.46.158,13.83.46.19,13.83.40.163,40.78.49.97,13.83.47.99,13.83.40.63,13.83.49.71,13.83.49.249,13.83.54.97,13.64.56.149,40.112.243.56","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-177","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli_test_authV2000001","defaultHostName":"webapp-authentication-test000002.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"publicNetworkAccess":null,"buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs","storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","defaultHostNameScope":"Global","privateLinkIdentifiers":null}}'
+=======
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002","name":"webapp-authentication-test000002","type":"Microsoft.Web/sites","kind":"app","location":"East
+        US","properties":{"name":"webapp-authentication-test000002","state":"Running","hostNames":["webapp-authentication-test000002.azurewebsites.net"],"webSpace":"cli_test_authV2000001-EastUSwebspace","selfLink":"https://waws-prod-blu-301.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli_test_authV2000001-EastUSwebspace/sites/webapp-authentication-test000002","repositorySiteName":"webapp-authentication-test000002","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["webapp-authentication-test000002.azurewebsites.net","webapp-authentication-test000002.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-authentication-test000002.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-authentication-test000002.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003","reserved":false,"isXenon":false,"hyperV":false,"sandboxType":null,"lastModifiedTimeUtc":"2025-10-18T07:47:36.79","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"outboundVnetRouting":{"allTraffic":false,"applicationTraffic":false,"contentShareTraffic":false,"imagePullTraffic":false,"backupRestoreTraffic":false,"managedIdentityTraffic":false},"legacyServiceEndpointTrafficEvaluation":null,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"","windowsFxVersion":null,"sandboxType":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":null,"elasticWebAppScaleLimit":0,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false,"webJobsEnabled":false},"functionAppConfig":null,"daprConfig":null,"deploymentId":"webapp-authentication-test000002","slotName":null,"trafficManagerHostNames":null,"sku":"Standard","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientAffinityProxyEnabled":false,"useQueryStringAffinity":false,"blockPathTraversal":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"clientCertExclusionEndPoints":null,"hostNamesDisabled":false,"ipMode":"IPv4","domainVerificationIdentifiers":null,"customDomainVerificationId":"70240F0BA32B9DD28948DBEC834A732C467825FB279A572BFED6A386F1954E0A","kind":"app","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"20.49.104.60","possibleInboundIpAddresses":"20.49.104.60","inboundIpv6Address":"2603:1030:210:9::68","possibleInboundIpv6Addresses":"2603:1030:210:9::68","ftpUsername":"webapp-authentication-test000002\\$webapp-authentication-test000002","ftpsHostName":"ftps://waws-prod-blu-301.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"20.88.177.135,20.88.178.45,20.88.178.104,20.88.178.172,20.88.178.194,20.88.178.207,20.49.104.60","possibleOutboundIpAddresses":"20.88.177.135,20.88.178.45,20.88.178.104,20.88.178.172,20.88.178.194,20.88.178.207,48.217.217.147,20.88.178.231,20.88.179.52,20.88.179.87,20.88.179.98,20.88.179.103,20.88.179.104,20.88.179.112,20.88.179.149,20.88.179.157,20.88.179.170,20.88.179.173,20.88.179.183,20.88.179.185,20.88.180.50,20.88.180.64,20.88.180.70,20.88.181.37,20.88.181.72,20.88.181.114,20.88.181.119,20.81.9.0,20.88.181.134,20.88.178.93,20.88.180.104,20.49.104.60","outboundIpv6Addresses":"2603:1030:20c:9::e0d,2603:1030:20c:9::e14,2603:1030:20c:9::e1c,2603:1030:20c:9::e24,2603:1030:20c:9::e29,2603:1030:20c:9::e34,2603:1030:210:9::68,2603:10e1:100:2::1431:683c","possibleOutboundIpv6Addresses":"2603:1030:20c:9::e0d,2603:1030:20c:9::e14,2603:1030:20c:9::e1c,2603:1030:20c:9::e24,2603:1030:20c:9::e29,2603:1030:20c:9::e34,2603:1030:20c:9::e3e,2603:1030:20c:9::e46,2603:1030:20c:9::e4d,2603:1030:20c:9::e54,2603:1030:20c:9::e59,2603:1030:20c:9::e5d,2603:1030:20c:9::e64,2603:1030:20c:9::e69,2603:1030:20c:9::e6d,2603:1030:20c:9::e72,2603:1030:20c:9::e75,2603:1030:20c:9::e7b,2603:1030:20c:9::e83,2603:1030:20c:9::e87,2603:1030:20c:9::e8b,2603:1030:20c:9::e93,2603:1030:20c:9::e98,2603:1030:20c:9::e9c,2603:1030:20c:9::ea3,2603:1030:20c:9::eaa,2603:1030:20c:9::eae,2603:1030:20c:9::eb6,2603:1030:20c:9::ebe,2603:1030:20c:9::ec6,2603:1030:210:9::68,2603:10e1:100:2::1431:683c","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-blu-301","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli_test_authV2000001","defaultHostName":"webapp-authentication-test000002.azurewebsites.net","slotSwapStatus":null,"httpsOnly":true,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"publicNetworkAccess":"Enabled","buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs,AppServiceAuthenticationLogs","inFlightFeatures":null,"storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"privateLinkIdentifiers":null,"sshEnabled":null}}'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002","name":"webapp-authentication-test000002","type":"Microsoft.Web/sites","kind":"app","location":"East
+        US","properties":{"name":"webapp-authentication-test000002","state":"Running","hostNames":["webapp-authentication-test000002.azurewebsites.net"],"webSpace":"cli_test_authV2000001-EastUSwebspace","selfLink":"https://waws-prod-blu-315.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli_test_authV2000001-EastUSwebspace/sites/webapp-authentication-test000002","repositorySiteName":"webapp-authentication-test000002","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["webapp-authentication-test000002.azurewebsites.net","webapp-authentication-test000002.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-authentication-test000002.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-authentication-test000002.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003","reserved":false,"isXenon":false,"hyperV":false,"sandboxType":null,"lastModifiedTimeUtc":"2025-10-17T10:39:47.0633333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"outboundVnetRouting":{"allTraffic":false,"applicationTraffic":false,"contentShareTraffic":false,"imagePullTraffic":false,"backupRestoreTraffic":false,"managedIdentityTraffic":false},"legacyServiceEndpointTrafficEvaluation":null,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"","windowsFxVersion":null,"sandboxType":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":null,"elasticWebAppScaleLimit":0,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false,"webJobsEnabled":false},"functionAppConfig":null,"daprConfig":null,"deploymentId":"webapp-authentication-test000002","slotName":null,"trafficManagerHostNames":null,"sku":"Standard","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientAffinityProxyEnabled":false,"useQueryStringAffinity":false,"blockPathTraversal":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"clientCertExclusionEndPoints":null,"hostNamesDisabled":false,"ipMode":"IPv4","domainVerificationIdentifiers":null,"customDomainVerificationId":"70240F0BA32B9DD28948DBEC834A732C467825FB279A572BFED6A386F1954E0A","kind":"app","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"20.119.8.0","possibleInboundIpAddresses":"20.119.8.0","inboundIpv6Address":"2603:1030:210:7::35","possibleInboundIpv6Addresses":"2603:1030:210:7::35","ftpUsername":"webapp-authentication-test000002\\$webapp-authentication-test000002","ftpsHostName":"ftps://waws-prod-blu-315.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"20.120.57.126,20.120.57.157,20.120.57.168,20.120.57.202,20.120.57.225,20.120.57.251,20.119.8.0","possibleOutboundIpAddresses":"20.120.57.126,20.120.57.157,20.120.57.168,20.120.57.202,20.120.57.225,20.120.57.251,135.237.48.119,20.120.58.20,20.120.58.60,20.120.58.210,20.120.58.218,20.120.58.235,20.120.58.255,20.120.59.0,20.120.59.21,20.120.59.107,20.120.59.200,20.120.59.206,20.120.59.247,20.120.60.94,20.120.60.97,20.120.60.118,20.120.60.157,20.120.60.165,20.120.60.192,20.120.60.200,20.120.60.203,20.120.56.58,20.120.61.0,20.120.61.2,20.120.61.11,20.119.8.0","outboundIpv6Addresses":"2603:1030:20c:f::90d,2603:1030:20c:f::90e,2603:1030:20c:f::90f,2603:1030:20c:f::910,2603:1030:20c:f::911,2603:1030:20c:f::912,2603:1030:210:7::35,2603:10e1:100:2::1477:800","possibleOutboundIpv6Addresses":"2603:1030:20c:f::90d,2603:1030:20c:f::90e,2603:1030:20c:f::90f,2603:1030:20c:f::910,2603:1030:20c:f::911,2603:1030:20c:f::912,2603:1030:20c:f::919,2603:1030:20c:f::91a,2603:1030:20c:f::91b,2603:1030:20c:f::91c,2603:1030:20c:f::91d,2603:1030:20c:f::91e,2603:1030:20c:f::91f,2603:1030:20c:f::920,2603:1030:20c:f::821,2603:1030:20c:f::921,2603:1030:20c:f::922,2603:1030:20c:f::923,2603:1030:20c:f::924,2603:1030:20c:f::925,2603:1030:20c:f::926,2603:1030:20c:f::927,2603:1030:20c:f::928,2603:1030:20c:f::929,2603:1030:20c:f::913,2603:1030:20c:f::914,2603:1030:20c:f::915,2603:1030:20c:f::916,2603:1030:20c:f::917,2603:1030:20c:f::918,2603:1030:210:7::35,2603:10e1:100:2::1477:800","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-blu-315","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli_test_authV2000001","defaultHostName":"webapp-authentication-test000002.azurewebsites.net","slotSwapStatus":null,"httpsOnly":true,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"publicNetworkAccess":"Enabled","buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs,AppServiceAuthenticationLogs","inFlightFeatures":null,"storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"privateLinkIdentifiers":null,"sshEnabled":null}}'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
     headers:
       cache-control:
       - no-cache
       content-length:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - '6980'
+=======
+      - '8917'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       content-type:
       - application/json
       date:
-      - Tue, 28 Mar 2023 11:20:16 GMT
+      - Fri, 17 Oct 2025 10:40:08 GMT
       etag:
+<<<<<<< HEAD
       - '"1D961673C633280"'
+=======
+      - '8920'
+      content-type:
+      - application/json
+      date:
+      - Sat, 18 Oct 2025 07:47:56 GMT
+      etag:
+      - '"1DC40037918FFF5"'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - '"1DC3F525C35BF4B"'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
       - no-cache
-      server:
-      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+<<<<<<< HEAD
+<<<<<<< HEAD
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '497'
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/f9f2c271-1dd2-4089-8606-9e1ae69569a0
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '800'
+      x-msedge-ref:
+      - 'Ref A: E667A80912EE4FDC8019D7F730B8A7EC Ref B: SYD03EDGE1311 Ref C: 2025-10-18T07:47:34Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/australiaeast/ea1b3b54-afba-411a-b7f5-f4b21ec55daa
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '800'
+      x-msedge-ref:
+      - 'Ref A: 23E4F568F1644D83926F969D0BFECB40 Ref B: SYD03EDGE0916 Ref C: 2025-10-17T10:39:42Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -566,54 +833,92 @@ interactions:
       ParameterSetName:
       - -g -n --plan
       User-Agent:
-      - AZURECLI/2.46.0 azsdk-python-azure-mgmt-web/7.0.0 Python/3.10.10 (Linux-5.15.0-1034-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_261_0
+      - AZURECLI/2.78.0 azsdk-python-core/1.35.0 Python/3.9.6 (macOS-26.0.1-arm64-arm-64bit)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/publishxml?api-version=2023-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/publishxml?api-version=2024-11-01
   response:
     body:
       string: <publishData><publishProfile profileName="webapp-authentication-test000002
         - Web Deploy" publishMethod="MSDeploy" publishUrl="webapp-authentication-test000002.scm.azurewebsites.net:443"
-        msdeploySite="webapp-authentication-test000002" userName="$webapp-authentication-test000002"
-        userPWD="fhnmeWRsAN9nnF5eGKEJXviwohPfMyC0LJPtoleK5rx49swuojmJEFyz6Bkg" destinationAppUrl="http://webapp-authentication-test000002.azurewebsites.net"
-        SQLServerDBConnectionString="" mySQLDBConnectionString="" hostingProviderForumLink=""
-        controlPanelLink="http://windows.azure.com" webSystem="WebSites"><databases
+        msdeploySite="webapp-authentication-test000002" userName="REDACTED" userPWD="REDACTED"
+        destinationAppUrl="https://webapp-authentication-test000002.azurewebsites.net"
+        SQLServerDBConnectionString="REDACTED" mySQLDBConnectionString="" hostingProviderForumLink=""
+        controlPanelLink="https://portal.azure.com" webSystem="WebSites"><databases
         /></publishProfile><publishProfile profileName="webapp-authentication-test000002
+<<<<<<< HEAD
+<<<<<<< HEAD
         - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-bay-177.ftp.azurewebsites.windows.net/site/wwwroot"
         ftpPassiveMode="True" userName="webapp-authentication-test000002\$webapp-authentication-test000002"
         userPWD="fhnmeWRsAN9nnF5eGKEJXviwohPfMyC0LJPtoleK5rx49swuojmJEFyz6Bkg" destinationAppUrl="http://webapp-authentication-test000002.azurewebsites.net"
         SQLServerDBConnectionString="" mySQLDBConnectionString="" hostingProviderForumLink=""
         controlPanelLink="http://windows.azure.com" webSystem="WebSites"><databases
+=======
+        - FTP" publishMethod="FTP" publishUrl="ftps://waws-prod-blu-301.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="REDACTED" userPWD="REDACTED" destinationAppUrl="https://webapp-authentication-test000002.azurewebsites.net"
+        SQLServerDBConnectionString="REDACTED" mySQLDBConnectionString="" hostingProviderForumLink=""
+        controlPanelLink="https://portal.azure.com" webSystem="WebSites"><databases
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+        - FTP" publishMethod="FTP" publishUrl="ftps://waws-prod-blu-315.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="REDACTED" userPWD="REDACTED" destinationAppUrl="https://webapp-authentication-test000002.azurewebsites.net"
+        SQLServerDBConnectionString="REDACTED" mySQLDBConnectionString="" hostingProviderForumLink=""
+        controlPanelLink="https://portal.azure.com" webSystem="WebSites"><databases
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
         /></publishProfile><publishProfile profileName="webapp-authentication-test000002
         - Zip Deploy" publishMethod="ZipDeploy" publishUrl="webapp-authentication-test000002.scm.azurewebsites.net:443"
-        userName="$webapp-authentication-test000002" userPWD="fhnmeWRsAN9nnF5eGKEJXviwohPfMyC0LJPtoleK5rx49swuojmJEFyz6Bkg"
-        destinationAppUrl="http://webapp-authentication-test000002.azurewebsites.net"
-        SQLServerDBConnectionString="" mySQLDBConnectionString="" hostingProviderForumLink=""
-        controlPanelLink="http://windows.azure.com" webSystem="WebSites"><databases
+        userName="REDACTED" userPWD="REDACTED" destinationAppUrl="https://webapp-authentication-test000002.azurewebsites.net"
+        SQLServerDBConnectionString="REDACTED" mySQLDBConnectionString="" hostingProviderForumLink=""
+        controlPanelLink="https://portal.azure.com" webSystem="WebSites"><databases
         /></publishProfile></publishData>
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1771'
+      - '1535'
       content-type:
       - application/xml
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Tue, 28 Mar 2023 11:20:16 GMT
+=======
+      - Sat, 18 Oct 2025 07:47:58 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:40:09 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
       - no-cache
-      server:
-      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+<<<<<<< HEAD
+<<<<<<< HEAD
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '11999'
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/australiaeast/26fffbac-28c1-4bb7-a6aa-73bf6807f801
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: 4FCB875C6C68495F8D277B4DF2350BEE Ref B: SYD03EDGE2112 Ref C: 2025-10-18T07:47:57Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/australiaeast/bf13d9c8-114f-45db-a5a8-9c1a50bfb2c4
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: 7986DB3317AE4D8E804817696CEF7480 Ref B: SYD03EDGE1311 Ref C: 2025-10-17T10:40:08Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -635,13 +940,12 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - python/3.10.10 (Linux-5.15.0-1034-azure-x86_64-with-glibc2.31) AZURECLI/2.46.0
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_261_0
+      - python/3.9.6 (macOS-26.0.1-arm64-arm-64bit) AZURECLI/2.78.0
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authSettings/list?api-version=2020-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettings","name":"authsettings","type":"Microsoft.Web/sites/config","location":"West
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettings","name":"authsettings","type":"Microsoft.Web/sites/config","location":"East
         US","properties":{"enabled":false,"unauthenticatedClientAction":null,"tokenStoreEnabled":null,"allowedExternalRedirectUrls":null,"defaultProvider":null,"clientId":null,"clientSecret":null,"clientSecretSettingName":null,"clientSecretCertificateThumbprint":null,"issuer":null,"allowedAudiences":null,"additionalLoginParams":null,"isAadAutoProvisioned":false,"aadClaimsAuthorization":null,"googleClientId":null,"googleClientSecret":null,"googleClientSecretSettingName":null,"googleOAuthScopes":null,"facebookAppId":null,"facebookAppSecret":null,"facebookAppSecretSettingName":null,"facebookOAuthScopes":null,"gitHubClientId":null,"gitHubClientSecret":null,"gitHubClientSecretSettingName":null,"gitHubOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"twitterConsumerSecretSettingName":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountClientSecretSettingName":null,"microsoftAccountOAuthScopes":null,"configVersion":"v1"}}'
     headers:
       cache-control:
@@ -651,25 +955,47 @@ interactions:
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Tue, 28 Mar 2023 11:20:19 GMT
+=======
+      - Sat, 18 Oct 2025 07:47:59 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:40:10 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
       - no-cache
-      server:
-      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+<<<<<<< HEAD
+<<<<<<< HEAD
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '11999'
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/c8721874-58fc-48af-ac99-c561b28167c0
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: DA81AEA18E1549ADB3275EF161EAF083 Ref B: SYD03EDGE1407 Ref C: 2025-10-18T07:47:59Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/d1a5debc-6e35-4e7f-86fc-158769d505af
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: 85C4031F8F93496BA6C830BF08E8E9E6 Ref B: SYD03EDGE1919 Ref C: 2025-10-17T10:40:10Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -689,39 +1015,462 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - python/3.10.10 (Linux-5.15.0-1034-azure-x86_64-with-glibc2.31) AZURECLI/2.46.0
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_261_0
+      - python/3.9.6 (macOS-26.0.1-arm64-arm-64bit) AZURECLI/2.78.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authSettingsV2/list?api-version=2020-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettingsV2","name":"authsettingsV2","type":"Microsoft.Web/sites/config","location":"West
-        US","properties":{}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettingsV2","name":"authsettingsV2","type":"Microsoft.Web/sites/config","location":"East
+        US","properties":{"platform":{"enabled":false}}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '279'
+      - '307'
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Tue, 28 Mar 2023 11:20:21 GMT
+=======
+      - Sat, 18 Oct 2025 07:48:00 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:40:13 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
       - no-cache
-      server:
-      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/3a0e8e3b-539b-454f-b4d1-a3270774d624
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 6FC087FFDC5F43F7A06B69F204D2EAAB Ref B: SYD03EDGE2007 Ref C: 2025-10-18T07:48:00Z'
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/5e5b77a4-5ca3-45d7-8e28-2deeb962e855
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: C1C263C9E2D04AA1BF3320CFD716C287 Ref B: SYD03EDGE1411 Ref C: 2025-10-17T10:40:11Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp auth config-version upgrade
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.9.6 (macOS-26.0.1-arm64-arm-64bit) AZURECLI/2.78.0
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authSettings/list?api-version=2020-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettings","name":"authsettings","type":"Microsoft.Web/sites/config","location":"East
+        US","properties":{"enabled":false,"unauthenticatedClientAction":null,"tokenStoreEnabled":null,"allowedExternalRedirectUrls":null,"defaultProvider":null,"clientId":null,"clientSecret":null,"clientSecretSettingName":null,"clientSecretCertificateThumbprint":null,"issuer":null,"allowedAudiences":null,"additionalLoginParams":null,"isAadAutoProvisioned":false,"aadClaimsAuthorization":null,"googleClientId":null,"googleClientSecret":null,"googleClientSecretSettingName":null,"googleOAuthScopes":null,"facebookAppId":null,"facebookAppSecret":null,"facebookAppSecretSettingName":null,"facebookOAuthScopes":null,"gitHubClientId":null,"gitHubClientSecret":null,"gitHubClientSecretSettingName":null,"gitHubOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"twitterConsumerSecretSettingName":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountClientSecretSettingName":null,"microsoftAccountOAuthScopes":null,"configVersion":"v1"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1237'
+      content-type:
+      - application/json
+      date:
+<<<<<<< HEAD
+      - Sat, 18 Oct 2025 07:48:01 GMT
+=======
+      - Fri, 17 Oct 2025 10:40:14 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+<<<<<<< HEAD
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/australiaeast/2b15e9e4-07e4-4709-9aa6-99faedcbf427
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: C82620C5BB2443DB9A100C986E87C2B9 Ref B: SYD03EDGE1106 Ref C: 2025-10-18T07:48:01Z'
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/00fae87d-2ce2-4082-ab0a-714ede8e4ab1
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: 41FE7D7196FD412586D636EC3AC912D6 Ref B: SYD03EDGE1108 Ref C: 2025-10-17T10:40:13Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp auth config-version upgrade
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - AZURECLI/2.78.0 azsdk-python-core/1.35.0 Python/3.9.6 (macOS-26.0.1-arm64-arm-64bit)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettings/list?api-version=2024-11-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettings","name":"authsettings","type":"Microsoft.Web/sites/config","location":"East
+        US","properties":{"enabled":false,"unauthenticatedClientAction":null,"tokenStoreEnabled":null,"allowedExternalRedirectUrls":null,"defaultProvider":null,"clientId":null,"clientSecret":null,"clientSecretSettingName":null,"clientSecretCertificateThumbprint":null,"issuer":null,"allowedAudiences":null,"additionalLoginParams":null,"isAadAutoProvisioned":false,"aadClaimsAuthorization":null,"googleClientId":null,"googleClientSecret":null,"googleClientSecretSettingName":null,"googleOAuthScopes":null,"facebookAppId":null,"facebookAppSecret":null,"facebookAppSecretSettingName":null,"facebookOAuthScopes":null,"gitHubClientId":null,"gitHubClientSecret":null,"gitHubClientSecretSettingName":null,"gitHubOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"twitterConsumerSecretSettingName":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountClientSecretSettingName":null,"microsoftAccountOAuthScopes":null,"configVersion":"v1"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1237'
+      content-type:
+      - application/json
+      date:
+<<<<<<< HEAD
+      - Sat, 18 Oct 2025 07:48:02 GMT
+=======
+      - Fri, 17 Oct 2025 10:40:15 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+<<<<<<< HEAD
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/b3302c83-acdc-4acd-9afd-8a6d026e9bad
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: 8D08BE5AF22145A4A621F46E34F2641C Ref B: SYD03EDGE0908 Ref C: 2025-10-18T07:48:02Z'
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/f97c5b3f-8175-404d-9c0e-f2e226a98a18
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: F20D97257CEA4D2BA709806D12B7D7DD Ref B: SYD03EDGE0814 Ref C: 2025-10-17T10:40:14Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp auth config-version upgrade
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.9.6 (macOS-26.0.1-arm64-arm-64bit) AZURECLI/2.78.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authSettingsV2/list?api-version=2020-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettingsV2","name":"authsettingsV2","type":"Microsoft.Web/sites/config","location":"East
+        US","properties":{"platform":{"enabled":false}}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '307'
+      content-type:
+      - application/json
+      date:
+<<<<<<< HEAD
+      - Sat, 18 Oct 2025 07:48:03 GMT
+=======
+      - Fri, 17 Oct 2025 10:40:16 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+<<<<<<< HEAD
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/16504def-aa1c-4450-abec-1547584f45df
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: CD1D10EAEE374350AD8E975C5B439635 Ref B: SYD03EDGE0805 Ref C: 2025-10-18T07:48:03Z'
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/288bd25c-4c12-4068-a56b-93bd2a5be0c6
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 85F0C42D898F44C1AAAA07DB3D000289 Ref B: SYD03EDGE0719 Ref C: 2025-10-17T10:40:16Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp auth config-version upgrade
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.9.6 (macOS-26.0.1-arm64-arm-64bit) AZURECLI/2.78.0
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authSettings/list?api-version=2020-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettings","name":"authsettings","type":"Microsoft.Web/sites/config","location":"East
+        US","properties":{"enabled":false,"unauthenticatedClientAction":null,"tokenStoreEnabled":null,"allowedExternalRedirectUrls":null,"defaultProvider":null,"clientId":null,"clientSecret":null,"clientSecretSettingName":null,"clientSecretCertificateThumbprint":null,"issuer":null,"allowedAudiences":null,"additionalLoginParams":null,"isAadAutoProvisioned":false,"aadClaimsAuthorization":null,"googleClientId":null,"googleClientSecret":null,"googleClientSecretSettingName":null,"googleOAuthScopes":null,"facebookAppId":null,"facebookAppSecret":null,"facebookAppSecretSettingName":null,"facebookOAuthScopes":null,"gitHubClientId":null,"gitHubClientSecret":null,"gitHubClientSecretSettingName":null,"gitHubOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"twitterConsumerSecretSettingName":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountClientSecretSettingName":null,"microsoftAccountOAuthScopes":null,"configVersion":"v1"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1237'
+      content-type:
+      - application/json
+      date:
+<<<<<<< HEAD
+      - Sat, 18 Oct 2025 07:48:04 GMT
+=======
+      - Fri, 17 Oct 2025 10:40:18 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+<<<<<<< HEAD
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/cf5a1387-5bc8-4b22-b0b7-bee2bc60a418
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: 546E6960C50D4959BAC84F86FE3153DD Ref B: SYD03EDGE1419 Ref C: 2025-10-18T07:48:04Z'
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/australiaeast/7c5acacd-8e07-4546-a262-389bf2960513
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: 32A160E1AA95469481C70A2D6463940C Ref B: SYD03EDGE1715 Ref C: 2025-10-17T10:40:16Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp auth config-version upgrade
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.9.6 (macOS-26.0.1-arm64-arm-64bit) AZURECLI/2.78.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authSettingsV2/list?api-version=2020-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettingsV2","name":"authsettingsV2","type":"Microsoft.Web/sites/config","location":"East
+        US","properties":{"platform":{"enabled":false}}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '307'
+      content-type:
+      - application/json
+      date:
+<<<<<<< HEAD
+      - Sat, 18 Oct 2025 07:48:05 GMT
+=======
+      - Fri, 17 Oct 2025 10:40:20 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+<<<<<<< HEAD
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/8dc7fcae-8139-49db-ab54-be6d8ee58b21
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: C2F02D06F5134B82BF4AA7CDA319075E Ref B: SYD03EDGE1317 Ref C: 2025-10-18T07:48:05Z'
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/712712b1-e967-4be1-976a-8ff5bba64c49
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: EFEA3F9F32314A2FBF2C5941CC92734B Ref B: SYD03EDGE0709 Ref C: 2025-10-17T10:40:19Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"platform": {"enabled": false}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp auth config-version upgrade
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.9.6 (macOS-26.0.1-arm64-arm-64bit) AZURECLI/2.78.0
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authSettingsV2?api-version=2020-12-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettingsV2","name":"authsettingsV2","type":"Microsoft.Web/sites/config","location":"East
+        US","properties":{"platform":{"enabled":false,"runtimeVersion":"~1"},"globalValidation":{"requireAuthentication":true,"unauthenticatedClientAction":"RedirectToLoginPage"},"identityProviders":{"azureActiveDirectory":{"enabled":true,"registration":{},"login":{"disableWWWAuthenticate":false},"validation":{"jwtClaimChecks":{},"defaultAuthorizationPolicy":{"allowedPrincipals":{}}}},"facebook":{"enabled":true,"registration":{},"login":{}},"gitHub":{"enabled":true,"registration":{},"login":{}},"google":{"enabled":true,"registration":{},"login":{},"validation":{}},"twitter":{"enabled":true,"registration":{}},"legacyMicrosoftAccount":{"enabled":true,"registration":{},"login":{},"validation":{}},"apple":{"enabled":true,"registration":{},"login":{}}},"login":{"routes":{},"tokenStore":{"enabled":false,"tokenRefreshExtensionHours":72.0,"fileSystem":{},"azureBlobStorage":{}},"preserveUrlFragmentsForLogins":false,"cookieExpiration":{"convention":"FixedTime","timeToExpiration":"08:00:00"},"nonce":{"validateNonce":true,"nonceExpirationInterval":"00:05:00"}},"httpSettings":{"requireHttps":true,"routes":{"apiPrefix":"/.auth"},"forwardProxy":{"convention":"NoProxy"}},"clearInboundClaimsMapping":"false"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1462'
+      content-type:
+      - application/json
+      date:
+<<<<<<< HEAD
+      - Sat, 18 Oct 2025 07:48:07 GMT
+=======
+      - Fri, 17 Oct 2025 10:40:21 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+<<<<<<< HEAD
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/bac0b2e2-05a0-4096-8909-f1251ead9e5d
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/06e4d3a4-a402-4dde-9ed2-ff312c6f446a
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '11999'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '799'
+      x-msedge-ref:
+<<<<<<< HEAD
+      - 'Ref A: E1742CD5FA0349C9940D95F29F4EFFBB Ref B: SYD03EDGE1721 Ref C: 2025-10-18T07:48:06Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - 'Ref A: 205F1B226C4B4DACBAE5F24159E696BD Ref B: SYD03EDGE1917 Ref C: 2025-10-17T10:40:20Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -741,39 +1490,60 @@ interactions:
       ParameterSetName:
       - -g -n --enabled --runtime-version
       User-Agent:
-      - python/3.10.10 (Linux-5.15.0-1034-azure-x86_64-with-glibc2.31) AZURECLI/2.46.0
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_261_0
+      - python/3.9.6 (macOS-26.0.1-arm64-arm-64bit) AZURECLI/2.78.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authSettingsV2/list?api-version=2020-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettingsV2","name":"authsettingsV2","type":"Microsoft.Web/sites/config","location":"West
-        US","properties":{}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettingsV2","name":"authsettingsV2","type":"Microsoft.Web/sites/config","location":"East
+        US","properties":{"platform":{"enabled":false,"runtimeVersion":"~1"},"globalValidation":{"requireAuthentication":true,"unauthenticatedClientAction":"RedirectToLoginPage"},"identityProviders":{"azureActiveDirectory":{"enabled":true,"registration":{},"login":{"disableWWWAuthenticate":false},"validation":{"jwtClaimChecks":{},"defaultAuthorizationPolicy":{"allowedPrincipals":{}}}},"facebook":{"enabled":true,"registration":{},"login":{}},"gitHub":{"enabled":true,"registration":{},"login":{}},"google":{"enabled":true,"registration":{},"login":{},"validation":{}},"twitter":{"enabled":true,"registration":{}},"legacyMicrosoftAccount":{"enabled":true,"registration":{},"login":{},"validation":{}},"apple":{"enabled":true,"registration":{},"login":{}}},"login":{"routes":{},"tokenStore":{"enabled":false,"tokenRefreshExtensionHours":72.0,"fileSystem":{},"azureBlobStorage":{}},"preserveUrlFragmentsForLogins":false,"cookieExpiration":{"convention":"FixedTime","timeToExpiration":"08:00:00"},"nonce":{"validateNonce":true,"nonceExpirationInterval":"00:05:00"}},"httpSettings":{"requireHttps":true,"routes":{"apiPrefix":"/.auth"},"forwardProxy":{"convention":"NoProxy"}},"clearInboundClaimsMapping":"false"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '279'
+      - '1462'
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Tue, 28 Mar 2023 11:20:21 GMT
+=======
+      - Sat, 18 Oct 2025 07:48:08 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:40:22 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
       - no-cache
-      server:
-      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/4a7fc722-3233-4110-90a5-f91b434c0765
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: D95164B3570F41878C8FA101187CD3A6 Ref B: SYD03EDGE2117 Ref C: 2025-10-18T07:48:08Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/02adb20e-d780-48ec-95a8-a34a870b2f03
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: AEDEDD0FC8944363888506B384895AA5 Ref B: SYD03EDGE1314 Ref C: 2025-10-17T10:40:22Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -795,41 +1565,62 @@ interactions:
       ParameterSetName:
       - -g -n --enabled --runtime-version
       User-Agent:
-      - python/3.10.10 (Linux-5.15.0-1034-azure-x86_64-with-glibc2.31) AZURECLI/2.46.0
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_261_0
+      - python/3.9.6 (macOS-26.0.1-arm64-arm-64bit) AZURECLI/2.78.0
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authSettings/list?api-version=2020-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettings","name":"authsettings","type":"Microsoft.Web/sites/config","location":"West
-        US","properties":{"enabled":false,"unauthenticatedClientAction":null,"tokenStoreEnabled":null,"allowedExternalRedirectUrls":null,"defaultProvider":null,"clientId":null,"clientSecret":null,"clientSecretSettingName":null,"clientSecretCertificateThumbprint":null,"issuer":null,"allowedAudiences":null,"additionalLoginParams":null,"isAadAutoProvisioned":false,"aadClaimsAuthorization":null,"googleClientId":null,"googleClientSecret":null,"googleClientSecretSettingName":null,"googleOAuthScopes":null,"facebookAppId":null,"facebookAppSecret":null,"facebookAppSecretSettingName":null,"facebookOAuthScopes":null,"gitHubClientId":null,"gitHubClientSecret":null,"gitHubClientSecretSettingName":null,"gitHubOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"twitterConsumerSecretSettingName":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountClientSecretSettingName":null,"microsoftAccountOAuthScopes":null,"configVersion":"v1"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettings","name":"authsettings","type":"Microsoft.Web/sites/config","location":"East
+        US","properties":{"enabled":false,"unauthenticatedClientAction":null,"tokenStoreEnabled":null,"allowedExternalRedirectUrls":null,"defaultProvider":null,"clientId":null,"clientSecret":null,"clientSecretSettingName":null,"clientSecretCertificateThumbprint":null,"issuer":null,"allowedAudiences":null,"additionalLoginParams":null,"isAadAutoProvisioned":false,"aadClaimsAuthorization":null,"googleClientId":null,"googleClientSecret":null,"googleClientSecretSettingName":null,"googleOAuthScopes":null,"facebookAppId":null,"facebookAppSecret":null,"facebookAppSecretSettingName":null,"facebookOAuthScopes":null,"gitHubClientId":null,"gitHubClientSecret":null,"gitHubClientSecretSettingName":null,"gitHubOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"twitterConsumerSecretSettingName":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountClientSecretSettingName":null,"microsoftAccountOAuthScopes":null,"isAuthFromFile":"False","configVersion":"v2"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1237'
+      - '1262'
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Tue, 28 Mar 2023 11:20:22 GMT
+=======
+      - Sat, 18 Oct 2025 07:48:09 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:40:23 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
       - no-cache
-      server:
-      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+<<<<<<< HEAD
+<<<<<<< HEAD
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '11998'
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/f5706fef-eafc-42c4-ba9f-a04c3892aef2
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '798'
+      x-msedge-ref:
+      - 'Ref A: 4F4177E6B36D4015850D3C33AC4ADA65 Ref B: SYD03EDGE2006 Ref C: 2025-10-18T07:48:08Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/af0f298b-89c8-4823-8011-8fb5040b3034
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: 23607E381246401785D3E2F24D7B313D Ref B: SYD03EDGE2018 Ref C: 2025-10-17T10:40:23Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -849,39 +1640,60 @@ interactions:
       ParameterSetName:
       - -g -n --enabled --runtime-version
       User-Agent:
-      - python/3.10.10 (Linux-5.15.0-1034-azure-x86_64-with-glibc2.31) AZURECLI/2.46.0
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_261_0
+      - python/3.9.6 (macOS-26.0.1-arm64-arm-64bit) AZURECLI/2.78.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authSettingsV2/list?api-version=2020-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettingsV2","name":"authsettingsV2","type":"Microsoft.Web/sites/config","location":"West
-        US","properties":{}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettingsV2","name":"authsettingsV2","type":"Microsoft.Web/sites/config","location":"East
+        US","properties":{"platform":{"enabled":false,"runtimeVersion":"~1"},"globalValidation":{"requireAuthentication":true,"unauthenticatedClientAction":"RedirectToLoginPage"},"identityProviders":{"azureActiveDirectory":{"enabled":true,"registration":{},"login":{"disableWWWAuthenticate":false},"validation":{"jwtClaimChecks":{},"defaultAuthorizationPolicy":{"allowedPrincipals":{}}}},"facebook":{"enabled":true,"registration":{},"login":{}},"gitHub":{"enabled":true,"registration":{},"login":{}},"google":{"enabled":true,"registration":{},"login":{},"validation":{}},"twitter":{"enabled":true,"registration":{}},"legacyMicrosoftAccount":{"enabled":true,"registration":{},"login":{},"validation":{}},"apple":{"enabled":true,"registration":{},"login":{}}},"login":{"routes":{},"tokenStore":{"enabled":false,"tokenRefreshExtensionHours":72.0,"fileSystem":{},"azureBlobStorage":{}},"preserveUrlFragmentsForLogins":false,"cookieExpiration":{"convention":"FixedTime","timeToExpiration":"08:00:00"},"nonce":{"validateNonce":true,"nonceExpirationInterval":"00:05:00"}},"httpSettings":{"requireHttps":true,"routes":{"apiPrefix":"/.auth"},"forwardProxy":{"convention":"NoProxy"}},"clearInboundClaimsMapping":"false"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '279'
+      - '1462'
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Tue, 28 Mar 2023 11:20:23 GMT
+=======
+      - Sat, 18 Oct 2025 07:48:09 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:40:24 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
       - no-cache
-      server:
-      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/31d67255-904c-4a03-b844-ba2c82379f1e
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: C56BB50C5E79451D85229651267060C7 Ref B: SYD03EDGE2110 Ref C: 2025-10-18T07:48:09Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/4acc36e0-f31e-4167-9af8-8b7ce7e5d424
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: B210A1B0662B4470987491A631EBC6A7 Ref B: SYD03EDGE1407 Ref C: 2025-10-17T10:40:24Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -889,7 +1701,21 @@ interactions:
       message: OK
 - request:
     body: '{"properties": {"platform": {"enabled": "true", "runtimeVersion": "1.2.8"},
-      "login": {"tokenStore": {"enabled": true}}}}'
+      "globalValidation": {"requireAuthentication": true, "unauthenticatedClientAction":
+      "RedirectToLoginPage"}, "identityProviders": {"azureActiveDirectory": {"enabled":
+      true, "registration": {}, "login": {"disableWWWAuthenticate": false}, "validation":
+      {"jwtClaimChecks": {}, "defaultAuthorizationPolicy": {"allowedPrincipals": {}}}},
+      "facebook": {"enabled": true, "registration": {}, "login": {}}, "gitHub": {"enabled":
+      true, "registration": {}, "login": {}}, "google": {"enabled": true, "registration":
+      {}, "login": {}, "validation": {}}, "twitter": {"enabled": true, "registration":
+      {}}, "legacyMicrosoftAccount": {"enabled": true, "registration": {}, "login":
+      {}, "validation": {}}, "apple": {"enabled": true, "registration": {}, "login":
+      {}}}, "login": {"routes": {}, "tokenStore": {"enabled": false, "tokenRefreshExtensionHours":
+      72.0, "fileSystem": {}, "azureBlobStorage": {}}, "preserveUrlFragmentsForLogins":
+      false, "cookieExpiration": {"convention": "FixedTime", "timeToExpiration": "08:00:00"},
+      "nonce": {"validateNonce": true, "nonceExpirationInterval": "00:05:00"}}, "httpSettings":
+      {"requireHttps": true, "routes": {"apiPrefix": "/.auth"}, "forwardProxy": {"convention":
+      "NoProxy"}}, "clearInboundClaimsMapping": "false"}}'
     headers:
       Accept:
       - '*/*'
@@ -900,49 +1726,74 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '120'
+      - '1308'
       Content-Type:
       - application/json
       ParameterSetName:
       - -g -n --enabled --runtime-version
       User-Agent:
-      - python/3.10.10 (Linux-5.15.0-1034-azure-x86_64-with-glibc2.31) AZURECLI/2.46.0
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_261_0
+      - python/3.9.6 (macOS-26.0.1-arm64-arm-64bit) AZURECLI/2.78.0
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authSettingsV2?api-version=2020-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettingsV2","name":"authsettingsV2","type":"Microsoft.Web/sites/config","location":"West
-        US","properties":{"platform":{"enabled":true,"runtimeVersion":"1.2.8"},"globalValidation":{"requireAuthentication":true,"unauthenticatedClientAction":"RedirectToLoginPage"},"identityProviders":{"azureActiveDirectory":{"enabled":true,"registration":{},"login":{"disableWWWAuthenticate":false},"validation":{"jwtClaimChecks":{},"defaultAuthorizationPolicy":{"allowedPrincipals":{}}}},"facebook":{"enabled":true,"registration":{},"login":{}},"gitHub":{"enabled":true,"registration":{},"login":{}},"google":{"enabled":true,"registration":{},"login":{},"validation":{}},"twitter":{"enabled":true,"registration":{}},"legacyMicrosoftAccount":{"enabled":true,"registration":{},"login":{},"validation":{}},"apple":{"enabled":true,"registration":{},"login":{}}},"login":{"routes":{},"tokenStore":{"enabled":true,"tokenRefreshExtensionHours":72.0,"fileSystem":{},"azureBlobStorage":{}},"preserveUrlFragmentsForLogins":false,"cookieExpiration":{"convention":"FixedTime","timeToExpiration":"08:00:00"},"nonce":{"validateNonce":true,"nonceExpirationInterval":"00:05:00"}},"httpSettings":{"requireHttps":true,"routes":{"apiPrefix":"/.auth"},"forwardProxy":{"convention":"NoProxy"}}}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettingsV2","name":"authsettingsV2","type":"Microsoft.Web/sites/config","location":"East
+        US","properties":{"platform":{"enabled":true,"runtimeVersion":"1.2.8"},"globalValidation":{"requireAuthentication":true,"unauthenticatedClientAction":"RedirectToLoginPage"},"identityProviders":{"azureActiveDirectory":{"enabled":true,"registration":{},"login":{"disableWWWAuthenticate":false},"validation":{"jwtClaimChecks":{},"defaultAuthorizationPolicy":{"allowedPrincipals":{},"allowedApplications":[]}}},"facebook":{"enabled":true,"registration":{},"login":{}},"gitHub":{"enabled":true,"registration":{},"login":{}},"google":{"enabled":true,"registration":{},"login":{},"validation":{}},"twitter":{"enabled":true,"registration":{}},"legacyMicrosoftAccount":{"enabled":true,"registration":{},"login":{},"validation":{}},"apple":{"enabled":true,"registration":{},"login":{}}},"login":{"routes":{},"tokenStore":{"enabled":false,"tokenRefreshExtensionHours":72.0,"fileSystem":{},"azureBlobStorage":{}},"preserveUrlFragmentsForLogins":false,"cookieExpiration":{"convention":"FixedTime","timeToExpiration":"08:00:00"},"nonce":{"validateNonce":true,"nonceExpirationInterval":"00:05:00"}},"httpSettings":{"requireHttps":true,"routes":{"apiPrefix":"/.auth"},"forwardProxy":{"convention":"NoProxy"}},"clearInboundClaimsMapping":"false"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1427'
+      - '1489'
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Tue, 28 Mar 2023 11:20:35 GMT
       etag:
       - '"1D961674A3840EB"'
+=======
+      - Sat, 18 Oct 2025 07:48:11 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:40:26 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
       - no-cache
-      server:
-      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+<<<<<<< HEAD
+<<<<<<< HEAD
       x-ms-ratelimit-remaining-subscription-writes:
       - '1198'
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/f522cec2-410b-4c6c-a7b0-9c44ce0858d8
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '11999'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: 364962CE62E24C1F9FFC89C15BB01980 Ref B: SYD03EDGE1321 Ref C: 2025-10-18T07:48:10Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/2bce505b-3787-4c12-ab90-6b59e7855bb4
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '11999'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: ED2B8254C4914F6AAFF920CDF5FAEB67 Ref B: SYD03EDGE0921 Ref C: 2025-10-17T10:40:25Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:

--- a/src/authV2/azext_authV2/tests/latest/recordings/test_authV2_excluded_paths_parsing.yaml
+++ b/src/authV2/azext_authV2/tests/latest/recordings/test_authV2_excluded_paths_parsing.yaml
@@ -24,19 +24,52 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003?api-version=2024-11-01
   response:
     body:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003","name":"webapp-authentication-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"eastus","properties":{"serverFarmId":74816,"name":"webapp-authentication-plan000003","sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1},"workerSize":"Small","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Small","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"cli_test_authV2000001-EastUSwebspace","subscription":"9e223dbe-3399-4e19-88eb-0975f02ac87f","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":0,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"East
         US","perSiteScaling":false,"elasticScaleEnabled":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"cli_test_authV2000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-blu-407_74816","targetWorkerCount":0,"targetWorkerSizeId":0,"targetWorkerSku":null,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null,"kubeEnvironmentProfile":null,"zoneRedundant":false,"maximumNumberOfZones":3,"currentNumberOfZonesUtilized":1,"migrateToVMSS":null,"vnetConnectionsUsed":null,"vnetConnectionsMax":null,"createdTime":"2025-10-17T04:23:56.35","asyncScalingEnabled":false,"isCustomMode":null,"powerState":null,"eligibleLogCategories":null},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'
+=======
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003","name":"webapp-authentication-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"eastus","properties":{"serverFarmId":97622,"name":"webapp-authentication-plan000003","sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1},"workerSize":"Small","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Small","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"cli_test_authV2000001-EastUSwebspace","subscription":"9e223dbe-3399-4e19-88eb-0975f02ac87f","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":0,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"East
+        US","perSiteScaling":false,"elasticScaleEnabled":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"cli_test_authV2000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-blu-301_97622","targetWorkerCount":0,"targetWorkerSizeId":0,"targetWorkerSku":null,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null,"kubeEnvironmentProfile":null,"zoneRedundant":false,"maximumNumberOfZones":3,"currentNumberOfZonesUtilized":1,"migrateToVMSS":null,"vnetConnectionsUsed":null,"vnetConnectionsMax":null,"createdTime":"2025-10-18T07:48:25.4133333","asyncScalingEnabled":false,"isCustomMode":null,"powerState":null,"eligibleLogCategories":null},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003","name":"webapp-authentication-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"eastus","properties":{"serverFarmId":60068,"name":"webapp-authentication-plan000003","sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1},"workerSize":"Small","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Small","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"cli_test_authV2000001-EastUSwebspace","subscription":"9e223dbe-3399-4e19-88eb-0975f02ac87f","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":0,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"East
+        US","perSiteScaling":false,"elasticScaleEnabled":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"cli_test_authV2000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-blu-523_60068","targetWorkerCount":0,"targetWorkerSizeId":0,"targetWorkerSku":null,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null,"kubeEnvironmentProfile":null,"zoneRedundant":false,"maximumNumberOfZones":3,"currentNumberOfZonesUtilized":1,"migrateToVMSS":null,"vnetConnectionsUsed":null,"vnetConnectionsMax":null,"createdTime":"2025-10-17T10:05:42.85","asyncScalingEnabled":false,"isCustomMode":null,"powerState":null,"eligibleLogCategories":null},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003","name":"webapp-authentication-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"eastus","properties":{"serverFarmId":78133,"name":"webapp-authentication-plan000003","sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1},"workerSize":"Small","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Small","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"cli_test_authV2000001-EastUSwebspace","subscription":"9e223dbe-3399-4e19-88eb-0975f02ac87f","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":0,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"East
+        US","perSiteScaling":false,"elasticScaleEnabled":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"cli_test_authV2000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-blu-409_78133","targetWorkerCount":0,"targetWorkerSizeId":0,"targetWorkerSku":null,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null,"kubeEnvironmentProfile":null,"zoneRedundant":false,"maximumNumberOfZones":3,"currentNumberOfZonesUtilized":1,"migrateToVMSS":null,"vnetConnectionsUsed":null,"vnetConnectionsMax":null,"createdTime":"2025-10-17T10:40:39.3233333","asyncScalingEnabled":false,"isCustomMode":null,"powerState":null,"eligibleLogCategories":null},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1829'
+      - '1834'
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Fri, 17 Oct 2025 04:23:57 GMT
       etag:
       - '"1DC3F1DDAB1EA4B"'
+=======
+      - Sat, 18 Oct 2025 07:48:28 GMT
+      etag:
+      - '"1DC400396241960"'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:05:44 GMT
+      etag:
+      - '"1DC3F4D99BB68A0"'
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - Fri, 17 Oct 2025 10:40:40 GMT
+      etag:
+      - '"1DC3F527B4E41EB"'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -50,13 +83,37 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/australiacentral/40d2076e-e448-4c72-91e0-e9d4e1a985bf
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/9dd4822b-49c8-4fd7-b26c-72a28b99bcd0
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/australiaeast/d0dbbcaf-646e-4271-98bf-092079673e60
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/f4c02a02-493a-407c-ab86-a57a103e796f
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-ms-ratelimit-remaining-subscription-global-writes:
       - '12000'
       x-ms-ratelimit-remaining-subscription-writes:
       - '800'
       x-msedge-ref:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - 'Ref A: 74090CD56FA24DB288F60927D9686C77 Ref B: SYD03EDGE1118 Ref C: 2025-10-17T04:23:46Z'
+=======
+      - 'Ref A: BCCC7CC7F0BA4B6DA47F113780325DB3 Ref B: SYD03EDGE1716 Ref C: 2025-10-18T07:48:18Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - 'Ref A: 856C89C4061F435487FCEEA7FD60FFFA Ref B: SYD03EDGE0906 Ref C: 2025-10-17T10:05:33Z'
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - 'Ref A: E23B5EFAC0DD4AFABB427B4C144DF526 Ref B: SYD03EDGE1721 Ref C: 2025-10-17T10:40:30Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -82,17 +139,44 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003","name":"webapp-authentication-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"East
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
         US","properties":{"serverFarmId":74816,"name":"webapp-authentication-plan000003","workerSize":"Small","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Small","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"cli_test_authV2000001-EastUSwebspace","subscription":"9e223dbe-3399-4e19-88eb-0975f02ac87f","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"East
         US","perSiteScaling":false,"elasticScaleEnabled":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"cli_test_authV2000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-blu-407_74816","targetWorkerCount":0,"targetWorkerSizeId":0,"targetWorkerSku":null,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null,"kubeEnvironmentProfile":null,"zoneRedundant":false,"maximumNumberOfZones":3,"currentNumberOfZonesUtilized":1,"migrateToVMSS":null,"vnetConnectionsUsed":0,"vnetConnectionsMax":2,"createdTime":"2025-10-17T04:23:56.35","asyncScalingEnabled":false,"isCustomMode":null,"powerState":null,"eligibleLogCategories":null},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'
+=======
+        US","properties":{"serverFarmId":97622,"name":"webapp-authentication-plan000003","workerSize":"Small","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Small","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"cli_test_authV2000001-EastUSwebspace","subscription":"9e223dbe-3399-4e19-88eb-0975f02ac87f","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"East
+        US","perSiteScaling":false,"elasticScaleEnabled":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"cli_test_authV2000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-blu-301_97622","targetWorkerCount":0,"targetWorkerSizeId":0,"targetWorkerSku":null,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null,"kubeEnvironmentProfile":null,"zoneRedundant":false,"maximumNumberOfZones":3,"currentNumberOfZonesUtilized":1,"migrateToVMSS":null,"vnetConnectionsUsed":0,"vnetConnectionsMax":2,"createdTime":"2025-10-18T07:48:25.4133333","asyncScalingEnabled":false,"isCustomMode":null,"powerState":null,"eligibleLogCategories":null},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+        US","properties":{"serverFarmId":60068,"name":"webapp-authentication-plan000003","workerSize":"Small","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Small","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"cli_test_authV2000001-EastUSwebspace","subscription":"9e223dbe-3399-4e19-88eb-0975f02ac87f","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"East
+        US","perSiteScaling":false,"elasticScaleEnabled":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"cli_test_authV2000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-blu-523_60068","targetWorkerCount":0,"targetWorkerSizeId":0,"targetWorkerSku":null,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null,"kubeEnvironmentProfile":null,"zoneRedundant":false,"maximumNumberOfZones":3,"currentNumberOfZonesUtilized":1,"migrateToVMSS":null,"vnetConnectionsUsed":0,"vnetConnectionsMax":2,"createdTime":"2025-10-17T10:05:42.85","asyncScalingEnabled":false,"isCustomMode":null,"powerState":null,"eligibleLogCategories":null},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+        US","properties":{"serverFarmId":78133,"name":"webapp-authentication-plan000003","workerSize":"Small","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Small","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"cli_test_authV2000001-EastUSwebspace","subscription":"9e223dbe-3399-4e19-88eb-0975f02ac87f","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"East
+        US","perSiteScaling":false,"elasticScaleEnabled":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"cli_test_authV2000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-blu-409_78133","targetWorkerCount":0,"targetWorkerSizeId":0,"targetWorkerSku":null,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null,"kubeEnvironmentProfile":null,"zoneRedundant":false,"maximumNumberOfZones":3,"currentNumberOfZonesUtilized":1,"migrateToVMSS":null,"vnetConnectionsUsed":0,"vnetConnectionsMax":2,"createdTime":"2025-10-17T10:40:39.3233333","asyncScalingEnabled":false,"isCustomMode":null,"powerState":null,"eligibleLogCategories":null},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1749'
+      - '1754'
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Fri, 17 Oct 2025 04:23:59 GMT
+=======
+      - Sat, 18 Oct 2025 07:48:30 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:05:46 GMT
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - Fri, 17 Oct 2025 10:40:43 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -108,7 +192,19 @@ interactions:
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - 'Ref A: 9C196E2FDC054170B36E91978695FC46 Ref B: SYD03EDGE1408 Ref C: 2025-10-17T04:23:59Z'
+=======
+      - 'Ref A: 1C420C605B334B90BB698D7A231514B8 Ref B: SYD03EDGE0816 Ref C: 2025-10-18T07:48:28Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - 'Ref A: 0B43655E1FFD44CE8D036643E7E6B04D Ref B: SYD03EDGE1409 Ref C: 2025-10-17T10:05:45Z'
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - 'Ref A: 8A4837D8A3DB48C1A97B004D3F6C9CD9 Ref B: SYD03EDGE1008 Ref C: 2025-10-17T10:40:41Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -146,7 +242,19 @@ interactions:
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Fri, 17 Oct 2025 04:23:59 GMT
+=======
+      - Sat, 18 Oct 2025 07:48:30 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:05:47 GMT
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - Fri, 17 Oct 2025 10:40:44 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -160,11 +268,35 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/30fbed97-1b03-4da8-a40b-8a7de0afab0a
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
       - 'Ref A: 5C555B3293CB4A7CA6FB4F5F1884865B Ref B: SYD03EDGE1716 Ref C: 2025-10-17T04:23:59Z'
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/d0ddcafb-f611-4dc0-a829-3dde8e302e38
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 460F2D02E2154C279558413EA8174EBB Ref B: SYD03EDGE1918 Ref C: 2025-10-18T07:48:30Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/8b4d6036-5cec-47bf-9bb3-16793a1dd7ac
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 8F198EA502E048DF95B128C0C9D08444 Ref B: SYD03EDGE1411 Ref C: 2025-10-17T10:05:46Z'
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/australiaeast/51cc3f7f-c510-4d88-858d-73f3bf663f8f
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 20CC1F2A270F4B90890721B9479F7AD8 Ref B: SYD03EDGE1416 Ref C: 2025-10-17T10:40:43Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -576,7 +708,19 @@ interactions:
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Fri, 17 Oct 2025 04:24:00 GMT
+=======
+      - Sat, 18 Oct 2025 07:48:31 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:05:47 GMT
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - Fri, 17 Oct 2025 10:40:44 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -592,7 +736,19 @@ interactions:
       x-ms-operation-identifier:
       - ''
       x-msedge-ref:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - 'Ref A: 844423C9E31F4739862A96C115A18D72 Ref B: SYD03EDGE0817 Ref C: 2025-10-17T04:24:00Z'
+=======
+      - 'Ref A: F2618E908FD643CDB736F24E0011408F Ref B: SYD03EDGE0706 Ref C: 2025-10-18T07:48:31Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - 'Ref A: 09C85775E50C40A3A55DE3A0787B96F8 Ref B: SYD03EDGE0711 Ref C: 2025-10-17T10:05:48Z'
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - 'Ref A: D61FA1A1788B40AEAE9245EE4C898917 Ref B: SYD03EDGE1018 Ref C: 2025-10-17T10:40:44Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -626,20 +782,64 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/sites/webapp-authentication-test000002","name":"webapp-authentication-test000002","type":"Microsoft.Web/sites","kind":"app","location":"East
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
         US","properties":{"name":"webapp-authentication-test000002","state":"Running","hostNames":["webapp-authentication-test000002.azurewebsites.net"],"webSpace":"cli_test_authV2000001-EastUSwebspace","selfLink":"https://waws-prod-blu-407.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli_test_authV2000001-EastUSwebspace/sites/webapp-authentication-test000002","repositorySiteName":"webapp-authentication-test000002","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["webapp-authentication-test000002.azurewebsites.net","webapp-authentication-test000002.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-authentication-test000002.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-authentication-test000002.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003","reserved":false,"isXenon":false,"hyperV":false,"sandboxType":null,"lastModifiedTimeUtc":"2025-10-17T04:24:02.87","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"outboundVnetRouting":{"allTraffic":false,"applicationTraffic":false,"contentShareTraffic":false,"imagePullTraffic":false,"backupRestoreTraffic":false,"managedIdentityTraffic":false},"legacyServiceEndpointTrafficEvaluation":null,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"","windowsFxVersion":null,"sandboxType":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
         all","description":"Allow all access"}],"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
         all","description":"Allow all access"}],"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":null,"elasticWebAppScaleLimit":0,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false,"webJobsEnabled":false},"functionAppConfig":null,"daprConfig":null,"deploymentId":"webapp-authentication-test000002","slotName":null,"trafficManagerHostNames":null,"sku":"Standard","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientAffinityProxyEnabled":false,"useQueryStringAffinity":false,"blockPathTraversal":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"clientCertExclusionEndPoints":null,"hostNamesDisabled":false,"ipMode":"IPv4","domainVerificationIdentifiers":null,"customDomainVerificationId":"70240F0BA32B9DD28948DBEC834A732C467825FB279A572BFED6A386F1954E0A","kind":"app","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"20.119.8.37","possibleInboundIpAddresses":"20.119.8.37","inboundIpv6Address":"2603:1030:210:8::6","possibleInboundIpv6Addresses":"2603:1030:210:8::6","ftpUsername":"webapp-authentication-test000002\\$webapp-authentication-test000002","ftpsHostName":"ftps://waws-prod-blu-407.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"20.246.138.95,20.246.138.167,20.246.138.253,20.246.139.201,20.246.139.212,20.246.139.249,20.119.8.37","possibleOutboundIpAddresses":"20.246.138.95,20.246.138.167,20.246.138.253,20.246.139.201,20.246.139.212,20.246.139.249,40.90.240.239,20.246.140.71,20.246.140.81,20.246.140.91,20.246.140.101,20.246.140.107,20.246.140.135,20.246.140.151,20.246.140.174,20.246.140.186,20.246.140.234,20.246.141.81,20.246.141.104,20.237.29.178,20.246.142.101,20.237.26.186,20.237.26.205,20.237.26.238,20.237.28.72,20.237.28.81,20.237.29.43,20.237.29.154,20.237.29.166,20.237.29.224,20.237.29.250,20.119.8.37","outboundIpv6Addresses":"2603:1030:20c:9::62c,2603:1030:20c:f::63c,2603:1030:20e:3::574,2603:1030:20e:3::576,2603:1030:20e:3::577,2603:1030:20c:f::63f,2603:1030:210:8::6,2603:10e1:100:2::1477:825","possibleOutboundIpv6Addresses":"2603:1030:20c:9::62c,2603:1030:20c:f::63c,2603:1030:20e:3::574,2603:1030:20e:3::576,2603:1030:20e:3::577,2603:1030:20c:f::63f,2603:1030:20c:f::640,2603:1030:20c:9::62f,2603:1030:20c:9::631,2603:1030:20c:f::641,2603:1030:20c:f::644,2603:1030:20c:9::632,2603:1030:20c:f::649,2603:1030:20c:f::64a,2603:1030:20e:3::57f,2603:1030:20e:3::582,2603:1030:20c:f::64e,2603:1030:20c:9::636,2603:1030:20c:f::651,2603:1030:20c:9::637,2603:1030:20e:3::587,2603:1030:20e:3::589,2603:1030:20e:3::58a,2603:1030:20c:9::638,2603:1030:20c:f::655,2603:1030:20c:f::656,2603:1030:20e:3::58e,2603:1030:20e:3::591,2603:1030:20e:3::592,2603:1030:20c:9::639,2603:1030:210:8::6,2603:10e1:100:2::1477:825","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-blu-407","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli_test_authV2000001","defaultHostName":"webapp-authentication-test000002.azurewebsites.net","slotSwapStatus":null,"httpsOnly":true,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"publicNetworkAccess":"Enabled","buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs,AppServiceAuthenticationLogs","inFlightFeatures":null,"storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"privateLinkIdentifiers":null,"sshEnabled":null}}'
+=======
+        US","properties":{"name":"webapp-authentication-test000002","state":"Running","hostNames":["webapp-authentication-test000002.azurewebsites.net"],"webSpace":"cli_test_authV2000001-EastUSwebspace","selfLink":"https://waws-prod-blu-301.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli_test_authV2000001-EastUSwebspace/sites/webapp-authentication-test000002","repositorySiteName":"webapp-authentication-test000002","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["webapp-authentication-test000002.azurewebsites.net","webapp-authentication-test000002.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-authentication-test000002.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-authentication-test000002.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003","reserved":false,"isXenon":false,"hyperV":false,"sandboxType":null,"lastModifiedTimeUtc":"2025-10-18T07:48:37.1366667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"outboundVnetRouting":{"allTraffic":false,"applicationTraffic":false,"contentShareTraffic":false,"imagePullTraffic":false,"backupRestoreTraffic":false,"managedIdentityTraffic":false},"legacyServiceEndpointTrafficEvaluation":null,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"","windowsFxVersion":null,"sandboxType":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":null,"elasticWebAppScaleLimit":0,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false,"webJobsEnabled":false},"functionAppConfig":null,"daprConfig":null,"deploymentId":"webapp-authentication-test000002","slotName":null,"trafficManagerHostNames":null,"sku":"Standard","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientAffinityProxyEnabled":false,"useQueryStringAffinity":false,"blockPathTraversal":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"clientCertExclusionEndPoints":null,"hostNamesDisabled":false,"ipMode":"IPv4","domainVerificationIdentifiers":null,"customDomainVerificationId":"70240F0BA32B9DD28948DBEC834A732C467825FB279A572BFED6A386F1954E0A","kind":"app","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"20.49.104.60","possibleInboundIpAddresses":"20.49.104.60","inboundIpv6Address":"2603:1030:210:9::68","possibleInboundIpv6Addresses":"2603:1030:210:9::68","ftpUsername":"webapp-authentication-test000002\\$webapp-authentication-test000002","ftpsHostName":"ftps://waws-prod-blu-301.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"20.88.177.135,20.88.178.45,20.88.178.104,20.88.178.172,20.88.178.194,20.88.178.207,20.49.104.60","possibleOutboundIpAddresses":"20.88.177.135,20.88.178.45,20.88.178.104,20.88.178.172,20.88.178.194,20.88.178.207,48.217.217.147,20.88.178.231,20.88.179.52,20.88.179.87,20.88.179.98,20.88.179.103,20.88.179.104,20.88.179.112,20.88.179.149,20.88.179.157,20.88.179.170,20.88.179.173,20.88.179.183,20.88.179.185,20.88.180.50,20.88.180.64,20.88.180.70,20.88.181.37,20.88.181.72,20.88.181.114,20.88.181.119,20.81.9.0,20.88.181.134,20.88.178.93,20.88.180.104,20.49.104.60","outboundIpv6Addresses":"2603:1030:20c:9::e0d,2603:1030:20c:9::e14,2603:1030:20c:9::e1c,2603:1030:20c:9::e24,2603:1030:20c:9::e29,2603:1030:20c:9::e34,2603:1030:210:9::68,2603:10e1:100:2::1431:683c","possibleOutboundIpv6Addresses":"2603:1030:20c:9::e0d,2603:1030:20c:9::e14,2603:1030:20c:9::e1c,2603:1030:20c:9::e24,2603:1030:20c:9::e29,2603:1030:20c:9::e34,2603:1030:20c:9::e3e,2603:1030:20c:9::e46,2603:1030:20c:9::e4d,2603:1030:20c:9::e54,2603:1030:20c:9::e59,2603:1030:20c:9::e5d,2603:1030:20c:9::e64,2603:1030:20c:9::e69,2603:1030:20c:9::e6d,2603:1030:20c:9::e72,2603:1030:20c:9::e75,2603:1030:20c:9::e7b,2603:1030:20c:9::e83,2603:1030:20c:9::e87,2603:1030:20c:9::e8b,2603:1030:20c:9::e93,2603:1030:20c:9::e98,2603:1030:20c:9::e9c,2603:1030:20c:9::ea3,2603:1030:20c:9::eaa,2603:1030:20c:9::eae,2603:1030:20c:9::eb6,2603:1030:20c:9::ebe,2603:1030:20c:9::ec6,2603:1030:210:9::68,2603:10e1:100:2::1431:683c","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-blu-301","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli_test_authV2000001","defaultHostName":"webapp-authentication-test000002.azurewebsites.net","slotSwapStatus":null,"httpsOnly":true,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"publicNetworkAccess":"Enabled","buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs,AppServiceAuthenticationLogs","inFlightFeatures":null,"storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"privateLinkIdentifiers":null,"sshEnabled":null}}'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+        US","properties":{"name":"webapp-authentication-test000002","state":"Running","hostNames":["webapp-authentication-test000002.azurewebsites.net"],"webSpace":"cli_test_authV2000001-EastUSwebspace","selfLink":"https://waws-prod-blu-523.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli_test_authV2000001-EastUSwebspace/sites/webapp-authentication-test000002","repositorySiteName":"webapp-authentication-test000002","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["webapp-authentication-test000002.azurewebsites.net","webapp-authentication-test000002.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-authentication-test000002.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-authentication-test000002.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003","reserved":false,"isXenon":false,"hyperV":false,"sandboxType":null,"lastModifiedTimeUtc":"2025-10-17T10:05:53.8266667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"outboundVnetRouting":{"allTraffic":false,"applicationTraffic":false,"contentShareTraffic":false,"imagePullTraffic":false,"backupRestoreTraffic":false,"managedIdentityTraffic":false},"legacyServiceEndpointTrafficEvaluation":null,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"","windowsFxVersion":null,"sandboxType":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":null,"elasticWebAppScaleLimit":0,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false,"webJobsEnabled":false},"functionAppConfig":null,"daprConfig":null,"deploymentId":"webapp-authentication-test000002","slotName":null,"trafficManagerHostNames":null,"sku":"Standard","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientAffinityProxyEnabled":false,"useQueryStringAffinity":false,"blockPathTraversal":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"clientCertExclusionEndPoints":null,"hostNamesDisabled":false,"ipMode":"IPv4","domainVerificationIdentifiers":null,"customDomainVerificationId":"70240F0BA32B9DD28948DBEC834A732C467825FB279A572BFED6A386F1954E0A","kind":"app","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"20.119.0.52","possibleInboundIpAddresses":"20.119.0.52","inboundIpv6Address":"2603:1030:210:8::10","possibleInboundIpv6Addresses":"2603:1030:210:8::10","ftpUsername":"webapp-authentication-test000002\\$webapp-authentication-test000002","ftpsHostName":"ftps://waws-prod-blu-523.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.226.144.245,52.226.144.254,52.226.145.12,52.226.145.73,52.226.145.109,52.226.145.151,52.226.147.6,52.226.147.9,52.226.147.16,52.226.147.22,52.226.147.37,52.226.147.38,52.226.147.41,52.226.147.45,52.226.147.73,52.226.147.77,52.226.147.104,52.226.147.115,20.119.0.52","possibleOutboundIpAddresses":"52.226.144.245,52.226.144.254,52.226.145.12,52.226.145.73,52.226.145.109,52.226.145.151,52.226.147.6,52.226.147.9,52.226.147.16,52.226.147.22,52.226.147.37,52.226.147.38,52.226.147.41,52.226.147.45,52.226.147.73,52.226.147.77,52.226.147.104,52.226.147.115,135.237.74.2,52.226.145.157,52.226.145.165,52.226.145.187,52.224.191.184,52.226.145.203,52.226.145.247,52.226.145.250,52.226.146.22,52.226.146.24,52.226.146.133,52.226.146.140,52.226.146.154,52.226.146.168,52.226.146.172,52.226.146.203,52.226.146.245,52.226.146.251,52.226.146.255,52.226.147.118,52.226.147.121,52.226.147.124,52.226.147.126,52.226.147.134,52.226.147.147,20.119.0.52","outboundIpv6Addresses":"2603:1030:20e:3::5b6,2603:1030:20e:3::5b7,2603:1030:20c:9::64e,2603:1030:20e:3::5ba,2603:1030:20c:9::650,2603:1030:20c:9::651,2603:1030:20e:3::5d2,2603:1030:20c:f::68e,2603:1030:20e:3::5d6,2603:1030:20c:9::664,2603:1030:20c:f::690,2603:1030:20c:f::692,2603:1030:20c:f::693,2603:1030:20e:3::5dc,2603:1030:20c:9::669,2603:1030:20e:3::5e0,2603:1030:20e:3::5e2,2603:1030:20c:9::66e,2603:1030:210:8::10,2603:10e1:100:2::1477:34","possibleOutboundIpv6Addresses":"2603:1030:20e:3::5b6,2603:1030:20e:3::5b7,2603:1030:20c:9::64e,2603:1030:20e:3::5ba,2603:1030:20c:9::650,2603:1030:20c:9::651,2603:1030:20e:3::5d2,2603:1030:20c:f::68e,2603:1030:20e:3::5d6,2603:1030:20c:9::664,2603:1030:20c:f::690,2603:1030:20c:f::692,2603:1030:20c:f::693,2603:1030:20e:3::5dc,2603:1030:20c:9::669,2603:1030:20e:3::5e0,2603:1030:20e:3::5e2,2603:1030:20c:9::66e,2603:1030:20c:f::67e,2603:1030:20c:f::680,2603:1030:20e:3::5be,2603:1030:20c:f::684,2603:1030:20c:9::655,2603:1030:20c:f::685,2603:1030:20c:f::686,2603:1030:20e:3::5c3,2603:1030:20c:9::659,2603:1030:20e:3::5c6,2603:1030:20c:f::68a,2603:1030:20c:f::68c,2603:1030:20e:3::5c8,2603:1030:20e:3::5cb,2603:1030:20e:3::5cc,2603:1030:20c:9::65d,2603:1030:20e:3::5cf,2603:1030:20c:9::660,2603:1030:20e:3::5e6,2603:1030:20e:3::5e8,2603:1030:20c:f::694,2603:1030:20c:f::695,2603:1030:20e:3::5ec,2603:1030:20c:9::675,2603:1030:210:8::10,2603:10e1:100:2::1477:34","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-blu-523","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli_test_authV2000001","defaultHostName":"webapp-authentication-test000002.azurewebsites.net","slotSwapStatus":null,"httpsOnly":true,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"publicNetworkAccess":"Enabled","buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs,AppServiceAuthenticationLogs","inFlightFeatures":null,"storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"privateLinkIdentifiers":null,"sshEnabled":null}}'
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+        US","properties":{"name":"webapp-authentication-test000002","state":"Running","hostNames":["webapp-authentication-test000002.azurewebsites.net"],"webSpace":"cli_test_authV2000001-EastUSwebspace","selfLink":"https://waws-prod-blu-409.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/cli_test_authV2000001-EastUSwebspace/sites/webapp-authentication-test000002","repositorySiteName":"webapp-authentication-test000002","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"siteScopedCertificatesEnabled":false,"afdEnabled":false,"enabledHostNames":["webapp-authentication-test000002.azurewebsites.net","webapp-authentication-test000002.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-authentication-test000002.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"webapp-authentication-test000002.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_authV2000001/providers/Microsoft.Web/serverfarms/webapp-authentication-plan000003","reserved":false,"isXenon":false,"hyperV":false,"sandboxType":null,"lastModifiedTimeUtc":"2025-10-17T10:40:47.62","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"outboundVnetRouting":{"allTraffic":false,"applicationTraffic":false,"contentShareTraffic":false,"imagePullTraffic":false,"backupRestoreTraffic":false,"managedIdentityTraffic":false},"legacyServiceEndpointTrafficEvaluation":null,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"","windowsFxVersion":null,"sandboxType":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"scmMinTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmSupportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":null,"elasticWebAppScaleLimit":0,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false,"webJobsEnabled":false},"functionAppConfig":null,"daprConfig":null,"deploymentId":"webapp-authentication-test000002","slotName":null,"trafficManagerHostNames":null,"sku":"Standard","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientAffinityProxyEnabled":false,"useQueryStringAffinity":false,"blockPathTraversal":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"clientCertExclusionEndPoints":null,"hostNamesDisabled":false,"ipMode":"IPv4","domainVerificationIdentifiers":null,"customDomainVerificationId":"70240F0BA32B9DD28948DBEC834A732C467825FB279A572BFED6A386F1954E0A","kind":"app","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"20.119.8.35","possibleInboundIpAddresses":"20.119.8.35","inboundIpv6Address":"2603:1030:210:9::5c","possibleInboundIpv6Addresses":"2603:1030:210:9::5c","ftpUsername":"webapp-authentication-test000002\\$webapp-authentication-test000002","ftpsHostName":"ftps://waws-prod-blu-409.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"20.231.254.168,20.231.254.207,20.231.255.29,20.231.255.39,20.231.255.98,20.231.255.137,20.119.8.35","possibleOutboundIpAddresses":"20.231.254.168,20.231.254.207,20.231.255.29,20.231.255.39,20.231.255.98,20.231.255.137,135.237.17.101,20.231.255.141,20.88.191.63,20.231.255.152,20.231.255.159,20.242.160.50,20.242.160.62,20.242.160.71,20.242.160.110,20.242.160.123,20.242.160.155,20.242.160.163,20.242.160.164,20.81.28.121,20.242.160.182,20.242.160.190,20.242.160.225,20.242.160.227,20.242.161.30,20.242.161.63,20.242.161.93,20.242.161.145,20.242.161.176,20.242.161.185,20.242.161.243,20.119.8.35","outboundIpv6Addresses":"2603:1030:20c:9::afd,2603:1030:20c:9::aff,2603:1030:20c:9::b03,2603:1030:20c:9::b07,2603:1030:20c:9::b0c,2603:1030:20c:9::b0e,2603:1030:210:9::5c,2603:10e1:100:2::1477:823","possibleOutboundIpv6Addresses":"2603:1030:20c:9::afd,2603:1030:20c:9::aff,2603:1030:20c:9::b03,2603:1030:20c:9::b07,2603:1030:20c:9::b0c,2603:1030:20c:9::b0e,2603:1030:20c:9::b12,2603:1030:20c:9::b17,2603:1030:20c:9::b1c,2603:1030:20c:9::b22,2603:1030:20c:9::b27,2603:1030:20c:9::b2b,2603:1030:20c:9::b32,2603:1030:20c:9::b38,2603:1030:20c:9::b3e,2603:1030:20c:9::b45,2603:1030:20c:9::b49,2603:1030:20c:9::b4d,2603:1030:20c:9::b57,2603:1030:20c:9::b5d,2603:1030:20c:9::b62,2603:1030:20c:9::b68,2603:1030:20c:9::b6f,2603:1030:20c:9::b73,2603:1030:20c:9::b7a,2603:1030:20c:9::b7e,2603:1030:20c:9::b81,2603:1030:20c:9::b86,2603:1030:20c:9::b8a,2603:1030:20c:9::b8f,2603:1030:210:9::5c,2603:10e1:100:2::1477:823","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-blu-409","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"cli_test_authV2000001","defaultHostName":"webapp-authentication-test000002.azurewebsites.net","slotSwapStatus":null,"httpsOnly":true,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"publicNetworkAccess":"Enabled","buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs,AppServiceAuthenticationLogs","inFlightFeatures":null,"storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"privateLinkIdentifiers":null,"sshEnabled":null}}'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
     headers:
       cache-control:
       - no-cache
       content-length:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - '8940'
+=======
+      - '9800'
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - '8949'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       content-type:
       - application/json
       date:
-      - Fri, 17 Oct 2025 04:24:22 GMT
+      - Fri, 17 Oct 2025 10:41:07 GMT
       etag:
+<<<<<<< HEAD
+<<<<<<< HEAD
       - '"1DC3F1DDE76C780"'
+=======
+      - '8925'
+      content-type:
+      - application/json
+      date:
+      - Sat, 18 Oct 2025 07:48:57 GMT
+      etag:
+      - '"1DC40039D6720D5"'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - '"1DC3F4D9FE733B5"'
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - '"1DC3F52803FB840"'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -653,11 +853,35 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/b01d1797-202b-4734-a942-f239bbe3ba5e
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '800'
       x-msedge-ref:
       - 'Ref A: 699CB0A7C5F0417289AB1F1469ECC637 Ref B: SYD03EDGE1320 Ref C: 2025-10-17T04:24:01Z'
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/australiasoutheast/cd6529c5-024b-4c17-b99e-b0038638efe8
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '800'
+      x-msedge-ref:
+      - 'Ref A: 889F2EDA399940439C191B46FA24C029 Ref B: SYD03EDGE0812 Ref C: 2025-10-18T07:48:32Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/australiasoutheast/a2624cef-f628-4eb7-8d9a-c5ef2e8f4c1f
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '800'
+      x-msedge-ref:
+      - 'Ref A: 4CD62D63F88D4690A5D6E684FE39E655 Ref B: SYD03EDGE1320 Ref C: 2025-10-17T10:05:49Z'
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/edebe773-0a33-4c17-8b25-d5b7d261fb15
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '800'
+      x-msedge-ref:
+      - 'Ref A: C3C80EAFF8DB4554A40A0EB7422F15E5 Ref B: SYD03EDGE2117 Ref C: 2025-10-17T10:40:45Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -693,7 +917,19 @@ interactions:
         SQLServerDBConnectionString="REDACTED" mySQLDBConnectionString="" hostingProviderForumLink=""
         controlPanelLink="https://portal.azure.com" webSystem="WebSites"><databases
         /></publishProfile><publishProfile profileName="webapp-authentication-test000002
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
         - FTP" publishMethod="FTP" publishUrl="ftps://waws-prod-blu-407.ftp.azurewebsites.windows.net/site/wwwroot"
+=======
+        - FTP" publishMethod="FTP" publishUrl="ftps://waws-prod-blu-301.ftp.azurewebsites.windows.net/site/wwwroot"
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+        - FTP" publishMethod="FTP" publishUrl="ftps://waws-prod-blu-523.ftp.azurewebsites.windows.net/site/wwwroot"
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+        - FTP" publishMethod="FTP" publishUrl="ftps://waws-prod-blu-409.ftp.azurewebsites.windows.net/site/wwwroot"
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
         ftpPassiveMode="True" userName="REDACTED" userPWD="REDACTED" destinationAppUrl="https://webapp-authentication-test000002.azurewebsites.net"
         SQLServerDBConnectionString="REDACTED" mySQLDBConnectionString="" hostingProviderForumLink=""
         controlPanelLink="https://portal.azure.com" webSystem="WebSites"><databases
@@ -711,7 +947,19 @@ interactions:
       content-type:
       - application/xml
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Fri, 17 Oct 2025 04:24:24 GMT
+=======
+      - Sat, 18 Oct 2025 07:48:57 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:06:14 GMT
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - Fri, 17 Oct 2025 10:41:09 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -725,11 +973,35 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/australiaeast/ca512c1e-1b87-4a44-9a57-edd07fd9fceb
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '799'
       x-msedge-ref:
       - 'Ref A: AAB4D6CFBD76479997EB1D5C66B617ED Ref B: SYD03EDGE0717 Ref C: 2025-10-17T04:24:23Z'
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/acfa57d0-5721-4285-a729-d014f7b8bb87
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: C3CEE737CEBC4479ACED9F329FD9333D Ref B: SYD03EDGE2121 Ref C: 2025-10-18T07:48:58Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/australiaeast/d7e4ff92-a6ba-4507-a5e8-ab292a368a35
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: 00BAACAF09F14C2D87B8377EECE26732 Ref B: SYD03EDGE0908 Ref C: 2025-10-17T10:06:14Z'
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/8f1fb56b-560d-443d-b582-550c7b6d2e58
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: 31CFDC986F4740C381263525993D10D0 Ref B: SYD03EDGE1313 Ref C: 2025-10-17T10:41:08Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -766,7 +1038,19 @@ interactions:
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Fri, 17 Oct 2025 04:24:24 GMT
+=======
+      - Sat, 18 Oct 2025 07:48:59 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:06:16 GMT
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - Fri, 17 Oct 2025 10:41:09 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -780,11 +1064,35 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/54505bd9-a6e1-40af-a3a3-cf815a601e1d
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '799'
       x-msedge-ref:
       - 'Ref A: 4903EAB93BD74B6C97E66CDD48EF475D Ref B: SYD03EDGE0815 Ref C: 2025-10-17T04:24:24Z'
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/f61bbd56-78de-4f24-8454-8343b5506811
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: BFD6014B414F4713B9D5A71A250506ED Ref B: SYD03EDGE2016 Ref C: 2025-10-18T07:48:59Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/80b5c9c5-0d59-45de-bb1a-fcbe459379fd
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: 7E78CC4041BC43B783F355C6402AA57E Ref B: SYD03EDGE0917 Ref C: 2025-10-17T10:06:15Z'
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/78fa2b1c-b851-4838-a65d-36cc1b04aafd
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: 423F6B477D6A4D908C6190DE56858D6D Ref B: SYD03EDGE1918 Ref C: 2025-10-17T10:41:09Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -819,7 +1127,19 @@ interactions:
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Fri, 17 Oct 2025 04:24:25 GMT
+=======
+      - Sat, 18 Oct 2025 07:48:59 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:06:16 GMT
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - Fri, 17 Oct 2025 10:41:11 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -833,11 +1153,35 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/australiaeast/e3e581d1-3017-4e57-975a-dc5bcf4ff0e5
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
       - 'Ref A: F37DD9A36E944BBEA0FC6B7AE9E375B3 Ref B: SYD03EDGE2111 Ref C: 2025-10-17T04:24:25Z'
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/dc8351a8-c57f-45c1-8b49-d0e925298743
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 7CEA564A446144B69438F8D9910AE6D5 Ref B: SYD03EDGE1112 Ref C: 2025-10-18T07:48:59Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/8a6c04b3-852b-42b9-a96e-254fd34dc6fc
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 1497B43730274B1A81B9FCCA8D608980 Ref B: SYD03EDGE0917 Ref C: 2025-10-17T10:06:17Z'
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/804eb0ac-bb68-4b51-85ef-deee0270d21d
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: D4FA607831794D7EBF89CA102152CA16 Ref B: SYD03EDGE1920 Ref C: 2025-10-17T10:41:10Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -874,7 +1218,19 @@ interactions:
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Fri, 17 Oct 2025 04:24:26 GMT
+=======
+      - Sat, 18 Oct 2025 07:49:00 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:06:17 GMT
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - Fri, 17 Oct 2025 10:41:11 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -888,11 +1244,35 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/96063a2b-7015-4933-a155-6df889d06dee
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '799'
       x-msedge-ref:
       - 'Ref A: A9C274595FB34707AA6BF4CB3AD2435C Ref B: SYD03EDGE0915 Ref C: 2025-10-17T04:24:26Z'
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/18840af7-39fa-447f-8add-028d15d42fec
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: 455256BD3C4F428FBEB37A1FBF009964 Ref B: SYD03EDGE1120 Ref C: 2025-10-18T07:49:00Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/b89f4ff5-3c24-4d39-8a96-1d4c3894a4ff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: 69A20988664241D1842F28A773DF9C68 Ref B: SYD03EDGE0815 Ref C: 2025-10-17T10:06:17Z'
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/2730ba83-1d87-4bbf-9fd9-e26e00d9a83c
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: CC10817D7B064D00852DDE80980EE2C0 Ref B: SYD03EDGE0816 Ref C: 2025-10-17T10:41:11Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -929,7 +1309,19 @@ interactions:
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Fri, 17 Oct 2025 04:24:27 GMT
+=======
+      - Sat, 18 Oct 2025 07:49:01 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:06:18 GMT
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - Fri, 17 Oct 2025 10:41:13 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -943,11 +1335,35 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/02147910-d478-4b59-a084-0b25f4a82e97
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '799'
       x-msedge-ref:
       - 'Ref A: BDABDF1089CD41799385E6E2C7E5A311 Ref B: SYD03EDGE2111 Ref C: 2025-10-17T04:24:27Z'
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/648f0b02-460e-406e-a01b-dff2a99f2953
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: EA266BE51EFC4E3BB135A713AE9CDDAC Ref B: SYD03EDGE1109 Ref C: 2025-10-18T07:49:01Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/ced96ae4-8a66-4dfb-8890-53919e168418
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: CB87087BFEE34C3A9153A2468F84463D Ref B: SYD03EDGE0821 Ref C: 2025-10-17T10:06:18Z'
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/australiaeast/9ad10ffb-ef51-4b5f-94ff-e14d689d166d
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: 759C51544E714D86808FB34F666788F0 Ref B: SYD03EDGE1311 Ref C: 2025-10-17T10:41:12Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -982,7 +1398,19 @@ interactions:
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Fri, 17 Oct 2025 04:24:28 GMT
+=======
+      - Sat, 18 Oct 2025 07:49:02 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:06:21 GMT
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - Fri, 17 Oct 2025 10:41:13 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -996,11 +1424,35 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/cc9cb08d-f620-4bb8-9dfc-dd9f6937e155
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
       - 'Ref A: 4BC4BD8152E248CAB7DC0B8124214F59 Ref B: SYD03EDGE0807 Ref C: 2025-10-17T04:24:27Z'
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/25de25b9-de3c-4387-850a-2b7c791189f0
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: BF29A29CC3FC454A9C41E875F2DE4DCD Ref B: SYD03EDGE0809 Ref C: 2025-10-18T07:49:02Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/australiacentral/95585e2e-94f6-4398-9c32-cb5a6bc46d14
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: E9D5C8A5886D4ABCAE6A87044EEDC9D4 Ref B: SYD03EDGE1909 Ref C: 2025-10-17T10:06:19Z'
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/f36ff29e-a8eb-44ca-a7ce-8f7a80c35a3c
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 0A1F06973625491F8CC3F2CE50572A0C Ref B: SYD03EDGE0807 Ref C: 2025-10-17T10:41:13Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -1037,7 +1489,19 @@ interactions:
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Fri, 17 Oct 2025 04:24:28 GMT
+=======
+      - Sat, 18 Oct 2025 07:49:02 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:06:22 GMT
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - Fri, 17 Oct 2025 10:41:14 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -1051,11 +1515,35 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/b8ea8e34-7a5b-4485-8f35-f1cdefc4a6b2
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '799'
       x-msedge-ref:
       - 'Ref A: D36B658EF206405688C538198BDF89BF Ref B: SYD03EDGE2015 Ref C: 2025-10-17T04:24:28Z'
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/d9fcec67-7f9a-4fb0-a648-3d738bf11c02
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: 712A708EEA9043CF99FDDBD3C318813E Ref B: SYD03EDGE1019 Ref C: 2025-10-18T07:49:03Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/c12800df-46c2-4db6-87c7-20af2da7eecf
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: 1A8F435ECF0F45549514ABEC1150DC5D Ref B: SYD03EDGE2108 Ref C: 2025-10-17T10:06:21Z'
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/51cde47b-d59d-4965-bd4f-2f3e4607b19c
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: EB3C0E2413344B6598A443AA507D6317 Ref B: SYD03EDGE1420 Ref C: 2025-10-17T10:41:14Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -1090,7 +1578,19 @@ interactions:
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Fri, 17 Oct 2025 04:24:30 GMT
+=======
+      - Sat, 18 Oct 2025 07:49:04 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:06:22 GMT
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - Fri, 17 Oct 2025 10:41:14 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -1104,11 +1604,35 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/a9f8d969-76c0-4738-8290-192b66d24d93
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
       - 'Ref A: B638B5B6F8594F749361AEA86657F166 Ref B: SYD03EDGE1913 Ref C: 2025-10-17T04:24:29Z'
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/australiaeast/01226764-232e-4baa-bd36-40800e20ef9d
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 6686EFB5DDCE4499ACC52EF4E74EE426 Ref B: SYD03EDGE2008 Ref C: 2025-10-18T07:49:03Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/a438c66d-d49a-48c3-a578-1b9e8a90b33c
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 34DA7B4DA0C842FFA05D1E7E09D601E6 Ref B: SYD03EDGE1117 Ref C: 2025-10-17T10:06:22Z'
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/dc7f592f-149a-4f66-a175-442013772032
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: DFBEB6BA0A364F5AA1D1CB72FC234E1B Ref B: SYD03EDGE0711 Ref C: 2025-10-17T10:41:15Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -1147,7 +1671,19 @@ interactions:
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Fri, 17 Oct 2025 04:24:31 GMT
+=======
+      - Sat, 18 Oct 2025 07:49:05 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:06:24 GMT
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - Fri, 17 Oct 2025 10:41:15 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -1161,13 +1697,37 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/9a406dc1-c6f6-4473-ba46-5a9ae409fae2
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/0f530bf9-be1c-421c-900a-77fedea2cee7
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/bfa80731-9c73-4000-9053-c4d3981ff0fc
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/da6966cc-a7c3-4ab2-8e72-47a4aadc8be1
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-ms-ratelimit-remaining-subscription-global-writes:
       - '11999'
       x-ms-ratelimit-remaining-subscription-writes:
       - '799'
       x-msedge-ref:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - 'Ref A: 33EF9B12EADB4789A194FAADBE21FEE6 Ref B: SYD03EDGE1921 Ref C: 2025-10-17T04:24:30Z'
+=======
+      - 'Ref A: 60186A2BFDFF4119A8CE2F8E57DC54D7 Ref B: SYD03EDGE1313 Ref C: 2025-10-18T07:49:04Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - 'Ref A: 9FDC0F206FA14CE09C10B00017D987DD Ref B: SYD03EDGE1017 Ref C: 2025-10-17T10:06:23Z'
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - 'Ref A: 34C08D9D91414F97B52E363D7C8CFCCE Ref B: SYD03EDGE1310 Ref C: 2025-10-17T10:41:16Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -1202,7 +1762,19 @@ interactions:
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Fri, 17 Oct 2025 04:24:31 GMT
+=======
+      - Sat, 18 Oct 2025 07:49:06 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:06:24 GMT
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - Fri, 17 Oct 2025 10:41:17 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -1216,11 +1788,35 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/7ad3dc03-27e2-40ff-97cb-0b9e5a20f2ba
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
       - 'Ref A: 56AFD11E2D0148FD8186FC0B36A386E4 Ref B: SYD03EDGE1418 Ref C: 2025-10-17T04:24:31Z'
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/a1def2a8-69ae-4284-8d30-59ac5f72e76e
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: FB80575F2CB84236A8B7BE7A2D3672B6 Ref B: SYD03EDGE1416 Ref C: 2025-10-18T07:49:06Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/df9df2fb-f865-4743-89dc-1305e3e54e49
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 93222AD91DC14E84ABAF26150B47D02E Ref B: SYD03EDGE1707 Ref C: 2025-10-17T10:06:25Z'
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/f5a7eeef-e6f7-4d2b-ac37-b7ee659c29a7
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 4E380804A791478DA7B786F3EF50A173 Ref B: SYD03EDGE1407 Ref C: 2025-10-17T10:41:17Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -1257,7 +1853,19 @@ interactions:
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Fri, 17 Oct 2025 04:24:32 GMT
+=======
+      - Sat, 18 Oct 2025 07:49:06 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:06:25 GMT
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - Fri, 17 Oct 2025 10:41:18 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -1271,11 +1879,35 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/c4174921-1d83-43ac-a02a-058092d0a200
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '799'
       x-msedge-ref:
       - 'Ref A: 3F23E20BD953441780C209A6D2A699BB Ref B: SYD03EDGE2121 Ref C: 2025-10-17T04:24:32Z'
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/ddd6348d-cd95-47f4-b702-372ccd44584f
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: 4338FBAF98B04975A96ECA72F785D0AD Ref B: SYD03EDGE1318 Ref C: 2025-10-18T07:49:06Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/fe90f6f2-2317-46c0-8fd7-0eea3c0e928b
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: 26642D0AFA8E4A7794B46314652DE7B4 Ref B: SYD03EDGE1911 Ref C: 2025-10-17T10:06:25Z'
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/3f343851-aa7d-4497-a99d-0458e0faf2d1
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: F7443F13FE914325A9AA15ADC90EEA66 Ref B: SYD03EDGE1414 Ref C: 2025-10-17T10:41:17Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -1310,7 +1942,19 @@ interactions:
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Fri, 17 Oct 2025 04:24:33 GMT
+=======
+      - Sat, 18 Oct 2025 07:49:07 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:06:26 GMT
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - Fri, 17 Oct 2025 10:41:18 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -1324,11 +1968,35 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/ffbca323-e3b9-414a-b805-6060f4854da9
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
       - 'Ref A: EFB9E2561CC647F492CFC2B5AB96DF55 Ref B: SYD03EDGE1412 Ref C: 2025-10-17T04:24:33Z'
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/f94d165d-7b5b-44aa-ad90-b93fe2bf009a
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 1CFEFB088A1046F586679DD1D72C0EF3 Ref B: SYD03EDGE1308 Ref C: 2025-10-18T07:49:07Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/7ee4d565-31c5-4a80-a035-2050f83bbb17
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: D07FE7A908EF4AFCA8FDC0A9E8B2851C Ref B: SYD03EDGE1011 Ref C: 2025-10-17T10:06:26Z'
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/982feb89-2a8a-4503-b74c-ff5cc8fbebe5
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 8AC3500A57504400897B1FB21CE840D6 Ref B: SYD03EDGE1707 Ref C: 2025-10-17T10:41:18Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -1383,7 +2051,19 @@ interactions:
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Fri, 17 Oct 2025 04:24:34 GMT
+=======
+      - Sat, 18 Oct 2025 07:49:09 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:06:27 GMT
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - Fri, 17 Oct 2025 10:41:20 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -1397,13 +2077,37 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/f64a0527-32bc-487f-8c97-65291d500595
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/fcad0e67-2502-4c36-87b4-5cf8fffc854c
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/b11390cf-7d37-4c09-8ac4-61505d3e1157
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/354683cd-8443-4842-8f76-e4a370fdb575
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-ms-ratelimit-remaining-subscription-global-writes:
       - '11999'
       x-ms-ratelimit-remaining-subscription-writes:
       - '799'
       x-msedge-ref:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - 'Ref A: 09805B9EBE544C4596A6CD03EEB29B84 Ref B: SYD03EDGE0706 Ref C: 2025-10-17T04:24:33Z'
+=======
+      - 'Ref A: 837A3C7D451B4AEB8E1D74B2E0B9C2B9 Ref B: SYD03EDGE0811 Ref C: 2025-10-18T07:49:08Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - 'Ref A: 6EBB678B912A4CA8B432DD20EF8D8D50 Ref B: SYD03EDGE0807 Ref C: 2025-10-17T10:06:27Z'
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - 'Ref A: 75218C68019747619E90D1E0B05F0D7F Ref B: SYD03EDGE1415 Ref C: 2025-10-17T10:41:19Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -1438,7 +2142,19 @@ interactions:
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Fri, 17 Oct 2025 04:24:34 GMT
+=======
+      - Sat, 18 Oct 2025 07:49:10 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:06:28 GMT
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - Fri, 17 Oct 2025 10:41:21 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -1452,11 +2168,35 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/8fac281c-d922-422e-a8a6-a36729e742f9
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
       - 'Ref A: 44977193C976475BAFABE5AE36673FB6 Ref B: SYD03EDGE1308 Ref C: 2025-10-17T04:24:35Z'
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/922a6bba-6665-4252-9834-925cce1a3d6d
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 0B54C2B764AA49478A5249AA2B6C4962 Ref B: SYD03EDGE0908 Ref C: 2025-10-18T07:49:10Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/e74d87d0-cdca-4f88-a921-f22f39bec515
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: F147B012C66741B284C1FF29890CF5AA Ref B: SYD03EDGE1920 Ref C: 2025-10-17T10:06:28Z'
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/0e724cac-537a-4a50-8dba-a2c7cdcc08ae
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 2968293124C14DE38E9D6AFD79DCE92D Ref B: SYD03EDGE1416 Ref C: 2025-10-17T10:41:21Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -1493,7 +2233,19 @@ interactions:
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Fri, 17 Oct 2025 04:24:36 GMT
+=======
+      - Sat, 18 Oct 2025 07:49:10 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:06:29 GMT
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - Fri, 17 Oct 2025 10:41:21 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -1507,11 +2259,35 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/f8dce432-517a-4a32-aac5-70df8054581a
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '799'
       x-msedge-ref:
       - 'Ref A: 0073A0892EB7425BAF22C82E04EC0136 Ref B: SYD03EDGE0710 Ref C: 2025-10-17T04:24:35Z'
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/43ed09f7-b1d9-49dd-aff9-5645a92ef105
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: 371BD35ED6504430B56C68340A751FA1 Ref B: SYD03EDGE0711 Ref C: 2025-10-18T07:49:11Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/992e4f66-a5d0-4300-ba7d-671b4d4718d6
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: C58F4FBB1A0B4EDEA257FFFD15B4EFC1 Ref B: SYD03EDGE1013 Ref C: 2025-10-17T10:06:29Z'
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/c1a81afa-e251-4a57-8669-4c05aa2dc287
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: 93D69E8A6245454C97BBAC4F25CD9606 Ref B: SYD03EDGE1914 Ref C: 2025-10-17T10:41:21Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -1546,7 +2322,19 @@ interactions:
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Fri, 17 Oct 2025 04:24:36 GMT
+=======
+      - Sat, 18 Oct 2025 07:49:11 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:06:29 GMT
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - Fri, 17 Oct 2025 10:41:22 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -1560,11 +2348,35 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/93496117-bfa9-4cfe-a9b1-fa78792da06d
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
       - 'Ref A: AACDF96506F34E2599A39CDF14CCCFC8 Ref B: SYD03EDGE1918 Ref C: 2025-10-17T04:24:36Z'
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/57a8c16b-388a-48e5-9878-36454c89a597
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: BF0812BCC2D74FBBB4F2FF026F49C310 Ref B: SYD03EDGE0914 Ref C: 2025-10-18T07:49:11Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/773bb538-ff65-4abb-a3b1-39ec68a92bf5
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: B2502165F7834F06B7BA1796CF1DD4F1 Ref B: SYD03EDGE1118 Ref C: 2025-10-17T10:06:29Z'
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/b109db71-65ef-4b4e-9eac-48851459e5e1
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: EC685629ACB5495B8454DB65FB887BF8 Ref B: SYD03EDGE1921 Ref C: 2025-10-17T10:41:22Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -1620,7 +2432,19 @@ interactions:
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Fri, 17 Oct 2025 04:24:38 GMT
+=======
+      - Sat, 18 Oct 2025 07:49:13 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:06:31 GMT
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - Fri, 17 Oct 2025 10:41:24 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -1634,13 +2458,37 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/57532bc3-ca2a-4ce9-a6f0-e8789ac9fb00
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/411b29cd-ab24-4513-ad74-6e4c8c41656c
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/08cdda33-830f-4aeb-9cea-91c53d5218b9
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/fd21019b-45e5-4903-aa85-ca2311da19bb
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-ms-ratelimit-remaining-subscription-global-writes:
       - '11999'
       x-ms-ratelimit-remaining-subscription-writes:
       - '799'
       x-msedge-ref:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - 'Ref A: D304E8D3D5C64559BEDEAEE22A88B179 Ref B: SYD03EDGE1711 Ref C: 2025-10-17T04:24:37Z'
+=======
+      - 'Ref A: 3AA457A24A904CF895BDEB41CC48937F Ref B: SYD03EDGE0921 Ref C: 2025-10-18T07:49:12Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - 'Ref A: 82F99D74C1A147C29AB063A5A8B6CF8E Ref B: SYD03EDGE0708 Ref C: 2025-10-17T10:06:30Z'
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - 'Ref A: A6994A0A089845A5B03CA39873ADD6A8 Ref B: SYD03EDGE1713 Ref C: 2025-10-17T10:41:23Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -1675,7 +2523,19 @@ interactions:
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Fri, 17 Oct 2025 04:24:39 GMT
+=======
+      - Sat, 18 Oct 2025 07:49:14 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:06:33 GMT
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - Fri, 17 Oct 2025 10:41:25 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -1689,11 +2549,35 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/33a9970e-e8a5-44b1-b601-50a1a589b51b
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
       - 'Ref A: 1446390B2EBD49239F1CDF9A827D12BE Ref B: SYD03EDGE0920 Ref C: 2025-10-17T04:24:38Z'
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/a2562990-f8b6-417c-9f66-253ceb801539
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 98D6814CA1C54BC697AD4BFB1C07D9B6 Ref B: SYD03EDGE1421 Ref C: 2025-10-18T07:49:14Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/265e506e-cad2-4739-81e6-9685fb837485
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: E3FFB71634B94C1FA2B0ABB230081EC5 Ref B: SYD03EDGE0705 Ref C: 2025-10-17T10:06:32Z'
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/79c8304e-7143-4b07-afed-2a19e8c58345
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 673C395BBF5B4317BA2BE1E5C713FAD3 Ref B: SYD03EDGE1907 Ref C: 2025-10-17T10:41:25Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -1730,7 +2614,19 @@ interactions:
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Fri, 17 Oct 2025 04:24:39 GMT
+=======
+      - Sat, 18 Oct 2025 07:49:15 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:06:34 GMT
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - Fri, 17 Oct 2025 10:41:25 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -1744,11 +2640,35 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/907ca8bb-fce7-4b90-bd33-20f0fb1a6b7b
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '799'
       x-msedge-ref:
       - 'Ref A: 48751DCB4D834E65B7C5C4A9CAFCFF6C Ref B: SYD03EDGE1909 Ref C: 2025-10-17T04:24:39Z'
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/94f1b99f-e5a6-4654-8255-08a85dfa321c
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: 2995140E8E824AAC8462604186328955 Ref B: SYD03EDGE0721 Ref C: 2025-10-18T07:49:15Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/85f6d329-7df8-45e2-80a1-7513665efb17
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: ECEE0D4CB5574F6EA70C41E5C4C27FEE Ref B: SYD03EDGE1921 Ref C: 2025-10-17T10:06:34Z'
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/428d8db2-9d98-49de-838f-0fa360fbc9f0
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: 85F0A05C70E845719282D82D278CAD45 Ref B: SYD03EDGE1710 Ref C: 2025-10-17T10:41:25Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -1783,7 +2703,19 @@ interactions:
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Fri, 17 Oct 2025 04:24:40 GMT
+=======
+      - Sat, 18 Oct 2025 07:49:16 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:06:34 GMT
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - Fri, 17 Oct 2025 10:41:26 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -1797,11 +2729,35 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/ac2c8b4d-d08c-4241-b010-3ba290846ac1
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
       - 'Ref A: 3909933CA7814892BF26D9390C0DDE54 Ref B: SYD03EDGE2014 Ref C: 2025-10-17T04:24:40Z'
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/8439ce75-78ee-4759-ac9f-c4efa9fd0797
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 3BF7167E71394E579860C567E50339E7 Ref B: SYD03EDGE2008 Ref C: 2025-10-18T07:49:15Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/f5a32fca-0e13-4e9a-b484-2dd765bd8ecd
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: F1C9EB998C82445E942FA57ABE2CE1DB Ref B: SYD03EDGE1914 Ref C: 2025-10-17T10:06:34Z'
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/6ccb9821-41ab-4e04-a51c-9c20e7ec9bdc
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 090E0FDAA6C145F19D8724273DDA6342 Ref B: SYD03EDGE1019 Ref C: 2025-10-17T10:41:26Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -1856,7 +2812,19 @@ interactions:
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Fri, 17 Oct 2025 04:24:42 GMT
+=======
+      - Sat, 18 Oct 2025 07:49:16 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:06:36 GMT
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - Fri, 17 Oct 2025 10:41:28 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -1870,13 +2838,37 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/e36a9f3a-8779-4cf9-a6d4-159a1ba9df94
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/aca4312c-6af8-4c3d-90e8-7a022d0ee4b0
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/41f5e535-ce40-407d-9b16-880b1b6dfa37
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/e35a601f-bc87-428c-980f-6bc9fafae12f
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-ms-ratelimit-remaining-subscription-global-writes:
       - '11999'
       x-ms-ratelimit-remaining-subscription-writes:
       - '799'
       x-msedge-ref:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - 'Ref A: 487B7B7346F64634AE4F72B1D0945321 Ref B: SYD03EDGE2016 Ref C: 2025-10-17T04:24:41Z'
+=======
+      - 'Ref A: 8B520C57B014482C9C99A2DA280C8A34 Ref B: SYD03EDGE1314 Ref C: 2025-10-18T07:49:16Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - 'Ref A: 5A6E598CC1174F8993EEA75DC75B44DE Ref B: SYD03EDGE1718 Ref C: 2025-10-17T10:06:35Z'
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - 'Ref A: C9AC25BFC3EF44449094CC0F7C989AD8 Ref B: SYD03EDGE2120 Ref C: 2025-10-17T10:41:27Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -1911,7 +2903,19 @@ interactions:
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Fri, 17 Oct 2025 04:24:42 GMT
+=======
+      - Sat, 18 Oct 2025 07:49:17 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:06:37 GMT
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - Fri, 17 Oct 2025 10:41:29 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -1925,11 +2929,35 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/95d17d41-a895-4d33-b1ef-9c206a111e46
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/a4628d8b-ac83-46d0-8deb-c9c018bbdbbd
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/c1963b56-3b5f-4c6e-bb2b-a7c5ebe5ea80
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/242b68c3-71b5-41c9-af8e-d94d6c9732ac
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-ms-ratelimit-remaining-subscription-global-reads:
-      - '16499'
+      - '16498'
       x-msedge-ref:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - 'Ref A: 92AF68C1162745AE80CC1663D873D70E Ref B: SYD03EDGE2010 Ref C: 2025-10-17T04:24:42Z'
+=======
+      - 'Ref A: 4AC7B20CF4104DE089CFCE15DB9E77F7 Ref B: SYD03EDGE1421 Ref C: 2025-10-18T07:49:18Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - 'Ref A: B9A848136DA54D0E899C46C842A7E046 Ref B: SYD03EDGE0914 Ref C: 2025-10-17T10:06:37Z'
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - 'Ref A: E4A399092CD04BF0B78F91A77816B20F Ref B: SYD03EDGE1715 Ref C: 2025-10-17T10:41:29Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -1966,7 +2994,19 @@ interactions:
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Fri, 17 Oct 2025 04:24:43 GMT
+=======
+      - Sat, 18 Oct 2025 07:49:18 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:06:38 GMT
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - Fri, 17 Oct 2025 10:41:30 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -1980,11 +3020,35 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/c1d8517a-973a-4dc3-afdf-6d2ad6465d19
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '799'
       x-msedge-ref:
       - 'Ref A: 856A0DBDB9454D7FBCC2603ED7470EEF Ref B: SYD03EDGE1009 Ref C: 2025-10-17T04:24:43Z'
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/a0ac3432-880d-49ce-9709-ab12cdc588d1
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: 6EB17059EA734158BE0C1BE7F37000DE Ref B: SYD03EDGE0908 Ref C: 2025-10-18T07:49:18Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/558ee471-097f-4b9a-a102-1e590c82e585
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: C884ED0C388B40AAAA064B61D5E7C1A9 Ref B: SYD03EDGE0815 Ref C: 2025-10-17T10:06:38Z'
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/812cad90-7179-4e51-b098-78ff753aa8fb
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: 17265AC8FD694DED9B184A211929AD84 Ref B: SYD03EDGE1317 Ref C: 2025-10-17T10:41:29Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -2019,7 +3083,19 @@ interactions:
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Fri, 17 Oct 2025 04:24:44 GMT
+=======
+      - Sat, 18 Oct 2025 07:49:20 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:06:39 GMT
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - Fri, 17 Oct 2025 10:41:31 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -2033,11 +3109,35 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/5de6da11-85ca-40f6-8b69-9fa89c3a9da4
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
       - 'Ref A: 85BB2B02E8DB45978A999FC31E1818BD Ref B: SYD03EDGE1007 Ref C: 2025-10-17T04:24:44Z'
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/3795e4f2-dff6-4c48-b29f-4be401cf5962
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: C037A23A6CB146198C8BCF196D4193F4 Ref B: SYD03EDGE0816 Ref C: 2025-10-18T07:49:19Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/2b3fb5df-984b-415f-8792-170f26f6864a
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: D0348F3D30D7449CB9917427C55DC83E Ref B: SYD03EDGE2009 Ref C: 2025-10-17T10:06:39Z'
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/d33975fc-1222-49fa-8f00-09552883549f
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 78181619395D438E9F8637202644FE86 Ref B: SYD03EDGE1317 Ref C: 2025-10-17T10:41:30Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -2093,7 +3193,19 @@ interactions:
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Fri, 17 Oct 2025 04:24:45 GMT
+=======
+      - Sat, 18 Oct 2025 07:49:20 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:06:41 GMT
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - Fri, 17 Oct 2025 10:41:32 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -2107,13 +3219,37 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/f4e2e03e-6bc7-490c-8e5f-c15d81d89776
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/dc6f0d92-6f9e-4de0-8297-dbebf0db562a
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/05d66984-540b-4890-9bc5-0c73e39f194a
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/252b0ad8-0951-4c3f-bdaf-1bc8e28c4614
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-ms-ratelimit-remaining-subscription-global-writes:
       - '11999'
       x-ms-ratelimit-remaining-subscription-writes:
       - '799'
       x-msedge-ref:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - 'Ref A: D6E35A7ABABE447CA418F4620D13FE09 Ref B: SYD03EDGE0818 Ref C: 2025-10-17T04:24:45Z'
+=======
+      - 'Ref A: DE39D0B3E62F425195AAC5F3BF412020 Ref B: SYD03EDGE1006 Ref C: 2025-10-18T07:49:20Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - 'Ref A: 0D422B05B1FA4AA683D57AAAF311B17E Ref B: SYD03EDGE1313 Ref C: 2025-10-17T10:06:40Z'
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - 'Ref A: F2AF508F64C34DFB99B55E85AC3A578F Ref B: SYD03EDGE1309 Ref C: 2025-10-17T10:41:31Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -2148,7 +3284,19 @@ interactions:
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Fri, 17 Oct 2025 04:24:46 GMT
+=======
+      - Sat, 18 Oct 2025 07:49:21 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:06:41 GMT
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - Fri, 17 Oct 2025 10:41:33 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -2162,11 +3310,35 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/73faeb55-1a84-474e-a5ad-993c30eb20e2
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
       - 'Ref A: 39B811F023A84793A186D7AFC614B654 Ref B: SYD03EDGE2011 Ref C: 2025-10-17T04:24:46Z'
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/495c2ef7-5adf-4139-898f-3436988dddd9
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 37E8D66DB3084205BC515A8AAFBA6DB4 Ref B: SYD03EDGE1311 Ref C: 2025-10-18T07:49:21Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/d946a57e-b380-45cf-abfe-380d005ec5fe
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: B338B95F123B4C33B3D230D89DE5FD52 Ref B: SYD03EDGE1005 Ref C: 2025-10-17T10:06:41Z'
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/62231b6f-5cdf-470d-b1ae-53b68a07d496
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 6F6CA8588FA14DB3893CBBE9465B9A3C Ref B: SYD03EDGE0719 Ref C: 2025-10-17T10:41:33Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -2203,7 +3375,19 @@ interactions:
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Fri, 17 Oct 2025 04:24:47 GMT
+=======
+      - Sat, 18 Oct 2025 07:49:22 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:06:42 GMT
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - Fri, 17 Oct 2025 10:41:33 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -2217,11 +3401,35 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/bd228841-d9c9-4486-90a6-1ee3b90fcd94
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '799'
       x-msedge-ref:
       - 'Ref A: 47CFAA84B77D4744812E4E672A10559A Ref B: SYD03EDGE0818 Ref C: 2025-10-17T04:24:47Z'
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/aafc606a-beb6-455a-8630-185b1d427fc4
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: 76E29F8710334F1CA93E40FE48487B6B Ref B: SYD03EDGE2112 Ref C: 2025-10-18T07:49:22Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/8f1211b9-ff3b-40c3-8d19-c0dbe220b008
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: 30AB90D6FF5A49419F435044CD8425C5 Ref B: SYD03EDGE1309 Ref C: 2025-10-17T10:06:42Z'
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/65f9b913-eca4-4e8e-8243-cf0e0f5dd791
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: 25444D641A804417993A441D841967CE Ref B: SYD03EDGE1722 Ref C: 2025-10-17T10:41:33Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -2256,7 +3464,19 @@ interactions:
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Fri, 17 Oct 2025 04:24:48 GMT
+=======
+      - Sat, 18 Oct 2025 07:49:22 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:06:43 GMT
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - Fri, 17 Oct 2025 10:41:35 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -2270,11 +3490,35 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/4d1226e6-320b-4e15-b82d-e937c13e87e2
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
       - 'Ref A: 97BB5C34DD4D4C4FB25AA880BD553D09 Ref B: SYD03EDGE1714 Ref C: 2025-10-17T04:24:48Z'
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/3dd96d55-bd83-4985-a832-09ca55e5ec55
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 61CA19E7758747EEB1D4E8A981163A19 Ref B: SYD03EDGE1419 Ref C: 2025-10-18T07:49:23Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/f8d9b154-c069-455c-ada3-cf050c9e6d23
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 5C3736179DAE4C97AA9BB85091D14BE5 Ref B: SYD03EDGE1711 Ref C: 2025-10-17T10:06:43Z'
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/007ad865-8e4e-4d8f-b77b-e649422f0b3a
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 74739E6A331946E9B58DD644EA1BCA36 Ref B: SYD03EDGE1910 Ref C: 2025-10-17T10:41:34Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:
@@ -2329,7 +3573,19 @@ interactions:
       content-type:
       - application/json
       date:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - Fri, 17 Oct 2025 04:24:49 GMT
+=======
+      - Sat, 18 Oct 2025 07:49:24 GMT
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - Fri, 17 Oct 2025 10:06:44 GMT
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - Fri, 17 Oct 2025 10:41:36 GMT
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       expires:
       - '-1'
       pragma:
@@ -2343,13 +3599,37 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/39203499-d7b9-4bf9-bd31-7e8f3a205d51
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/0aa8adbb-763d-4283-8f84-0891980f0c24
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/113318e3-f93f-4e4a-a095-75b1fcf5b854
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=bbf48380-10d9-4b16-bbc1-6f320c300908/westus/76890d80-fc64-44b6-8668-e14770f615a3
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-ms-ratelimit-remaining-subscription-global-writes:
       - '11999'
       x-ms-ratelimit-remaining-subscription-writes:
       - '799'
       x-msedge-ref:
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
       - 'Ref A: 5101473C6B82478094E8685FB7D78AD3 Ref B: SYD03EDGE0722 Ref C: 2025-10-17T04:24:48Z'
+=======
+      - 'Ref A: DF4207D6BF304895BC10BEA55B9BB6FA Ref B: SYD03EDGE2022 Ref C: 2025-10-18T07:49:23Z'
+>>>>>>> 4fd554e11 (rerecorded cassettes)
+=======
+      - 'Ref A: 7A79D683BC2547D8914F31D8B3CBFB82 Ref B: SYD03EDGE1911 Ref C: 2025-10-17T10:06:43Z'
+>>>>>>> 3c998828f (fixed logic for json loading)
+=======
+      - 'Ref A: 1FC18F8B6FD84488A40D8E589CE330E3 Ref B: SYD03EDGE1318 Ref C: 2025-10-17T10:41:35Z'
+>>>>>>> e75e3eb0f (Update authV2 tests: fix API version compatibility and large response handling)
       x-powered-by:
       - ASP.NET
     status:

--- a/src/authV2/azext_authV2/tests/latest/test_authV2_scenario.py
+++ b/src/authV2/azext_authV2/tests/latest/test_authV2_scenario.py
@@ -16,6 +16,7 @@ TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))
 class Authv2ScenarioTest(ScenarioTest):
 
     @ResourceGroupPreparer(name_prefix='cli_test_authV2')
+    @AllowLargeResponse()
     def test_authV2_clientsecret_param_combinations(self, resource_group):
         webapp_name = self.create_random_name('webapp-authentication-test', 40)
         plan_name = self.create_random_name('webapp-authentication-plan', 40)
@@ -29,13 +30,17 @@ class Authv2ScenarioTest(ScenarioTest):
 
         # testing show command for newly created app and initial fields
         self.cmd('webapp auth show -g {} -n {}'.format(resource_group, webapp_name)).assert_with_checks([
-            JMESPathCheck('properties', {})
+            JMESPathCheck('properties.platform.enabled', False)
         ])
+        
+        # upgrade to v2 before using v2 commands
+        self.cmd('webapp auth config-version upgrade -g {} -n {}'.format(resource_group, webapp_name))
 
         # # update and verify
         self.cmd('webapp auth update -g {} -n {} --enabled true --runtime-version 1.2.8'
                 .format(resource_group, webapp_name)).assert_with_checks([
-                    JMESPathCheck('platform', "{'enabled': True, 'runtimeVersion': '1.2.8'}")
+                    JMESPathCheck('platform.enabled', True),
+                    JMESPathCheck('platform.runtimeVersion', '1.2.8')
         ])
         
         with self.assertRaisesRegex(ArgumentUsageError, 'Usage Error: --client-secret and --client-secret-setting-name cannot both be '
@@ -79,6 +84,7 @@ class Authv2ScenarioTest(ScenarioTest):
                 .format(resource_group, webapp_name))
 
     @ResourceGroupPreparer(name_prefix='cli_test_authV2')
+    @AllowLargeResponse()
     def test_authV2_auth(self, resource_group):
         webapp_name = self.create_random_name('webapp-authentication-test', 40)
         plan_name = self.create_random_name('webapp-authentication-plan', 40)
@@ -92,17 +98,21 @@ class Authv2ScenarioTest(ScenarioTest):
 
         # testing show command for newly created app and initial fields
         self.cmd('webapp auth show -g {} -n {}'.format(resource_group, webapp_name)).assert_with_checks([
-            JMESPathCheck('properties', {})
+            JMESPathCheck('properties.platform.enabled', False)
         ])
+        
+        self.cmd('webapp auth config-version upgrade -g {} -n {}'.format(resource_group, webapp_name))
 
         # # update and verify
         self.cmd('webapp auth update -g {} -n {} --enabled true --runtime-version 1.2.8'
                 .format(resource_group, webapp_name)).assert_with_checks([
-                    JMESPathCheck('platform', "{'enabled': True, 'runtimeVersion': '1.2.8'}")
+                    JMESPathCheck('platform.enabled', True),
+                    JMESPathCheck('platform.runtimeVersion', '1.2.8')
         ])
 
 
     @ResourceGroupPreparer(name_prefix='cli_test_authV2')
+    @AllowLargeResponse()
     def test_authV2_authclassic(self, resource_group):
         webapp_name = self.create_random_name('webapp-authentication-test', 40)
         plan_name = self.create_random_name('webapp-authentication-plan', 40)

--- a/src/authV2/setup.py
+++ b/src/authV2/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     from distutils import log as logger
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
 
-VERSION = '1.0.0'
+VERSION = '1.0.1'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
### Related command
`az webapp auth update -g {resource-group} --excluded-paths {paths}`

### Description
1. Fixed logic for parsing excluded paths for auth update
2. Added new test and recording for the parsing fix
3. Fixed errors in AuthV2 scenario tests which were affecting this PR
4. Re-recorded their tests

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 