### PR TITLE
{CI} Skip service name check for deploy-to-azure and include extension name in azdev linter/style logs

### DIFF
--- a/scripts/ci/azdev_linter_style.py
+++ b/scripts/ci/azdev_linter_style.py
@@ -204,8 +204,9 @@ def azdev_on_external_extension(index_json, azdev_type):
         # azdev test support external extension
         # azdev_extension.style()
 
-        logger.info('Checking service name for external extensions')
-        service_name.check()
+        logger.info('Checking service name for external extensions: %s', name)
+        if name != 'deploy-to-azure':
+            service_name.check()
 
         az_extension.remove()
 
@@ -245,7 +246,7 @@ def azdev_on_internal_extension(modified_files, azdev_type):
                 logger.error(statement_msg)
                 exit(1)
 
-        logger.info('Checking service name for internal extensions')
+        logger.info('Checking service name for internal extensions: %s', name)
         service_name.check()
 
         azdev_extension.remove()


### PR DESCRIPTION
There is an external extension called deploy-to-azure that created its own command [az container app xxx](https://github.com/Azure/deploy-to-azure-cli-extension/blob/master/deploy-to-azure/azext_deploy_to_azure/dev/aks/commands.py) (about five years ago).
In CI, there is a check that verifies whether external extension commands are registered in service_name.json.
Recently, it suddenly started reporting:
[No entry of container in service_name.json. Please add one to the file.](https://dev.azure.com/azclitools/public/public%20Team/_build/results?buildId=279186&view=logs&j=506b8f13-8269-5210-246e-a3964e53141e&t=db7247cb-300d-5b59-fd6c-6258fad20b89&l=280)
I don’t understand why this error is appearing now, since container was never in service_name.json before.
This causes all PRs that submit index.json for the external extension to fail.

✅ Temporarily Plan
Skip the service name check for deploy-to-azure
This change will have the least impact and avoid blocking other extension releases.

🔍 To-Do Options
- Add container to service_name.json
  But will this conflict with the[ container entry](https://github.com/Azure/azure-cli/blob/dev/src/azure-cli/service_name.json#L153) in the main repo?
- Ask the service team if this extension is still needed and whether it can be deprecated.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
