### PR TITLE
Quantum: fix live test for quantum extension

### DIFF
--- a/src/quantum/azext_quantum/tests/latest/test_quantum_jobs.py
+++ b/src/quantum/azext_quantum/tests/latest/test_quantum_jobs.py
@@ -248,7 +248,7 @@ class QuantumJobsScenarioTest(ScenarioTest):
         self.assertEqual(len(jobs_list), 1)
     
         jobs_list = self.cmd("az quantum job list --skip 1 -o json").get_output_in_json()
-        self.assertEqual(len(jobs_list), 1)
+        self.assertEqual(len(jobs_list), 2)
 
         jobs_list = self.cmd("az quantum job list --orderby Target --top 1 -o json").get_output_in_json()
         self.assertEqual(len(jobs_list), 1)
@@ -257,7 +257,7 @@ class QuantumJobsScenarioTest(ScenarioTest):
         self.assertTrue("rigetti" not in results)
 
         jobs_list = self.cmd("az quantum job list --orderby Target --skip 1 -o json").get_output_in_json()
-        self.assertEqual(len(jobs_list), 1)
+        self.assertEqual(len(jobs_list), 2)
         results = str(jobs_list)
         self.assertIn("rigetti", results)
         self.assertTrue("ionq" not in results)


### PR DESCRIPTION
This is test change only, no changes to the actual extension.
Fix test that expected only 1 job when querying using skip 1 but 3 jobs were created initially.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
