### PR TITLE
[k8s-extension] remove base url override in list extensions

### DIFF
--- a/src/k8s-extension/azext_k8s_extension/vendored_sdks/_source_control_configuration_client.py
+++ b/src/k8s-extension/azext_k8s_extension/vendored_sdks/_source_control_configuration_client.py
@@ -233,8 +233,6 @@ class SourceControlConfigurationClient(MultiApiClientMixin, _SDKClient):
         else:
             raise ValueError("API version {} does not have operation group 'extension_types'".format(api_version))
         self._config.api_version = api_version
-        # Remove this after testing is done for 2023-05-01-preview
-        self._client._base_url = "https://management.azure.com"
         return OperationClass(self._client, self._config, Serializer(self._models_dict(api_version)), Deserializer(self._models_dict(api_version)))
 
     @property


### PR DESCRIPTION
private clouds have different arm endpoints so this base url override was breaking the `az k8s-extension extension-types list-by-location` call

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
