### PR TITLE
Fix(agent-init): replace max_tokens with max_completion_tokens for connection check of Azure OpenAI service

### DIFF
--- a/src/aks-agent/HISTORY.rst
+++ b/src/aks-agent/HISTORY.rst
@@ -12,9 +12,13 @@ To release a new version, please select a new version number (usually plus 1 to 
 Pending
 +++++++
 
+1.0.0b11
+++++++++
+* Fix(agent-init): replace max_tokens with max_completion_tokens for connection check of Azure OpenAI service.
+
 1.0.0b10
 ++++++++
-* pin supabase==2.8.0 to avoid "ModuleNotFoundError: No module named 'supabase_auth.http_clients'"
+* Pin supabase==2.8.0 to avoid "ModuleNotFoundError: No module named 'supabase_auth.http_clients'"
 
 1.0.0b9
 +++++++

--- a/src/aks-agent/azext_aks_agent/agent/llm_providers/azure_provider.py
+++ b/src/aks-agent/azext_aks_agent/agent/llm_providers/azure_provider.py
@@ -76,7 +76,7 @@ class AzureProvider(LLMProvider):
         payload = {
             "model": deployment_name,
             "messages": [{"role": "user", "content": "ping"}],
-            "max_tokens": 16
+            "max_completion_tokens": 16
         }
 
         try:

--- a/src/aks-agent/azext_aks_agent/agent/llm_providers/base.py
+++ b/src/aks-agent/azext_aks_agent/agent/llm_providers/base.py
@@ -157,4 +157,6 @@ class LLMProvider(ABC):
         Returns a tuple of (is_valid: bool, message: str, action: str)
         where action can be "retry_input", "connection_error", or "save".
         """
+        # TODO(mainred): leverage 3rd party libraries like litellm instead of
+        # calling http request in each provider to complete the connection check.
         raise NotImplementedError()

--- a/src/aks-agent/setup.py
+++ b/src/aks-agent/setup.py
@@ -9,7 +9,7 @@ from codecs import open as open1
 
 from setuptools import find_packages, setup
 
-VERSION = "1.0.0b10"
+VERSION = "1.0.0b11"
 
 CLASSIFIERS = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
---
Before this check, when validating gpt-5, it raises the following error, while it works for gpt-4.1 though.
```
Please re-run `az aks agent-init` to correct the input parameters. Client error: 400 Client Error: Bad Request for url: https://qinhao-ai.openai.azure.com/openai/deployments/gpt-5/chat/completions?api-version=2025-04-01-preview - {
  "error": {
    "message": "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.",
    "type": "invalid_request_error",
    "param": "max_tokens",
    "code": "unsupported_parameter"
  }
}
```

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
