### PR TITLE
[Redisenterprise] `az redisenterprise database wait`: Fix schema buiding issue

### DIFF
--- a/src/redisenterprise/azext_redisenterprise/custom.py
+++ b/src/redisenterprise/azext_redisenterprise/custom.py
@@ -23,7 +23,7 @@ from .aaz.latest.redisenterprise.database import Update as _DatabaseUpdate
 from .aaz.latest.redisenterprise.database import Wait as _DatabaseWait
 from .aaz.latest.redisenterprise import List as _ClusterList
 from .aaz.latest.redisenterprise import Show as _ClusterShow
-from .aaz.latest.redisenterprise import Wait as _DatabaseWait
+from .aaz.latest.redisenterprise import Wait as _ClusterWait
 from .aaz.latest.redisenterprise import Update as _Update
 from azure.cli.core.azclierror import (
     MutuallyExclusiveArgumentError,


### PR DESCRIPTION
The cluster-level Wait was imported as `_DatabaseWait`, overwriting the database-level Wait import. This caused `DatabaseWait` to inherit the wrong base class, making its `_build_arguments_schema` customization operate on a non-existing database_name parameter.

Renamed the alias to `_ClusterWait` to match sibling imports (`_ClusterList`, `_ClusterShow`).

<img width="1313" height="613" alt="image" src="https://github.com/user-attachments/assets/55fc7bfe-d4fa-4053-8ff6-abfcea5558ba" />

This fix is to unblock the Test Extension Loading pipeline step which are sensitive to import resolution order.
> Note: The step should fail but succeed due to another known issue.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az redisenterprise database wait --help`

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
