### PR TITLE
[confcom] Run testing against built extension

### DIFF
--- a/src/confcom/azext_confcom/tests/conftest.py
+++ b/src/confcom/azext_confcom/tests/conftest.py
@@ -3,24 +3,17 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-import functools
+import fcntl
 import importlib
+import os
 import subprocess
 import tempfile
+import psutil
 import pytest
 import sys
 import shutil
 
 from pathlib import Path
-
-
-# This is required to work around the implementation of azdev test. It runs
-# separate pytest invocations for each test, making it impossible to respect the
-# session scope. Therefore, we need to manually ensure wheels are not built
-# separately for each test.
-@functools.lru_cache()
-def get_wheel_dir():
-    return Path(tempfile.mkdtemp(prefix="confcom_wheels_"))
 
 
 # This fixture ensures tests are run against final built wheels of the extension
@@ -34,28 +27,51 @@ def run_on_wheel(request):
     extensions_to_build = {module.__name__.split(".")[0] for module in modules_to_test}
     extension_dirs = {Path(a.split("/azext_")[0]) for a in request.config.args}
 
-    build_dir = get_wheel_dir()
-    if not any(build_dir.iterdir()):
+    # Azdev doesn't respect the session scope of the fixture, therefore we need
+    # to implement equivalent behaviour by getting a unique ID for the current
+    # run and using that to determine if wheels have already been built. Search
+    # process parentage until we find the first shell process and use it's
+    # child's PID as the run ID.
+    parent = psutil.Process(os.getpid())
+    while not any(parent.cmdline()[0].endswith(i) for i in ["bash", "sh"]):
+        parent = parent.parent()
+    RUN_ID = parent.children()[0].pid
 
-        # Delete the extensions build dir, as azdev extension build doesn't
-        # reliably handle changes
-        for extension_dir in extension_dirs:
-            if (extension_dir / "build").exists():
-                shutil.rmtree((extension_dir / "build").as_posix(), ignore_errors=True)
+    build_dir = Path(tempfile.gettempdir()) / f"wheels_{RUN_ID}"
+    build_dir.mkdir(exist_ok=True)
 
-        # Build all extensions being tested into wheels
-        for extension in extensions_to_build:
-            subprocess.run(
-                ["azdev", "extension", "build", extension.replace("azext_", ""), "--dist-dir", build_dir.as_posix()],
-                check=True,
-            )
+    # Build all extensions being tested into wheels
+    for extension in extensions_to_build:
 
-            # Add the wheel to the path and reload extension modules so the
-            # tests pick up the wheel code over the unbuilt code
-            sys.path.insert(0, build_dir.glob("*.whl").__next__().as_posix())
-            for module in list(sys.modules.values()):
-                if extension in module.__name__ and module not in modules_to_test:
-                    del sys.modules[module.__name__]
-                    importlib.import_module(module.__name__)
+        extension_name = extension.replace("azext_", "")
+
+        # Ensure we acquire a lock while operating on the build dir to avoid races
+        lock_file = build_dir / ".dir.lock"
+        with lock_file.open("w") as f:
+            fcntl.flock(f, fcntl.LOCK_EX)
+            try:
+
+                # Delete the extensions build dir, as azdev extension build doesn't
+                # reliably handle changes
+                for extension_dir in extension_dirs:
+                    if (extension_dir / "build").exists():
+                        shutil.rmtree((extension_dir / "build").as_posix(), ignore_errors=True)
+
+                if not any(build_dir.glob(f"{extension_name}*.whl")):
+                    subprocess.run(
+                        ["azdev", "extension", "build", extension.replace("azext_", ""), "--dist-dir", build_dir.as_posix()],
+                        check=True,
+                    )
+
+            finally:
+                fcntl.flock(f, fcntl.LOCK_UN)
+
+    # Add the wheel to the path and reload extension modules so the
+    # tests pick up the wheel code over the unbuilt code
+    sys.path.insert(0, build_dir.glob("*.whl").__next__().as_posix())
+    for module in list(sys.modules.values()):
+        if extension in module.__name__ and module not in modules_to_test:
+            del sys.modules[module.__name__]
+            importlib.import_module(module.__name__)
 
     yield


### PR DESCRIPTION
### Why

This repos CI uses azdev to run each extensions tests, however this means it's testing the local modules which might have breaking differences compared to what we ship to customers.

### How

- [x] Add a new autouse pytest fixture (currently scoped to the confcom extension but designed to apply to all extensions) which builds wheels for each extension being tested, and swaps out the non-test modules

The modules actually running the tests are the only part not swapped for the built version to handle tests which rely on unshipped code/data

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

Note: This is strictly a testing only change, so no version bump or history update is required