### PR TITLE
aks bastion: allow using public FQDN

### DIFF
--- a/src/aks-preview/azext_aks_preview/_help.py
+++ b/src/aks-preview/azext_aks_preview/_help.py
@@ -4188,6 +4188,9 @@ helps['aks bastion'] = """
         - name: --admin
           type: bool
           short-summary: Use the cluster admin credentials to connect to the bastion.
+        - name: --public-fqdn
+          type: bool
+          short-summary: Get private cluster credential with server address to be public fqdn.
     examples:
         - name: Connect to a managed Kubernetes cluster using Azure Bastion with custom port and admin credentials.
           text: az aks bastion -g MyResourceGroup --name MyManagedCluster --bastion MyBastionResource --port 50001 --admin

--- a/src/aks-preview/azext_aks_preview/custom.py
+++ b/src/aks-preview/azext_aks_preview/custom.py
@@ -4969,7 +4969,7 @@ def aks_loadbalancer_rebalance_nodes(
     return aks_loadbalancer_rebalance_internal(managed_clusters_client, parameters)
 
 
-def aks_bastion(cmd, client, resource_group_name, name, bastion=None, port=None, admin=False, yes=False):
+def aks_bastion(cmd, client, resource_group_name, name, bastion=None, port=None, admin=False, yes=False, public_fqdn=False):
     import asyncio
     import tempfile
 
@@ -4998,6 +4998,7 @@ def aks_bastion(cmd, client, resource_group_name, name, bastion=None, port=None,
                     port,
                     mc_id,
                     kubeconfig_path,
+                    public_fqdn=public_fqdn,
                     test_hook=os.getenv("AKS_BASTION_TEST_HOOK"),
                 )
             )


### PR DESCRIPTION
When users have public FQDN on their private cluster and want to use normal DNS resolution for bastion, we should let them.

