### PR TITLE
[containerapp] Fix failing ACA apps when run together

### DIFF
--- a/src/containerapp/azext_containerapp/tests/latest/test_containerapp_function.py
+++ b/src/containerapp/azext_containerapp/tests/latest/test_containerapp_function.py
@@ -28,11 +28,22 @@ TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))
 
 
 class ContainerappFunctionTests(ScenarioTest):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Install application-insights extension if not already installed
+        try:
+            result = run(['az', 'extension', 'show', '--name', 'application-insights'],
+                         capture_output=True, text=True)
+            if result.returncode != 0:
+                cmd = ['azdev', 'extension', 'add', 'application-insights']
+                run(cmd, check=True)
+                sleep(120)
+        except Exception:
+            pass
+
     def __init__(self, *arg, **kwargs):
         super().__init__(*arg, random_config_dir=True, **kwargs)
-        cmd = ['azdev', 'extension', 'add', 'application-insights']
-        run(cmd, check=True)
-        sleep(120)
     
 
     @AllowLargeResponse(8192)


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
azdev test azext_containerapp

This isn't customer-facing at all. Running all containerapp tests with `azdev test azext_containerapp` fails for me (on multiple machines) because of application-insights extension installation. This (admittedly copilot generated) change fixes this (again, on multiple machines) so the test-suite can be run at once


### General Guidelines

- [X] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [X] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [X] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)
