### PR TITLE
[Containerapp] `az containerapp compose create`: Fix `TypeError` when docker-compose file include `env_file` without `environment`

### DIFF
--- a/src/containerapp/HISTORY.rst
+++ b/src/containerapp/HISTORY.rst
@@ -5,7 +5,8 @@ Release History
 upcoming
 ++++++
 * 'az containerapp function invocations': Update application insights query 
-* 'az containerapp function keys': Update minimum replica check 
+* 'az containerapp function keys': Update minimum replica check
+* 'az containerapp compose create': Fix `TypeError` when docker-compose file include `env_file` without `environment`
 
 1.3.0b1
 ++++++

--- a/src/containerapp/setup.py
+++ b/src/containerapp/setup.py
@@ -47,7 +47,7 @@ CLASSIFIERS = [
 ]
 
 # TODO: Add any additional SDK dependencies here
-DEPENDENCIES = ['pycomposefile>=0.0.29', 'docker', 'kubernetes==24.2.0']
+DEPENDENCIES = ['pycomposefile>=0.0.34', 'docker', 'kubernetes==24.2.0']
 
 # Install pack CLI to build runnable application images from source
 _ = get_pack_exec_path()


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
Same as https://github.com/Azure/azure-cli/pull/32601/files

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
