### PR TITLE
Fix typo in availability schema property name

### DIFF
--- a/src/notification-hub/azext_notification_hub/aaz/latest/notification_hub/_check_availability.py
+++ b/src/notification-hub/azext_notification_hub/aaz/latest/notification_hub/_check_availability.py
@@ -181,8 +181,8 @@ class CheckAvailability(AAZCommand):
             _schema_on_200.id = AAZStrType(
                 flags={"read_only": True},
             )
-            _schema_on_200.is_availiable = AAZBoolType(
-                serialized_name="isAvailiable",
+            _schema_on_200.is_available = AAZBoolType(
+                serialized_name="isAvailable",
             )
             _schema_on_200.location = AAZStrType()
             _schema_on_200.name = AAZStrType(


### PR DESCRIPTION
Typo in the schema property, in the final output.
cli output sample:
{
  "id": "[cut]",
  "isAvailiable": true,
  "name": "[cut]",
  "type": "Microsoft.NotificationHubs/namespaces/checkNamespaceAvailability"
}

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
