### PR TITLE
{AKS} Fix DCR create/update for container network logs and high log scale mode

### DIFF
--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -11,10 +11,10 @@ To release a new version, please select a new version number (usually plus 1 to 
 
 Pending
 +++++++
-* `az aks nodepool update`: Support `--node-vm-size` to resize VM size of an existing VMSS-based agent pool (preview). Requires AFEC registration `Microsoft.ContainerService/AgentPoolVMSSResize`.
 
 20.0.0b4
 +++++++
+* `az aks nodepool update`: Support `--node-vm-size` to resize VM size of an existing VMSS-based agent pool (preview). Requires AFEC registration `Microsoft.ContainerService/AgentPoolVMSSResize`.
 * `az aks create/update`: Fix DCR not being created or updated when `--enable-container-network-logs`, `--enable-retina-flow-logs`, or `--enable-high-log-scale-mode` flags are used, ensuring the Data Collection Rule streams (e.g. `Microsoft-ContainerLogV2-HighScale`) are kept in sync.
 * `az aks update`: Add validation for `--enable-high-log-scale-mode` on the update path requiring the monitoring addon with MSI authentication to be enabled
 

--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -17,6 +17,11 @@ Pending
 ++++++
 * Vendor new SDK and bump API version to 2026-02-02-preview.
 
+20.0.0b3
++++++++
+* `az aks create/update`: Fix DCR not being created or updated when `--enable-container-network-logs`, `--enable-retina-flow-logs`, or `--enable-high-log-scale-mode` flags are used, ensuring the Data Collection Rule streams (e.g. `Microsoft-ContainerLogV2-HighScale`) are kept in sync.
+* `az aks update`: Add validation for `--enable-high-log-scale-mode` on the update path requiring the monitoring addon with MSI authentication to be enabled
+
 20.0.0b2
 +++++++
 * `az aks nodepool update`: clean up some useless code in the update managed gpu function. 
@@ -24,6 +29,7 @@ Pending
 * `az aks machine add`: Add `--eviction-policy` flag support to set the eviction policy for a machine.
 * `az aks machine add`: Add `--enable-ultra-ssd` flag support to enable ultra ssd on a machine.
 * `az aks update`: Fix V2-only NAT gateway params (e.g. `--nat-gateway-managed-outbound-ipv6-count`) being rejected on update when `--outbound-type` is not re-specified for an already-V2 cluster.
+
 
 20.0.0b2
 +++++++

--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -50,6 +50,11 @@ Pending
 * `az aks namespace update`: Fix location should use existing namespace location.
 * `az aks nodepool update`: Add `--disable-artifact-streaming` to disable artifact streaming.
 
+19.0.0b28
++++++++
+* `az aks create/update`: Fix DCR not being created or updated when `--enable-container-network-logs`, `--enable-retina-flow-logs`, or `--enable-high-log-scale-mode` flags are used, ensuring the Data Collection Rule streams (e.g. `Microsoft-ContainerLogV2-HighScale`) are kept in sync.
+* `az aks update`: Add validation for `--enable-high-log-scale-mode` on the update path requiring the monitoring addon with MSI authentication to be enabled.
+
 19.0.0b27
 +++++++
 * `az aks nodepool add`: Fix `InvalidParameter` error when `mode` is `Machines`.
@@ -59,11 +64,6 @@ Pending
 * `az aks create/update`: Add `--enable-app-routing-istio` / `--disable-app-routing-istio` (short: `--enable-ari` / `--disable-ari`) flags to enable or disable Istio as a Gateway API implementation for App Routing.
 * `az aks approuting gateway istio enable/disable`: Add new subcommands to enable or disable the Istio Gateway API implementation for App Routing on an existing cluster.
 * Add 'mTLS' as a transit encryption type option for `--acns-transit-encryption-type` in `az aks create/update`
-
-19.0.0b26
-+++++++
-* `az aks create/update`: Fix DCR not being created or updated when `--enable-container-network-logs`, `--enable-retina-flow-logs`, or `--enable-high-log-scale-mode` flags are used, ensuring the Data Collection Rule streams (e.g. `Microsoft-ContainerLogV2-HighScale`) are kept in sync.
-* `az aks update`: Add validation for `--enable-high-log-scale-mode` on the update path requiring the monitoring addon with MSI authentication to be enabled.
 
 19.0.0b25
 +++++++

--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -60,6 +60,11 @@ Pending
 * `az aks approuting gateway istio enable/disable`: Add new subcommands to enable or disable the Istio Gateway API implementation for App Routing on an existing cluster.
 * Add 'mTLS' as a transit encryption type option for `--acns-transit-encryption-type` in `az aks create/update`
 
+19.0.0b26
++++++++
+* `az aks create/update`: Fix DCR not being created or updated when `--enable-container-network-logs`, `--enable-retina-flow-logs`, or `--enable-high-log-scale-mode` flags are used, ensuring the Data Collection Rule streams (e.g. `Microsoft-ContainerLogV2-HighScale`) are kept in sync.
+* `az aks update`: Add validation for `--enable-high-log-scale-mode` on the update path requiring the monitoring addon with MSI authentication to be enabled.
+
 19.0.0b25
 +++++++
 * `az aks create`: Add `--enable-continuous-control-plane-and-addon-monitor` to enable continuous control plane and addon monitor.

--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -30,12 +30,6 @@ Pending
 * `az aks machine add`: Add `--enable-ultra-ssd` flag support to enable ultra ssd on a machine.
 * `az aks update`: Fix V2-only NAT gateway params (e.g. `--nat-gateway-managed-outbound-ipv6-count`) being rejected on update when `--outbound-type` is not re-specified for an already-V2 cluster.
 
-
-20.0.0b2
-+++++++
-* `az aks create/update`: Fix DCR not being created or updated when `--enable-container-network-logs`, `--enable-retina-flow-logs`, or `--enable-high-log-scale-mode` flags are used, ensuring the Data Collection Rule streams (e.g. `Microsoft-ContainerLogV2-HighScale`) are kept in sync.
-* `az aks update`: Add validation for `--enable-high-log-scale-mode` on the update path requiring the monitoring addon with MSI authentication to be enabled.
-
 20.0.0b1
 +++++++
 * [Breaking Change] `az aks create/update`: Change `--nat-gateway-outbound-ips` and `--nat-gateway-outbound-ip-prefixes` to use comma-separated values, consistent with load balancer outbound IP parameters.

--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -25,6 +25,11 @@ Pending
 * `az aks machine add`: Add `--enable-ultra-ssd` flag support to enable ultra ssd on a machine.
 * `az aks update`: Fix V2-only NAT gateway params (e.g. `--nat-gateway-managed-outbound-ipv6-count`) being rejected on update when `--outbound-type` is not re-specified for an already-V2 cluster.
 
+20.0.0b2
++++++++
+* `az aks create/update`: Fix DCR not being created or updated when `--enable-container-network-logs`, `--enable-retina-flow-logs`, or `--enable-high-log-scale-mode` flags are used, ensuring the Data Collection Rule streams (e.g. `Microsoft-ContainerLogV2-HighScale`) are kept in sync.
+* `az aks update`: Add validation for `--enable-high-log-scale-mode` on the update path requiring the monitoring addon with MSI authentication to be enabled.
+
 20.0.0b1
 +++++++
 * [Breaking Change] `az aks create/update`: Change `--nat-gateway-outbound-ips` and `--nat-gateway-outbound-ip-prefixes` to use comma-separated values, consistent with load balancer outbound IP parameters.
@@ -49,11 +54,6 @@ Pending
 * Add managed GPU enablement option to node pool property in `az aks nodepool add` and `az aks nodepool update`.
 * `az aks namespace update`: Fix location should use existing namespace location.
 * `az aks nodepool update`: Add `--disable-artifact-streaming` to disable artifact streaming.
-
-19.0.0b28
-+++++++
-* `az aks create/update`: Fix DCR not being created or updated when `--enable-container-network-logs`, `--enable-retina-flow-logs`, or `--enable-high-log-scale-mode` flags are used, ensuring the Data Collection Rule streams (e.g. `Microsoft-ContainerLogV2-HighScale`) are kept in sync.
-* `az aks update`: Add validation for `--enable-high-log-scale-mode` on the update path requiring the monitoring addon with MSI authentication to be enabled.
 
 19.0.0b27
 +++++++

--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -13,14 +13,14 @@ Pending
 +++++++
 * `az aks nodepool update`: Support `--node-vm-size` to resize VM size of an existing VMSS-based agent pool (preview). Requires AFEC registration `Microsoft.ContainerService/AgentPoolVMSSResize`.
 
-20.0.0b3
-++++++
-* Vendor new SDK and bump API version to 2026-02-02-preview.
-
-20.0.0b3
+20.0.0b4
 +++++++
 * `az aks create/update`: Fix DCR not being created or updated when `--enable-container-network-logs`, `--enable-retina-flow-logs`, or `--enable-high-log-scale-mode` flags are used, ensuring the Data Collection Rule streams (e.g. `Microsoft-ContainerLogV2-HighScale`) are kept in sync.
 * `az aks update`: Add validation for `--enable-high-log-scale-mode` on the update path requiring the monitoring addon with MSI authentication to be enabled
+
+20.0.0b3
+++++++
+* Vendor new SDK and bump API version to 2026-02-02-preview.
 
 20.0.0b2
 +++++++

--- a/src/aks-preview/azext_aks_preview/_helpers.py
+++ b/src/aks-preview/azext_aks_preview/_helpers.py
@@ -389,6 +389,27 @@ def check_is_azure_cli_core_editable_installed():
     return False
 
 
+def get_monitoring_addon_key(addon_profiles, monitoring_addon_name):
+    """Return the canonical key for the monitoring addon, normalizing non-standard casing.
+
+    The API response may return the monitoring addon key in any casing (e.g.
+    "omsagent", "omsAgent", "oMSaGent").  This helper performs a
+    case-insensitive lookup and, when a non-standard key is found, re-keys
+    addon_profiles in-place so that subsequent code always uses the canonical
+    monitoring_addon_name (lowercase) form.
+    """
+    if addon_profiles is None:
+        return monitoring_addon_name
+    if monitoring_addon_name in addon_profiles:
+        return monitoring_addon_name
+    target_lower = monitoring_addon_name.lower()
+    for key in list(addon_profiles):
+        if key.lower() == target_lower:
+            addon_profiles[monitoring_addon_name] = addon_profiles.pop(key)
+            return monitoring_addon_name
+    return monitoring_addon_name
+
+
 def check_is_monitoring_addon_enabled(addons, instance):
     is_monitoring_addon_enabled = False
     is_monitoring_addon = False
@@ -401,10 +422,11 @@ def check_is_monitoring_addon_enabled(addons, instance):
                     is_monitoring_addon = True
                     break
         addon_profiles = instance.addon_profiles or {}
+        monitoring_addon_key = get_monitoring_addon_key(addon_profiles, CONST_MONITORING_ADDON_NAME)
         is_monitoring_addon_enabled = (
             is_monitoring_addon
-            and CONST_MONITORING_ADDON_NAME in addon_profiles
-            and addon_profiles[CONST_MONITORING_ADDON_NAME].enabled
+            and monitoring_addon_key in addon_profiles
+            and addon_profiles[monitoring_addon_key].enabled
         )
     except Exception as ex:  # pylint: disable=broad-except
         logger.debug("failed to check monitoring addon enabled: %s", ex)

--- a/src/aks-preview/azext_aks_preview/custom.py
+++ b/src/aks-preview/azext_aks_preview/custom.py
@@ -562,7 +562,7 @@ def ensure_container_insights_for_monitoring_preview(
             )
 
             resources = get_resources_client(cmd.cli_ctx, cluster_subscription)
-            for _ in range(3):
+            for attempt in range(3):
                 try:
                     if enable_syslog:
                         resources.begin_create_or_update_by_id(
@@ -578,8 +578,12 @@ def ensure_container_insights_for_monitoring_preview(
                         )
                     error = None
                     break
-                except CLIError as e:
+                except (CLIError, HttpResponseError) as e:
                     error = e
+                    # Wait before retry to allow workspace tables to become available
+                    if attempt < 2:
+                        import time
+                        time.sleep(30)
             else:
                 raise error
 

--- a/src/aks-preview/azext_aks_preview/custom.py
+++ b/src/aks-preview/azext_aks_preview/custom.py
@@ -66,6 +66,7 @@ from azext_aks_preview._helpers import (
     check_is_private_link_cluster,
     get_cluster_snapshot_by_snapshot_id,
     get_k8s_extension_module,
+    get_monitoring_addon_key,
     get_nodepool_snapshot_by_snapshot_id,
     print_or_merge_credentials,
     process_message_for_run_command,
@@ -3076,14 +3077,16 @@ def aks_disable_addons(cmd, client, resource_group_name, name, addons, no_wait=F
     subscription_id = get_subscription_id(cmd.cli_ctx)
 
     try:
+        addon_profiles = instance.addon_profiles or {}
+        monitoring_addon_key = get_monitoring_addon_key(addon_profiles, CONST_MONITORING_ADDON_NAME)
         if (
             addons == "monitoring" and
-            CONST_MONITORING_ADDON_NAME in instance.addon_profiles and
-            instance.addon_profiles[CONST_MONITORING_ADDON_NAME].enabled and
+            monitoring_addon_key in addon_profiles and
+            addon_profiles[monitoring_addon_key].enabled and
             CONST_MONITORING_USING_AAD_MSI_AUTH in
-            instance.addon_profiles[CONST_MONITORING_ADDON_NAME].config and
+            addon_profiles[monitoring_addon_key].config and
             str(
-                instance.addon_profiles[CONST_MONITORING_ADDON_NAME].config[
+                addon_profiles[monitoring_addon_key].config[
                     CONST_MONITORING_USING_AAD_MSI_AUTH
                 ]
             ).lower() == "true"
@@ -3091,7 +3094,7 @@ def aks_disable_addons(cmd, client, resource_group_name, name, addons, no_wait=F
             # remove the DCR association because otherwise the DCR can't be deleted
             ensure_container_insights_for_monitoring(
                 cmd,
-                instance.addon_profiles[CONST_MONITORING_ADDON_NAME],
+                addon_profiles[monitoring_addon_key],
                 subscription_id,
                 resource_group_name,
                 name,
@@ -3194,11 +3197,13 @@ def aks_enable_addons(
     if (
         is_monitoring_addon_enabled
     ):
+        addon_profiles = instance.addon_profiles or {}
+        monitoring_addon_key = get_monitoring_addon_key(addon_profiles, CONST_MONITORING_ADDON_NAME)
         if (
             CONST_MONITORING_USING_AAD_MSI_AUTH in
-            instance.addon_profiles[CONST_MONITORING_ADDON_NAME].config and
+            addon_profiles[monitoring_addon_key].config and
             str(
-                instance.addon_profiles[CONST_MONITORING_ADDON_NAME].config[
+                addon_profiles[monitoring_addon_key].config[
                     CONST_MONITORING_USING_AAD_MSI_AUTH
                 ]
             ).lower() == "true"
@@ -3206,10 +3211,15 @@ def aks_enable_addons(
             if not msi_auth:
                 raise ArgumentUsageError(
                     "--enable-msi-auth-for-monitoring can not be used on clusters with service principal auth.")
+            # Auto-enable HLSM when CNL is active and HLSM wasn't explicitly set
+            if enable_high_log_scale_mode is None and \
+               (addon_profiles[monitoring_addon_key].config or {}).get(
+                   "enableRetinaNetworkFlags", "").lower() == "true":
+                enable_high_log_scale_mode = True
             # create a Data Collection Rule (DCR) and associate it with the cluster
             ensure_container_insights_for_monitoring(
                 cmd,
-                instance.addon_profiles[CONST_MONITORING_ADDON_NAME],
+                addon_profiles[monitoring_addon_key],
                 subscription_id,
                 resource_group_name,
                 name,
@@ -3237,7 +3247,7 @@ def aks_enable_addons(
                 raise ArgumentUsageError("--ampls-resource-id can not be used without MSI auth.")
             ensure_container_insights_for_monitoring(
                 cmd,
-                instance.addon_profiles[CONST_MONITORING_ADDON_NAME],
+                addon_profiles[monitoring_addon_key],
                 subscription_id,
                 resource_group_name,
                 name,

--- a/src/aks-preview/azext_aks_preview/custom.py
+++ b/src/aks-preview/azext_aks_preview/custom.py
@@ -563,7 +563,7 @@ def ensure_container_insights_for_monitoring_preview(
             )
 
             resources = get_resources_client(cmd.cli_ctx, cluster_subscription)
-            for _ in range(3):
+            for attempt in range(3):
                 try:
                     if enable_syslog:
                         resources.begin_create_or_update_by_id(

--- a/src/aks-preview/azext_aks_preview/custom.py
+++ b/src/aks-preview/azext_aks_preview/custom.py
@@ -563,7 +563,7 @@ def ensure_container_insights_for_monitoring_preview(
             )
 
             resources = get_resources_client(cmd.cli_ctx, cluster_subscription)
-            for attempt in range(3):
+            for _ in range(3):
                 try:
                     if enable_syslog:
                         resources.begin_create_or_update_by_id(

--- a/src/aks-preview/azext_aks_preview/custom.py
+++ b/src/aks-preview/azext_aks_preview/custom.py
@@ -563,7 +563,7 @@ def ensure_container_insights_for_monitoring_preview(
             )
 
             resources = get_resources_client(cmd.cli_ctx, cluster_subscription)
-            for attempt in range(3):
+            for _ in range(3):
                 try:
                     if enable_syslog:
                         resources.begin_create_or_update_by_id(
@@ -581,9 +581,6 @@ def ensure_container_insights_for_monitoring_preview(
                     break
                 except (CLIError, HttpResponseError) as e:
                     error = e
-                    # Wait before retry to allow workspace tables to become available
-                    if attempt < 2:
-                        time.sleep(30)
             else:
                 raise error
 

--- a/src/aks-preview/azext_aks_preview/custom.py
+++ b/src/aks-preview/azext_aks_preview/custom.py
@@ -582,7 +582,6 @@ def ensure_container_insights_for_monitoring_preview(
                     error = e
                     # Wait before retry to allow workspace tables to become available
                     if attempt < 2:
-                        import time
                         time.sleep(30)
             else:
                 raise error

--- a/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
@@ -7869,6 +7869,13 @@ class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):
 
         if existing_key:
             addon_profile = mc.addon_profiles[existing_key]
+            # Detect workspace change: if the workspace is different from the existing one,
+            # trigger DCR postprocessing so the DCR destination gets updated.
+            old_config = addon_profile.config or {}
+            old_workspace = old_config.get(CONST_MONITORING_LOG_ANALYTICS_WORKSPACE_RESOURCE_ID, "")
+            if old_workspace and old_workspace.lower() != workspace_resource_id.lower():
+                self.context.set_intermediate(
+                    "monitoring_addon_postprocessing_required", True, overwrite_exists=True)
         else:
             addon_profile = self.models.ManagedClusterAddonProfile(enabled=False)
             existing_key = CONST_MONITORING_ADDON_NAME

--- a/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
@@ -5292,6 +5292,19 @@ class AKSPreviewManagedClusterCreateDecorator(AKSManagedClusterCreateDecorator):
                     "Could not create a role assignment for subnet. Are you an Owner on this subscription?"
                 )
 
+    def _should_create_dcra(self) -> bool:
+        """Return True if any flag that triggers a DCRA/DCR create or update was provided."""
+        params = self.context.raw_param
+        return (
+            params.get("enable_addons") is not None or
+            params.get("enable-azure-monitor-logs") is not None or
+            params.get("enable_container_network_logs") is not None or
+            params.get("enable_retina_flow_logs") is not None or
+            params.get("disable_container_network_logs") is not None or
+            params.get("disable_retina_flow_logs") is not None or
+            params.get("enable_high_log_scale_mode") is not None
+        )
+
     # pylint: disable=too-many-locals,too-many-branches
     def postprocessing_after_mc_created(self, cluster: ManagedCluster) -> None:
         """Postprocessing performed after the cluster is created.
@@ -5317,13 +5330,7 @@ class AKSPreviewManagedClusterCreateDecorator(AKSManagedClusterCreateDecorator):
                     self.context.external_functions.add_monitoring_role_assignment(
                         cluster, cluster_resource_id, self.cmd
                     )
-            elif (self.context.raw_param.get("enable_addons") is not None or
-                  self.context.raw_param.get("enable-azure-monitor-logs") is not None or
-                  self.context.raw_param.get("enable_container_network_logs") is not None or
-                  self.context.raw_param.get("enable_retina_flow_logs") is not None or
-                  self.context.raw_param.get("disable_container_network_logs") is not None or
-                  self.context.raw_param.get("disable_retina_flow_logs") is not None or
-                  self.context.raw_param.get("enable_high_log_scale_mode") is not None):
+            elif self._should_create_dcra():
                 # Create/update the DCR when CNL or HLSM flags change so that the DCR streams
                 # (e.g. Microsoft-ContainerLogV2-HighScale) are kept in sync.
                 cnl_or_hlsm_changing = (
@@ -5852,6 +5859,49 @@ class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):
                     config = monitoring_addon_profile.config or {}
                     config["enableRetinaNetworkFlags"] = str(container_network_logs_enabled)
                     mc.addon_profiles[CONST_MONITORING_ADDON_NAME].config = config
+
+        # When enabling CNL, the DCR must be updated to add the high-scale stream.
+        # Set the postprocessing intermediate so that the update path calls ensure_container_insights.
+        if self.context.raw_param.get("enable_container_network_logs") or \
+           self.context.raw_param.get("enable_retina_flow_logs"):
+            self.context.set_intermediate("monitoring_addon_postprocessing_required", True, overwrite_exists=True)
+
+        # When --enable-high-log-scale-mode is passed standalone on the update path, validate that
+        # monitoring with MSI auth is already enabled, then trigger the DCR update via postprocessing.
+        enable_high_log_scale_mode = self.context.raw_param.get("enable_high_log_scale_mode")
+        if enable_high_log_scale_mode is True:
+            addon_consts = self.context.get_addon_consts()
+            CONST_MONITORING_ADDON_NAME = addon_consts.get("CONST_MONITORING_ADDON_NAME")
+            CONST_MONITORING_USING_AAD_MSI_AUTH = addon_consts.get("CONST_MONITORING_USING_AAD_MSI_AUTH")
+
+            # Resolve the addon profile, handling both "omsagent" and "omsAgent" key variants.
+            monitoring_addon_profile = None
+            if mc.addon_profiles:
+                monitoring_addon_profile = (
+                    mc.addon_profiles.get(CONST_MONITORING_ADDON_NAME) or
+                    mc.addon_profiles.get(CONST_MONITORING_ADDON_NAME_CAMELCASE)
+                )
+
+            if not monitoring_addon_profile or not monitoring_addon_profile.enabled:
+                raise RequiredArgumentMissingError(
+                    "--enable-high-log-scale-mode requires the Azure Monitor logs addon (omsagent) "
+                    "to be enabled on the cluster. Please enable it first with "
+                    "--enable-addons monitoring or --enable-azure-monitor-logs."
+                )
+
+            addon_config = monitoring_addon_profile.config or {}
+            msi_auth_enabled = (
+                CONST_MONITORING_USING_AAD_MSI_AUTH in addon_config and
+                str(addon_config[CONST_MONITORING_USING_AAD_MSI_AUTH]).lower() == "true"
+            )
+            if not msi_auth_enabled:
+                raise RequiredArgumentMissingError(
+                    "--enable-high-log-scale-mode requires MSI authentication to be enabled "
+                    "for the monitoring addon. Please enable it with --enable-msi-auth-for-monitoring."
+                )
+
+            self.context.set_intermediate("monitoring_addon_postprocessing_required", True, overwrite_exists=True)
+
         return mc
 
     # pylint: disable=too-many-statements,too-many-locals,too-many-branches

--- a/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
@@ -5318,8 +5318,21 @@ class AKSPreviewManagedClusterCreateDecorator(AKSManagedClusterCreateDecorator):
                         cluster, cluster_resource_id, self.cmd
                     )
             elif (self.context.raw_param.get("enable_addons") is not None or
-                  self.context.raw_param.get("enable-azure-monitor-logs") is not None):
-                # Create the DCR Association here
+                  self.context.raw_param.get("enable-azure-monitor-logs") is not None or
+                  self.context.raw_param.get("enable_container_network_logs") is not None or
+                  self.context.raw_param.get("enable_retina_flow_logs") is not None or
+                  self.context.raw_param.get("disable_container_network_logs") is not None or
+                  self.context.raw_param.get("disable_retina_flow_logs") is not None or
+                  self.context.raw_param.get("enable_high_log_scale_mode") is not None):
+                # Create/update the DCR when CNL or HLSM flags change so that the DCR streams
+                # (e.g. Microsoft-ContainerLogV2-HighScale) are kept in sync.
+                cnl_or_hlsm_changing = (
+                    self.context.raw_param.get("enable_container_network_logs") is not None or
+                    self.context.raw_param.get("enable_retina_flow_logs") is not None or
+                    self.context.raw_param.get("disable_container_network_logs") is not None or
+                    self.context.raw_param.get("disable_retina_flow_logs") is not None or
+                    self.context.raw_param.get("enable_high_log_scale_mode") is not None
+                )
                 addon_consts = self.context.get_addon_consts()
                 CONST_MONITORING_ADDON_NAME = addon_consts.get("CONST_MONITORING_ADDON_NAME")
                 self.context.external_functions.ensure_container_insights_for_monitoring(
@@ -5331,7 +5344,7 @@ class AKSPreviewManagedClusterCreateDecorator(AKSManagedClusterCreateDecorator):
                     self.context.get_location(),
                     remove_monitoring=False,
                     aad_route=self.context.get_enable_msi_auth_for_monitoring(),
-                    create_dcr=False,
+                    create_dcr=cnl_or_hlsm_changing,
                     create_dcra=True,
                     enable_syslog=self.context.get_enable_syslog(),
                     data_collection_settings=self.context.get_data_collection_settings(),

--- a/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
@@ -191,6 +191,7 @@ def _get_monitoring_addon_key_from_consts(addon_profiles, addon_consts):
         addon_consts.get("CONST_MONITORING_ADDON_NAME"),
     )
 
+
 # pylint: disable=too-few-public-methods
 class AKSPreviewManagedClusterModels(AKSManagedClusterModels):
     """Store the models used in aks series of commands.
@@ -5596,7 +5597,6 @@ class AKSPreviewManagedClusterCreateDecorator(AKSManagedClusterCreateDecorator):
             params.get("enable_retina_flow_logs") is not None or
             params.get("enable_high_log_scale_mode") is not None
         )
-
 
 
 class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):

--- a/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
@@ -7,6 +7,7 @@
 import copy
 import datetime
 import os
+import random
 import time
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Tuple, TypeVar, Union
@@ -4684,9 +4685,12 @@ class AKSPreviewManagedClusterCreateDecorator(AKSManagedClusterCreateDecorator):
         if not workspace_resource_id:
             ensure_workspace_func = (
                 self.context.external_functions.ensure_default_log_analytics_workspace_for_monitoring)
-            # Retry with backoff to handle 409 Conflict when workspace is still provisioning
-            # (common when parallel tests or commands target the same default workspace)
-            for attempt in range(3):
+            # Retry with exponential backoff + jitter to handle 409 Conflict when
+            # workspace is still provisioning (common when parallel commands target
+            # the same default workspace).  Delays: ~5 s, ~10 s, ~20 s (worst-case
+            # total ~52 s; fast path ~7 s if the first retry succeeds).
+            max_attempts = 4
+            for attempt in range(max_attempts):
                 try:
                     workspace_resource_id = ensure_workspace_func(
                         self.cmd,
@@ -4695,8 +4699,10 @@ class AKSPreviewManagedClusterCreateDecorator(AKSManagedClusterCreateDecorator):
                     )
                     break
                 except (HttpResponseError, ResourceExistsError):
-                    if attempt < 2:
-                        time.sleep(30)
+                    if attempt < max_attempts - 1:
+                        base_delay = 5 * (2 ** attempt)  # 5 s, 10 s, 20 s
+                        jitter = random.uniform(0, base_delay * 0.5)
+                        time.sleep(base_delay + jitter)
                     else:
                         raise
 
@@ -4723,26 +4729,9 @@ class AKSPreviewManagedClusterCreateDecorator(AKSManagedClusterCreateDecorator):
         }
         mc.addon_profiles[CONST_MONITORING_ADDON_NAME] = addon_profile
 
-        # Create DCR before the cluster is created (matching base class build_monitoring_addon_profile pattern).
-        # The DCRA will be created later in postprocessing_after_mc_created.
-        self.context.external_functions.ensure_container_insights_for_monitoring(
-            self.cmd,
-            addon_profile,
-            self.context.get_subscription_id(),
-            self.context.get_resource_group_name(),
-            self.context.get_name(),
-            self.context.get_location(),
-            remove_monitoring=False,
-            aad_route=self.context.get_enable_msi_auth_for_monitoring(),
-            create_dcr=True,
-            create_dcra=False,
-            enable_syslog=self.context.get_enable_syslog(),
-            data_collection_settings=self.context.get_data_collection_settings(),
-            is_private_cluster=self.context.get_enable_private_cluster(),
-            ampls_resource_id=self.context.get_ampls_resource_id(),
-            enable_high_log_scale_mode=self.context.get_enable_high_log_scale_mode(),
-        )
-
+        # DCR and DCRA creation is deferred to postprocessing_after_mc_created
+        # (_postprocess_monitoring_enable) so that all flags are finalized and
+        # the cluster exists.  Only MSI clusters need a DCR.
         self.context.set_intermediate("monitoring_addon_enabled", True, overwrite_exists=True)
 
     def _setup_opentelemetry_metrics(self, mc: ManagedCluster) -> None:
@@ -5612,7 +5601,7 @@ class AKSPreviewManagedClusterCreateDecorator(AKSManagedClusterCreateDecorator):
                 self.context.get_location(),
                 remove_monitoring=False,
                 aad_route=self.context.get_enable_msi_auth_for_monitoring(),
-                create_dcr=self._is_cnl_or_hlsm_changing(),
+                create_dcr=True,
                 create_dcra=True,
                 enable_syslog=self.context.get_enable_syslog(),
                 data_collection_settings=self.context.get_data_collection_settings(),
@@ -5942,17 +5931,9 @@ class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):
         if container_network_logs_enabled is not None:
             if mc.addon_profiles:
                 addon_consts = self.context.get_addon_consts()
-                CONST_MONITORING_ADDON_NAME = addon_consts.get("CONST_MONITORING_ADDON_NAME")
-                # Handle both "omsagent" and "omsAgent" key variants
-                monitoring_addon_profile = (
-                    mc.addon_profiles.get(CONST_MONITORING_ADDON_NAME) or
-                    mc.addon_profiles.get(CONST_MONITORING_ADDON_NAME_CAMELCASE)
-                )
+                monitoring_addon_key = _get_monitoring_addon_key(mc, addon_consts)
+                monitoring_addon_profile = mc.addon_profiles.get(monitoring_addon_key)
                 if monitoring_addon_profile:
-                    monitoring_addon_key = (
-                        CONST_MONITORING_ADDON_NAME if CONST_MONITORING_ADDON_NAME in mc.addon_profiles
-                        else CONST_MONITORING_ADDON_NAME_CAMELCASE
-                    )
                     config = monitoring_addon_profile.config or {}
                     config["enableRetinaNetworkFlags"] = str(container_network_logs_enabled)
                     mc.addon_profiles[monitoring_addon_key].config = config
@@ -7913,9 +7894,12 @@ class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):
         if not workspace_resource_id:
             ensure_workspace_func = (
                 self.context.external_functions.ensure_default_log_analytics_workspace_for_monitoring)
-            # Retry with backoff to handle 409 Conflict when workspace is still provisioning
-            # (common when parallel tests or commands target the same default workspace)
-            for attempt in range(3):
+            # Retry with exponential backoff + jitter to handle 409 Conflict when
+            # workspace is still provisioning (common when parallel commands target
+            # the same default workspace).  Delays: ~5 s, ~10 s, ~20 s (worst-case
+            # total ~52 s; fast path ~7 s if the first retry succeeds).
+            max_attempts = 4
+            for attempt in range(max_attempts):
                 try:
                     workspace_resource_id = ensure_workspace_func(
                         self.cmd,
@@ -7924,8 +7908,10 @@ class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):
                     )
                     break
                 except (HttpResponseError, ResourceExistsError):
-                    if attempt < 2:
-                        time.sleep(30)
+                    if attempt < max_attempts - 1:
+                        base_delay = 5 * (2 ** attempt)  # 5 s, 10 s, 20 s
+                        jitter = random.uniform(0, base_delay * 0.5)
+                        time.sleep(base_delay + jitter)
                     else:
                         raise
 

--- a/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
@@ -5345,98 +5345,6 @@ class AKSPreviewManagedClusterCreateDecorator(AKSManagedClusterCreateDecorator):
                     "Could not create a role assignment for subnet. Are you an Owner on this subscription?"
                 )
 
-    def _should_create_dcra(self) -> bool:
-        """Return True if any flag that triggers a DCRA/DCR create or update was provided."""
-        params = self.context.raw_param
-        return (
-            params.get("enable_addons") is not None or
-            params.get("enable_azure_monitor_logs") is not None or
-            self._is_cnl_or_hlsm_changing()
-        )
-
-    def _is_cnl_or_hlsm_changing(self) -> bool:
-        """Return True if any CNL or High Log Scale Mode flag was provided."""
-        params = self.context.raw_param
-        return (
-            params.get("enable_container_network_logs") is not None or
-            params.get("enable_retina_flow_logs") is not None or
-            params.get("disable_container_network_logs") is not None or
-            params.get("disable_retina_flow_logs") is not None or
-            params.get("enable_high_log_scale_mode") is not None
-        )
-
-    def _postprocess_monitoring_enable(self, cluster: ManagedCluster) -> None:
-        """Handle monitoring addon postprocessing for the enable case."""
-        enable_msi_auth_for_monitoring = self.context.get_enable_msi_auth_for_monitoring()
-        if not enable_msi_auth_for_monitoring:
-            # add cluster spn/msi Monitoring Metrics Publisher role assignment to publish metrics to MDM
-            # mdm metrics is supported only in azure public cloud, so add the role assignment only in this cloud
-            cloud_name = self.cmd.cli_ctx.cloud.name
-            if cloud_name.lower() == "azurecloud":
-                cluster_resource_id = resource_id(
-                    subscription=self.context.get_subscription_id(),
-                    resource_group=self.context.get_resource_group_name(),
-                    namespace="Microsoft.ContainerService",
-                    type="managedClusters",
-                    name=self.context.get_name(),
-                )
-                self.context.external_functions.add_monitoring_role_assignment(
-                    cluster, cluster_resource_id, self.cmd
-                )
-        elif self._should_create_dcra():
-            addon_consts = self.context.get_addon_consts()
-            monitoring_addon_key = _get_monitoring_addon_key(cluster, addon_consts)
-            self.context.external_functions.ensure_container_insights_for_monitoring(
-                self.cmd,
-                cluster.addon_profiles[monitoring_addon_key],
-                self.context.get_subscription_id(),
-                self.context.get_resource_group_name(),
-                self.context.get_name(),
-                self.context.get_location(),
-                remove_monitoring=False,
-                aad_route=self.context.get_enable_msi_auth_for_monitoring(),
-                create_dcr=self._is_cnl_or_hlsm_changing(),
-                create_dcra=True,
-                enable_syslog=self.context.get_enable_syslog(),
-                data_collection_settings=self.context.get_data_collection_settings(),
-                is_private_cluster=self.context.get_enable_private_cluster(),
-                ampls_resource_id=self.context.get_ampls_resource_id(),
-                enable_high_log_scale_mode=self.context.get_enable_high_log_scale_mode(),
-            )
-
-    def _postprocess_monitoring_disable(self) -> None:
-        """Handle monitoring addon postprocessing for the disable case."""
-        addon_consts = self.context.get_addon_consts()
-        CONST_MONITORING_ADDON_NAME = addon_consts.get("CONST_MONITORING_ADDON_NAME")
-
-        # Get the current cluster state to check config before it was disabled
-        current_cluster = self.client.get(self.context.get_resource_group_name(), self.context.get_name())
-
-        if (current_cluster.addon_profiles and
-                CONST_MONITORING_ADDON_NAME in current_cluster.addon_profiles):
-
-            addon_profile = current_cluster.addon_profiles[CONST_MONITORING_ADDON_NAME]
-
-            try:
-                self.context.external_functions.ensure_container_insights_for_monitoring(
-                    self.cmd,
-                    addon_profile,
-                    self.context.get_subscription_id(),
-                    self.context.get_resource_group_name(),
-                    self.context.get_name(),
-                    self.context.get_location(),
-                    remove_monitoring=True,
-                    aad_route=True,
-                    create_dcr=False,
-                    create_dcra=True,
-                    enable_syslog=False,
-                    data_collection_settings=None,
-                    ampls_resource_id=None,
-                    enable_high_log_scale_mode=False
-                )
-            except TypeError:
-                pass
-
     # pylint: disable=too-many-locals,too-many-branches
     def postprocessing_after_mc_created(self, cluster: ManagedCluster) -> None:
         """Postprocessing performed after the cluster is created.
@@ -5626,6 +5534,98 @@ class AKSPreviewManagedClusterCreateDecorator(AKSManagedClusterCreateDecorator):
                 headers=self.context.get_aks_custom_headers(),
             )
         return cluster
+
+    def _should_create_dcra(self) -> bool:
+        """Return True if any flag that triggers a DCRA/DCR create or update was provided."""
+        params = self.context.raw_param
+        return (
+            params.get("enable_addons") is not None or
+            params.get("enable_azure_monitor_logs") is not None or
+            self._is_cnl_or_hlsm_changing()
+        )
+
+    def _is_cnl_or_hlsm_changing(self) -> bool:
+        """Return True if any CNL or High Log Scale Mode flag was provided."""
+        params = self.context.raw_param
+        return (
+            params.get("enable_container_network_logs") is not None or
+            params.get("enable_retina_flow_logs") is not None or
+            params.get("disable_container_network_logs") is not None or
+            params.get("disable_retina_flow_logs") is not None or
+            params.get("enable_high_log_scale_mode") is not None
+        )
+
+    def _postprocess_monitoring_enable(self, cluster: ManagedCluster) -> None:
+        """Handle monitoring addon postprocessing for the enable case."""
+        enable_msi_auth_for_monitoring = self.context.get_enable_msi_auth_for_monitoring()
+        if not enable_msi_auth_for_monitoring:
+            # add cluster spn/msi Monitoring Metrics Publisher role assignment to publish metrics to MDM
+            # mdm metrics is supported only in azure public cloud, so add the role assignment only in this cloud
+            cloud_name = self.cmd.cli_ctx.cloud.name
+            if cloud_name.lower() == "azurecloud":
+                cluster_resource_id = resource_id(
+                    subscription=self.context.get_subscription_id(),
+                    resource_group=self.context.get_resource_group_name(),
+                    namespace="Microsoft.ContainerService",
+                    type="managedClusters",
+                    name=self.context.get_name(),
+                )
+                self.context.external_functions.add_monitoring_role_assignment(
+                    cluster, cluster_resource_id, self.cmd
+                )
+        elif self._should_create_dcra():
+            addon_consts = self.context.get_addon_consts()
+            monitoring_addon_key = _get_monitoring_addon_key(cluster, addon_consts)
+            self.context.external_functions.ensure_container_insights_for_monitoring(
+                self.cmd,
+                cluster.addon_profiles[monitoring_addon_key],
+                self.context.get_subscription_id(),
+                self.context.get_resource_group_name(),
+                self.context.get_name(),
+                self.context.get_location(),
+                remove_monitoring=False,
+                aad_route=self.context.get_enable_msi_auth_for_monitoring(),
+                create_dcr=self._is_cnl_or_hlsm_changing(),
+                create_dcra=True,
+                enable_syslog=self.context.get_enable_syslog(),
+                data_collection_settings=self.context.get_data_collection_settings(),
+                is_private_cluster=self.context.get_enable_private_cluster(),
+                ampls_resource_id=self.context.get_ampls_resource_id(),
+                enable_high_log_scale_mode=self.context.get_enable_high_log_scale_mode(),
+            )
+
+    def _postprocess_monitoring_disable(self) -> None:
+        """Handle monitoring addon postprocessing for the disable case."""
+        addon_consts = self.context.get_addon_consts()
+        CONST_MONITORING_ADDON_NAME = addon_consts.get("CONST_MONITORING_ADDON_NAME")
+
+        # Get the current cluster state to check config before it was disabled
+        current_cluster = self.client.get(self.context.get_resource_group_name(), self.context.get_name())
+
+        if (current_cluster.addon_profiles and
+                CONST_MONITORING_ADDON_NAME in current_cluster.addon_profiles):
+
+            addon_profile = current_cluster.addon_profiles[CONST_MONITORING_ADDON_NAME]
+
+            try:
+                self.context.external_functions.ensure_container_insights_for_monitoring(
+                    self.cmd,
+                    addon_profile,
+                    self.context.get_subscription_id(),
+                    self.context.get_resource_group_name(),
+                    self.context.get_name(),
+                    self.context.get_location(),
+                    remove_monitoring=True,
+                    aad_route=True,
+                    create_dcr=False,
+                    create_dcra=True,
+                    enable_syslog=False,
+                    data_collection_settings=None,
+                    ampls_resource_id=None,
+                    enable_high_log_scale_mode=False
+                )
+            except TypeError:
+                pass
 
 
 class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):

--- a/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
@@ -439,7 +439,24 @@ class AKSPreviewManagedClusterContext(AKSManagedClusterContext):
         elif enable_azure_monitor_logs:
             result = True
         elif enable_msi_auth_for_monitoring is False:
-            result = False
+            # The base class returns False when service_principal_profile.client_id is not None,
+            # but MSI-based clusters set client_id to "msi". Check if the monitoring addon
+            # already has useAADAuth=true, which indicates MSI auth is actually in use.
+            addon_consts = self.get_addon_consts()
+            CONST_MONITORING_ADDON_NAME = addon_consts.get("CONST_MONITORING_ADDON_NAME")
+            CONST_MONITORING_USING_AAD_MSI_AUTH = addon_consts.get("CONST_MONITORING_USING_AAD_MSI_AUTH")
+            if self.mc and self.mc.addon_profiles:
+                monitoring_profile = (
+                    self.mc.addon_profiles.get(CONST_MONITORING_ADDON_NAME) or
+                    self.mc.addon_profiles.get(CONST_MONITORING_ADDON_NAME_CAMELCASE)
+                )
+                if (monitoring_profile and monitoring_profile.config and
+                    str(monitoring_profile.config.get(CONST_MONITORING_USING_AAD_MSI_AUTH, "")).lower() == "true"):
+                    result = True
+                else:
+                    result = False
+            else:
+                result = False
         elif enable_msi_auth_for_monitoring is None and not disable_msi_auth and not enable_msi_auth:
             result = True
         else:
@@ -5342,9 +5359,14 @@ class AKSPreviewManagedClusterCreateDecorator(AKSManagedClusterCreateDecorator):
                 )
                 addon_consts = self.context.get_addon_consts()
                 CONST_MONITORING_ADDON_NAME = addon_consts.get("CONST_MONITORING_ADDON_NAME")
+                # The API response may return the addon key as either "omsagent" or "omsAgent"
+                monitoring_addon_key = CONST_MONITORING_ADDON_NAME
+                if CONST_MONITORING_ADDON_NAME not in cluster.addon_profiles and \
+                   CONST_MONITORING_ADDON_NAME_CAMELCASE in cluster.addon_profiles:
+                    monitoring_addon_key = CONST_MONITORING_ADDON_NAME_CAMELCASE
                 self.context.external_functions.ensure_container_insights_for_monitoring(
                     self.cmd,
-                    cluster.addon_profiles[CONST_MONITORING_ADDON_NAME],
+                    cluster.addon_profiles[monitoring_addon_key],
                     self.context.get_subscription_id(),
                     self.context.get_resource_group_name(),
                     self.context.get_name(),
@@ -8131,14 +8153,21 @@ class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):
             CONST_MONITORING_ADDON_NAME = addon_consts.get("CONST_MONITORING_ADDON_NAME")
             CONST_MONITORING_USING_AAD_MSI_AUTH = addon_consts.get("CONST_MONITORING_USING_AAD_MSI_AUTH")
 
-            if (cluster.addon_profiles and
-                    CONST_MONITORING_ADDON_NAME in cluster.addon_profiles and
-                    cluster.addon_profiles[CONST_MONITORING_ADDON_NAME].enabled):
+            # The API response may return the addon key as either "omsagent" or "omsAgent"
+            monitoring_addon_key = None
+            if cluster.addon_profiles:
+                if CONST_MONITORING_ADDON_NAME in cluster.addon_profiles:
+                    monitoring_addon_key = CONST_MONITORING_ADDON_NAME
+                elif CONST_MONITORING_ADDON_NAME_CAMELCASE in cluster.addon_profiles:
+                    monitoring_addon_key = CONST_MONITORING_ADDON_NAME_CAMELCASE
+
+            if (monitoring_addon_key and
+                    cluster.addon_profiles[monitoring_addon_key].enabled):
 
                 # Check if MSI auth is enabled
                 if (CONST_MONITORING_USING_AAD_MSI_AUTH in
-                    cluster.addon_profiles[CONST_MONITORING_ADDON_NAME].config and
-                    str(cluster.addon_profiles[CONST_MONITORING_ADDON_NAME].config[
+                    cluster.addon_profiles[monitoring_addon_key].config and
+                    str(cluster.addon_profiles[monitoring_addon_key].config[
                         CONST_MONITORING_USING_AAD_MSI_AUTH]).lower() == "true"):
 
                     # Check parameter sizes to identify what might be causing large headers
@@ -8153,7 +8182,7 @@ class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):
 
                     self.context.external_functions.ensure_container_insights_for_monitoring(
                         self.cmd,
-                        cluster.addon_profiles[CONST_MONITORING_ADDON_NAME],
+                        cluster.addon_profiles[monitoring_addon_key],
                         self.context.get_subscription_id(),
                         self.context.get_resource_group_name(),
                         self.context.get_name(),

--- a/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
@@ -5898,11 +5898,19 @@ class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):
             if mc.addon_profiles:
                 addon_consts = self.context.get_addon_consts()
                 CONST_MONITORING_ADDON_NAME = addon_consts.get("CONST_MONITORING_ADDON_NAME")
-                monitoring_addon_profile = mc.addon_profiles.get(CONST_MONITORING_ADDON_NAME)
+                # Handle both "omsagent" and "omsAgent" key variants
+                monitoring_addon_profile = (
+                    mc.addon_profiles.get(CONST_MONITORING_ADDON_NAME) or
+                    mc.addon_profiles.get(CONST_MONITORING_ADDON_NAME_CAMELCASE)
+                )
                 if monitoring_addon_profile:
+                    monitoring_addon_key = (
+                        CONST_MONITORING_ADDON_NAME if CONST_MONITORING_ADDON_NAME in mc.addon_profiles
+                        else CONST_MONITORING_ADDON_NAME_CAMELCASE
+                    )
                     config = monitoring_addon_profile.config or {}
                     config["enableRetinaNetworkFlags"] = str(container_network_logs_enabled)
-                    mc.addon_profiles[CONST_MONITORING_ADDON_NAME].config = config
+                    mc.addon_profiles[monitoring_addon_key].config = config
 
         # When enabling CNL, the DCR must be updated to add the high-scale stream.
         # Set the postprocessing intermediate so that the update path calls ensure_container_insights.

--- a/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
@@ -27,7 +27,6 @@ from azext_aks_preview._consts import (
     CONST_MANAGED_CLUSTER_SKU_TIER_FREE,
     CONST_MANAGED_CLUSTER_SKU_TIER_PREMIUM,
     CONST_MANAGED_CLUSTER_SKU_TIER_STANDARD,
-    CONST_MONITORING_ADDON_NAME_CAMELCASE,
     CONST_NETWORK_DATAPLANE_CILIUM,
     CONST_NETWORK_PLUGIN_AZURE,
     CONST_NETWORK_PLUGIN_MODE_OVERLAY,
@@ -2868,7 +2867,6 @@ class AKSPreviewManagedClusterContext(AKSManagedClusterContext):
                 # 1. New API: azureMonitorProfile.containerInsights.enabled
                 # 2. Legacy: addonProfiles.omsagent.enabled (or omsAgent with camelCase)
                 addon_consts = self.get_addon_consts()
-                CONST_MONITORING_ADDON_NAME = addon_consts.get("CONST_MONITORING_ADDON_NAME")
 
                 # Check new API location
                 container_insights_enabled = (
@@ -3020,7 +3018,6 @@ class AKSPreviewManagedClusterContext(AKSManagedClusterContext):
 
             # Validate that monitoring addon is enabled (either being enabled now or already enabled in cluster)
             addon_consts = self.get_addon_consts()
-            CONST_MONITORING_ADDON_NAME = addon_consts.get("CONST_MONITORING_ADDON_NAME")
 
             # Check if monitoring is being enabled in the command
             enable_addons = self.raw_param.get("enable_addons")
@@ -5554,8 +5551,11 @@ class AKSPreviewManagedClusterCreateDecorator(AKSManagedClusterCreateDecorator):
                 )
         elif self._should_create_dcra():
             addon_consts = self.context.get_addon_consts()
-            monitoring_addon_key = _get_monitoring_addon_key_from_consts(
-                cluster.addon_profiles, addon_consts) if cluster.addon_profiles else addon_consts.get("CONST_MONITORING_ADDON_NAME")
+            monitoring_addon_key = (
+                _get_monitoring_addon_key_from_consts(cluster.addon_profiles, addon_consts)
+                if cluster.addon_profiles
+                else addon_consts.get("CONST_MONITORING_ADDON_NAME")
+            )
             self.context.external_functions.ensure_container_insights_for_monitoring(
                 self.cmd,
                 cluster.addon_profiles[monitoring_addon_key],
@@ -5879,10 +5879,8 @@ class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):
         """
         self._ensure_mc(mc)
 
-        # Call the base class implementation if it exists (CLI >= 2.84.0 added this method to the base).
-        # This ensures any base-class monitoring handling (e.g., enable/disable) is applied first.
-        if hasattr(super(), 'update_monitoring_profile_flow_logs'):
-            mc = super().update_monitoring_profile_flow_logs(mc)
+        # Do not call super() — the base class HLSM validation does not handle
+        # preview-specific flags (--enable-azure-monitor-logs, --enable-addons monitoring).
 
         # Trigger validation for high log scale mode when container network logs are enabled.
         # This ensures proper error messages are raised before cluster update if the user
@@ -8201,8 +8199,11 @@ class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):
             addon_consts = self.context.get_addon_consts()
             CONST_MONITORING_USING_AAD_MSI_AUTH = addon_consts.get("CONST_MONITORING_USING_AAD_MSI_AUTH")
 
-            monitoring_addon_key = _get_monitoring_addon_key_from_consts(
-                cluster.addon_profiles, addon_consts) if cluster.addon_profiles else addon_consts.get("CONST_MONITORING_ADDON_NAME")
+            monitoring_addon_key = (
+                _get_monitoring_addon_key_from_consts(cluster.addon_profiles, addon_consts)
+                if cluster.addon_profiles
+                else addon_consts.get("CONST_MONITORING_ADDON_NAME")
+            )
 
             if (cluster.addon_profiles and
                     monitoring_addon_key in cluster.addon_profiles and

--- a/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
@@ -54,6 +54,7 @@ from azext_aks_preview._consts import (
     CONST_ACNS_DATAPATH_ACCELERATION_MODE_NONE,
     CONST_TRANSIT_ENCRYPTION_TYPE_MTLS,
     CONST_ADVANCED_NETWORKPOLICIES_L7,
+    CONST_MONITORING_ADDON_NAME_CAMELCASE,
 )
 from azext_aks_preview.azurecontainerstorage._consts import (
     CONST_ACSTOR_EXT_INSTALLATION_NAME,

--- a/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
@@ -5914,6 +5914,11 @@ class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):
         """
         self._ensure_mc(mc)
 
+        # Call the base class implementation if it exists (CLI >= 2.84.0 added this method to the base).
+        # This ensures any base-class monitoring handling (e.g., enable/disable) is applied first.
+        if hasattr(super(), 'update_monitoring_profile_flow_logs'):
+            mc = super().update_monitoring_profile_flow_logs(mc)
+
         # Trigger validation for high log scale mode when container network logs are enabled.
         # This ensures proper error messages are raised before cluster update if the user
         # explicitly disables high log scale mode while enabling container network logs.
@@ -5950,35 +5955,45 @@ class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):
         # monitoring with MSI auth is already enabled, then trigger the DCR update via postprocessing.
         enable_high_log_scale_mode = self.context.raw_param.get("enable_high_log_scale_mode")
         if enable_high_log_scale_mode is True:
-            addon_consts = self.context.get_addon_consts()
-            CONST_MONITORING_ADDON_NAME = addon_consts.get("CONST_MONITORING_ADDON_NAME")
-            CONST_MONITORING_USING_AAD_MSI_AUTH = addon_consts.get("CONST_MONITORING_USING_AAD_MSI_AUTH")
-
-            # Resolve the addon profile, handling both "omsagent" and "omsAgent" key variants.
-            monitoring_addon_profile = None
-            if mc.addon_profiles:
-                monitoring_addon_profile = (
-                    mc.addon_profiles.get(CONST_MONITORING_ADDON_NAME) or
-                    mc.addon_profiles.get(CONST_MONITORING_ADDON_NAME_CAMELCASE)
-                )
-
-            if not monitoring_addon_profile or not monitoring_addon_profile.enabled:
-                raise RequiredArgumentMissingError(
-                    "--enable-high-log-scale-mode requires the Azure Monitor logs addon (omsagent) "
-                    "to be enabled on the cluster. Please enable it first with "
-                    "--enable-addons monitoring or --enable-azure-monitor-logs."
-                )
-
-            addon_config = monitoring_addon_profile.config or {}
-            msi_auth_enabled = (
-                CONST_MONITORING_USING_AAD_MSI_AUTH in addon_config and
-                str(addon_config[CONST_MONITORING_USING_AAD_MSI_AUTH]).lower() == "true"
+            # Check if monitoring is being enabled in the same command
+            enable_azure_monitor_logs = self.context.raw_param.get("enable_azure_monitor_logs")
+            enable_addons = self.context.raw_param.get("enable_addons")
+            monitoring_being_enabled = (
+                enable_azure_monitor_logs or
+                (enable_addons and "monitoring" in enable_addons)
             )
-            if not msi_auth_enabled:
-                raise RequiredArgumentMissingError(
-                    "--enable-high-log-scale-mode requires MSI authentication to be enabled "
-                    "for the monitoring addon. Please enable it with --enable-msi-auth-for-monitoring."
+
+            if not monitoring_being_enabled:
+                # Only validate existing addon state when not enabling monitoring simultaneously
+                addon_consts = self.context.get_addon_consts()
+                CONST_MONITORING_ADDON_NAME = addon_consts.get("CONST_MONITORING_ADDON_NAME")
+                CONST_MONITORING_USING_AAD_MSI_AUTH = addon_consts.get("CONST_MONITORING_USING_AAD_MSI_AUTH")
+
+                # Resolve the addon profile, handling both "omsagent" and "omsAgent" key variants.
+                monitoring_addon_profile = None
+                if mc.addon_profiles:
+                    monitoring_addon_profile = (
+                        mc.addon_profiles.get(CONST_MONITORING_ADDON_NAME) or
+                        mc.addon_profiles.get(CONST_MONITORING_ADDON_NAME_CAMELCASE)
+                    )
+
+                if not monitoring_addon_profile or not monitoring_addon_profile.enabled:
+                    raise RequiredArgumentMissingError(
+                        "--enable-high-log-scale-mode requires the Azure Monitor logs addon (omsagent) "
+                        "to be enabled on the cluster. Please enable it first with "
+                        "--enable-addons monitoring or --enable-azure-monitor-logs."
+                    )
+
+                addon_config = monitoring_addon_profile.config or {}
+                msi_auth_enabled = (
+                    CONST_MONITORING_USING_AAD_MSI_AUTH in addon_config and
+                    str(addon_config[CONST_MONITORING_USING_AAD_MSI_AUTH]).lower() == "true"
                 )
+                if not msi_auth_enabled:
+                    raise RequiredArgumentMissingError(
+                        "--enable-high-log-scale-mode requires MSI authentication to be enabled "
+                        "for the monitoring addon. Please enable it with --enable-msi-auth-for-monitoring."
+                    )
 
             self.context.set_intermediate("monitoring_addon_postprocessing_required", True, overwrite_exists=True)
 
@@ -8012,10 +8027,14 @@ class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):
 
         # Now disable the addon and clear configuration
         mc.addon_profiles[addon_key].enabled = False
+        mc.addon_profiles[addon_key].config = None
 
-        # Use empty dict instead of None - setting config=None causes the SDK serializer
-        # to omit the config key entirely, which Azure interprets as "keep existing config"
-        mc.addon_profiles[addon_key].config = {}
+        # Also disable azureMonitorProfile.containerInsights (the new API surface)
+        # The RP uses containerInsights.enabled as the source of truth; if it remains
+        # true while the legacy addon is disabled, the RP re-enables the addon.
+        if (mc.azure_monitor_profile and
+                mc.azure_monitor_profile.container_insights):
+            mc.azure_monitor_profile.container_insights.enabled = False
 
         # Also disable OpenTelemetry logs when disabling Azure Monitor logs
         if opentelemetry_logs_enabled:
@@ -8154,7 +8173,10 @@ class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):
         # update acns in network_profile
         mc = self.update_acns_in_network_profile(mc)
         # update update_monitoring_profile_flow_logs
-        mc = self.update_monitoring_profile_flow_logs(mc)
+        # Only call here if the base class doesn't already call it in update_mc_profile_default
+        # (CLI >= 2.84.0 added this call to the base class)
+        if not hasattr(super(), 'update_monitoring_profile_flow_logs'):
+            mc = self.update_monitoring_profile_flow_logs(mc)
         # update kubernetes support plan
         mc = self.update_k8s_support_plan(mc)
         # update AI toolchain operator

--- a/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
@@ -7,6 +7,7 @@
 import copy
 import datetime
 import os
+import time
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Tuple, TypeVar, Union
 
@@ -56,6 +57,7 @@ from azext_aks_preview._consts import (
     CONST_TRANSIT_ENCRYPTION_TYPE_MTLS,
     CONST_ADVANCED_NETWORKPOLICIES_L7,
 )
+from azure.core.exceptions import HttpResponseError, ResourceExistsError
 from azext_aks_preview.azurecontainerstorage._consts import (
     CONST_ACSTOR_EXT_INSTALLATION_NAME,
     CONST_ACSTOR_V1_EXT_INSTALLATION_NAME,
@@ -4682,11 +4684,21 @@ class AKSPreviewManagedClusterCreateDecorator(AKSManagedClusterCreateDecorator):
         if not workspace_resource_id:
             ensure_workspace_func = (
                 self.context.external_functions.ensure_default_log_analytics_workspace_for_monitoring)
-            workspace_resource_id = ensure_workspace_func(
-                self.cmd,
-                self.context.get_subscription_id(),
-                self.context.get_resource_group_name()
-            )
+            # Retry with backoff to handle 409 Conflict when workspace is still provisioning
+            # (common when parallel tests or commands target the same default workspace)
+            for attempt in range(3):
+                try:
+                    workspace_resource_id = ensure_workspace_func(
+                        self.cmd,
+                        self.context.get_subscription_id(),
+                        self.context.get_resource_group_name()
+                    )
+                    break
+                except (HttpResponseError, ResourceExistsError):
+                    if attempt < 2:
+                        time.sleep(30)
+                    else:
+                        raise
 
         # Sanitize and configure
         sanitize_func = self.context.external_functions.sanitize_loganalytics_ws_resource_id
@@ -7901,11 +7913,21 @@ class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):
         if not workspace_resource_id:
             ensure_workspace_func = (
                 self.context.external_functions.ensure_default_log_analytics_workspace_for_monitoring)
-            workspace_resource_id = ensure_workspace_func(
-                self.cmd,
-                self.context.get_subscription_id(),
-                self.context.get_resource_group_name()
-            )
+            # Retry with backoff to handle 409 Conflict when workspace is still provisioning
+            # (common when parallel tests or commands target the same default workspace)
+            for attempt in range(3):
+                try:
+                    workspace_resource_id = ensure_workspace_func(
+                        self.cmd,
+                        self.context.get_subscription_id(),
+                        self.context.get_resource_group_name()
+                    )
+                    break
+                except (HttpResponseError, ResourceExistsError):
+                    if attempt < 2:
+                        time.sleep(30)
+                    else:
+                        raise
 
         # Sanitize and configure
         sanitize_func = self.context.external_functions.sanitize_loganalytics_ws_resource_id
@@ -7939,6 +7961,13 @@ class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):
             CONST_MONITORING_LOG_ANALYTICS_WORKSPACE_RESOURCE_ID: workspace_resource_id,
             CONST_MONITORING_USING_AAD_MSI_AUTH: enable_msi_auth
         }
+
+        # Also set enableRetinaNetworkFlags if container network logs are being enabled
+        # in the same command. This must be done here because update_monitoring_profile_flow_logs
+        # may run before update_addon_profiles when the base class calls it first.
+        container_network_logs_enabled = self.context.get_container_network_logs(mc)
+        if container_network_logs_enabled is not None:
+            new_config["enableRetinaNetworkFlags"] = str(container_network_logs_enabled)
 
         # Replace the entire config, not just individual keys
         addon_profile.config = new_config

--- a/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
@@ -183,6 +183,21 @@ ServiceMeshProfile = TypeVar("ServiceMeshProfile")
 ResourceReference = TypeVar("ResourceReference")
 
 
+def _get_monitoring_addon_key(cluster, addon_consts):
+    """Resolve the monitoring addon key from the cluster's addon_profiles.
+
+    The API response may return the addon key as either "omsagent" or "omsAgent".
+    Returns the key present in addon_profiles, or the default constant if neither is found.
+    """
+    const_monitoring = addon_consts.get("CONST_MONITORING_ADDON_NAME")
+    if cluster.addon_profiles:
+        if const_monitoring in cluster.addon_profiles:
+            return const_monitoring
+        if CONST_MONITORING_ADDON_NAME_CAMELCASE in cluster.addon_profiles:
+            return CONST_MONITORING_ADDON_NAME_CAMELCASE
+    return const_monitoring
+
+
 # pylint: disable=too-few-public-methods
 class AKSPreviewManagedClusterModels(AKSManagedClusterModels):
     """Store the models used in aks series of commands.
@@ -5335,13 +5350,92 @@ class AKSPreviewManagedClusterCreateDecorator(AKSManagedClusterCreateDecorator):
         params = self.context.raw_param
         return (
             params.get("enable_addons") is not None or
-            params.get("enable-azure-monitor-logs") is not None or
+            params.get("enable_azure_monitor_logs") is not None or
+            self._is_cnl_or_hlsm_changing()
+        )
+
+    def _is_cnl_or_hlsm_changing(self) -> bool:
+        """Return True if any CNL or High Log Scale Mode flag was provided."""
+        params = self.context.raw_param
+        return (
             params.get("enable_container_network_logs") is not None or
             params.get("enable_retina_flow_logs") is not None or
             params.get("disable_container_network_logs") is not None or
             params.get("disable_retina_flow_logs") is not None or
             params.get("enable_high_log_scale_mode") is not None
         )
+
+    def _postprocess_monitoring_enable(self, cluster: ManagedCluster) -> None:
+        """Handle monitoring addon postprocessing for the enable case."""
+        enable_msi_auth_for_monitoring = self.context.get_enable_msi_auth_for_monitoring()
+        if not enable_msi_auth_for_monitoring:
+            # add cluster spn/msi Monitoring Metrics Publisher role assignment to publish metrics to MDM
+            # mdm metrics is supported only in azure public cloud, so add the role assignment only in this cloud
+            cloud_name = self.cmd.cli_ctx.cloud.name
+            if cloud_name.lower() == "azurecloud":
+                cluster_resource_id = resource_id(
+                    subscription=self.context.get_subscription_id(),
+                    resource_group=self.context.get_resource_group_name(),
+                    namespace="Microsoft.ContainerService",
+                    type="managedClusters",
+                    name=self.context.get_name(),
+                )
+                self.context.external_functions.add_monitoring_role_assignment(
+                    cluster, cluster_resource_id, self.cmd
+                )
+        elif self._should_create_dcra():
+            addon_consts = self.context.get_addon_consts()
+            monitoring_addon_key = _get_monitoring_addon_key(cluster, addon_consts)
+            self.context.external_functions.ensure_container_insights_for_monitoring(
+                self.cmd,
+                cluster.addon_profiles[monitoring_addon_key],
+                self.context.get_subscription_id(),
+                self.context.get_resource_group_name(),
+                self.context.get_name(),
+                self.context.get_location(),
+                remove_monitoring=False,
+                aad_route=self.context.get_enable_msi_auth_for_monitoring(),
+                create_dcr=self._is_cnl_or_hlsm_changing(),
+                create_dcra=True,
+                enable_syslog=self.context.get_enable_syslog(),
+                data_collection_settings=self.context.get_data_collection_settings(),
+                is_private_cluster=self.context.get_enable_private_cluster(),
+                ampls_resource_id=self.context.get_ampls_resource_id(),
+                enable_high_log_scale_mode=self.context.get_enable_high_log_scale_mode(),
+            )
+
+    def _postprocess_monitoring_disable(self) -> None:
+        """Handle monitoring addon postprocessing for the disable case."""
+        addon_consts = self.context.get_addon_consts()
+        CONST_MONITORING_ADDON_NAME = addon_consts.get("CONST_MONITORING_ADDON_NAME")
+
+        # Get the current cluster state to check config before it was disabled
+        current_cluster = self.client.get(self.context.get_resource_group_name(), self.context.get_name())
+
+        if (current_cluster.addon_profiles and
+                CONST_MONITORING_ADDON_NAME in current_cluster.addon_profiles):
+
+            addon_profile = current_cluster.addon_profiles[CONST_MONITORING_ADDON_NAME]
+
+            try:
+                self.context.external_functions.ensure_container_insights_for_monitoring(
+                    self.cmd,
+                    addon_profile,
+                    self.context.get_subscription_id(),
+                    self.context.get_resource_group_name(),
+                    self.context.get_name(),
+                    self.context.get_location(),
+                    remove_monitoring=True,
+                    aad_route=True,
+                    create_dcr=False,
+                    create_dcra=True,
+                    enable_syslog=False,
+                    data_collection_settings=None,
+                    ampls_resource_id=None,
+                    enable_high_log_scale_mode=False
+                )
+            except TypeError:
+                pass
 
     # pylint: disable=too-many-locals,too-many-branches
     def postprocessing_after_mc_created(self, cluster: ManagedCluster) -> None:
@@ -5352,56 +5446,7 @@ class AKSPreviewManagedClusterCreateDecorator(AKSManagedClusterCreateDecorator):
         # monitoring addon
         monitoring_addon_enabled = self.context.get_intermediate("monitoring_addon_enabled", default_value=False)
         if monitoring_addon_enabled:
-            enable_msi_auth_for_monitoring = self.context.get_enable_msi_auth_for_monitoring()
-            if not enable_msi_auth_for_monitoring:
-                # add cluster spn/msi Monitoring Metrics Publisher role assignment to publish metrics to MDM
-                # mdm metrics is supported only in azure public cloud, so add the role assignment only in this cloud
-                cloud_name = self.cmd.cli_ctx.cloud.name
-                if cloud_name.lower() == "azurecloud":
-                    cluster_resource_id = resource_id(
-                        subscription=self.context.get_subscription_id(),
-                        resource_group=self.context.get_resource_group_name(),
-                        namespace="Microsoft.ContainerService",
-                        type="managedClusters",
-                        name=self.context.get_name(),
-                    )
-                    self.context.external_functions.add_monitoring_role_assignment(
-                        cluster, cluster_resource_id, self.cmd
-                    )
-            elif self._should_create_dcra():
-                # Create/update the DCR when CNL or HLSM flags change so that the DCR streams
-                # (e.g. Microsoft-ContainerLogV2-HighScale) are kept in sync.
-                cnl_or_hlsm_changing = (
-                    self.context.raw_param.get("enable_container_network_logs") is not None or
-                    self.context.raw_param.get("enable_retina_flow_logs") is not None or
-                    self.context.raw_param.get("disable_container_network_logs") is not None or
-                    self.context.raw_param.get("disable_retina_flow_logs") is not None or
-                    self.context.raw_param.get("enable_high_log_scale_mode") is not None
-                )
-                addon_consts = self.context.get_addon_consts()
-                CONST_MONITORING_ADDON_NAME = addon_consts.get("CONST_MONITORING_ADDON_NAME")
-                # The API response may return the addon key as either "omsagent" or "omsAgent"
-                monitoring_addon_key = CONST_MONITORING_ADDON_NAME
-                if CONST_MONITORING_ADDON_NAME not in cluster.addon_profiles and \
-                   CONST_MONITORING_ADDON_NAME_CAMELCASE in cluster.addon_profiles:
-                    monitoring_addon_key = CONST_MONITORING_ADDON_NAME_CAMELCASE
-                self.context.external_functions.ensure_container_insights_for_monitoring(
-                    self.cmd,
-                    cluster.addon_profiles[monitoring_addon_key],
-                    self.context.get_subscription_id(),
-                    self.context.get_resource_group_name(),
-                    self.context.get_name(),
-                    self.context.get_location(),
-                    remove_monitoring=False,
-                    aad_route=self.context.get_enable_msi_auth_for_monitoring(),
-                    create_dcr=cnl_or_hlsm_changing,
-                    create_dcra=True,
-                    enable_syslog=self.context.get_enable_syslog(),
-                    data_collection_settings=self.context.get_data_collection_settings(),
-                    is_private_cluster=self.context.get_enable_private_cluster(),
-                    ampls_resource_id=self.context.get_ampls_resource_id(),
-                    enable_high_log_scale_mode=self.context.get_enable_high_log_scale_mode(),
-                )
+            self._postprocess_monitoring_enable(cluster)
 
         # Handle monitoring addon postprocessing (disable case) - same logic as aks_disable_addons
         monitoring_addon_disable_postprocessing_required = self.context.get_intermediate(
@@ -5409,39 +5454,7 @@ class AKSPreviewManagedClusterCreateDecorator(AKSManagedClusterCreateDecorator):
         )
 
         if monitoring_addon_disable_postprocessing_required:
-            addon_consts = self.context.get_addon_consts()
-            CONST_MONITORING_ADDON_NAME = addon_consts.get("CONST_MONITORING_ADDON_NAME")
-
-            # Get the current cluster state to check config before it was disabled
-            current_cluster = self.client.get(self.context.get_resource_group_name(), self.context.get_name())
-
-            if (current_cluster.addon_profiles and
-                    CONST_MONITORING_ADDON_NAME in current_cluster.addon_profiles):
-
-                # Use the current cluster addon profile for cleanup
-                addon_profile = current_cluster.addon_profiles[CONST_MONITORING_ADDON_NAME]
-
-                # Call ensure_container_insights_for_monitoring with remove_monitoring=True (same as aks_disable_addons)
-                try:
-                    self.context.external_functions.ensure_container_insights_for_monitoring(
-                        self.cmd,
-                        addon_profile,
-                        self.context.get_subscription_id(),
-                        self.context.get_resource_group_name(),
-                        self.context.get_name(),
-                        self.context.get_location(),
-                        remove_monitoring=True,
-                        aad_route=True,
-                        create_dcr=False,
-                        create_dcra=True,
-                        enable_syslog=False,
-                        data_collection_settings=None,
-                        ampls_resource_id=None,
-                        enable_high_log_scale_mode=False
-                    )
-                except TypeError:
-                    # Ignore TypeError just like aks_disable_addons does
-                    pass
+            self._postprocess_monitoring_disable()
 
         # ingress appgw addon
         ingress_appgw_addon_enabled = self.context.get_intermediate("ingress_appgw_addon_enabled", default_value=False)
@@ -8202,18 +8215,12 @@ class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):
         )
         if monitoring_addon_postprocessing_required:
             addon_consts = self.context.get_addon_consts()
-            CONST_MONITORING_ADDON_NAME = addon_consts.get("CONST_MONITORING_ADDON_NAME")
             CONST_MONITORING_USING_AAD_MSI_AUTH = addon_consts.get("CONST_MONITORING_USING_AAD_MSI_AUTH")
 
-            # The API response may return the addon key as either "omsagent" or "omsAgent"
-            monitoring_addon_key = None
-            if cluster.addon_profiles:
-                if CONST_MONITORING_ADDON_NAME in cluster.addon_profiles:
-                    monitoring_addon_key = CONST_MONITORING_ADDON_NAME
-                elif CONST_MONITORING_ADDON_NAME_CAMELCASE in cluster.addon_profiles:
-                    monitoring_addon_key = CONST_MONITORING_ADDON_NAME_CAMELCASE
+            monitoring_addon_key = _get_monitoring_addon_key(cluster, addon_consts)
 
-            if (monitoring_addon_key and
+            if (cluster.addon_profiles and
+                    monitoring_addon_key in cluster.addon_profiles and
                     cluster.addon_profiles[monitoring_addon_key].enabled):
 
                 # Check if MSI auth is enabled

--- a/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
@@ -57,7 +57,6 @@ from azext_aks_preview._consts import (
     CONST_TRANSIT_ENCRYPTION_TYPE_MTLS,
     CONST_ADVANCED_NETWORKPOLICIES_L7,
 )
-from azure.core.exceptions import HttpResponseError, ResourceExistsError
 from azext_aks_preview.azurecontainerstorage._consts import (
     CONST_ACSTOR_EXT_INSTALLATION_NAME,
     CONST_ACSTOR_V1_EXT_INSTALLATION_NAME,
@@ -102,6 +101,7 @@ from azext_aks_preview.azuremonitormetrics.azuremonitorprofile import (
 from azext_aks_preview.custom import (
     ensure_container_insights_for_monitoring_preview,
 )
+from azure.core.exceptions import HttpResponseError, ResourceExistsError
 from azure.cli.command_modules.acs._client_factory import get_graph_client
 from azure.cli.command_modules.acs._consts import (
     CONST_OUTBOUND_TYPE_LOAD_BALANCER,

--- a/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
@@ -191,7 +191,6 @@ def _get_monitoring_addon_key_from_consts(addon_profiles, addon_consts):
         addon_consts.get("CONST_MONITORING_ADDON_NAME"),
     )
 
-
 # pylint: disable=too-few-public-methods
 class AKSPreviewManagedClusterModels(AKSManagedClusterModels):
     """Store the models used in aks series of commands.
@@ -4691,8 +4690,8 @@ class AKSPreviewManagedClusterCreateDecorator(AKSManagedClusterCreateDecorator):
         mc.addon_profiles[CONST_MONITORING_ADDON_NAME] = addon_profile
 
         # DCR and DCRA creation is deferred to postprocessing_after_mc_created
-        # (_postprocess_monitoring_enable) so that all flags are finalized and
-        # the cluster exists.  Only MSI clusters need a DCR.
+        # so that all flags are finalized and the cluster exists.
+        # Only MSI clusters need a DCR.
         self.context.set_intermediate("monitoring_addon_enabled", True, overwrite_exists=True)
 
     def _setup_opentelemetry_metrics(self, mc: ManagedCluster) -> None:
@@ -5331,7 +5330,46 @@ class AKSPreviewManagedClusterCreateDecorator(AKSManagedClusterCreateDecorator):
         # monitoring addon
         monitoring_addon_enabled = self.context.get_intermediate("monitoring_addon_enabled", default_value=False)
         if monitoring_addon_enabled:
-            self._postprocess_monitoring_enable(cluster)
+            enable_msi_auth_for_monitoring = self.context.get_enable_msi_auth_for_monitoring()
+            if not enable_msi_auth_for_monitoring:
+                # add cluster spn/msi Monitoring Metrics Publisher role assignment to publish metrics to MDM
+                # mdm metrics is supported only in azure public cloud, so add the role assignment only in this cloud
+                cloud_name = self.cmd.cli_ctx.cloud.name
+                if cloud_name.lower() == "azurecloud":
+                    cluster_resource_id = resource_id(
+                        subscription=self.context.get_subscription_id(),
+                        resource_group=self.context.get_resource_group_name(),
+                        namespace="Microsoft.ContainerService",
+                        type="managedClusters",
+                        name=self.context.get_name(),
+                    )
+                    self.context.external_functions.add_monitoring_role_assignment(
+                        cluster, cluster_resource_id, self.cmd
+                    )
+            elif self._should_create_dcra():
+                addon_consts = self.context.get_addon_consts()
+                monitoring_addon_key = (
+                    _get_monitoring_addon_key_from_consts(cluster.addon_profiles, addon_consts)
+                    if cluster.addon_profiles
+                    else addon_consts.get("CONST_MONITORING_ADDON_NAME")
+                )
+                self.context.external_functions.ensure_container_insights_for_monitoring(
+                    self.cmd,
+                    cluster.addon_profiles[monitoring_addon_key],
+                    self.context.get_subscription_id(),
+                    self.context.get_resource_group_name(),
+                    self.context.get_name(),
+                    self.context.get_location(),
+                    remove_monitoring=False,
+                    aad_route=self.context.get_enable_msi_auth_for_monitoring(),
+                    create_dcr=True,
+                    create_dcra=True,
+                    enable_syslog=self.context.get_enable_syslog(),
+                    data_collection_settings=self.context.get_data_collection_settings(),
+                    is_private_cluster=self.context.get_enable_private_cluster(),
+                    ampls_resource_id=self.context.get_ampls_resource_id(),
+                    enable_high_log_scale_mode=self.context.get_enable_high_log_scale_mode(),
+                )
 
         # Handle monitoring addon postprocessing (disable case) - same logic as aks_disable_addons
         monitoring_addon_disable_postprocessing_required = self.context.get_intermediate(
@@ -5339,7 +5377,36 @@ class AKSPreviewManagedClusterCreateDecorator(AKSManagedClusterCreateDecorator):
         )
 
         if monitoring_addon_disable_postprocessing_required:
-            self._postprocess_monitoring_disable()
+            addon_consts = self.context.get_addon_consts()
+            CONST_MONITORING_ADDON_NAME = addon_consts.get("CONST_MONITORING_ADDON_NAME")
+
+            # Get the current cluster state to check config before it was disabled
+            current_cluster = self.client.get(self.context.get_resource_group_name(), self.context.get_name())
+
+            if (current_cluster.addon_profiles and
+                    CONST_MONITORING_ADDON_NAME in current_cluster.addon_profiles):
+
+                addon_profile = current_cluster.addon_profiles[CONST_MONITORING_ADDON_NAME]
+
+                try:
+                    self.context.external_functions.ensure_container_insights_for_monitoring(
+                        self.cmd,
+                        addon_profile,
+                        self.context.get_subscription_id(),
+                        self.context.get_resource_group_name(),
+                        self.context.get_name(),
+                        self.context.get_location(),
+                        remove_monitoring=True,
+                        aad_route=True,
+                        create_dcr=False,
+                        create_dcra=True,
+                        enable_syslog=False,
+                        data_collection_settings=None,
+                        ampls_resource_id=None,
+                        enable_high_log_scale_mode=False
+                    )
+                except TypeError:
+                    pass
 
         # ingress appgw addon
         ingress_appgw_addon_enabled = self.context.get_intermediate("ingress_appgw_addon_enabled", default_value=False)
@@ -5522,91 +5589,14 @@ class AKSPreviewManagedClusterCreateDecorator(AKSManagedClusterCreateDecorator):
         )
 
     def _is_cnl_or_hlsm_changing(self) -> bool:
-        """Return True if any CNL or High Log Scale Mode flag was provided."""
+        """Return True if any CNL or High Log Scale Mode enable flag was provided."""
         params = self.context.raw_param
         return (
             params.get("enable_container_network_logs") is not None or
             params.get("enable_retina_flow_logs") is not None or
-            params.get("disable_container_network_logs") is not None or
-            params.get("disable_retina_flow_logs") is not None or
             params.get("enable_high_log_scale_mode") is not None
         )
 
-    def _postprocess_monitoring_enable(self, cluster: ManagedCluster) -> None:
-        """Handle monitoring addon postprocessing for the enable case."""
-        enable_msi_auth_for_monitoring = self.context.get_enable_msi_auth_for_monitoring()
-        if not enable_msi_auth_for_monitoring:
-            # add cluster spn/msi Monitoring Metrics Publisher role assignment to publish metrics to MDM
-            # mdm metrics is supported only in azure public cloud, so add the role assignment only in this cloud
-            cloud_name = self.cmd.cli_ctx.cloud.name
-            if cloud_name.lower() == "azurecloud":
-                cluster_resource_id = resource_id(
-                    subscription=self.context.get_subscription_id(),
-                    resource_group=self.context.get_resource_group_name(),
-                    namespace="Microsoft.ContainerService",
-                    type="managedClusters",
-                    name=self.context.get_name(),
-                )
-                self.context.external_functions.add_monitoring_role_assignment(
-                    cluster, cluster_resource_id, self.cmd
-                )
-        elif self._should_create_dcra():
-            addon_consts = self.context.get_addon_consts()
-            monitoring_addon_key = (
-                _get_monitoring_addon_key_from_consts(cluster.addon_profiles, addon_consts)
-                if cluster.addon_profiles
-                else addon_consts.get("CONST_MONITORING_ADDON_NAME")
-            )
-            self.context.external_functions.ensure_container_insights_for_monitoring(
-                self.cmd,
-                cluster.addon_profiles[monitoring_addon_key],
-                self.context.get_subscription_id(),
-                self.context.get_resource_group_name(),
-                self.context.get_name(),
-                self.context.get_location(),
-                remove_monitoring=False,
-                aad_route=self.context.get_enable_msi_auth_for_monitoring(),
-                create_dcr=True,
-                create_dcra=True,
-                enable_syslog=self.context.get_enable_syslog(),
-                data_collection_settings=self.context.get_data_collection_settings(),
-                is_private_cluster=self.context.get_enable_private_cluster(),
-                ampls_resource_id=self.context.get_ampls_resource_id(),
-                enable_high_log_scale_mode=self.context.get_enable_high_log_scale_mode(),
-            )
-
-    def _postprocess_monitoring_disable(self) -> None:
-        """Handle monitoring addon postprocessing for the disable case."""
-        addon_consts = self.context.get_addon_consts()
-        CONST_MONITORING_ADDON_NAME = addon_consts.get("CONST_MONITORING_ADDON_NAME")
-
-        # Get the current cluster state to check config before it was disabled
-        current_cluster = self.client.get(self.context.get_resource_group_name(), self.context.get_name())
-
-        if (current_cluster.addon_profiles and
-                CONST_MONITORING_ADDON_NAME in current_cluster.addon_profiles):
-
-            addon_profile = current_cluster.addon_profiles[CONST_MONITORING_ADDON_NAME]
-
-            try:
-                self.context.external_functions.ensure_container_insights_for_monitoring(
-                    self.cmd,
-                    addon_profile,
-                    self.context.get_subscription_id(),
-                    self.context.get_resource_group_name(),
-                    self.context.get_name(),
-                    self.context.get_location(),
-                    remove_monitoring=True,
-                    aad_route=True,
-                    create_dcr=False,
-                    create_dcra=True,
-                    enable_syslog=False,
-                    data_collection_settings=None,
-                    ampls_resource_id=None,
-                    enable_high_log_scale_mode=False
-                )
-            except TypeError:
-                pass
 
 
 class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):

--- a/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
@@ -3039,6 +3039,27 @@ class AKSPreviewManagedClusterContext(AKSManagedClusterContext):
             # Auto-enable high log scale mode
             return True
 
+        # If user explicitly disables HLSM, check if CNL is already enabled on the cluster
+        if enable_high_log_scale_mode is False:
+            cnl_already_enabled = False
+            if self.mc and self.mc.addon_profiles:
+                addon_consts = self.get_addon_consts()
+                CONST_MONITORING_ADDON_NAME = addon_consts.get("CONST_MONITORING_ADDON_NAME")
+                monitoring_profile = (
+                    self.mc.addon_profiles.get(CONST_MONITORING_ADDON_NAME) or
+                    self.mc.addon_profiles.get(CONST_MONITORING_ADDON_NAME_CAMELCASE)
+                )
+                if monitoring_profile and monitoring_profile.config:
+                    cnl_already_enabled = str(
+                        monitoring_profile.config.get("enableRetinaNetworkFlags", "")
+                    ).lower() == "true"
+            if cnl_already_enabled:
+                raise MutuallyExclusiveArgumentError(
+                    "Cannot explicitly disable --enable-high-log-scale-mode while "
+                    "container network logs are enabled on the cluster. "
+                    "Please disable container network logs first with --disable-container-network-logs."
+                )
+
         # If container network logs are not being enabled, return the original value
         # Return False if not explicitly set to maintain backward compatibility with base class
         if enable_high_log_scale_mode is None:
@@ -5682,6 +5703,7 @@ class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):
             (self.context.get_nat_gateway_managed_outbound_ipv6_count(), None),
             (self.context.get_nat_gateway_outbound_ip_ids(), None),
             (self.context.get_nat_gateway_outbound_ip_prefix_ids(), None),
+            (self.context.raw_param.get("enable_high_log_scale_mode"), None),
         ]
 
     def check_raw_parameters(self):
@@ -5922,6 +5944,28 @@ class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):
                     "for the monitoring addon. Please enable it with --enable-msi-auth-for-monitoring."
                 )
 
+            self.context.set_intermediate("monitoring_addon_postprocessing_required", True, overwrite_exists=True)
+
+        elif enable_high_log_scale_mode is False:
+            # Check if CNL is already enabled on the cluster — cannot disable HLSM while CNL is on
+            cnl_already_enabled = False
+            if mc.addon_profiles:
+                addon_consts = self.context.get_addon_consts()
+                CONST_MONITORING_ADDON_NAME = addon_consts.get("CONST_MONITORING_ADDON_NAME")
+                monitoring_profile = (
+                    mc.addon_profiles.get(CONST_MONITORING_ADDON_NAME) or
+                    mc.addon_profiles.get(CONST_MONITORING_ADDON_NAME_CAMELCASE)
+                )
+                if monitoring_profile and monitoring_profile.config:
+                    cnl_already_enabled = str(
+                        monitoring_profile.config.get("enableRetinaNetworkFlags", "")
+                    ).lower() == "true"
+            if cnl_already_enabled:
+                raise MutuallyExclusiveArgumentError(
+                    "Cannot explicitly disable --enable-high-log-scale-mode while "
+                    "container network logs are enabled on the cluster. "
+                    "Please disable container network logs first with --disable-container-network-logs."
+                )
             self.context.set_intermediate("monitoring_addon_postprocessing_required", True, overwrite_exists=True)
 
         return mc

--- a/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
@@ -450,11 +450,11 @@ class AKSPreviewManagedClusterContext(AKSManagedClusterContext):
                     self.mc.addon_profiles.get(CONST_MONITORING_ADDON_NAME) or
                     self.mc.addon_profiles.get(CONST_MONITORING_ADDON_NAME_CAMELCASE)
                 )
-                if (monitoring_profile and monitoring_profile.config and
-                    str(monitoring_profile.config.get(CONST_MONITORING_USING_AAD_MSI_AUTH, "")).lower() == "true"):
-                    result = True
-                else:
-                    result = False
+                result = bool(
+                    monitoring_profile and monitoring_profile.config and
+                    str(monitoring_profile.config.get(
+                        CONST_MONITORING_USING_AAD_MSI_AUTH, "")).lower() == "true"
+                )
             else:
                 result = False
         elif enable_msi_auth_for_monitoring is None and not disable_msi_auth and not enable_msi_auth:

--- a/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
@@ -7,8 +7,6 @@
 import copy
 import datetime
 import os
-import random
-import time
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Tuple, TypeVar, Union
 
@@ -68,6 +66,7 @@ from azext_aks_preview._helpers import (
     check_is_azure_cli_core_editable_installed,
     check_is_private_cluster,
     get_cluster_snapshot_by_snapshot_id,
+    get_monitoring_addon_key,
     filter_hard_taints,
 )
 from azext_aks_preview._loadbalancer import create_load_balancer_profile
@@ -102,7 +101,6 @@ from azext_aks_preview.azuremonitormetrics.azuremonitorprofile import (
 from azext_aks_preview.custom import (
     ensure_container_insights_for_monitoring_preview,
 )
-from azure.core.exceptions import HttpResponseError, ResourceExistsError
 from azure.cli.command_modules.acs._client_factory import get_graph_client
 from azure.cli.command_modules.acs._consts import (
     CONST_OUTBOUND_TYPE_LOAD_BALANCER,
@@ -186,19 +184,12 @@ ServiceMeshProfile = TypeVar("ServiceMeshProfile")
 ResourceReference = TypeVar("ResourceReference")
 
 
-def _get_monitoring_addon_key(cluster, addon_consts):
-    """Resolve the monitoring addon key from the cluster's addon_profiles.
-
-    The API response may return the addon key as either "omsagent" or "omsAgent".
-    Returns the key present in addon_profiles, or the default constant if neither is found.
-    """
-    const_monitoring = addon_consts.get("CONST_MONITORING_ADDON_NAME")
-    if cluster.addon_profiles:
-        if const_monitoring in cluster.addon_profiles:
-            return const_monitoring
-        if CONST_MONITORING_ADDON_NAME_CAMELCASE in cluster.addon_profiles:
-            return CONST_MONITORING_ADDON_NAME_CAMELCASE
-    return const_monitoring
+def _get_monitoring_addon_key_from_consts(addon_profiles, addon_consts):
+    """Thin wrapper around get_monitoring_addon_key that unpacks addon_consts dict."""
+    return get_monitoring_addon_key(
+        addon_profiles,
+        addon_consts.get("CONST_MONITORING_ADDON_NAME"),
+    )
 
 
 # pylint: disable=too-few-public-methods
@@ -461,13 +452,11 @@ class AKSPreviewManagedClusterContext(AKSManagedClusterContext):
             # but MSI-based clusters set client_id to "msi". Check if the monitoring addon
             # already has useAADAuth=true, which indicates MSI auth is actually in use.
             addon_consts = self.get_addon_consts()
-            CONST_MONITORING_ADDON_NAME = addon_consts.get("CONST_MONITORING_ADDON_NAME")
             CONST_MONITORING_USING_AAD_MSI_AUTH = addon_consts.get("CONST_MONITORING_USING_AAD_MSI_AUTH")
             if self.mc and self.mc.addon_profiles:
-                monitoring_profile = (
-                    self.mc.addon_profiles.get(CONST_MONITORING_ADDON_NAME) or
-                    self.mc.addon_profiles.get(CONST_MONITORING_ADDON_NAME_CAMELCASE)
-                )
+                monitoring_addon_key = _get_monitoring_addon_key_from_consts(
+                    self.mc.addon_profiles, addon_consts)
+                monitoring_profile = self.mc.addon_profiles.get(monitoring_addon_key)
                 result = bool(
                     monitoring_profile and monitoring_profile.config and
                     str(monitoring_profile.config.get(
@@ -1084,15 +1073,13 @@ class AKSPreviewManagedClusterContext(AKSManagedClusterContext):
                 "monitoring" in enable_addons or
                 bool(self.raw_param.get("enable_azure_monitor_logs"))
             )
-            monitoring_already_enabled = (
-                mc.addon_profiles and
-                (
-                    (mc.addon_profiles.get("omsagent") and
-                     mc.addon_profiles["omsagent"].enabled) or
-                    (mc.addon_profiles.get(CONST_MONITORING_ADDON_NAME_CAMELCASE) and
-                     mc.addon_profiles[CONST_MONITORING_ADDON_NAME_CAMELCASE].enabled)
+            monitoring_already_enabled = False
+            if mc.addon_profiles:
+                addon_consts = self.get_addon_consts()
+                mk = _get_monitoring_addon_key_from_consts(mc.addon_profiles, addon_consts)
+                monitoring_already_enabled = bool(
+                    mc.addon_profiles.get(mk) and mc.addon_profiles[mk].enabled
                 )
-            )
             monitoring_enabled = monitoring_being_enabled or monitoring_already_enabled
             if not acns_enabled or not monitoring_enabled:
                 raise InvalidArgumentValueError(
@@ -2890,15 +2877,13 @@ class AKSPreviewManagedClusterContext(AKSManagedClusterContext):
                     self.mc.azure_monitor_profile.container_insights.enabled
                 )
 
-                # Check legacy addon location (try both lowercase and camelCase)
+                # Check legacy addon location
                 monitoring_addon_enabled = False
                 if self.mc.addon_profiles:
-                    # Try lowercase first (constant value)
-                    if CONST_MONITORING_ADDON_NAME in self.mc.addon_profiles:
-                        monitoring_addon_enabled = self.mc.addon_profiles[CONST_MONITORING_ADDON_NAME].enabled
-                    # Try camelCase variant (what Azure actually returns)
-                    elif CONST_MONITORING_ADDON_NAME_CAMELCASE in self.mc.addon_profiles:
-                        monitoring_addon_enabled = self.mc.addon_profiles[CONST_MONITORING_ADDON_NAME_CAMELCASE].enabled
+                    addon_consts = self.get_addon_consts()
+                    mk = _get_monitoring_addon_key_from_consts(self.mc.addon_profiles, addon_consts)
+                    if mk in self.mc.addon_profiles:
+                        monitoring_addon_enabled = self.mc.addon_profiles[mk].enabled
 
                 monitoring_addon_currently_enabled = container_insights_enabled or monitoring_addon_enabled
 
@@ -3047,10 +3032,9 @@ class AKSPreviewManagedClusterContext(AKSManagedClusterContext):
             # Check if monitoring addon is already enabled in the cluster
             monitoring_addon_enabled = False
             if self.mc and self.mc.addon_profiles:
-                if CONST_MONITORING_ADDON_NAME in self.mc.addon_profiles:
-                    monitoring_addon_enabled = self.mc.addon_profiles[CONST_MONITORING_ADDON_NAME].enabled
-                elif CONST_MONITORING_ADDON_NAME_CAMELCASE in self.mc.addon_profiles:
-                    monitoring_addon_enabled = self.mc.addon_profiles[CONST_MONITORING_ADDON_NAME_CAMELCASE].enabled
+                mk = _get_monitoring_addon_key_from_consts(self.mc.addon_profiles, addon_consts)
+                if mk in self.mc.addon_profiles:
+                    monitoring_addon_enabled = self.mc.addon_profiles[mk].enabled
 
             if not monitoring_being_enabled and not enable_azure_monitor_logs and not monitoring_addon_enabled:
                 raise RequiredArgumentMissingError(
@@ -3066,11 +3050,8 @@ class AKSPreviewManagedClusterContext(AKSManagedClusterContext):
             cnl_already_enabled = False
             if self.mc and self.mc.addon_profiles:
                 addon_consts = self.get_addon_consts()
-                CONST_MONITORING_ADDON_NAME = addon_consts.get("CONST_MONITORING_ADDON_NAME")
-                monitoring_profile = (
-                    self.mc.addon_profiles.get(CONST_MONITORING_ADDON_NAME) or
-                    self.mc.addon_profiles.get(CONST_MONITORING_ADDON_NAME_CAMELCASE)
-                )
+                mk = _get_monitoring_addon_key_from_consts(self.mc.addon_profiles, addon_consts)
+                monitoring_profile = self.mc.addon_profiles.get(mk)
                 if monitoring_profile and monitoring_profile.config:
                     cnl_already_enabled = str(
                         monitoring_profile.config.get("enableRetinaNetworkFlags", "")
@@ -3083,9 +3064,6 @@ class AKSPreviewManagedClusterContext(AKSManagedClusterContext):
                 )
 
         # If container network logs are not being enabled, return the original value
-        # Return False if not explicitly set to maintain backward compatibility with base class
-        if enable_high_log_scale_mode is None:
-            return False
         return enable_high_log_scale_mode
 
     def _get_enable_vpa(self, enable_validation: bool = False) -> bool:
@@ -4685,26 +4663,11 @@ class AKSPreviewManagedClusterCreateDecorator(AKSManagedClusterCreateDecorator):
         if not workspace_resource_id:
             ensure_workspace_func = (
                 self.context.external_functions.ensure_default_log_analytics_workspace_for_monitoring)
-            # Retry with exponential backoff + jitter to handle 409 Conflict when
-            # workspace is still provisioning (common when parallel commands target
-            # the same default workspace).  Delays: ~5 s, ~10 s, ~20 s (worst-case
-            # total ~52 s; fast path ~7 s if the first retry succeeds).
-            max_attempts = 4
-            for attempt in range(max_attempts):
-                try:
-                    workspace_resource_id = ensure_workspace_func(
-                        self.cmd,
-                        self.context.get_subscription_id(),
-                        self.context.get_resource_group_name()
-                    )
-                    break
-                except (HttpResponseError, ResourceExistsError):
-                    if attempt < max_attempts - 1:
-                        base_delay = 5 * (2 ** attempt)  # 5 s, 10 s, 20 s
-                        jitter = random.uniform(0, base_delay * 0.5)
-                        time.sleep(base_delay + jitter)
-                    else:
-                        raise
+            workspace_resource_id = ensure_workspace_func(
+                self.cmd,
+                self.context.get_subscription_id(),
+                self.context.get_resource_group_name()
+            )
 
         # Sanitize and configure
         sanitize_func = self.context.external_functions.sanitize_loganalytics_ws_resource_id
@@ -5591,7 +5554,8 @@ class AKSPreviewManagedClusterCreateDecorator(AKSManagedClusterCreateDecorator):
                 )
         elif self._should_create_dcra():
             addon_consts = self.context.get_addon_consts()
-            monitoring_addon_key = _get_monitoring_addon_key(cluster, addon_consts)
+            monitoring_addon_key = _get_monitoring_addon_key_from_consts(
+                cluster.addon_profiles, addon_consts) if cluster.addon_profiles else addon_consts.get("CONST_MONITORING_ADDON_NAME")
             self.context.external_functions.ensure_container_insights_for_monitoring(
                 self.cmd,
                 cluster.addon_profiles[monitoring_addon_key],
@@ -5931,7 +5895,7 @@ class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):
         if container_network_logs_enabled is not None:
             if mc.addon_profiles:
                 addon_consts = self.context.get_addon_consts()
-                monitoring_addon_key = _get_monitoring_addon_key(mc, addon_consts)
+                monitoring_addon_key = _get_monitoring_addon_key_from_consts(mc.addon_profiles, addon_consts)
                 monitoring_addon_profile = mc.addon_profiles.get(monitoring_addon_key)
                 if monitoring_addon_profile:
                     config = monitoring_addon_profile.config or {}
@@ -5959,16 +5923,13 @@ class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):
             if not monitoring_being_enabled:
                 # Only validate existing addon state when not enabling monitoring simultaneously
                 addon_consts = self.context.get_addon_consts()
-                CONST_MONITORING_ADDON_NAME = addon_consts.get("CONST_MONITORING_ADDON_NAME")
                 CONST_MONITORING_USING_AAD_MSI_AUTH = addon_consts.get("CONST_MONITORING_USING_AAD_MSI_AUTH")
 
-                # Resolve the addon profile, handling both "omsagent" and "omsAgent" key variants.
+                # Resolve the addon profile, normalizing non-standard key casing.
                 monitoring_addon_profile = None
                 if mc.addon_profiles:
-                    monitoring_addon_profile = (
-                        mc.addon_profiles.get(CONST_MONITORING_ADDON_NAME) or
-                        mc.addon_profiles.get(CONST_MONITORING_ADDON_NAME_CAMELCASE)
-                    )
+                    mk = _get_monitoring_addon_key_from_consts(mc.addon_profiles, addon_consts)
+                    monitoring_addon_profile = mc.addon_profiles.get(mk)
 
                 if not monitoring_addon_profile or not monitoring_addon_profile.enabled:
                     raise RequiredArgumentMissingError(
@@ -5995,11 +5956,8 @@ class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):
             cnl_already_enabled = False
             if mc.addon_profiles:
                 addon_consts = self.context.get_addon_consts()
-                CONST_MONITORING_ADDON_NAME = addon_consts.get("CONST_MONITORING_ADDON_NAME")
-                monitoring_profile = (
-                    mc.addon_profiles.get(CONST_MONITORING_ADDON_NAME) or
-                    mc.addon_profiles.get(CONST_MONITORING_ADDON_NAME_CAMELCASE)
-                )
+                mk = _get_monitoring_addon_key_from_consts(mc.addon_profiles, addon_consts)
+                monitoring_profile = mc.addon_profiles.get(mk)
                 if monitoring_profile and monitoring_profile.config:
                     cnl_already_enabled = str(
                         monitoring_profile.config.get("enableRetinaNetworkFlags", "")
@@ -7894,26 +7852,11 @@ class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):
         if not workspace_resource_id:
             ensure_workspace_func = (
                 self.context.external_functions.ensure_default_log_analytics_workspace_for_monitoring)
-            # Retry with exponential backoff + jitter to handle 409 Conflict when
-            # workspace is still provisioning (common when parallel commands target
-            # the same default workspace).  Delays: ~5 s, ~10 s, ~20 s (worst-case
-            # total ~52 s; fast path ~7 s if the first retry succeeds).
-            max_attempts = 4
-            for attempt in range(max_attempts):
-                try:
-                    workspace_resource_id = ensure_workspace_func(
-                        self.cmd,
-                        self.context.get_subscription_id(),
-                        self.context.get_resource_group_name()
-                    )
-                    break
-                except (HttpResponseError, ResourceExistsError):
-                    if attempt < max_attempts - 1:
-                        base_delay = 5 * (2 ** attempt)  # 5 s, 10 s, 20 s
-                        jitter = random.uniform(0, base_delay * 0.5)
-                        time.sleep(base_delay + jitter)
-                    else:
-                        raise
+            workspace_resource_id = ensure_workspace_func(
+                self.cmd,
+                self.context.get_subscription_id(),
+                self.context.get_resource_group_name()
+            )
 
         # Sanitize and configure
         sanitize_func = self.context.external_functions.sanitize_loganalytics_ws_resource_id
@@ -7964,16 +7907,14 @@ class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):
     def _disable_azure_monitor_logs(self, mc: ManagedCluster) -> None:
         """Disable Azure Monitor logs configuration."""
         addon_consts = self.context.get_addon_consts()
-        CONST_MONITORING_ADDON_NAME = addon_consts.get("CONST_MONITORING_ADDON_NAME")
         CONST_MONITORING_USING_AAD_MSI_AUTH = addon_consts.get("CONST_MONITORING_USING_AAD_MSI_AUTH")
 
-        # Check if the addon profile exists (check both lowercase and camelCase)
+        # Normalize the addon key (handles any casing variant)
         addon_key = None
         if mc.addon_profiles:
-            if CONST_MONITORING_ADDON_NAME in mc.addon_profiles:
-                addon_key = CONST_MONITORING_ADDON_NAME
-            elif CONST_MONITORING_ADDON_NAME_CAMELCASE in mc.addon_profiles:
-                addon_key = CONST_MONITORING_ADDON_NAME_CAMELCASE
+            addon_key = _get_monitoring_addon_key_from_consts(mc.addon_profiles, addon_consts)
+            if addon_key not in mc.addon_profiles:
+                addon_key = None
 
         # If the addon profile doesn't exist at all, there's nothing to disable
         if not addon_key:
@@ -8009,15 +7950,12 @@ class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):
             # Fetch the current cluster state from Azure (same as aks_disable_addons line 2791)
             current_cluster = self.client.get(self.context.get_resource_group_name(), self.context.get_name())
 
-            # Find the addon key in current_cluster (it may have different casing)
-            current_addon_key = None
-            if current_cluster.addon_profiles:
-                if CONST_MONITORING_ADDON_NAME in current_cluster.addon_profiles:
-                    current_addon_key = CONST_MONITORING_ADDON_NAME
-                elif CONST_MONITORING_ADDON_NAME_CAMELCASE in current_cluster.addon_profiles:
-                    current_addon_key = CONST_MONITORING_ADDON_NAME_CAMELCASE
+            # Find the addon key in current_cluster (normalize casing)
+            current_addon_key = _get_monitoring_addon_key_from_consts(
+                current_cluster.addon_profiles, addon_consts) if current_cluster.addon_profiles else None
+            has_addon = current_addon_key and current_addon_key in (current_cluster.addon_profiles or {})
 
-            if current_addon_key:
+            if has_addon:
                 try:
                     # Use the current cluster's addon profile for cleanup (not the modified mc object)
                     self.context.external_functions.ensure_container_insights_for_monitoring(
@@ -8263,7 +8201,8 @@ class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):
             addon_consts = self.context.get_addon_consts()
             CONST_MONITORING_USING_AAD_MSI_AUTH = addon_consts.get("CONST_MONITORING_USING_AAD_MSI_AUTH")
 
-            monitoring_addon_key = _get_monitoring_addon_key(cluster, addon_consts)
+            monitoring_addon_key = _get_monitoring_addon_key_from_consts(
+                cluster.addon_profiles, addon_consts) if cluster.addon_profiles else addon_consts.get("CONST_MONITORING_ADDON_NAME")
 
             if (cluster.addon_profiles and
                     monitoring_addon_key in cluster.addon_profiles and

--- a/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
@@ -1083,8 +1083,12 @@ class AKSPreviewManagedClusterContext(AKSManagedClusterContext):
             )
             monitoring_already_enabled = (
                 mc.addon_profiles and
-                mc.addon_profiles.get("omsagent") and
-                mc.addon_profiles["omsagent"].enabled
+                (
+                    (mc.addon_profiles.get("omsagent") and
+                     mc.addon_profiles["omsagent"].enabled) or
+                    (mc.addon_profiles.get(CONST_MONITORING_ADDON_NAME_CAMELCASE) and
+                     mc.addon_profiles[CONST_MONITORING_ADDON_NAME_CAMELCASE].enabled)
+                )
             )
             monitoring_enabled = monitoring_being_enabled or monitoring_already_enabled
             if not acns_enabled or not monitoring_enabled:
@@ -4707,16 +4711,27 @@ class AKSPreviewManagedClusterCreateDecorator(AKSManagedClusterCreateDecorator):
         }
         mc.addon_profiles[CONST_MONITORING_ADDON_NAME] = addon_profile
 
+        # Create DCR before the cluster is created (matching base class build_monitoring_addon_profile pattern).
+        # The DCRA will be created later in postprocessing_after_mc_created.
+        self.context.external_functions.ensure_container_insights_for_monitoring(
+            self.cmd,
+            addon_profile,
+            self.context.get_subscription_id(),
+            self.context.get_resource_group_name(),
+            self.context.get_name(),
+            self.context.get_location(),
+            remove_monitoring=False,
+            aad_route=self.context.get_enable_msi_auth_for_monitoring(),
+            create_dcr=True,
+            create_dcra=False,
+            enable_syslog=self.context.get_enable_syslog(),
+            data_collection_settings=self.context.get_data_collection_settings(),
+            is_private_cluster=self.context.get_enable_private_cluster(),
+            ampls_resource_id=self.context.get_ampls_resource_id(),
+            enable_high_log_scale_mode=self.context.get_enable_high_log_scale_mode(),
+        )
+
         self.context.set_intermediate("monitoring_addon_enabled", True, overwrite_exists=True)
-
-        # Call ensure_container_insights_for_monitoring with all parameters (similar to postprocessing)
-        CONST_MONITORING_ADDON_NAME = addon_consts.get("CONST_MONITORING_ADDON_NAME")
-        if (mc.addon_profiles and
-                CONST_MONITORING_ADDON_NAME in mc.addon_profiles and
-                mc.addon_profiles[CONST_MONITORING_ADDON_NAME].enabled):
-
-            # Set intermediate value to trigger postprocessing
-            self.context.set_intermediate("monitoring_addon_postprocessing_required", True, overwrite_exists=True)
 
     def _setup_opentelemetry_metrics(self, mc: ManagedCluster) -> None:
         """Set up OpenTelemetry metrics configuration."""
@@ -7915,13 +7930,6 @@ class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):
 
         mc.addon_profiles[existing_key] = addon_profile
         self.context.set_intermediate("monitoring_addon_enabled", True, overwrite_exists=True)
-        # Call ensure_container_insights_for_monitoring with all parameters (similar to postprocessing)
-        if (mc.addon_profiles and
-                existing_key in mc.addon_profiles and
-                mc.addon_profiles[existing_key].enabled):
-
-            # Set intermediate value to trigger postprocessing
-            self.context.set_intermediate("monitoring_addon_postprocessing_required", True, overwrite_exists=True)
 
     def _disable_azure_monitor_logs(self, mc: ManagedCluster) -> None:
         """Disable Azure Monitor logs configuration."""
@@ -8005,8 +8013,9 @@ class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):
         # Now disable the addon and clear configuration
         mc.addon_profiles[addon_key].enabled = False
 
-        # Clear the config to remove old workspace resource ID and other settings
-        mc.addon_profiles[addon_key].config = None
+        # Use empty dict instead of None - setting config=None causes the SDK serializer
+        # to omit the config key entirely, which Azure interprets as "keep existing config"
+        mc.addon_profiles[addon_key].config = {}
 
         # Also disable OpenTelemetry logs when disabling Azure Monitor logs
         if opentelemetry_logs_enabled:

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -19322,6 +19322,445 @@ spec:
             checks=[self.is_empty()],
         )
 
+    @live_only()
+    @AllowLargeResponse()
+    @AKSCustomResourceGroupPreparer(
+        random_name_length=17,
+        name_prefix="clitest",
+        location="eastus2euap",
+    )
+    def test_aks_create_with_azuremonitorlogs_and_cnl(
+        self, resource_group, resource_group_location
+    ):
+        """Test that --enable-azure-monitor-logs with --enable-container-network-logs creates DCR/DCRA correctly.
+
+        This covers the scenario where monitoring is enabled via --enable-azure-monitor-logs (not --enable-addons monitoring)
+        combined with --enable-container-network-logs. The DCRA postprocessing must detect enable_azure_monitor_logs
+        to trigger ensure_container_insights_for_monitoring and create the DCR with ContainerNetworkLogs stream.
+        """
+        self.test_resources_count = 0
+        aks_name = self.create_random_name("cliakstest", 16)
+        self.kwargs.update(
+            {
+                "resource_group": resource_group,
+                "name": aks_name,
+                "ssh_key_value": self.generate_ssh_keys(),
+                "location": resource_group_location,
+            }
+        )
+
+        create_cmd = (
+            "aks create --resource-group={resource_group} --name={name} --location={location} "
+            "--ssh-key-value={ssh_key_value} --node-count=1 --tier standard "
+            "--network-plugin azure --network-dataplane=cilium --network-plugin-mode overlay "
+            "--enable-acns --enable-container-network-logs "
+            "--enable-azure-monitor-logs --enable-high-log-scale-mode "
+            "--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/AdvancedNetworkingFlowLogsPreview "
+        )
+
+        response = self.cmd(
+            create_cmd,
+            checks=[
+                self.check("provisioningState", "Succeeded"),
+                self.check("addonProfiles.omsagent.enabled", True),
+                self.check("addonProfiles.omsagent.config.useAADAuth", "true"),
+                self.check("addonProfiles.omsagent.config.enableRetinaNetworkFlags", "True"),
+            ],
+        ).get_output_in_json()
+
+        cluster_resource_id = response["id"]
+        subscription = cluster_resource_id.split("/")[2]
+
+        # Verify DCR was created with ContainerNetworkLogs stream
+        location = resource_group_location
+        dataCollectionRuleName = f"MSCI-{location}-{aks_name}"
+        dataCollectionRuleName = dataCollectionRuleName[0:64]
+        dcr_resource_id = f"/subscriptions/{subscription}/resourceGroups/{resource_group}/providers/Microsoft.Insights/dataCollectionRules/{dataCollectionRuleName}"
+
+        get_cmd = f'rest --method get --url https://management.azure.com{dcr_resource_id}?api-version=2022-06-01'
+        self.cmd(get_cmd, checks=[
+            self.check('properties.dataFlows[0].streams[-1]', 'Microsoft-ContainerNetworkLogs'),
+        ])
+
+        # Verify DCRA was created
+        dcra_resource_id = f"{cluster_resource_id}/providers/Microsoft.Insights/dataCollectionRuleAssociations/ContainerInsightsExtension"
+        get_cmd = f'rest --method get --url https://management.azure.com{dcra_resource_id}?api-version=2022-06-01'
+        self.cmd(get_cmd, checks=[
+            self.check('properties.dataCollectionRuleId', f'{dcr_resource_id}')
+        ])
+
+        # delete
+        self.cmd(
+            "aks delete -g {resource_group} -n {name} --yes --no-wait",
+            checks=[self.is_empty()],
+        )
+
+    @live_only()
+    @AllowLargeResponse()
+    @AKSCustomResourceGroupPreparer(
+        random_name_length=17,
+        name_prefix="clitest",
+        location="westus2",
+    )
+    def test_aks_update_enable_azuremonitorlogs_with_hlsm(
+        self, resource_group, resource_group_location
+    ):
+        """Test that --enable-azure-monitor-logs with --enable-high-log-scale-mode on update creates DCR with HighScale stream.
+
+        Creates a plain cluster, then updates it with --enable-azure-monitor-logs --enable-high-log-scale-mode,
+        and verifies that the DCR is created with the Microsoft-ContainerLogV2-HighScale stream.
+        """
+        self.test_resources_count = 0
+        aks_name = self.create_random_name("cliakstest", 16)
+        node_vm_size = "standard_d2s_v3"
+        self.kwargs.update(
+            {
+                "resource_group": resource_group,
+                "name": aks_name,
+                "location": resource_group_location,
+                "ssh_key_value": self.generate_ssh_keys(),
+                "node_vm_size": node_vm_size,
+            }
+        )
+
+        # Create a plain cluster without monitoring
+        create_cmd = (
+            "aks create --resource-group={resource_group} --name={name} --location={location} "
+            "--ssh-key-value={ssh_key_value} --node-vm-size={node_vm_size} "
+            "--enable-managed-identity --output=json"
+        )
+        self.cmd(create_cmd, checks=[
+            self.check("provisioningState", "Succeeded"),
+        ])
+
+        # Update: enable monitoring with high log scale mode
+        update_cmd = (
+            "aks update --resource-group={resource_group} --name={name} --yes "
+            "--enable-azure-monitor-logs --enable-high-log-scale-mode --output=json"
+        )
+        self.cmd(update_cmd, checks=[
+            self.check("provisioningState", "Succeeded"),
+            self.check("addonProfiles.omsagent.enabled", True),
+            self.check("addonProfiles.omsagent.config.useAADAuth", "true"),
+        ])
+
+        # Verify aks show reflects the update
+        show_cmd = "aks show --resource-group={resource_group} --name={name} --output=json"
+        response = self.cmd(show_cmd, checks=[
+            self.check("provisioningState", "Succeeded"),
+            self.check("addonProfiles.omsagent.enabled", True),
+        ]).get_output_in_json()
+
+        cluster_resource_id = response["id"]
+        subscription = cluster_resource_id.split("/")[2]
+
+        # Verify DCR was created with HighScale stream
+        location = resource_group_location
+        dataCollectionRuleName = f"MSCI-{location}-{aks_name}"
+        dataCollectionRuleName = dataCollectionRuleName[0:64]
+        dcr_resource_id = f"/subscriptions/{subscription}/resourceGroups/{resource_group}/providers/Microsoft.Insights/dataCollectionRules/{dataCollectionRuleName}"
+
+        get_cmd = f'rest --method get --url https://management.azure.com{dcr_resource_id}?api-version=2022-06-01'
+        self.cmd(get_cmd, checks=[
+            self.check('properties.dataFlows[0].streams[1]', 'Microsoft-ContainerLogV2-HighScale'),
+        ])
+
+        # delete
+        self.cmd(
+            "aks delete -g {resource_group} -n {name} --yes --no-wait",
+            checks=[self.is_empty()],
+        )
+
+    @live_only()
+    @AllowLargeResponse()
+    @AKSCustomResourceGroupPreparer(
+        random_name_length=17,
+        name_prefix="clitest",
+        location="eastus2euap",
+    )
+    def test_aks_create_with_retina_flow_logs_alias(
+        self, resource_group, resource_group_location
+    ):
+        """Test that --enable-retina-flow-logs works as an alias for --enable-container-network-logs.
+
+        This verifies the alias parameter path: enable_retina_flow_logs is treated identically to
+        enable_container_network_logs in get_container_network_logs() and _is_cnl_or_hlsm_changing().
+        """
+        self.test_resources_count = 0
+        aks_name = self.create_random_name("cliakstest", 16)
+        self.kwargs.update(
+            {
+                "resource_group": resource_group,
+                "name": aks_name,
+                "ssh_key_value": self.generate_ssh_keys(),
+                "location": resource_group_location,
+            }
+        )
+
+        create_cmd = (
+            "aks create --resource-group={resource_group} --name={name} --location={location} "
+            "--ssh-key-value={ssh_key_value} --node-count=1 --tier standard "
+            "--network-plugin azure --network-dataplane=cilium --network-plugin-mode overlay "
+            "--enable-acns --enable-retina-flow-logs "
+            "--enable-addons monitoring --enable-high-log-scale-mode "
+            "--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/AdvancedNetworkingFlowLogsPreview "
+        )
+
+        response = self.cmd(
+            create_cmd,
+            checks=[
+                self.check("provisioningState", "Succeeded"),
+                self.check("addonProfiles.omsagent.enabled", True),
+                self.check("addonProfiles.omsagent.config.enableRetinaNetworkFlags", "True"),
+            ],
+        ).get_output_in_json()
+
+        cluster_resource_id = response["id"]
+        subscription = cluster_resource_id.split("/")[2]
+
+        # Verify DCR was created with ContainerNetworkLogs stream
+        location = resource_group_location
+        dataCollectionRuleName = f"MSCI-{location}-{aks_name}"
+        dataCollectionRuleName = dataCollectionRuleName[0:64]
+        dcr_resource_id = f"/subscriptions/{subscription}/resourceGroups/{resource_group}/providers/Microsoft.Insights/dataCollectionRules/{dataCollectionRuleName}"
+
+        get_cmd = f'rest --method get --url https://management.azure.com{dcr_resource_id}?api-version=2022-06-01'
+        self.cmd(get_cmd, checks=[
+            self.check('properties.dataFlows[0].streams[-1]', 'Microsoft-ContainerNetworkLogs'),
+        ])
+
+        # Disable via the alias — run twice like test_aks_create_acns_with_flow_logs
+        # (first run applies the change, second run verifies the result)
+        disable_cmd = "aks update --resource-group={resource_group} --name={name} --disable-retina-flow-logs -o json"
+        self.cmd(disable_cmd, checks=[self.check("provisioningState", "Succeeded")])
+        self.cmd(
+            disable_cmd,
+            checks=[
+                self.check("provisioningState", "Succeeded"),
+                self.check("addonProfiles.omsagent.config.enableRetinaNetworkFlags", "False"),
+            ],
+        )
+
+        # delete
+        self.cmd(
+            "aks delete -g {resource_group} -n {name} --yes --no-wait",
+            checks=[self.is_empty()],
+        )
+
+    @live_only()
+    @AllowLargeResponse()
+    @AKSCustomResourceGroupPreparer(
+        random_name_length=17,
+        name_prefix="clitest",
+        location="eastus2euap",
+    )
+    def test_aks_update_enable_cnl_via_azuremonitorlogs(
+        self, resource_group, resource_group_location
+    ):
+        """Test enabling CNL on an existing ACNS cluster by adding --enable-azure-monitor-logs on update.
+
+        Creates an ACNS cluster without monitoring, then updates with --enable-azure-monitor-logs
+        --enable-container-network-logs to cover the update decorator path for enabling both
+        monitoring and CNL simultaneously.
+        """
+        self.test_resources_count = 0
+        aks_name = self.create_random_name("cliakstest", 16)
+        self.kwargs.update(
+            {
+                "resource_group": resource_group,
+                "name": aks_name,
+                "ssh_key_value": self.generate_ssh_keys(),
+                "location": resource_group_location,
+            }
+        )
+
+        # Create an ACNS cluster without monitoring
+        create_cmd = (
+            "aks create --resource-group={resource_group} --name={name} --location={location} "
+            "--ssh-key-value={ssh_key_value} --node-count=1 --tier standard "
+            "--network-plugin azure --network-dataplane=cilium --network-plugin-mode overlay "
+            "--enable-acns --enable-managed-identity --output=json "
+        )
+        self.cmd(create_cmd, checks=[
+            self.check("provisioningState", "Succeeded"),
+            self.check("networkProfile.advancedNetworking.enabled", True),
+        ])
+
+        # Update: enable monitoring + CNL together
+        update_cmd = (
+            "aks update --resource-group={resource_group} --name={name} --yes "
+            "--enable-azure-monitor-logs --enable-container-network-logs --enable-high-log-scale-mode "
+            "--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/AdvancedNetworkingFlowLogsPreview "
+            "--output=json"
+        )
+        self.cmd(update_cmd, checks=[
+            self.check("provisioningState", "Succeeded"),
+            self.check("addonProfiles.omsagent.enabled", True),
+            self.check("addonProfiles.omsagent.config.enableRetinaNetworkFlags", "True"),
+        ])
+
+        # Verify DCR was created with ContainerNetworkLogs stream
+        show_cmd = "aks show --resource-group={resource_group} --name={name} --output=json"
+        response = self.cmd(show_cmd).get_output_in_json()
+
+        cluster_resource_id = response["id"]
+        subscription = cluster_resource_id.split("/")[2]
+
+        location = resource_group_location
+        dataCollectionRuleName = f"MSCI-{location}-{aks_name}"
+        dataCollectionRuleName = dataCollectionRuleName[0:64]
+        dcr_resource_id = f"/subscriptions/{subscription}/resourceGroups/{resource_group}/providers/Microsoft.Insights/dataCollectionRules/{dataCollectionRuleName}"
+
+        get_cmd = f'rest --method get --url https://management.azure.com{dcr_resource_id}?api-version=2022-06-01'
+        self.cmd(get_cmd, checks=[
+            self.check('properties.dataFlows[0].streams[-1]', 'Microsoft-ContainerNetworkLogs'),
+        ])
+
+        # delete
+        self.cmd(
+            "aks delete -g {resource_group} -n {name} --yes --no-wait",
+            checks=[self.is_empty()],
+        )
+
+    @live_only()
+    @AllowLargeResponse()
+    @AKSCustomResourceGroupPreparer(
+        random_name_length=17,
+        name_prefix="clitest",
+        location="westus2",
+    )
+    def test_aks_update_disable_azuremonitorlogs(
+        self, resource_group, resource_group_location
+    ):
+        """Test disabling Azure Monitor Logs via --disable-azure-monitor-logs on update.
+
+        Creates a cluster with --enable-azure-monitor-logs, then disables monitoring
+        with --disable-azure-monitor-logs. Verifies the _disable_azure_monitor_logs code path
+        which performs DCR/DCRA cleanup before disabling the addon.
+        """
+        self.test_resources_count = 0
+        aks_name = self.create_random_name("cliakstest", 16)
+        self.kwargs.update(
+            {
+                "resource_group": resource_group,
+                "name": aks_name,
+                "ssh_key_value": self.generate_ssh_keys(),
+                "location": resource_group_location,
+            }
+        )
+
+        # Create cluster with Azure Monitor Logs enabled
+        create_cmd = (
+            "aks create --resource-group={resource_group} --name={name} --location={location} "
+            "--ssh-key-value={ssh_key_value} --node-count=1 "
+            "--enable-azure-monitor-logs --enable-managed-identity --output=json"
+        )
+        self.cmd(create_cmd, checks=[
+            self.check("provisioningState", "Succeeded"),
+            self.check("addonProfiles.omsagent.enabled", True),
+        ])
+
+        # Disable Azure Monitor Logs
+        disable_cmd = (
+            "aks update --resource-group={resource_group} --name={name} --yes "
+            "--disable-azure-monitor-logs --output=json"
+        )
+        self.cmd(disable_cmd, checks=[
+            self.check("provisioningState", "Succeeded"),
+            self.check("addonProfiles.omsagent.enabled", False),
+        ])
+
+        # Verify aks show confirms monitoring is disabled
+        show_cmd = "aks show --resource-group={resource_group} --name={name} --output=json"
+        self.cmd(show_cmd, checks=[
+            self.check("provisioningState", "Succeeded"),
+            self.check("addonProfiles.omsagent.enabled", False),
+        ])
+
+        # delete
+        self.cmd(
+            "aks delete -g {resource_group} -n {name} --yes --no-wait",
+            checks=[self.is_empty()],
+        )
+
+    @live_only()
+    @AllowLargeResponse()
+    @AKSCustomResourceGroupPreparer(
+        random_name_length=17,
+        name_prefix="clitest",
+        location="westus2",
+    )
+    def test_aks_update_standalone_enable_high_log_scale_mode(
+        self, resource_group, resource_group_location
+    ):
+        """Test standalone --enable-high-log-scale-mode on update path.
+
+        Creates a cluster with monitoring enabled, then updates with just
+        --enable-high-log-scale-mode to verify the DCR is updated with
+        the Microsoft-ContainerLogV2-HighScale stream.
+        """
+        self.test_resources_count = 0
+        aks_name = self.create_random_name("cliakstest", 16)
+        self.kwargs.update(
+            {
+                "resource_group": resource_group,
+                "name": aks_name,
+                "ssh_key_value": self.generate_ssh_keys(),
+                "location": resource_group_location,
+            }
+        )
+
+        # Create cluster with Azure Monitor Logs enabled
+        create_cmd = (
+            "aks create --resource-group={resource_group} --name={name} --location={location} "
+            "--ssh-key-value={ssh_key_value} --node-count=1 "
+            "--enable-azure-monitor-logs --enable-managed-identity --output=json"
+        )
+        self.cmd(create_cmd, checks=[
+            self.check("provisioningState", "Succeeded"),
+            self.check("addonProfiles.omsagent.enabled", True),
+        ])
+
+        # Update: enable high log scale mode standalone
+        update_cmd = (
+            "aks update --resource-group={resource_group} --name={name} --yes "
+            "--enable-high-log-scale-mode --output=json"
+        )
+        response = self.cmd(update_cmd, checks=[
+            self.check("provisioningState", "Succeeded"),
+        ]).get_output_in_json()
+
+        cluster_resource_id = response["id"]
+        subscription = cluster_resource_id.split("/")[2]
+        location = resource_group_location
+        dataCollectionRuleName = f"MSCI-{location}-{aks_name}"
+        dataCollectionRuleName = dataCollectionRuleName[0:64]
+        dcr_resource_id = (
+            f"/subscriptions/{subscription}/resourceGroups/{resource_group}"
+            f"/providers/Microsoft.Insights/dataCollectionRules/{dataCollectionRuleName}"
+        )
+
+        # Verify DCR contains the HighScale stream
+        get_cmd = f'rest --method get --url https://management.azure.com{dcr_resource_id}?api-version=2022-06-01'
+        self.cmd(get_cmd, checks=[
+            self.check('properties.dataFlows[0].streams[-1]', 'Microsoft-ContainerLogV2-HighScale'),
+        ])
+
+        # Now disable high log scale mode
+        disable_cmd = (
+            "aks update --resource-group={resource_group} --name={name} --yes "
+            "--enable-high-log-scale-mode false --output=json"
+        )
+        self.cmd(disable_cmd, checks=[
+            self.check("provisioningState", "Succeeded"),
+        ])
+
+        # delete
+        self.cmd(
+            "aks delete -g {resource_group} -n {name} --yes --no-wait",
+            checks=[self.is_empty()],
+        )
+
     @AllowLargeResponse()
     @AKSCustomResourceGroupPreparer(
         random_name_length=17,

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -19765,6 +19765,53 @@ spec:
     @AKSCustomResourceGroupPreparer(
         random_name_length=17,
         name_prefix="clitest",
+        location="westus2",
+    )
+    def test_aks_update_disable_hlsm_error_when_cnl_enabled(
+        self, resource_group, resource_group_location
+    ):
+        """Test that disabling --enable-high-log-scale-mode raises an error
+        when container network logs are already enabled on the cluster."""
+        self.test_resources_count = 0
+        aks_name = self.create_random_name("cliakstest", 16)
+        self.kwargs.update(
+            {
+                "resource_group": resource_group,
+                "name": aks_name,
+                "ssh_key_value": self.generate_ssh_keys(),
+                "location": resource_group_location,
+            }
+        )
+
+        # Create cluster with monitoring + CNL + HLSM
+        create_cmd = (
+            "aks create --resource-group={resource_group} --name={name} --location={location} "
+            "--ssh-key-value={ssh_key_value} --node-count=1 "
+            "--enable-azure-monitor-logs --enable-managed-identity "
+            "--enable-acns --enable-container-network-logs --output=json"
+        )
+        self.cmd(create_cmd, checks=[
+            self.check("provisioningState", "Succeeded"),
+        ])
+
+        # Attempt to disable HLSM while CNL is still enabled — should fail
+        disable_cmd = (
+            "aks update --resource-group={resource_group} --name={name} --yes "
+            "--enable-high-log-scale-mode false --output=json"
+        )
+        with self.assertRaisesRegex(Exception, "container network logs"):
+            self.cmd(disable_cmd)
+
+        # delete
+        self.cmd(
+            "aks delete -g {resource_group} -n {name} --yes --no-wait",
+            checks=[self.is_empty()],
+        )
+
+    @AllowLargeResponse()
+    @AKSCustomResourceGroupPreparer(
+        random_name_length=17,
+        name_prefix="clitest",
         location="westcentralus",
     )
     def test_aks_create_with_enable_cost_analysis(

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -19739,6 +19739,10 @@ spec:
             self.check("addonProfiles.omsagent.enabled", True),
         ])
 
+        # Wait for any in-progress addon operations to complete before update
+        wait_cmd = 'aks wait --resource-group={resource_group} --name={name} --updated --timeout=1800'
+        self.cmd(wait_cmd, checks=[self.is_empty()])
+
         # Update: enable high log scale mode standalone
         update_cmd = (
             "aks update --resource-group={resource_group} --name={name} --yes "

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -19761,6 +19761,7 @@ spec:
             checks=[self.is_empty()],
         )
 
+    @live_only()
     @AllowLargeResponse()
     @AKSCustomResourceGroupPreparer(
         random_name_length=17,

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -19743,7 +19743,7 @@ spec:
         # Verify DCR contains the HighScale stream
         get_cmd = f'rest --method get --url https://management.azure.com{dcr_resource_id}?api-version=2022-06-01'
         self.cmd(get_cmd, checks=[
-            self.check('properties.dataFlows[0].streams[-1]', 'Microsoft-ContainerLogV2-HighScale'),
+            self.check("contains(properties.dataFlows[0].streams, 'Microsoft-ContainerLogV2-HighScale')", True),
         ])
 
         # Now disable high log scale mode

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -19748,6 +19748,10 @@ spec:
             self.check("contains(properties.dataFlows[0].streams, 'Microsoft-ContainerLogV2-HighScale')", True),
         ])
 
+        # Wait for any in-progress addon operations to complete before next update
+        wait_cmd = 'aks wait --resource-group={resource_group} --name={name} --updated --timeout=1800'
+        self.cmd(wait_cmd, checks=[self.is_empty()])
+
         # Now disable high log scale mode
         disable_cmd = (
             "aks update --resource-group={resource_group} --name={name} --yes "

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -19433,6 +19433,10 @@ spec:
             self.check("provisioningState", "Succeeded"),
         ])
 
+        # Wait for any in-progress addon operations to complete before next update
+        wait_cmd = 'aks wait --resource-group={resource_group} --name={name} --updated --timeout=1800'
+        self.cmd(wait_cmd, checks=[self.is_empty()])
+
         # Update: enable monitoring with high log scale mode
         update_cmd = (
             "aks update --resource-group={resource_group} --name={name} --yes "
@@ -19529,6 +19533,10 @@ spec:
             self.check('properties.dataFlows[0].streams[-1]', 'Microsoft-ContainerNetworkLogs'),
         ])
 
+        # Wait for any in-progress addon operations to complete before next update
+        wait_cmd = 'aks wait --resource-group={resource_group} --name={name} --updated --timeout=1800'
+        self.cmd(wait_cmd, checks=[self.is_empty()])
+
         # Disable via the alias — run twice like test_aks_create_acns_with_flow_logs
         # (first run applies the change, second run verifies the result)
         disable_cmd = "aks update --resource-group={resource_group} --name={name} --disable-retina-flow-logs -o json"
@@ -19586,6 +19594,10 @@ spec:
             self.check("networkProfile.advancedNetworking.enabled", True),
         ])
 
+        # Wait for any in-progress addon operations to complete before next update
+        wait_cmd = 'aks wait --resource-group={resource_group} --name={name} --updated --timeout=1800'
+        self.cmd(wait_cmd, checks=[self.is_empty()])
+
         # Update: enable monitoring + CNL together
         update_cmd = (
             "aks update --resource-group={resource_group} --name={name} --yes "
@@ -19593,14 +19605,18 @@ spec:
             "--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/AdvancedNetworkingFlowLogsPreview "
             "--output=json"
         )
-        self.cmd(update_cmd, checks=[
+        self.cmd(update_cmd)
+
+        # Wait for the update to fully complete, then verify via aks show
+        self.cmd(wait_cmd, checks=[self.is_empty()])
+        show_cmd = "aks show --resource-group={resource_group} --name={name} --output=json"
+        self.cmd(show_cmd, checks=[
             self.check("provisioningState", "Succeeded"),
             self.check("addonProfiles.omsagent.enabled", True),
             self.check("addonProfiles.omsagent.config.enableRetinaNetworkFlags", "True"),
         ])
 
         # Verify DCR was created with ContainerNetworkLogs stream
-        show_cmd = "aks show --resource-group={resource_group} --name={name} --output=json"
         response = self.cmd(show_cmd).get_output_in_json()
 
         cluster_resource_id = response["id"]

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -19661,12 +19661,14 @@ spec:
         ])
 
         # Disable Azure Monitor Logs
+        # Note: provisioningState may be "Updating" here due to a race between
+        # DCRA deletion (fire-and-forget LRO) and the subsequent PUT request.
+        # The aks show below verifies the final Succeeded state.
         disable_cmd = (
             "aks update --resource-group={resource_group} --name={name} --yes "
             "--disable-azure-monitor-logs --output=json"
         )
         self.cmd(disable_cmd, checks=[
-            self.check("provisioningState", "Succeeded"),
             self.check("addonProfiles.omsagent.enabled", False),
         ])
 

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_helpers.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_helpers.py
@@ -11,6 +11,7 @@ from azext_aks_preview._helpers import (
     check_is_private_link_cluster,
     get_cluster_snapshot,
     get_cluster_snapshot_by_snapshot_id,
+    get_monitoring_addon_key,
     get_nodepool_snapshot,
     get_nodepool_snapshot_by_snapshot_id,
     process_message_for_run_command,
@@ -210,6 +211,54 @@ class FilterHardTaintsTestCase(unittest.TestCase):
         ]
         expected_filtered_taints = ["key3=value3:PreferNoSchedule", "key5:PreferNoSchedule"]
         self.assertEqual(filter_hard_taints(input_taints), expected_filtered_taints)
+
+
+class TestGetMonitoringAddonKey(unittest.TestCase):
+    """Tests for the get_monitoring_addon_key helper."""
+
+    def test_returns_canonical_when_present(self):
+        addon_profiles = {"omsagent": Mock(enabled=True)}
+        result = get_monitoring_addon_key(addon_profiles, "omsagent")
+        self.assertEqual(result, "omsagent")
+        # dict should be unchanged
+        self.assertIn("omsagent", addon_profiles)
+
+    def test_normalizes_camelcase_key(self):
+        addon_profiles = {"omsAgent": Mock(enabled=True)}
+        result = get_monitoring_addon_key(addon_profiles, "omsagent")
+        self.assertEqual(result, "omsagent")
+        # dict should have been re-keyed
+        self.assertIn("omsagent", addon_profiles)
+        self.assertNotIn("omsAgent", addon_profiles)
+
+    def test_normalizes_arbitrary_casing(self):
+        addon_profiles = {"OMSagent": Mock(enabled=True)}
+        result = get_monitoring_addon_key(addon_profiles, "omsagent")
+        self.assertEqual(result, "omsagent")
+        self.assertIn("omsagent", addon_profiles)
+        self.assertNotIn("OMSagent", addon_profiles)
+
+    def test_returns_canonical_when_none_profiles(self):
+        result = get_monitoring_addon_key(None, "omsagent")
+        self.assertEqual(result, "omsagent")
+
+    def test_returns_canonical_when_key_not_present(self):
+        addon_profiles = {"some_other_addon": Mock(enabled=True)}
+        result = get_monitoring_addon_key(addon_profiles, "omsagent")
+        self.assertEqual(result, "omsagent")
+
+    def test_prefers_exact_match_over_case_insensitive(self):
+        # If both canonical and variant exist, canonical wins (no re-keying)
+        addon_profiles = {
+            "omsagent": Mock(enabled=True),
+            "omsAgent": Mock(enabled=False),
+        }
+        result = get_monitoring_addon_key(addon_profiles, "omsagent")
+        self.assertEqual(result, "omsagent")
+        # Both keys should still be present (no re-keying needed)
+        self.assertIn("omsagent", addon_profiles)
+        self.assertIn("omsAgent", addon_profiles)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
@@ -7880,6 +7880,198 @@ class AKSPreviewManagedClusterCreateDecoratorTestCase(unittest.TestCase):
         result = ctx_1.get_enable_azure_monitor_logs()
         self.assertTrue(result)
 
+    # ------------------------------------------------------------------
+    # Tests for postprocessing_after_mc_created:
+    # cnl_or_hlsm_changing flag logic → create_dcr passed to
+    # ensure_container_insights_for_monitoring
+    # ------------------------------------------------------------------
+    def _make_postprocessing_decorator(self, extra_raw_params):
+        """Helper: build a minimal Create decorator ready for postprocessing tests."""
+        raw_params = {
+            "name": "test_name",
+            "resource_group_name": "test_rg_name",
+            "location": "test_location",
+            "enable_msi_auth_for_monitoring": True,
+            "enable_syslog": False,
+            "data_collection_settings": None,
+        }
+        raw_params.update(extra_raw_params)
+        dec = AKSPreviewManagedClusterCreateDecorator(
+            self.cmd,
+            self.client,
+            raw_params,
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        mc = self.models.ManagedCluster(location="test_location")
+        dec.context.attach_mc(mc)
+        dec.context.set_intermediate("subscription_id", "test_subscription_id")
+        dec.context.set_intermediate("monitoring_addon_enabled", True)
+        return dec
+
+    def _make_cluster_with_monitoring(self):
+        """Helper: build a minimal cluster object that has the monitoring addon profile."""
+        return self.models.ManagedCluster(
+            location="test_location",
+            addon_profiles={
+                CONST_MONITORING_ADDON_NAME: self.models.ManagedClusterAddonProfile(enabled=True)
+            },
+        )
+
+    def test_postprocessing_create_dcr_false_when_only_enable_addons(self):
+        """create_dcr=False when only enable_addons triggers ensure_container_insights_for_monitoring.
+
+        enable_addons is in the outer condition but NOT in cnl_or_hlsm_changing,
+        so create_dcr must be False.
+        """
+        dec = self._make_postprocessing_decorator({"enable_addons": "monitoring"})
+        cluster = self._make_cluster_with_monitoring()
+        external_functions = dec.context.external_functions
+        with patch.object(
+            external_functions, "ensure_container_insights_for_monitoring", return_value=None
+        ) as mock_ecifm:
+            dec.postprocessing_after_mc_created(cluster)
+        mock_ecifm.assert_called_once()
+        _, kwargs = mock_ecifm.call_args
+        self.assertFalse(kwargs["create_dcr"])
+
+    def test_postprocessing_ensure_container_insights_not_called_without_relevant_flags(self):
+        """ensure_container_insights_for_monitoring is NOT called when no relevant flags are set.
+
+        When neither enable_addons, enable-azure-monitor-logs, nor any CNL/HLSM flag is
+        present in raw_params, the outer elif is not entered.
+        """
+        dec = self._make_postprocessing_decorator({})
+        cluster = self._make_cluster_with_monitoring()
+        external_functions = dec.context.external_functions
+        with patch.object(
+            external_functions, "ensure_container_insights_for_monitoring", return_value=None
+        ) as mock_ecifm:
+            dec.postprocessing_after_mc_created(cluster)
+        mock_ecifm.assert_not_called()
+
+    def test_postprocessing_create_dcr_true_when_enable_container_network_logs(self):
+        """create_dcr=True when enable_container_network_logs is set.
+
+        enable_container_network_logs is in cnl_or_hlsm_changing, so create_dcr must be True.
+        get_enable_high_log_scale_mode is mocked to bypass ACNS/monitoring validation.
+        """
+        dec = self._make_postprocessing_decorator({"enable_container_network_logs": True})
+        cluster = self._make_cluster_with_monitoring()
+        external_functions = dec.context.external_functions
+        with patch.object(
+            external_functions, "ensure_container_insights_for_monitoring", return_value=None
+        ) as mock_ecifm, patch.object(
+            dec.context, "get_enable_high_log_scale_mode", return_value=True
+        ):
+            dec.postprocessing_after_mc_created(cluster)
+        mock_ecifm.assert_called_once()
+        _, kwargs = mock_ecifm.call_args
+        self.assertTrue(kwargs["create_dcr"])
+
+    def test_postprocessing_create_dcr_true_when_enable_retina_flow_logs(self):
+        """create_dcr=True when the deprecated enable_retina_flow_logs flag is set.
+
+        enable_retina_flow_logs is in cnl_or_hlsm_changing, so create_dcr must be True.
+        """
+        dec = self._make_postprocessing_decorator({"enable_retina_flow_logs": True})
+        cluster = self._make_cluster_with_monitoring()
+        external_functions = dec.context.external_functions
+        with patch.object(
+            external_functions, "ensure_container_insights_for_monitoring", return_value=None
+        ) as mock_ecifm, patch.object(
+            dec.context, "get_enable_high_log_scale_mode", return_value=True
+        ):
+            dec.postprocessing_after_mc_created(cluster)
+        mock_ecifm.assert_called_once()
+        _, kwargs = mock_ecifm.call_args
+        self.assertTrue(kwargs["create_dcr"])
+
+    def test_postprocessing_create_dcr_true_when_disable_container_network_logs(self):
+        """create_dcr=True when disable_container_network_logs is set.
+
+        disable_container_network_logs is in cnl_or_hlsm_changing, so create_dcr must be True.
+        """
+        dec = self._make_postprocessing_decorator({"disable_container_network_logs": True})
+        cluster = self._make_cluster_with_monitoring()
+        external_functions = dec.context.external_functions
+        with patch.object(
+            external_functions, "ensure_container_insights_for_monitoring", return_value=None
+        ) as mock_ecifm:
+            dec.postprocessing_after_mc_created(cluster)
+        mock_ecifm.assert_called_once()
+        _, kwargs = mock_ecifm.call_args
+        self.assertTrue(kwargs["create_dcr"])
+
+    def test_postprocessing_create_dcr_true_when_disable_retina_flow_logs(self):
+        """create_dcr=True when the deprecated disable_retina_flow_logs flag is set.
+
+        disable_retina_flow_logs is in cnl_or_hlsm_changing, so create_dcr must be True.
+        """
+        dec = self._make_postprocessing_decorator({"disable_retina_flow_logs": True})
+        cluster = self._make_cluster_with_monitoring()
+        external_functions = dec.context.external_functions
+        with patch.object(
+            external_functions, "ensure_container_insights_for_monitoring", return_value=None
+        ) as mock_ecifm:
+            dec.postprocessing_after_mc_created(cluster)
+        mock_ecifm.assert_called_once()
+        _, kwargs = mock_ecifm.call_args
+        self.assertTrue(kwargs["create_dcr"])
+
+    def test_postprocessing_create_dcr_true_when_enable_high_log_scale_mode_true(self):
+        """create_dcr=True when enable_high_log_scale_mode=True is set.
+
+        enable_high_log_scale_mode is in cnl_or_hlsm_changing (any non-None value counts),
+        so create_dcr must be True.
+        """
+        dec = self._make_postprocessing_decorator({"enable_high_log_scale_mode": True})
+        cluster = self._make_cluster_with_monitoring()
+        external_functions = dec.context.external_functions
+        with patch.object(
+            external_functions, "ensure_container_insights_for_monitoring", return_value=None
+        ) as mock_ecifm:
+            dec.postprocessing_after_mc_created(cluster)
+        mock_ecifm.assert_called_once()
+        _, kwargs = mock_ecifm.call_args
+        self.assertTrue(kwargs["create_dcr"])
+
+    def test_postprocessing_create_dcr_true_when_enable_high_log_scale_mode_false(self):
+        """create_dcr=True when enable_high_log_scale_mode=False is explicitly set.
+
+        The cnl_or_hlsm_changing check uses `is not None`, so even an explicit False
+        value means the DCR must be updated.
+        """
+        dec = self._make_postprocessing_decorator({"enable_high_log_scale_mode": False})
+        cluster = self._make_cluster_with_monitoring()
+        external_functions = dec.context.external_functions
+        with patch.object(
+            external_functions, "ensure_container_insights_for_monitoring", return_value=None
+        ) as mock_ecifm:
+            dec.postprocessing_after_mc_created(cluster)
+        mock_ecifm.assert_called_once()
+        _, kwargs = mock_ecifm.call_args
+        self.assertTrue(kwargs["create_dcr"])
+
+    def test_postprocessing_create_dcr_true_when_cnl_and_hlsm_both_set(self):
+        """create_dcr=True when both enable_container_network_logs and enable_high_log_scale_mode are set.
+
+        Both flags are individually sufficient to set cnl_or_hlsm_changing=True.
+        """
+        dec = self._make_postprocessing_decorator(
+            {"enable_container_network_logs": True, "enable_high_log_scale_mode": True}
+        )
+        cluster = self._make_cluster_with_monitoring()
+        external_functions = dec.context.external_functions
+        with patch.object(
+            external_functions, "ensure_container_insights_for_monitoring", return_value=None
+        ) as mock_ecifm, patch.object(
+            dec.context, "get_enable_high_log_scale_mode", return_value=True
+        ):
+            dec.postprocessing_after_mc_created(cluster)
+        mock_ecifm.assert_called_once()
+        _, kwargs = mock_ecifm.call_args
+        self.assertTrue(kwargs["create_dcr"])
+
 
     def test_set_up_health_monitor_profile(self):
         # no flag - no change
@@ -12868,6 +13060,8 @@ class AKSPreviewManagedClusterUpdateDecoratorTestCase(unittest.TestCase):
             },
         )
         self.assertEqual(dec_mc_1, ground_truth_mc_1)
+        # Verify HLSM is auto-enabled when CNL is enabled
+        self.assertTrue(dec_1.context.get_enable_high_log_scale_mode())
 
         # Case 2: acns is enabled, monitoring is enabled, disable retina network flow logs
         dec_2 = AKSPreviewManagedClusterUpdateDecorator(
@@ -13112,6 +13306,8 @@ class AKSPreviewManagedClusterUpdateDecoratorTestCase(unittest.TestCase):
             },
         )
         self.assertEqual(dec_mc_7, ground_truth_mc_7)
+        # Verify HLSM is auto-enabled when using deprecated flag
+        self.assertTrue(dec_7.context.get_enable_high_log_scale_mode())
 
         # Case 8: Error when explicitly disabling high log scale mode with container network logs enabled
         dec_8 = AKSPreviewManagedClusterUpdateDecorator(
@@ -13240,6 +13436,441 @@ class AKSPreviewManagedClusterUpdateDecoratorTestCase(unittest.TestCase):
             ),
         }
         self.assertEqual(dec_mc_11.addon_profiles["omsagent"], ground_truth_mc_11["omsagent"])
+
+        # Case 12: Verify monitoring_addon_postprocessing_required is set when CNL is enabled (update path)
+        # This test verifies the fix for the bug where DCR is not updated when enabling CNL on update
+        dec_12 = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "enable_container_network_logs": True,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        mc_12 = self.models.ManagedCluster(
+            location="test_location",
+            network_profile=self.models.ContainerServiceNetworkProfile(
+                network_plugin="azure",
+                network_plugin_mode="overlay",
+                network_dataplane="cilium",
+                pod_cidr="100.64.0.0/16",
+                service_cidr="192.168.0.0/16",
+                advanced_networking=self.models.AdvancedNetworking(
+                    enabled=True,
+                ),
+            ),
+            addon_profiles={
+                "omsagent": self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                )
+            },
+        )
+        dec_12.context.attach_mc(mc_12)
+        dec_mc_12 = dec_12.update_monitoring_profile_flow_logs(mc_12)
+        # Verify the intermediate is set to trigger DCR update in postprocessing
+        self.assertTrue(dec_12.context.get_intermediate("monitoring_addon_postprocessing_required"))
+        # Verify HLSM is auto-enabled when CNL is enabled
+        self.assertTrue(dec_12.context.get_enable_high_log_scale_mode())
+        ground_truth_mc_12 = self.models.ManagedCluster(
+            location="test_location",
+            network_profile=self.models.ContainerServiceNetworkProfile(
+                network_plugin="azure",
+                network_plugin_mode="overlay",
+                network_dataplane="cilium",
+                pod_cidr="100.64.0.0/16",
+                service_cidr="192.168.0.0/16",
+                advanced_networking=self.models.AdvancedNetworking(
+                    enabled=True,
+                ),
+            ),
+            addon_profiles={
+                "omsagent": self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                    config={"enableRetinaNetworkFlags": "True"}
+                )
+            },
+        )
+        self.assertEqual(dec_mc_12, ground_truth_mc_12)
+
+        # Case 13: Verify monitoring_addon_postprocessing_required is NOT set when CNL is disabled (update path)
+        # Disabling CNL should not trigger DCR update
+        dec_13 = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "disable_container_network_logs": True,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        mc_13 = self.models.ManagedCluster(
+            location="test_location",
+            network_profile=self.models.ContainerServiceNetworkProfile(
+                network_plugin="azure",
+                network_plugin_mode="overlay",
+                network_dataplane="cilium",
+                pod_cidr="100.64.0.0/16",
+                service_cidr="192.168.0.0/16",
+                advanced_networking=self.models.AdvancedNetworking(
+                    enabled=True,
+                ),
+            ),
+            addon_profiles={
+                "omsagent": self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                    config={"enableRetinaNetworkFlags": "True"}
+                )
+            },
+        )
+        dec_13.context.attach_mc(mc_13)
+        dec_mc_13 = dec_13.update_monitoring_profile_flow_logs(mc_13)
+        # Disabling CNL should not set the postprocessing intermediate
+        self.assertFalse(dec_13.context.get_intermediate("monitoring_addon_postprocessing_required", default_value=False))
+        ground_truth_mc_13 = self.models.ManagedCluster(
+            location="test_location",
+            network_profile=self.models.ContainerServiceNetworkProfile(
+                network_plugin="azure",
+                network_plugin_mode="overlay",
+                network_dataplane="cilium",
+                pod_cidr="100.64.0.0/16",
+                service_cidr="192.168.0.0/16",
+                advanced_networking=self.models.AdvancedNetworking(
+                    enabled=True,
+                ),
+            ),
+            addon_profiles={
+                "omsagent": self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                    config={"enableRetinaNetworkFlags": "False"}
+                )
+            },
+        )
+        self.assertEqual(dec_mc_13, ground_truth_mc_13)
+
+        # Case 14: Verify monitoring_addon_postprocessing_required is set when using deprecated flag (update path)
+        dec_14 = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "enable_retina_flow_logs": True,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        mc_14 = self.models.ManagedCluster(
+            location="test_location",
+            network_profile=self.models.ContainerServiceNetworkProfile(
+                network_plugin="azure",
+                network_plugin_mode="overlay",
+                network_dataplane="cilium",
+                pod_cidr="100.64.0.0/16",
+                service_cidr="192.168.0.0/16",
+                advanced_networking=self.models.AdvancedNetworking(
+                    enabled=True,
+                ),
+            ),
+            addon_profiles={
+                "omsagent": self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                )
+            },
+        )
+        dec_14.context.attach_mc(mc_14)
+        dec_mc_14 = dec_14.update_monitoring_profile_flow_logs(mc_14)
+        # Verify the intermediate is set to trigger DCR update in postprocessing
+        self.assertTrue(dec_14.context.get_intermediate("monitoring_addon_postprocessing_required"))
+        # Verify HLSM is auto-enabled when using deprecated flag
+        self.assertTrue(dec_14.context.get_enable_high_log_scale_mode())
+
+        # Case 15: Standalone HLSM enable with monitoring addon enabled and MSI auth
+        # This test verifies the fix for the bug where standalone --enable-high-log-scale-mode was silently ignored
+        dec_15 = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "enable_high_log_scale_mode": True,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        mc_15 = self.models.ManagedCluster(
+            location="test_location",
+            network_profile=self.models.ContainerServiceNetworkProfile(
+                network_plugin="azure",
+            ),
+            addon_profiles={
+                "omsagent": self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                    config={
+                        CONST_MONITORING_USING_AAD_MSI_AUTH: "true",
+                    }
+                )
+            },
+        )
+        dec_15.context.attach_mc(mc_15)
+        dec_mc_15 = dec_15.update_monitoring_profile_flow_logs(mc_15)
+        # Verify the intermediate is set to trigger DCR update in postprocessing
+        self.assertTrue(dec_15.context.get_intermediate("monitoring_addon_postprocessing_required"))
+
+        # Case 16: Standalone HLSM enable without monitoring addon (should error)
+        dec_16 = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "enable_high_log_scale_mode": True,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        mc_16 = self.models.ManagedCluster(
+            location="test_location",
+            network_profile=self.models.ContainerServiceNetworkProfile(
+                network_plugin="azure",
+            ),
+        )
+        dec_16.context.attach_mc(mc_16)
+        with self.assertRaises(RequiredArgumentMissingError):
+            dec_16.update_monitoring_profile_flow_logs(mc_16)
+
+        # Case 17: Standalone HLSM enable without MSI auth (should error)
+        dec_17 = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "enable_high_log_scale_mode": True,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        mc_17 = self.models.ManagedCluster(
+            location="test_location",
+            network_profile=self.models.ContainerServiceNetworkProfile(
+                network_plugin="azure",
+            ),
+            addon_profiles={
+                "omsagent": self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                    config={}
+                )
+            },
+        )
+        dec_17.context.attach_mc(mc_17)
+        with self.assertRaises(RequiredArgumentMissingError):
+            dec_17.update_monitoring_profile_flow_logs(mc_17)
+
+        # Case 18: Verify HLSM is NOT triggered when explicitly set to False
+        dec_18 = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "enable_high_log_scale_mode": False,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        mc_18 = self.models.ManagedCluster(
+            location="test_location",
+            network_profile=self.models.ContainerServiceNetworkProfile(
+                network_plugin="azure",
+            ),
+            addon_profiles={
+                "omsagent": self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                    config={
+                        CONST_MONITORING_USING_AAD_MSI_AUTH: "true",
+                    }
+                )
+            },
+        )
+        dec_18.context.attach_mc(mc_18)
+        dec_mc_18 = dec_18.update_monitoring_profile_flow_logs(mc_18)
+        # HLSM=false should not trigger postprocessing
+        self.assertFalse(dec_18.context.get_intermediate("monitoring_addon_postprocessing_required", default_value=False))
+
+        # Case 19: Standalone HLSM enable with omsAgent (camelCase key)
+        dec_19 = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "enable_high_log_scale_mode": True,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        mc_19 = self.models.ManagedCluster(
+            location="test_location",
+            network_profile=self.models.ContainerServiceNetworkProfile(
+                network_plugin="azure",
+            ),
+            addon_profiles={
+                "omsAgent": self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                    config={
+                        CONST_MONITORING_USING_AAD_MSI_AUTH: "true",
+                    }
+                )
+            },
+        )
+        dec_19.context.attach_mc(mc_19)
+        dec_mc_19 = dec_19.update_monitoring_profile_flow_logs(mc_19)
+        # Verify the intermediate is set to trigger DCR update in postprocessing
+        self.assertTrue(dec_19.context.get_intermediate("monitoring_addon_postprocessing_required"))
+
+    def test_update_standalone_high_log_scale_mode(self):
+        """Tests for Bug 1 fix: --enable-high-log-scale-mode standalone on update path.
+
+        Before this fix, --enable-high-log-scale-mode alone on an existing cluster was silently
+        ignored because monitoring_addon_postprocessing_required was never set, so the DCR was
+        never updated.
+        """
+        # Case 1: Happy path - monitoring enabled with MSI auth → sets postprocessing intermediate
+        dec_1 = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {"enable_high_log_scale_mode": True},
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        mc_1 = self.models.ManagedCluster(
+            location="test_location",
+            addon_profiles={
+                "omsagent": self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                    config={CONST_MONITORING_USING_AAD_MSI_AUTH: "true"},
+                )
+            },
+        )
+        dec_1.context.attach_mc(mc_1)
+        dec_1.update_monitoring_profile_flow_logs(mc_1)
+        self.assertTrue(dec_1.context.get_intermediate("monitoring_addon_postprocessing_required"))
+
+        # Case 2: Monitoring addon present but not enabled → RequiredArgumentMissingError
+        dec_2 = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {"enable_high_log_scale_mode": True},
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        mc_2 = self.models.ManagedCluster(
+            location="test_location",
+            addon_profiles={
+                "omsagent": self.models.ManagedClusterAddonProfile(
+                    enabled=False,
+                    config={CONST_MONITORING_USING_AAD_MSI_AUTH: "true"},
+                )
+            },
+        )
+        dec_2.context.attach_mc(mc_2)
+        with self.assertRaises(RequiredArgumentMissingError):
+            dec_2.update_monitoring_profile_flow_logs(mc_2)
+
+        # Case 3: No monitoring addon at all → RequiredArgumentMissingError
+        dec_3 = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {"enable_high_log_scale_mode": True},
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        mc_3 = self.models.ManagedCluster(location="test_location")
+        dec_3.context.attach_mc(mc_3)
+        with self.assertRaises(RequiredArgumentMissingError):
+            dec_3.update_monitoring_profile_flow_logs(mc_3)
+
+        # Case 4: Monitoring enabled but MSI auth missing → RequiredArgumentMissingError
+        dec_4 = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {"enable_high_log_scale_mode": True},
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        mc_4 = self.models.ManagedCluster(
+            location="test_location",
+            addon_profiles={
+                "omsagent": self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                    config={},
+                )
+            },
+        )
+        dec_4.context.attach_mc(mc_4)
+        with self.assertRaises(RequiredArgumentMissingError):
+            dec_4.update_monitoring_profile_flow_logs(mc_4)
+
+        # Case 5: Monitoring enabled but MSI auth set to "false" → RequiredArgumentMissingError
+        dec_5 = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {"enable_high_log_scale_mode": True},
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        mc_5 = self.models.ManagedCluster(
+            location="test_location",
+            addon_profiles={
+                "omsagent": self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                    config={CONST_MONITORING_USING_AAD_MSI_AUTH: "false"},
+                )
+            },
+        )
+        dec_5.context.attach_mc(mc_5)
+        with self.assertRaises(RequiredArgumentMissingError):
+            dec_5.update_monitoring_profile_flow_logs(mc_5)
+
+        # Case 6: enable_high_log_scale_mode=False → no postprocessing, no error
+        dec_6 = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {"enable_high_log_scale_mode": False},
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        mc_6 = self.models.ManagedCluster(
+            location="test_location",
+            addon_profiles={
+                "omsagent": self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                    config={CONST_MONITORING_USING_AAD_MSI_AUTH: "true"},
+                )
+            },
+        )
+        dec_6.context.attach_mc(mc_6)
+        dec_6.update_monitoring_profile_flow_logs(mc_6)
+        self.assertFalse(
+            dec_6.context.get_intermediate("monitoring_addon_postprocessing_required", default_value=False)
+        )
+
+        # Case 7: Not specified (None) → no postprocessing triggered
+        dec_7 = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {},
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        mc_7 = self.models.ManagedCluster(
+            location="test_location",
+            addon_profiles={
+                "omsagent": self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                    config={CONST_MONITORING_USING_AAD_MSI_AUTH: "true"},
+                )
+            },
+        )
+        dec_7.context.attach_mc(mc_7)
+        dec_7.update_monitoring_profile_flow_logs(mc_7)
+        self.assertFalse(
+            dec_7.context.get_intermediate("monitoring_addon_postprocessing_required", default_value=False)
+        )
+
+        # Case 8: camelCase "omsAgent" key is also recognised
+        dec_8 = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {"enable_high_log_scale_mode": True},
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        mc_8 = self.models.ManagedCluster(
+            location="test_location",
+            addon_profiles={
+                "omsAgent": self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                    config={CONST_MONITORING_USING_AAD_MSI_AUTH: "true"},
+                )
+            },
+        )
+        dec_8.context.attach_mc(mc_8)
+        dec_8.update_monitoring_profile_flow_logs(mc_8)
+        self.assertTrue(dec_8.context.get_intermediate("monitoring_addon_postprocessing_required"))
 
     def test_update_node_provisioning_profile(self):
         dec_0 = AKSPreviewManagedClusterUpdateDecorator(

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
@@ -5366,6 +5366,57 @@ class AKSPreviewManagedClusterContextTestCase(unittest.TestCase):
         with self.assertRaises(MutuallyExclusiveArgumentError):
             ctx.get_enable_high_log_scale_mode()
 
+    def test_get_enable_high_log_scale_mode_update_error_disable_hlsm_with_existing_cnl(self):
+        """Test error when user disables HLSM while CNL is already enabled on the cluster.
+
+        When CNL (enableRetinaNetworkFlags) is already set to 'True' on the existing cluster
+        and the user passes --enable-high-log-scale-mode false without --enable-container-network-logs,
+        the method should raise a MutuallyExclusiveArgumentError.
+        """
+        ctx = AKSPreviewManagedClusterContext(
+            self.cmd,
+            AKSManagedClusterParamDict({
+                "enable_high_log_scale_mode": False,
+            }),
+            self.models,
+            decorator_mode=DecoratorMode.UPDATE,
+        )
+        mc = self.models.ManagedCluster(
+            location="test_location",
+            addon_profiles={
+                "omsagent": self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                    config={"enableRetinaNetworkFlags": "True"},
+                )
+            },
+        )
+        ctx.attach_mc(mc)
+        with self.assertRaises(MutuallyExclusiveArgumentError):
+            ctx.get_enable_high_log_scale_mode()
+
+    def test_get_enable_high_log_scale_mode_update_error_disable_hlsm_with_existing_cnl_camelcase(self):
+        """Test error when user disables HLSM while CNL is already enabled (omsAgent camelCase key)."""
+        ctx = AKSPreviewManagedClusterContext(
+            self.cmd,
+            AKSManagedClusterParamDict({
+                "enable_high_log_scale_mode": False,
+            }),
+            self.models,
+            decorator_mode=DecoratorMode.UPDATE,
+        )
+        mc = self.models.ManagedCluster(
+            location="test_location",
+            addon_profiles={
+                "omsAgent": self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                    config={"enableRetinaNetworkFlags": "True"},
+                )
+            },
+        )
+        ctx.attach_mc(mc)
+        with self.assertRaises(MutuallyExclusiveArgumentError):
+            ctx.get_enable_high_log_scale_mode()
+
     def test_get_enable_high_log_scale_mode_update_monitoring_camelcase_key(self):
         """Test auto-enable HLSM in update mode when monitoring uses camelCase 'omsAgent' key."""
         ctx = AKSPreviewManagedClusterContext(
@@ -14122,7 +14173,7 @@ class AKSPreviewManagedClusterUpdateDecoratorTestCase(unittest.TestCase):
         with self.assertRaises(RequiredArgumentMissingError):
             dec_5.update_monitoring_profile_flow_logs(mc_5)
 
-        # Case 6: enable_high_log_scale_mode=False → no postprocessing, no error
+        # Case 6: enable_high_log_scale_mode=False (no CNL) → postprocessing triggered to update DCR
         dec_6 = AKSPreviewManagedClusterUpdateDecorator(
             self.cmd,
             self.client,
@@ -14140,7 +14191,7 @@ class AKSPreviewManagedClusterUpdateDecoratorTestCase(unittest.TestCase):
         )
         dec_6.context.attach_mc(mc_6)
         dec_6.update_monitoring_profile_flow_logs(mc_6)
-        self.assertFalse(
+        self.assertTrue(
             dec_6.context.get_intermediate("monitoring_addon_postprocessing_required", default_value=False)
         )
 
@@ -14308,6 +14359,32 @@ class AKSPreviewManagedClusterUpdateDecoratorTestCase(unittest.TestCase):
         self.assertFalse(
             dec.context.get_intermediate("monitoring_addon_postprocessing_required", default_value=False)
         )
+
+    def test_update_disable_hlsm_error_when_cnl_already_enabled(self):
+        """Test that disabling HLSM raises error when CNL is already enabled on the cluster."""
+        dec = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "enable_high_log_scale_mode": False,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        mc = self.models.ManagedCluster(
+            location="test_location",
+            addon_profiles={
+                "omsagent": self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                    config={
+                        "enableRetinaNetworkFlags": "True",
+                        CONST_MONITORING_USING_AAD_MSI_AUTH: "true",
+                    }
+                )
+            },
+        )
+        dec.context.attach_mc(mc)
+        with self.assertRaises(MutuallyExclusiveArgumentError):
+            dec.update_monitoring_profile_flow_logs(mc)
 
     def test_update_postprocessing_with_camelcase_addon_key(self):
         """Test that update postprocessing works when the API response uses 'omsAgent' (camelCase).

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
@@ -13911,6 +13911,59 @@ class AKSPreviewManagedClusterUpdateDecoratorTestCase(unittest.TestCase):
         )
         self.assertEqual(dec_mc_13, ground_truth_mc_13)
 
+        # Case 13b: Disable CNL with omsAgent (camelCase key) - verifies the fix
+        # for the bug where disable-container-network-logs didn't work when Azure API
+        # returned the addon profile key as "omsAgent" instead of "omsagent"
+        dec_13b = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "disable_container_network_logs": True,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        mc_13b = self.models.ManagedCluster(
+            location="test_location",
+            network_profile=self.models.ContainerServiceNetworkProfile(
+                network_plugin="azure",
+                network_plugin_mode="overlay",
+                network_dataplane="cilium",
+                pod_cidr="100.64.0.0/16",
+                service_cidr="192.168.0.0/16",
+                advanced_networking=self.models.AdvancedNetworking(
+                    enabled=True,
+                ),
+            ),
+            addon_profiles={
+                "omsAgent": self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                    config={"enableRetinaNetworkFlags": "True"}
+                )
+            },
+        )
+        dec_13b.context.attach_mc(mc_13b)
+        dec_mc_13b = dec_13b.update_monitoring_profile_flow_logs(mc_13b)
+        ground_truth_mc_13b = self.models.ManagedCluster(
+            location="test_location",
+            network_profile=self.models.ContainerServiceNetworkProfile(
+                network_plugin="azure",
+                network_plugin_mode="overlay",
+                network_dataplane="cilium",
+                pod_cidr="100.64.0.0/16",
+                service_cidr="192.168.0.0/16",
+                advanced_networking=self.models.AdvancedNetworking(
+                    enabled=True,
+                ),
+            ),
+            addon_profiles={
+                "omsAgent": self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                    config={"enableRetinaNetworkFlags": "False"}
+                )
+            },
+        )
+        self.assertEqual(dec_mc_13b, ground_truth_mc_13b)
+
         # Case 14: Verify monitoring_addon_postprocessing_required is set when using deprecated flag (update path)
         dec_14 = AKSPreviewManagedClusterUpdateDecorator(
             self.cmd,
@@ -14043,8 +14096,8 @@ class AKSPreviewManagedClusterUpdateDecoratorTestCase(unittest.TestCase):
         )
         dec_18.context.attach_mc(mc_18)
         dec_mc_18 = dec_18.update_monitoring_profile_flow_logs(mc_18)
-        # HLSM=false should not trigger postprocessing
-        self.assertFalse(dec_18.context.get_intermediate("monitoring_addon_postprocessing_required", default_value=False))
+        # HLSM=false should trigger postprocessing to update DCR (remove high-scale stream)
+        self.assertTrue(dec_18.context.get_intermediate("monitoring_addon_postprocessing_required", default_value=False))
 
         # Case 19: Standalone HLSM enable with omsAgent (camelCase key)
         dec_19 = AKSPreviewManagedClusterUpdateDecorator(

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
@@ -11592,7 +11592,7 @@ class AKSPreviewManagedClusterUpdateDecoratorTestCase(unittest.TestCase):
         # Verify: omsAgent should be disabled
         self.assertIn("omsAgent", mc_1.addon_profiles)
         self.assertFalse(mc_1.addon_profiles["omsAgent"].enabled)
-        self.assertEqual(mc_1.addon_profiles["omsAgent"].config, {})
+        self.assertIsNone(mc_1.addon_profiles["omsAgent"].config)
 
     def test_disable_azure_monitor_logs_with_omsagent_lowercase(self):
         # Test that _disable_azure_monitor_logs handles omsagent (lowercase) correctly
@@ -11628,7 +11628,7 @@ class AKSPreviewManagedClusterUpdateDecoratorTestCase(unittest.TestCase):
         # Verify: omsagent should be disabled
         self.assertIn("omsagent", mc_1.addon_profiles)
         self.assertFalse(mc_1.addon_profiles["omsagent"].enabled)
-        self.assertEqual(mc_1.addon_profiles["omsagent"].config, {})
+        self.assertIsNone(mc_1.addon_profiles["omsagent"].config)
 
     def test_get_enable_opentelemetry_logs_validation_with_omsagent_camelcase(self):
         # Test that OpenTelemetry logs validation recognizes omsAgent (camelCase) as enabled

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
@@ -14386,8 +14386,8 @@ class AKSPreviewManagedClusterUpdateDecoratorTestCase(unittest.TestCase):
         self.assertTrue(dec.context.get_enable_high_log_scale_mode())
         self.assertTrue(dec.context.get_intermediate("monitoring_addon_postprocessing_required"))
 
-    def test_update_disable_hlsm_standalone_no_postprocessing(self):
-        """Test that disabling HLSM standalone (no CNL flag) does not trigger postprocessing."""
+    def test_update_disable_hlsm_standalone_triggers_postprocessing(self):
+        """Test that disabling HLSM standalone (no CNL flag) triggers postprocessing to update DCR."""
         dec = AKSPreviewManagedClusterUpdateDecorator(
             self.cmd,
             self.client,
@@ -14409,7 +14409,7 @@ class AKSPreviewManagedClusterUpdateDecoratorTestCase(unittest.TestCase):
         )
         dec.context.attach_mc(mc)
         dec.update_monitoring_profile_flow_logs(mc)
-        self.assertFalse(
+        self.assertTrue(
             dec.context.get_intermediate("monitoring_addon_postprocessing_required", default_value=False)
         )
 

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
@@ -73,7 +73,7 @@ from azext_aks_preview.managed_cluster_decorator import (
     AKSPreviewManagedClusterCreateDecorator,
     AKSPreviewManagedClusterModels,
     AKSPreviewManagedClusterUpdateDecorator,
-    _get_monitoring_addon_key,
+    _get_monitoring_addon_key_from_consts,
 )
 from azext_aks_preview.tests.latest.utils import get_test_data_file_path
 from azure.cli.command_modules.acs._consts import (
@@ -136,7 +136,7 @@ class AKSPreviewManagedClusterModelsTestCase(unittest.TestCase):
 
 
 class AKSPreviewGetMonitoringAddonKeyTestCase(unittest.TestCase):
-    """Tests for the standalone _get_monitoring_addon_key helper function."""
+    """Tests for the _get_monitoring_addon_key_from_consts helper function."""
 
     def setUp(self):
         register_aks_preview_resource_type()
@@ -148,49 +148,40 @@ class AKSPreviewGetMonitoringAddonKeyTestCase(unittest.TestCase):
         }
 
     def test_returns_lowercase_key_when_present(self):
-        cluster = self.models.ManagedCluster(
-            location="test_location",
-            addon_profiles={
-                CONST_MONITORING_ADDON_NAME: self.models.ManagedClusterAddonProfile(enabled=True),
-            },
-        )
-        result = _get_monitoring_addon_key(cluster, self.addon_consts)
+        addon_profiles = {
+            CONST_MONITORING_ADDON_NAME: self.models.ManagedClusterAddonProfile(enabled=True),
+        }
+        result = _get_monitoring_addon_key_from_consts(addon_profiles, self.addon_consts)
         self.assertEqual(result, CONST_MONITORING_ADDON_NAME)
 
-    def test_returns_camelcase_key_when_present(self):
-        cluster = self.models.ManagedCluster(
-            location="test_location",
-            addon_profiles={
-                CONST_MONITORING_ADDON_NAME_CAMELCASE: self.models.ManagedClusterAddonProfile(enabled=True),
-            },
-        )
-        result = _get_monitoring_addon_key(cluster, self.addon_consts)
-        self.assertEqual(result, CONST_MONITORING_ADDON_NAME_CAMELCASE)
+    def test_normalizes_camelcase_key(self):
+        addon_profiles = {
+            CONST_MONITORING_ADDON_NAME_CAMELCASE: self.models.ManagedClusterAddonProfile(enabled=True),
+        }
+        result = _get_monitoring_addon_key_from_consts(addon_profiles, self.addon_consts)
+        # After normalization, the canonical key should always be returned
+        self.assertEqual(result, CONST_MONITORING_ADDON_NAME)
+        # Dict should have been re-keyed in place
+        self.assertIn(CONST_MONITORING_ADDON_NAME, addon_profiles)
+        self.assertNotIn(CONST_MONITORING_ADDON_NAME_CAMELCASE, addon_profiles)
 
     def test_prefers_lowercase_when_both_present(self):
-        cluster = self.models.ManagedCluster(
-            location="test_location",
-            addon_profiles={
-                CONST_MONITORING_ADDON_NAME: self.models.ManagedClusterAddonProfile(enabled=True),
-                CONST_MONITORING_ADDON_NAME_CAMELCASE: self.models.ManagedClusterAddonProfile(enabled=True),
-            },
-        )
-        result = _get_monitoring_addon_key(cluster, self.addon_consts)
+        addon_profiles = {
+            CONST_MONITORING_ADDON_NAME: self.models.ManagedClusterAddonProfile(enabled=True),
+            CONST_MONITORING_ADDON_NAME_CAMELCASE: self.models.ManagedClusterAddonProfile(enabled=True),
+        }
+        result = _get_monitoring_addon_key_from_consts(addon_profiles, self.addon_consts)
         self.assertEqual(result, CONST_MONITORING_ADDON_NAME)
 
     def test_returns_default_when_no_addon_profiles(self):
-        cluster = self.models.ManagedCluster(location="test_location")
-        result = _get_monitoring_addon_key(cluster, self.addon_consts)
+        result = _get_monitoring_addon_key_from_consts(None, self.addon_consts)
         self.assertEqual(result, CONST_MONITORING_ADDON_NAME)
 
     def test_returns_default_when_neither_key_present(self):
-        cluster = self.models.ManagedCluster(
-            location="test_location",
-            addon_profiles={
-                "some_other_addon": self.models.ManagedClusterAddonProfile(enabled=True),
-            },
-        )
-        result = _get_monitoring_addon_key(cluster, self.addon_consts)
+        addon_profiles = {
+            "some_other_addon": self.models.ManagedClusterAddonProfile(enabled=True),
+        }
+        result = _get_monitoring_addon_key_from_consts(addon_profiles, self.addon_consts)
         self.assertEqual(result, CONST_MONITORING_ADDON_NAME)
 
 
@@ -4897,7 +4888,7 @@ class AKSPreviewManagedClusterContextTestCase(unittest.TestCase):
         """Test default behavior when no container network logs or high log scale mode is specified.
 
         When enable_high_log_scale_mode is not explicitly set and container network logs are not enabled,
-        the method should return False (not None) to maintain backward compatibility with the base class.
+        the method should return None to align with the base class behavior.
         """
         ctx = AKSPreviewManagedClusterContext(
             self.cmd,
@@ -4906,7 +4897,7 @@ class AKSPreviewManagedClusterContextTestCase(unittest.TestCase):
             decorator_mode=DecoratorMode.CREATE,
         )
         result = ctx.get_enable_high_log_scale_mode()
-        self.assertFalse(result)
+        self.assertIsNone(result)
 
     def test_get_enable_high_log_scale_mode_explicit_false_without_cnl(self):
         """Test when user explicitly sets enable_high_log_scale_mode to False without container network logs.
@@ -11723,6 +11714,7 @@ class AKSPreviewManagedClusterUpdateDecoratorTestCase(unittest.TestCase):
         # Verify: The parent class normalizes addon keys to lowercase in-place,
         # so "omsAgent" becomes "omsagent". The key point is no duplicate is created.
         self.assertIn("omsagent", mc_1.addon_profiles)
+        self.assertNotIn("omsAgent", mc_1.addon_profiles)
         self.assertEqual(len([k for k in mc_1.addon_profiles if k.lower() == "omsagent"]), 1)  # No duplicate
         self.assertTrue(mc_1.addon_profiles["omsagent"].enabled)
         self.assertEqual(
@@ -11797,10 +11789,10 @@ class AKSPreviewManagedClusterUpdateDecoratorTestCase(unittest.TestCase):
         # Call _disable_azure_monitor_logs
         dec_1._disable_azure_monitor_logs(mc_1)
 
-        # Verify: omsAgent should be disabled
-        self.assertIn("omsAgent", mc_1.addon_profiles)
-        self.assertFalse(mc_1.addon_profiles["omsAgent"].enabled)
-        self.assertIsNone(mc_1.addon_profiles["omsAgent"].config)
+        # After normalization, the camelCase key is re-keyed to canonical lowercase
+        self.assertIn("omsagent", mc_1.addon_profiles)
+        self.assertFalse(mc_1.addon_profiles["omsagent"].enabled)
+        self.assertIsNone(mc_1.addon_profiles["omsagent"].config)
 
     def test_disable_azure_monitor_logs_with_omsagent_lowercase(self):
         # Test that _disable_azure_monitor_logs handles omsagent (lowercase) correctly
@@ -11914,9 +11906,9 @@ class AKSPreviewManagedClusterUpdateDecoratorTestCase(unittest.TestCase):
 
         dec_1._disable_azure_monitor_logs(mc_1)
 
-        # Verify addon profile is disabled
-        self.assertFalse(mc_1.addon_profiles["omsAgent"].enabled)
-        self.assertIsNone(mc_1.addon_profiles["omsAgent"].config)
+        # After normalization, the camelCase key is re-keyed to the canonical lowercase form
+        self.assertFalse(mc_1.addon_profiles["omsagent"].enabled)
+        self.assertIsNone(mc_1.addon_profiles["omsagent"].config)
 
         # Verify container_insights is also disabled
         self.assertFalse(mc_1.azure_monitor_profile.container_insights.enabled)
@@ -14326,7 +14318,7 @@ class AKSPreviewManagedClusterUpdateDecoratorTestCase(unittest.TestCase):
                 ),
             ),
             addon_profiles={
-                "omsAgent": self.models.ManagedClusterAddonProfile(
+                "omsagent": self.models.ManagedClusterAddonProfile(
                     enabled=True,
                     config={"enableRetinaNetworkFlags": "False"}
                 )
@@ -16475,6 +16467,99 @@ class AKSPreviewManagedClusterUpdateDecoratorTestCase(unittest.TestCase):
         self.assertTrue(
             dec.context.get_intermediate("monitoring_addon_postprocessing_required", default_value=False)
         )
+
+    def test_disable_monitoring_clears_cnl_and_hlsm_config(self):
+        """Disabling monitoring addon should wipe config including enableRetinaNetworkFlags (CNL)
+        and any HLSM-related settings, so that re-enabling does not carry them forward."""
+        dec = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "disable_azure_monitor_logs": True,
+                "yes": True,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        mc = self.models.ManagedCluster(
+            location="test_location",
+            addon_profiles={
+                CONST_MONITORING_ADDON_NAME: self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                    config={
+                        "logAnalyticsWorkspaceResourceID": "/subscriptions/test/workspace",
+                        CONST_MONITORING_USING_AAD_MSI_AUTH: "false",
+                        "enableRetinaNetworkFlags": "true",
+                    },
+                ),
+            },
+        )
+        dec.context.attach_mc(mc)
+        dec.client = Mock()
+        dec.client.get = Mock(return_value=mc)
+
+        dec._disable_azure_monitor_logs(mc)
+
+        # Config should be completely wiped — no CNL or HLSM values survive
+        self.assertFalse(mc.addon_profiles[CONST_MONITORING_ADDON_NAME].enabled)
+        self.assertIsNone(mc.addon_profiles[CONST_MONITORING_ADDON_NAME].config)
+
+    def test_reenable_monitoring_after_disable_does_not_carry_cnl(self):
+        """Re-enabling monitoring after disable should produce a fresh config
+        without enableRetinaNetworkFlags (CNL) or HLSM-related keys."""
+        # Step 1: start with monitoring enabled + CNL (useAADAuth=false to skip DCR cleanup)
+        mc = self.models.ManagedCluster(
+            location="test_location",
+            addon_profiles={
+                CONST_MONITORING_ADDON_NAME: self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                    config={
+                        "logAnalyticsWorkspaceResourceID": "/subscriptions/test/workspace",
+                        CONST_MONITORING_USING_AAD_MSI_AUTH: "false",
+                        "enableRetinaNetworkFlags": "true",
+                    },
+                ),
+            },
+        )
+
+        # Step 2: disable monitoring
+        dec_disable = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "disable_azure_monitor_logs": True,
+                "yes": True,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        dec_disable.context.attach_mc(mc)
+        dec_disable.client = Mock()
+        dec_disable.client.get = Mock(return_value=mc)
+        dec_disable._disable_azure_monitor_logs(mc)
+        self.assertIsNone(mc.addon_profiles[CONST_MONITORING_ADDON_NAME].config)
+
+        # Step 3: re-enable monitoring (no CNL flag passed)
+        # Simulate server round-trip: after PUT with config=None, the server
+        # returns the addon with config as empty dict, not None.
+        mc.addon_profiles[CONST_MONITORING_ADDON_NAME].config = {}
+        dec_enable = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "enable_azure_monitor_logs": True,
+                "workspace_resource_id": "/subscriptions/test/resourceGroups/test/providers/Microsoft.OperationalInsights/workspaces/new-workspace",
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        dec_enable.context.attach_mc(mc)
+        dec_enable.context.set_intermediate("subscription_id", "test-subscription-id")
+        dec_enable._setup_azure_monitor_logs(mc)
+
+        # Config should only have workspace + MSI auth — no CNL or HLSM keys
+        addon_config = mc.addon_profiles[CONST_MONITORING_ADDON_NAME].config
+        self.assertTrue(mc.addon_profiles[CONST_MONITORING_ADDON_NAME].enabled)
+        self.assertIn("logAnalyticsWorkspaceResourceID", addon_config)
+        self.assertIn(CONST_MONITORING_USING_AAD_MSI_AUTH, addon_config)
+        self.assertNotIn("enableRetinaNetworkFlags", addon_config)
 
 
 if __name__ == "__main__":

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
@@ -43,6 +43,7 @@ from azext_aks_preview._consts import (
     CONST_APP_ROUTING_ISTIO_MODE_ENABLED,
     CONST_APP_ROUTING_ISTIO_MODE_DISABLED,
     CONST_MONITORING_ADDON_NAME,
+    CONST_MONITORING_ADDON_NAME_CAMELCASE,
     CONST_MONITORING_LOG_ANALYTICS_WORKSPACE_RESOURCE_ID,
     CONST_MONITORING_USING_AAD_MSI_AUTH,
     CONST_NODEPOOL_MODE_SYSTEM,
@@ -5392,6 +5393,36 @@ class AKSPreviewManagedClusterContextTestCase(unittest.TestCase):
         result = ctx.get_enable_high_log_scale_mode()
         self.assertTrue(result)
 
+    def test_get_enable_msi_auth_for_monitoring_with_msi_service_principal(self):
+        """Test that MSI auth is correctly detected when service_principal_profile.client_id='msi'.
+
+        The base class returns False when client_id is not None, but MSI-based clusters set
+        client_id to 'msi'. The preview override should check the addon config for useAADAuth.
+        """
+        ctx = AKSPreviewManagedClusterContext(
+            self.cmd,
+            AKSManagedClusterParamDict({}),
+            self.models,
+            decorator_mode=DecoratorMode.UPDATE,
+        )
+        mc = self.models.ManagedCluster(
+            location="test_location",
+            service_principal_profile=self.models.ManagedClusterServicePrincipalProfile(
+                client_id="msi",
+            ),
+            addon_profiles={
+                "omsagent": self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                    config={
+                        CONST_MONITORING_USING_AAD_MSI_AUTH: "true",
+                    }
+                )
+            },
+        )
+        ctx.attach_mc(mc)
+        result = ctx.get_enable_msi_auth_for_monitoring()
+        self.assertTrue(result)
+
     def test_get_enable_default_domain(self):
         # default value
         ctx_1 = AKSPreviewManagedClusterContext(
@@ -8317,6 +8348,33 @@ class AKSPreviewManagedClusterCreateDecoratorTestCase(unittest.TestCase):
             {"enable_container_network_logs": True, "enable_high_log_scale_mode": True}
         )
         cluster = self._make_cluster_with_monitoring()
+        external_functions = dec.context.external_functions
+        with patch.object(
+            external_functions, "ensure_container_insights_for_monitoring", return_value=None
+        ) as mock_ecifm, patch.object(
+            dec.context, "get_enable_high_log_scale_mode", return_value=True
+        ):
+            dec.postprocessing_after_mc_created(cluster)
+        mock_ecifm.assert_called_once()
+        _, kwargs = mock_ecifm.call_args
+        self.assertTrue(kwargs["create_dcr"])
+
+    def test_postprocessing_create_dcr_true_with_camelcase_addon_key(self):
+        """create_dcr=True when the API response uses the camelCase 'omsAgent' addon key.
+
+        The API may return 'omsAgent' instead of 'omsagent'. The postprocessing must
+        handle both key variants to ensure the DCR is updated.
+        """
+        dec = self._make_postprocessing_decorator(
+            {"enable_container_network_logs": True, "enable_high_log_scale_mode": True}
+        )
+        # Build cluster with camelCase addon key (as the API might return)
+        cluster = self.models.ManagedCluster(
+            location="test_location",
+            addon_profiles={
+                CONST_MONITORING_ADDON_NAME_CAMELCASE: self.models.ManagedClusterAddonProfile(enabled=True)
+            },
+        )
         external_functions = dec.context.external_functions
         with patch.object(
             external_functions, "ensure_container_insights_for_monitoring", return_value=None
@@ -14250,6 +14308,71 @@ class AKSPreviewManagedClusterUpdateDecoratorTestCase(unittest.TestCase):
         self.assertFalse(
             dec.context.get_intermediate("monitoring_addon_postprocessing_required", default_value=False)
         )
+
+    def test_update_postprocessing_with_camelcase_addon_key(self):
+        """Test that update postprocessing works when the API response uses 'omsAgent' (camelCase).
+
+        The API may return the monitoring addon as 'omsAgent' instead of 'omsagent'.
+        The postprocessing must handle both key variants so the DCR gets updated.
+        """
+        dec = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "enable_container_network_logs": True,
+                "enable_high_log_scale_mode": True,
+                "name": "test_name",
+                "resource_group_name": "test_rg_name",
+                "location": "test_location",
+                "enable_msi_auth_for_monitoring": True,
+                "enable_syslog": False,
+                "data_collection_settings": None,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        mc = self.models.ManagedCluster(
+            location="test_location",
+            network_profile=self.models.ContainerServiceNetworkProfile(
+                advanced_networking=self.models.AdvancedNetworking(
+                    enabled=True,
+                ),
+            ),
+            addon_profiles={
+                "omsagent": self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                    config={
+                        CONST_MONITORING_USING_AAD_MSI_AUTH: "true",
+                    }
+                )
+            },
+        )
+        dec.context.attach_mc(mc)
+        dec.context.set_intermediate("subscription_id", "test_subscription_id")
+        # Simulate profile update setting the postprocessing flag
+        dec.update_monitoring_profile_flow_logs(mc)
+        self.assertTrue(dec.context.get_intermediate("monitoring_addon_postprocessing_required"))
+
+        # Build API response cluster with camelCase addon key
+        cluster = self.models.ManagedCluster(
+            location="test_location",
+            addon_profiles={
+                CONST_MONITORING_ADDON_NAME_CAMELCASE: self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                    config={
+                        CONST_MONITORING_USING_AAD_MSI_AUTH: "true",
+                    }
+                )
+            },
+        )
+        external_functions = dec.context.external_functions
+        with patch.object(
+            external_functions, "ensure_container_insights_for_monitoring", return_value=None
+        ) as mock_ecifm:
+            dec.postprocessing_after_mc_created(cluster)
+        mock_ecifm.assert_called_once()
+        _, kwargs = mock_ecifm.call_args
+        self.assertTrue(kwargs["create_dcr"])
+        self.assertTrue(kwargs["enable_high_log_scale_mode"])
 
     def test_update_node_provisioning_profile(self):
         dec_0 = AKSPreviewManagedClusterUpdateDecorator(

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
@@ -73,6 +73,7 @@ from azext_aks_preview.managed_cluster_decorator import (
     AKSPreviewManagedClusterCreateDecorator,
     AKSPreviewManagedClusterModels,
     AKSPreviewManagedClusterUpdateDecorator,
+    _get_monitoring_addon_key,
 )
 from azext_aks_preview.tests.latest.utils import get_test_data_file_path
 from azure.cli.command_modules.acs._consts import (
@@ -132,6 +133,65 @@ class AKSPreviewManagedClusterModelsTestCase(unittest.TestCase):
             models.pod_identity_models.ManagedClusterPodIdentityException,
             getattr(module, "ManagedClusterPodIdentityException"),
         )
+
+
+class AKSPreviewGetMonitoringAddonKeyTestCase(unittest.TestCase):
+    """Tests for the standalone _get_monitoring_addon_key helper function."""
+
+    def setUp(self):
+        register_aks_preview_resource_type()
+        self.cli_ctx = MockCLI()
+        self.cmd = MockCmd(self.cli_ctx)
+        self.models = AKSPreviewManagedClusterModels(self.cmd, CUSTOM_MGMT_AKS_PREVIEW)
+        self.addon_consts = {
+            "CONST_MONITORING_ADDON_NAME": CONST_MONITORING_ADDON_NAME,
+        }
+
+    def test_returns_lowercase_key_when_present(self):
+        cluster = self.models.ManagedCluster(
+            location="test_location",
+            addon_profiles={
+                CONST_MONITORING_ADDON_NAME: self.models.ManagedClusterAddonProfile(enabled=True),
+            },
+        )
+        result = _get_monitoring_addon_key(cluster, self.addon_consts)
+        self.assertEqual(result, CONST_MONITORING_ADDON_NAME)
+
+    def test_returns_camelcase_key_when_present(self):
+        cluster = self.models.ManagedCluster(
+            location="test_location",
+            addon_profiles={
+                CONST_MONITORING_ADDON_NAME_CAMELCASE: self.models.ManagedClusterAddonProfile(enabled=True),
+            },
+        )
+        result = _get_monitoring_addon_key(cluster, self.addon_consts)
+        self.assertEqual(result, CONST_MONITORING_ADDON_NAME_CAMELCASE)
+
+    def test_prefers_lowercase_when_both_present(self):
+        cluster = self.models.ManagedCluster(
+            location="test_location",
+            addon_profiles={
+                CONST_MONITORING_ADDON_NAME: self.models.ManagedClusterAddonProfile(enabled=True),
+                CONST_MONITORING_ADDON_NAME_CAMELCASE: self.models.ManagedClusterAddonProfile(enabled=True),
+            },
+        )
+        result = _get_monitoring_addon_key(cluster, self.addon_consts)
+        self.assertEqual(result, CONST_MONITORING_ADDON_NAME)
+
+    def test_returns_default_when_no_addon_profiles(self):
+        cluster = self.models.ManagedCluster(location="test_location")
+        result = _get_monitoring_addon_key(cluster, self.addon_consts)
+        self.assertEqual(result, CONST_MONITORING_ADDON_NAME)
+
+    def test_returns_default_when_neither_key_present(self):
+        cluster = self.models.ManagedCluster(
+            location="test_location",
+            addon_profiles={
+                "some_other_addon": self.models.ManagedClusterAddonProfile(enabled=True),
+            },
+        )
+        result = _get_monitoring_addon_key(cluster, self.addon_consts)
+        self.assertEqual(result, CONST_MONITORING_ADDON_NAME)
 
 
 class AKSPreviewManagedClusterContextTestCase(unittest.TestCase):
@@ -8282,11 +8342,11 @@ class AKSPreviewManagedClusterCreateDecoratorTestCase(unittest.TestCase):
             },
         )
 
-    def test_postprocessing_create_dcr_false_when_only_enable_addons(self):
-        """create_dcr=False when only enable_addons triggers ensure_container_insights_for_monitoring.
+    def test_postprocessing_create_dcr_true_when_only_enable_addons(self):
+        """create_dcr=True when enable_addons triggers ensure_container_insights_for_monitoring.
 
-        enable_addons is in the outer condition but NOT in cnl_or_hlsm_changing,
-        so create_dcr must be False.
+        DCR creation is now always requested during postprocessing so the
+        DCR is created alongside the DCRA after the cluster exists.
         """
         dec = self._make_postprocessing_decorator({"enable_addons": "monitoring"})
         cluster = self._make_cluster_with_monitoring()
@@ -8297,7 +8357,7 @@ class AKSPreviewManagedClusterCreateDecoratorTestCase(unittest.TestCase):
             dec.postprocessing_after_mc_created(cluster)
         mock_ecifm.assert_called_once()
         _, kwargs = mock_ecifm.call_args
-        self.assertFalse(kwargs["create_dcr"])
+        self.assertTrue(kwargs["create_dcr"])
 
     def test_postprocessing_ensure_container_insights_not_called_without_relevant_flags(self):
         """ensure_container_insights_for_monitoring is NOT called when no relevant flags are set.
@@ -8464,11 +8524,11 @@ class AKSPreviewManagedClusterCreateDecoratorTestCase(unittest.TestCase):
         _, kwargs = mock_ecifm.call_args
         self.assertTrue(kwargs["create_dcr"])
 
-    def test_postprocessing_create_dcr_false_when_enable_azure_monitor_logs(self):
-        """create_dcr=False when enable_azure_monitor_logs triggers ensure_container_insights_for_monitoring.
+    def test_postprocessing_create_dcr_true_when_enable_azure_monitor_logs(self):
+        """create_dcr=True when enable_azure_monitor_logs triggers ensure_container_insights_for_monitoring.
 
-        enable_azure_monitor_logs is in the outer _should_create_dcra condition but NOT in
-        _is_cnl_or_hlsm_changing, so create_dcr must be False.
+        DCR creation is now always requested during postprocessing so the
+        DCR is created alongside the DCRA after the cluster exists.
         """
         dec = self._make_postprocessing_decorator({"enable_azure_monitor_logs": True})
         cluster = self._make_cluster_with_monitoring()
@@ -8479,8 +8539,156 @@ class AKSPreviewManagedClusterCreateDecoratorTestCase(unittest.TestCase):
             dec.postprocessing_after_mc_created(cluster)
         mock_ecifm.assert_called_once()
         _, kwargs = mock_ecifm.call_args
-        self.assertFalse(kwargs["create_dcr"])
+        self.assertTrue(kwargs["create_dcr"])
 
+    # ------------------------------------------------------------------
+    # Tests for _should_create_dcra and _is_cnl_or_hlsm_changing helpers
+    # ------------------------------------------------------------------
+    def test_is_cnl_or_hlsm_changing_true_for_cnl_flags(self):
+        """_is_cnl_or_hlsm_changing returns True when any CNL/HLSM flag is set."""
+        for param_name in [
+            "enable_container_network_logs",
+            "enable_retina_flow_logs",
+            "disable_container_network_logs",
+            "disable_retina_flow_logs",
+        ]:
+            dec = self._make_postprocessing_decorator({param_name: True})
+            self.assertTrue(dec._is_cnl_or_hlsm_changing(), f"Expected True for {param_name}")
+
+    def test_is_cnl_or_hlsm_changing_true_for_hlsm_flag(self):
+        dec = self._make_postprocessing_decorator({"enable_high_log_scale_mode": True})
+        self.assertTrue(dec._is_cnl_or_hlsm_changing())
+
+    def test_is_cnl_or_hlsm_changing_false_when_no_flags(self):
+        dec = self._make_postprocessing_decorator({})
+        self.assertFalse(dec._is_cnl_or_hlsm_changing())
+
+    def test_should_create_dcra_true_for_enable_addons(self):
+        dec = self._make_postprocessing_decorator({"enable_addons": "monitoring"})
+        self.assertTrue(dec._should_create_dcra())
+
+    def test_should_create_dcra_true_for_enable_azure_monitor_logs(self):
+        dec = self._make_postprocessing_decorator({"enable_azure_monitor_logs": True})
+        self.assertTrue(dec._should_create_dcra())
+
+    def test_should_create_dcra_true_for_cnl_flag(self):
+        dec = self._make_postprocessing_decorator({"enable_container_network_logs": True})
+        self.assertTrue(dec._should_create_dcra())
+
+    def test_should_create_dcra_false_when_no_relevant_flags(self):
+        dec = self._make_postprocessing_decorator({})
+        self.assertFalse(dec._should_create_dcra())
+
+    # ------------------------------------------------------------------
+    # Tests for _postprocess_monitoring_disable
+    # ------------------------------------------------------------------
+    def test_postprocess_monitoring_disable_calls_ensure_container_insights(self):
+        """_postprocess_monitoring_disable calls ensure_container_insights with remove_monitoring=True."""
+        dec = self._make_postprocessing_decorator({})
+        # Mock client.get to return cluster with monitoring addon
+        cluster_with_monitoring = self.models.ManagedCluster(
+            location="test_location",
+            addon_profiles={
+                CONST_MONITORING_ADDON_NAME: self.models.ManagedClusterAddonProfile(enabled=True)
+            },
+        )
+        dec.client = Mock()
+        dec.client.get = Mock(return_value=cluster_with_monitoring)
+        external_functions = dec.context.external_functions
+        with patch.object(
+            external_functions, "ensure_container_insights_for_monitoring", return_value=None
+        ) as mock_ecifm:
+            dec._postprocess_monitoring_disable()
+        mock_ecifm.assert_called_once()
+        _, kwargs = mock_ecifm.call_args
+        self.assertTrue(kwargs["remove_monitoring"])
+
+    def test_postprocess_monitoring_disable_no_addon_is_noop(self):
+        """_postprocess_monitoring_disable is a no-op when no monitoring addon on current cluster."""
+        dec = self._make_postprocessing_decorator({})
+        cluster_without_monitoring = self.models.ManagedCluster(location="test_location")
+        dec.client = Mock()
+        dec.client.get = Mock(return_value=cluster_without_monitoring)
+        external_functions = dec.context.external_functions
+        with patch.object(
+            external_functions, "ensure_container_insights_for_monitoring", return_value=None
+        ) as mock_ecifm:
+            dec._postprocess_monitoring_disable()
+        mock_ecifm.assert_not_called()
+
+    def test_postprocess_monitoring_disable_swallows_type_error(self):
+        """_postprocess_monitoring_disable should not raise on TypeError from ensure_container_insights."""
+        dec = self._make_postprocessing_decorator({})
+        cluster_with_monitoring = self.models.ManagedCluster(
+            location="test_location",
+            addon_profiles={
+                CONST_MONITORING_ADDON_NAME: self.models.ManagedClusterAddonProfile(enabled=True)
+            },
+        )
+        dec.client = Mock()
+        dec.client.get = Mock(return_value=cluster_with_monitoring)
+        external_functions = dec.context.external_functions
+        with patch.object(
+            external_functions, "ensure_container_insights_for_monitoring", side_effect=TypeError("test")
+        ):
+            # Should not raise
+            dec._postprocess_monitoring_disable()
+
+    # ------------------------------------------------------------------
+    # Tests for put_mc conditional postprocessing
+    # ------------------------------------------------------------------
+    def test_put_mc_with_postprocessing(self):
+        """put_mc waits for the operation and calls postprocessing when needed."""
+        dec = self._make_postprocessing_decorator({"enable_addons": "monitoring"})
+        mc = dec.context.mc
+        dec.client = Mock()
+        mock_poller = Mock()
+        dec.client.begin_create_or_update = Mock(return_value=mock_poller)
+        returned_cluster = self._make_cluster_with_monitoring()
+        with patch(
+            "azext_aks_preview.managed_cluster_decorator.LongRunningOperation",
+            return_value=Mock(return_value=returned_cluster),
+        ), patch.object(dec, "postprocessing_after_mc_created") as mock_post, \
+           patch.object(dec, "immediate_processing_after_request"):
+            result = dec.put_mc(mc)
+        mock_post.assert_called_once_with(returned_cluster)
+        self.assertEqual(result, returned_cluster)
+
+    def test_put_mc_without_postprocessing_uses_sdk_no_wait(self):
+        """put_mc uses sdk_no_wait when no postprocessing is required."""
+        dec = self._make_postprocessing_decorator({})
+        mc = dec.context.mc
+        dec.client = Mock()
+        expected_result = Mock()
+        with patch.object(dec, "check_is_postprocessing_required", return_value=False), \
+             patch(
+                 "azext_aks_preview.managed_cluster_decorator.sdk_no_wait",
+                 return_value=expected_result,
+             ) as mock_sdk_no_wait:
+            result = dec.put_mc(mc)
+        mock_sdk_no_wait.assert_called_once()
+        self.assertEqual(result, expected_result)
+
+    # ------------------------------------------------------------------
+    # Test for postprocessing_after_mc_created with monitoring_being_enabled bypass
+    # ------------------------------------------------------------------
+    def test_postprocessing_enable_hlsm_with_monitoring_being_enabled_simultaneously(self):
+        """When enable_high_log_scale_mode=True and monitoring is being enabled in same command,
+        the standalone HLSM validation should be skipped (monitoring_being_enabled=True path)."""
+        dec = self._make_postprocessing_decorator({
+            "enable_addons": "monitoring",
+            "enable_high_log_scale_mode": True,
+        })
+        cluster = self._make_cluster_with_monitoring()
+        external_functions = dec.context.external_functions
+        with patch.object(
+            external_functions, "ensure_container_insights_for_monitoring", return_value=None
+        ) as mock_ecifm:
+            dec.postprocessing_after_mc_created(cluster)
+        mock_ecifm.assert_called_once()
+        _, kwargs = mock_ecifm.call_args
+        self.assertTrue(kwargs["create_dcr"])
+        self.assertTrue(kwargs["enable_high_log_scale_mode"])
 
     def test_set_up_health_monitor_profile(self):
         # no flag - no change
@@ -11629,6 +11837,124 @@ class AKSPreviewManagedClusterUpdateDecoratorTestCase(unittest.TestCase):
         self.assertIn("omsagent", mc_1.addon_profiles)
         self.assertFalse(mc_1.addon_profiles["omsagent"].enabled)
         self.assertIsNone(mc_1.addon_profiles["omsagent"].config)
+
+    def test_disable_azure_monitor_logs_disables_container_insights(self):
+        # Test that _disable_azure_monitor_logs disables both addon profile AND
+        # azureMonitorProfile.containerInsights (the new API surface)
+        dec_1 = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "disable_azure_monitor_logs": True,
+                "yes": True,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+
+        mc_1 = self.models.ManagedCluster(
+            location="test_location",
+            addon_profiles={
+                "omsagent": self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                    config={
+                        "logAnalyticsWorkspaceResourceID": "/subscriptions/test/workspace",
+                        "useAADAuth": "false"
+                    }
+                )
+            },
+            azure_monitor_profile=self.models.ManagedClusterAzureMonitorProfile(
+                container_insights=self.models.ManagedClusterAzureMonitorProfileContainerInsights(
+                    enabled=True,
+                    log_analytics_workspace_resource_id="/subscriptions/test/workspace"
+                )
+            ),
+        )
+        dec_1.context.attach_mc(mc_1)
+
+        dec_1._disable_azure_monitor_logs(mc_1)
+
+        # Verify addon profile is disabled
+        self.assertFalse(mc_1.addon_profiles["omsagent"].enabled)
+        self.assertIsNone(mc_1.addon_profiles["omsagent"].config)
+
+        # Verify container_insights is also disabled
+        self.assertFalse(mc_1.azure_monitor_profile.container_insights.enabled)
+
+    def test_disable_azure_monitor_logs_disables_container_insights_camelcase(self):
+        # Same test but with omsAgent (camelCase) key
+        dec_1 = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "disable_azure_monitor_logs": True,
+                "yes": True,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+
+        mc_1 = self.models.ManagedCluster(
+            location="test_location",
+            addon_profiles={
+                "omsAgent": self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                    config={
+                        "logAnalyticsWorkspaceResourceID": "/subscriptions/test/workspace",
+                        "useAADAuth": "false"
+                    }
+                )
+            },
+            azure_monitor_profile=self.models.ManagedClusterAzureMonitorProfile(
+                container_insights=self.models.ManagedClusterAzureMonitorProfileContainerInsights(
+                    enabled=True,
+                    log_analytics_workspace_resource_id="/subscriptions/test/workspace"
+                )
+            ),
+        )
+        dec_1.context.attach_mc(mc_1)
+
+        dec_1._disable_azure_monitor_logs(mc_1)
+
+        # Verify addon profile is disabled
+        self.assertFalse(mc_1.addon_profiles["omsAgent"].enabled)
+        self.assertIsNone(mc_1.addon_profiles["omsAgent"].config)
+
+        # Verify container_insights is also disabled
+        self.assertFalse(mc_1.azure_monitor_profile.container_insights.enabled)
+
+    def test_disable_azure_monitor_logs_without_container_insights(self):
+        # Test that disable works when container_insights is not set (addon-only cluster)
+        dec_1 = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "disable_azure_monitor_logs": True,
+                "yes": True,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+
+        mc_1 = self.models.ManagedCluster(
+            location="test_location",
+            addon_profiles={
+                "omsagent": self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                    config={
+                        "logAnalyticsWorkspaceResourceID": "/subscriptions/test/workspace",
+                        "useAADAuth": "false"
+                    }
+                )
+            },
+        )
+        dec_1.context.attach_mc(mc_1)
+
+        dec_1._disable_azure_monitor_logs(mc_1)
+
+        # Verify addon profile is disabled
+        self.assertFalse(mc_1.addon_profiles["omsagent"].enabled)
+        self.assertIsNone(mc_1.addon_profiles["omsagent"].config)
+
+        # container_insights was never set, should not error
+        self.assertIsNone(mc_1.azure_monitor_profile)
 
     def test_get_enable_opentelemetry_logs_validation_with_omsagent_camelcase(self):
         # Test that OpenTelemetry logs validation recognizes omsAgent (camelCase) as enabled
@@ -15917,6 +16243,238 @@ class AKSPreviewManagedClusterUpdateDecoratorTestCase(unittest.TestCase):
             ),
         )
         self.assertEqual(dec_mc_3, ground_truth_mc_3)
+
+    # ------------------------------------------------------------------
+    # Tests for _setup_azure_monitor_logs setting enableRetinaNetworkFlags
+    # ------------------------------------------------------------------
+    def test_setup_azure_monitor_logs_sets_retina_flags_when_cnl_enabled(self):
+        """_setup_azure_monitor_logs sets enableRetinaNetworkFlags in config when CNL is being enabled."""
+        dec = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "enable_azure_monitor_logs": True,
+                "enable_container_network_logs": True,
+                "workspace_resource_id": "/subscriptions/test/resourceGroups/test/providers/Microsoft.OperationalInsights/workspaces/test",
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        mc = self.models.ManagedCluster(
+            location="test_location",
+            network_profile=self.models.ContainerServiceNetworkProfile(
+                advanced_networking=self.models.AdvancedNetworking(enabled=True),
+            ),
+            addon_profiles={},
+        )
+        dec.context.attach_mc(mc)
+
+        with patch.object(
+            dec.context.external_functions,
+            "sanitize_loganalytics_ws_resource_id",
+            side_effect=lambda x: x,
+        ):
+            dec._setup_azure_monitor_logs(mc)
+
+        addon_profile = mc.addon_profiles.get(CONST_MONITORING_ADDON_NAME)
+        self.assertIsNotNone(addon_profile)
+        self.assertEqual(addon_profile.config.get("enableRetinaNetworkFlags"), "True")
+
+    def test_setup_azure_monitor_logs_no_retina_flags_without_cnl(self):
+        """_setup_azure_monitor_logs does NOT set enableRetinaNetworkFlags when CNL is not specified."""
+        dec = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "enable_azure_monitor_logs": True,
+                "workspace_resource_id": "/subscriptions/test/resourceGroups/test/providers/Microsoft.OperationalInsights/workspaces/test",
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        mc = self.models.ManagedCluster(
+            location="test_location",
+            addon_profiles={},
+        )
+        dec.context.attach_mc(mc)
+
+        with patch.object(
+            dec.context.external_functions,
+            "sanitize_loganalytics_ws_resource_id",
+            side_effect=lambda x: x,
+        ):
+            dec._setup_azure_monitor_logs(mc)
+
+        addon_profile = mc.addon_profiles.get(CONST_MONITORING_ADDON_NAME)
+        self.assertIsNotNone(addon_profile)
+        self.assertNotIn("enableRetinaNetworkFlags", addon_profile.config)
+
+    # ------------------------------------------------------------------
+    # Tests for _disable_azure_monitor_logs disabling containerInsights
+    # ------------------------------------------------------------------
+    def test_disable_azure_monitor_logs_disables_container_insights_with_msi_auth(self):
+        """_disable_azure_monitor_logs sets containerInsights.enabled=False when MSI auth is enabled,
+        triggering DCR/DCRA cleanup path."""
+        dec = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "disable_azure_monitor_logs": True,
+                "yes": True,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        mc = self.models.ManagedCluster(
+            location="test_location",
+            addon_profiles={
+                CONST_MONITORING_ADDON_NAME: self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                    config={
+                        CONST_MONITORING_USING_AAD_MSI_AUTH: "true",
+                        CONST_MONITORING_LOG_ANALYTICS_WORKSPACE_RESOURCE_ID: "/subscriptions/test/rg/ws",
+                    },
+                ),
+            },
+            azure_monitor_profile=self.models.ManagedClusterAzureMonitorProfile(
+                container_insights=self.models.ManagedClusterAzureMonitorProfileContainerInsights(
+                    enabled=True,
+                ),
+            ),
+        )
+        dec.context.attach_mc(mc)
+        dec.client = Mock()
+        dec.client.get = Mock(return_value=mc)
+        with patch.object(dec.context, "get_subscription_id", return_value="test-sub"), \
+             patch.object(dec.context, "get_resource_group_name", return_value="test-rg"), \
+             patch.object(dec.context, "get_name", return_value="test-cluster"), \
+             patch.object(
+                 dec.context.external_functions, "ensure_container_insights_for_monitoring", return_value=None,
+             ):
+            dec._disable_azure_monitor_logs(mc)
+        self.assertFalse(mc.addon_profiles[CONST_MONITORING_ADDON_NAME].enabled)
+        self.assertFalse(mc.azure_monitor_profile.container_insights.enabled)
+
+    def test_disable_azure_monitor_logs_no_container_insights_skips(self):
+        """_disable_azure_monitor_logs works fine when azureMonitorProfile has no containerInsights."""
+        dec = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "disable_azure_monitor_logs": True,
+                "yes": True,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        mc = self.models.ManagedCluster(
+            location="test_location",
+            addon_profiles={
+                CONST_MONITORING_ADDON_NAME: self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                    config={
+                        CONST_MONITORING_USING_AAD_MSI_AUTH: "false",
+                    },
+                ),
+            },
+        )
+        dec.context.attach_mc(mc)
+        dec.client = Mock()
+        dec.client.get = Mock(return_value=mc)
+        dec._disable_azure_monitor_logs(mc)
+        self.assertFalse(mc.addon_profiles[CONST_MONITORING_ADDON_NAME].enabled)
+
+    # ------------------------------------------------------------------
+    # Tests for update_monitoring_profile_flow_logs: monitoring_being_enabled bypass
+    # ------------------------------------------------------------------
+    def test_update_hlsm_standalone_skips_validation_when_monitoring_being_enabled(self):
+        """When enable_high_log_scale_mode=True and monitoring is being enabled simultaneously,
+        the validation of existing addon state is skipped."""
+        dec = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "enable_high_log_scale_mode": True,
+                "enable_azure_monitor_logs": True,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        # No monitoring addon present yet — would raise RequiredArgumentMissingError
+        # if validation wasn't bypassed.
+        mc = self.models.ManagedCluster(location="test_location")
+        dec.context.attach_mc(mc)
+        # Should NOT raise because monitoring is being enabled in the same command
+        dec.update_monitoring_profile_flow_logs(mc)
+        self.assertTrue(
+            dec.context.get_intermediate("monitoring_addon_postprocessing_required", default_value=False)
+        )
+
+    def test_update_hlsm_standalone_skips_validation_when_enable_addons_monitoring(self):
+        """When enable_high_log_scale_mode=True and --enable-addons monitoring in same command,
+        the validation of existing addon state is skipped."""
+        dec = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "enable_high_log_scale_mode": True,
+                "enable_addons": "monitoring",
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        mc = self.models.ManagedCluster(location="test_location")
+        dec.context.attach_mc(mc)
+        dec.update_monitoring_profile_flow_logs(mc)
+        self.assertTrue(
+            dec.context.get_intermediate("monitoring_addon_postprocessing_required", default_value=False)
+        )
+
+    def test_update_enable_cnl_sets_postprocessing_flag(self):
+        """Enabling CNL via enable_container_network_logs sets the postprocessing flag."""
+        dec = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {"enable_container_network_logs": True},
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        mc = self.models.ManagedCluster(
+            location="test_location",
+            network_profile=self.models.ContainerServiceNetworkProfile(
+                advanced_networking=self.models.AdvancedNetworking(enabled=True),
+            ),
+            addon_profiles={
+                CONST_MONITORING_ADDON_NAME: self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                    config={CONST_MONITORING_USING_AAD_MSI_AUTH: "true"},
+                )
+            },
+        )
+        dec.context.attach_mc(mc)
+        dec.update_monitoring_profile_flow_logs(mc)
+        self.assertTrue(
+            dec.context.get_intermediate("monitoring_addon_postprocessing_required", default_value=False)
+        )
+
+    def test_update_enable_retina_flow_logs_sets_postprocessing_flag(self):
+        """Enabling CNL via legacy enable_retina_flow_logs sets the postprocessing flag."""
+        dec = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {"enable_retina_flow_logs": True},
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        mc = self.models.ManagedCluster(
+            location="test_location",
+            network_profile=self.models.ContainerServiceNetworkProfile(
+                advanced_networking=self.models.AdvancedNetworking(enabled=True),
+            ),
+            addon_profiles={
+                CONST_MONITORING_ADDON_NAME: self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                    config={CONST_MONITORING_USING_AAD_MSI_AUTH: "true"},
+                )
+            },
+        )
+        dec.context.attach_mc(mc)
+        dec.update_monitoring_profile_flow_logs(mc)
+        self.assertTrue(
+            dec.context.get_intermediate("monitoring_addon_postprocessing_required", default_value=False)
+        )
 
 
 if __name__ == "__main__":

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
@@ -5160,6 +5160,33 @@ class AKSPreviewManagedClusterContextTestCase(unittest.TestCase):
         result = ctx.get_container_network_logs(mc)
         self.assertTrue(result)
 
+    def test_get_container_network_logs_with_monitoring_camelcase_key_on_mc(self):
+        """Test get_container_network_logs succeeds when monitoring uses omsAgent (camelCase) key on mc."""
+        ctx = AKSPreviewManagedClusterContext(
+            self.cmd,
+            AKSManagedClusterParamDict({
+                "enable_container_network_logs": True,
+            }),
+            self.models,
+            decorator_mode=DecoratorMode.UPDATE,
+        )
+        mc = self.models.ManagedCluster(
+            location="test_location",
+            network_profile=self.models.ContainerServiceNetworkProfile(
+                advanced_networking=self.models.AdvancedNetworking(
+                    enabled=True,
+                ),
+            ),
+            addon_profiles={
+                "omsAgent": self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                )
+            },
+        )
+        ctx.attach_mc(mc)
+        result = ctx.get_container_network_logs(mc)
+        self.assertTrue(result)
+
     def test_get_container_network_logs_error_without_acns(self):
         """Test get_container_network_logs raises error when ACNS is not enabled."""
         ctx = AKSPreviewManagedClusterContext(
@@ -11565,7 +11592,7 @@ class AKSPreviewManagedClusterUpdateDecoratorTestCase(unittest.TestCase):
         # Verify: omsAgent should be disabled
         self.assertIn("omsAgent", mc_1.addon_profiles)
         self.assertFalse(mc_1.addon_profiles["omsAgent"].enabled)
-        self.assertIsNone(mc_1.addon_profiles["omsAgent"].config)
+        self.assertEqual(mc_1.addon_profiles["omsAgent"].config, {})
 
     def test_disable_azure_monitor_logs_with_omsagent_lowercase(self):
         # Test that _disable_azure_monitor_logs handles omsagent (lowercase) correctly
@@ -11601,7 +11628,7 @@ class AKSPreviewManagedClusterUpdateDecoratorTestCase(unittest.TestCase):
         # Verify: omsagent should be disabled
         self.assertIn("omsagent", mc_1.addon_profiles)
         self.assertFalse(mc_1.addon_profiles["omsagent"].enabled)
-        self.assertIsNone(mc_1.addon_profiles["omsagent"].config)
+        self.assertEqual(mc_1.addon_profiles["omsagent"].config, {})
 
     def test_get_enable_opentelemetry_logs_validation_with_omsagent_camelcase(self):
         # Test that OpenTelemetry logs validation recognizes omsAgent (camelCase) as enabled

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
@@ -5237,6 +5237,161 @@ class AKSPreviewManagedClusterContextTestCase(unittest.TestCase):
         result = ctx.get_container_network_logs(mc)
         self.assertTrue(result)
 
+    def test_get_container_network_logs_with_azure_monitor_logs(self):
+        """Test get_container_network_logs succeeds when monitoring is enabled via enable_azure_monitor_logs param."""
+        ctx = AKSPreviewManagedClusterContext(
+            self.cmd,
+            AKSManagedClusterParamDict({
+                "enable_container_network_logs": True,
+                "enable_acns": True,
+                "enable_azure_monitor_logs": True,
+            }),
+            self.models,
+            decorator_mode=DecoratorMode.CREATE,
+        )
+        mc = self.models.ManagedCluster(
+            location="test_location",
+            network_profile=self.models.ContainerServiceNetworkProfile(
+                advanced_networking=self.models.AdvancedNetworking(
+                    enabled=True,
+                ),
+            ),
+        )
+        ctx.attach_mc(mc)
+        result = ctx.get_container_network_logs(mc)
+        self.assertTrue(result)
+
+    def test_get_container_network_logs_legacy_disable_retina_flow_logs(self):
+        """Test get_container_network_logs returns False when legacy disable_retina_flow_logs is specified."""
+        ctx = AKSPreviewManagedClusterContext(
+            self.cmd,
+            AKSManagedClusterParamDict({
+                "disable_retina_flow_logs": True,
+            }),
+            self.models,
+            decorator_mode=DecoratorMode.UPDATE,
+        )
+        mc = self.models.ManagedCluster(location="test_location")
+        ctx.attach_mc(mc)
+        result = ctx.get_container_network_logs(mc)
+        self.assertFalse(result)
+
+    def test_get_container_network_logs_with_acns_already_on_mc(self):
+        """Test get_container_network_logs succeeds when ACNS is already enabled on mc (not via raw param)."""
+        ctx = AKSPreviewManagedClusterContext(
+            self.cmd,
+            AKSManagedClusterParamDict({
+                "enable_container_network_logs": True,
+                "enable_addons": "monitoring",
+            }),
+            self.models,
+            decorator_mode=DecoratorMode.UPDATE,
+        )
+        mc = self.models.ManagedCluster(
+            location="test_location",
+            network_profile=self.models.ContainerServiceNetworkProfile(
+                advanced_networking=self.models.AdvancedNetworking(
+                    enabled=True,
+                ),
+            ),
+        )
+        ctx.attach_mc(mc)
+        result = ctx.get_container_network_logs(mc)
+        self.assertTrue(result)
+
+    def test_get_enable_high_log_scale_mode_cnl_with_explicit_true(self):
+        """Test when user enables both CNL and HLSM=True explicitly. Should succeed and return True."""
+        ctx = AKSPreviewManagedClusterContext(
+            self.cmd,
+            AKSManagedClusterParamDict({
+                "enable_container_network_logs": True,
+                "enable_high_log_scale_mode": True,
+                "enable_acns": True,
+                "enable_addons": "monitoring",
+            }),
+            self.models,
+            decorator_mode=DecoratorMode.CREATE,
+        )
+        result = ctx.get_enable_high_log_scale_mode()
+        self.assertTrue(result)
+
+    def test_get_enable_high_log_scale_mode_update_explicit_false_without_cnl(self):
+        """Test that HLSM=False without CNL returns False in update mode without error."""
+        ctx = AKSPreviewManagedClusterContext(
+            self.cmd,
+            AKSManagedClusterParamDict({
+                "enable_high_log_scale_mode": False,
+            }),
+            self.models,
+            decorator_mode=DecoratorMode.UPDATE,
+        )
+        mc = self.models.ManagedCluster(
+            location="test_location",
+            addon_profiles={
+                "omsagent": self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                )
+            },
+        )
+        ctx.attach_mc(mc)
+        result = ctx.get_enable_high_log_scale_mode()
+        self.assertFalse(result)
+
+    def test_get_enable_high_log_scale_mode_update_error_explicit_false_with_cnl(self):
+        """Test error when user explicitly disables HLSM with CNL enabled in update mode."""
+        ctx = AKSPreviewManagedClusterContext(
+            self.cmd,
+            AKSManagedClusterParamDict({
+                "enable_container_network_logs": True,
+                "enable_high_log_scale_mode": False,
+            }),
+            self.models,
+            decorator_mode=DecoratorMode.UPDATE,
+        )
+        mc = self.models.ManagedCluster(
+            location="test_location",
+            network_profile=self.models.ContainerServiceNetworkProfile(
+                advanced_networking=self.models.AdvancedNetworking(
+                    enabled=True,
+                ),
+            ),
+            addon_profiles={
+                "omsagent": self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                )
+            },
+        )
+        ctx.attach_mc(mc)
+        with self.assertRaises(MutuallyExclusiveArgumentError):
+            ctx.get_enable_high_log_scale_mode()
+
+    def test_get_enable_high_log_scale_mode_update_monitoring_camelcase_key(self):
+        """Test auto-enable HLSM in update mode when monitoring uses camelCase 'omsAgent' key."""
+        ctx = AKSPreviewManagedClusterContext(
+            self.cmd,
+            AKSManagedClusterParamDict({
+                "enable_container_network_logs": True,
+            }),
+            self.models,
+            decorator_mode=DecoratorMode.UPDATE,
+        )
+        mc = self.models.ManagedCluster(
+            location="test_location",
+            network_profile=self.models.ContainerServiceNetworkProfile(
+                advanced_networking=self.models.AdvancedNetworking(
+                    enabled=True,
+                ),
+            ),
+            addon_profiles={
+                "omsAgent": self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                )
+            },
+        )
+        ctx.attach_mc(mc)
+        result = ctx.get_enable_high_log_scale_mode()
+        self.assertTrue(result)
+
     def test_get_enable_default_domain(self):
         # default value
         ctx_1 = AKSPreviewManagedClusterContext(
@@ -5894,6 +6049,65 @@ class AKSPreviewManagedClusterCreateDecoratorTestCase(unittest.TestCase):
             # Verify high log scale mode is auto-enabled
             self.assertTrue(dec.context.get_enable_high_log_scale_mode())
 
+    def test_set_up_addon_profiles_cnl_and_hlsm_flag_without_value(self):
+        """Regression test: CREATE with --enable-container-network-logs --enable-acns
+        --enable-addons monitoring --enable-high-log-scale-mode (flag without boolean value).
+
+        When --enable-high-log-scale-mode is passed without a value, get_three_state_flag()
+        sets it to True via nargs='?'. This must NOT trigger the 'Container network logs
+        requires --enable-acns...' error when ACNS and monitoring are both provided.
+        """
+        dec = AKSPreviewManagedClusterCreateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "enable_addons": "monitoring",
+                "enable_container_network_logs": True,
+                "enable_high_log_scale_mode": True,  # simulates --enable-high-log-scale-mode without value
+                "enable_acns": True,
+                "workspace_resource_id": "test_workspace_resource_id",
+                "enable_msi_auth_for_monitoring": True,
+                "enable_syslog": False,
+                "data_collection_settings": None,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        network_profile = self.models.ContainerServiceNetworkProfile(
+            advanced_networking=self.models.AdvancedNetworking(enabled=True),
+        )
+        mc = self.models.ManagedCluster(location="test_location", network_profile=network_profile)
+        dec.context.attach_mc(mc)
+        dec.context.set_intermediate("subscription_id", "test_subscription_id")
+        external_functions = dec.context.external_functions
+        with patch.object(external_functions, 'ensure_container_insights_for_monitoring', return_value=None):
+            # Should NOT raise InvalidArgumentValueError
+            dec_mc = dec.set_up_addon_profiles(mc)
+            self.assertTrue(dec.context.get_enable_high_log_scale_mode())
+
+    def test_set_up_addon_profiles_hlsm_only_no_cnl(self):
+        """Test that enabling HLSM without CNL does not set enableRetinaNetworkFlags in config."""
+        dec = AKSPreviewManagedClusterCreateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "enable_addons": "monitoring",
+                "enable_high_log_scale_mode": True,
+                "workspace_resource_id": "test_workspace_resource_id",
+                "enable_msi_auth_for_monitoring": True,
+                "enable_syslog": False,
+                "data_collection_settings": None,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        mc = self.models.ManagedCluster(location="test_location")
+        dec.context.attach_mc(mc)
+        dec.context.set_intermediate("subscription_id", "test_subscription_id")
+        external_functions = dec.context.external_functions
+        with patch.object(external_functions, 'ensure_container_insights_for_monitoring', return_value=None):
+            dec_mc = dec.set_up_addon_profiles(mc)
+            # enableRetinaNetworkFlags should NOT be set when CNL is not enabled
+            omsagent_config = dec_mc.addon_profiles[CONST_MONITORING_ADDON_NAME].config
+            self.assertNotIn("enableRetinaNetworkFlags", omsagent_config)
 
     def test_set_up_http_proxy_config(self):
         dec_1 = AKSPreviewManagedClusterCreateDecorator(
@@ -13913,6 +14127,129 @@ class AKSPreviewManagedClusterUpdateDecoratorTestCase(unittest.TestCase):
         dec_8.context.attach_mc(mc_8)
         dec_8.update_monitoring_profile_flow_logs(mc_8)
         self.assertTrue(dec_8.context.get_intermediate("monitoring_addon_postprocessing_required"))
+
+    def test_update_monitoring_profile_flow_logs_no_flags_noop(self):
+        """Test that update_monitoring_profile_flow_logs is a no-op when no CNL/HLSM flags are specified."""
+        dec = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {},
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        mc = self.models.ManagedCluster(
+            location="test_location",
+            addon_profiles={
+                "omsagent": self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                    config={"enableRetinaNetworkFlags": "True"},
+                )
+            },
+        )
+        dec.context.attach_mc(mc)
+        dec_mc = dec.update_monitoring_profile_flow_logs(mc)
+        # Existing config should remain unchanged
+        self.assertEqual(
+            dec_mc.addon_profiles["omsagent"].config["enableRetinaNetworkFlags"],
+            "True",
+        )
+        self.assertFalse(
+            dec.context.get_intermediate("monitoring_addon_postprocessing_required", default_value=False)
+        )
+
+    def test_update_enable_cnl_with_azure_monitor_logs_on_cluster(self):
+        """Test enabling CNL on update when monitoring was enabled via enable_azure_monitor_logs on existing cluster."""
+        dec = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "enable_container_network_logs": True,
+                "enable_azure_monitor_logs": True,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        mc = self.models.ManagedCluster(
+            location="test_location",
+            network_profile=self.models.ContainerServiceNetworkProfile(
+                advanced_networking=self.models.AdvancedNetworking(
+                    enabled=True,
+                ),
+            ),
+            addon_profiles={
+                "omsagent": self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                )
+            },
+        )
+        dec.context.attach_mc(mc)
+        dec_mc = dec.update_monitoring_profile_flow_logs(mc)
+        self.assertEqual(
+            dec_mc.addon_profiles["omsagent"].config["enableRetinaNetworkFlags"],
+            "True",
+        )
+        self.assertTrue(dec.context.get_intermediate("monitoring_addon_postprocessing_required"))
+
+    def test_update_cnl_explicit_true_hlsm_with_prerequisites(self):
+        """Test enabling CNL + HLSM=True explicitly on update with all prerequisites met."""
+        dec = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "enable_container_network_logs": True,
+                "enable_high_log_scale_mode": True,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        mc = self.models.ManagedCluster(
+            location="test_location",
+            network_profile=self.models.ContainerServiceNetworkProfile(
+                advanced_networking=self.models.AdvancedNetworking(
+                    enabled=True,
+                ),
+            ),
+            addon_profiles={
+                "omsagent": self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                    config={
+                        CONST_MONITORING_USING_AAD_MSI_AUTH: "true",
+                    }
+                )
+            },
+        )
+        dec.context.attach_mc(mc)
+        dec_mc = dec.update_monitoring_profile_flow_logs(mc)
+        self.assertEqual(
+            dec_mc.addon_profiles["omsagent"].config["enableRetinaNetworkFlags"],
+            "True",
+        )
+        self.assertTrue(dec.context.get_enable_high_log_scale_mode())
+        self.assertTrue(dec.context.get_intermediate("monitoring_addon_postprocessing_required"))
+
+    def test_update_disable_hlsm_standalone_no_postprocessing(self):
+        """Test that disabling HLSM standalone (no CNL flag) does not trigger postprocessing."""
+        dec = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "enable_high_log_scale_mode": False,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        mc = self.models.ManagedCluster(
+            location="test_location",
+            addon_profiles={
+                "omsagent": self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                    config={
+                        CONST_MONITORING_USING_AAD_MSI_AUTH: "true",
+                    }
+                )
+            },
+        )
+        dec.context.attach_mc(mc)
+        dec.update_monitoring_profile_flow_logs(mc)
+        self.assertFalse(
+            dec.context.get_intermediate("monitoring_addon_postprocessing_required", default_value=False)
+        )
 
     def test_update_node_provisioning_profile(self):
         dec_0 = AKSPreviewManagedClusterUpdateDecorator(

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
@@ -8402,10 +8402,10 @@ class AKSPreviewManagedClusterCreateDecoratorTestCase(unittest.TestCase):
         _, kwargs = mock_ecifm.call_args
         self.assertTrue(kwargs["create_dcr"])
 
-    def test_postprocessing_create_dcr_true_when_disable_container_network_logs(self):
-        """create_dcr=True when disable_container_network_logs is set.
+    def test_postprocessing_no_dcr_when_disable_container_network_logs(self):
+        """ensure_container_insights is NOT called when only disable_container_network_logs is set.
 
-        disable_container_network_logs is in cnl_or_hlsm_changing, so create_dcr must be True.
+        Disable flags should not trigger DCR/DCRA creation.
         """
         dec = self._make_postprocessing_decorator({"disable_container_network_logs": True})
         cluster = self._make_cluster_with_monitoring()
@@ -8414,14 +8414,12 @@ class AKSPreviewManagedClusterCreateDecoratorTestCase(unittest.TestCase):
             external_functions, "ensure_container_insights_for_monitoring", return_value=None
         ) as mock_ecifm:
             dec.postprocessing_after_mc_created(cluster)
-        mock_ecifm.assert_called_once()
-        _, kwargs = mock_ecifm.call_args
-        self.assertTrue(kwargs["create_dcr"])
+        mock_ecifm.assert_not_called()
 
-    def test_postprocessing_create_dcr_true_when_disable_retina_flow_logs(self):
-        """create_dcr=True when the deprecated disable_retina_flow_logs flag is set.
+    def test_postprocessing_no_dcr_when_disable_retina_flow_logs(self):
+        """ensure_container_insights is NOT called when only disable_retina_flow_logs is set.
 
-        disable_retina_flow_logs is in cnl_or_hlsm_changing, so create_dcr must be True.
+        Disable flags should not trigger DCR/DCRA creation.
         """
         dec = self._make_postprocessing_decorator({"disable_retina_flow_logs": True})
         cluster = self._make_cluster_with_monitoring()
@@ -8430,9 +8428,7 @@ class AKSPreviewManagedClusterCreateDecoratorTestCase(unittest.TestCase):
             external_functions, "ensure_container_insights_for_monitoring", return_value=None
         ) as mock_ecifm:
             dec.postprocessing_after_mc_created(cluster)
-        mock_ecifm.assert_called_once()
-        _, kwargs = mock_ecifm.call_args
-        self.assertTrue(kwargs["create_dcr"])
+        mock_ecifm.assert_not_called()
 
     def test_postprocessing_create_dcr_true_when_enable_high_log_scale_mode_true(self):
         """create_dcr=True when enable_high_log_scale_mode=True is set.
@@ -8536,15 +8532,22 @@ class AKSPreviewManagedClusterCreateDecoratorTestCase(unittest.TestCase):
     # Tests for _should_create_dcra and _is_cnl_or_hlsm_changing helpers
     # ------------------------------------------------------------------
     def test_is_cnl_or_hlsm_changing_true_for_cnl_flags(self):
-        """_is_cnl_or_hlsm_changing returns True when any CNL/HLSM flag is set."""
+        """_is_cnl_or_hlsm_changing returns True when any CNL/HLSM enable flag is set."""
         for param_name in [
             "enable_container_network_logs",
             "enable_retina_flow_logs",
+        ]:
+            dec = self._make_postprocessing_decorator({param_name: True})
+            self.assertTrue(dec._is_cnl_or_hlsm_changing(), f"Expected True for {param_name}")
+
+    def test_is_cnl_or_hlsm_changing_false_for_disable_flags(self):
+        """_is_cnl_or_hlsm_changing returns False when only disable flags are set."""
+        for param_name in [
             "disable_container_network_logs",
             "disable_retina_flow_logs",
         ]:
             dec = self._make_postprocessing_decorator({param_name: True})
-            self.assertTrue(dec._is_cnl_or_hlsm_changing(), f"Expected True for {param_name}")
+            self.assertFalse(dec._is_cnl_or_hlsm_changing(), f"Expected False for {param_name}")
 
     def test_is_cnl_or_hlsm_changing_true_for_hlsm_flag(self):
         dec = self._make_postprocessing_decorator({"enable_high_log_scale_mode": True})
@@ -8571,11 +8574,14 @@ class AKSPreviewManagedClusterCreateDecoratorTestCase(unittest.TestCase):
         self.assertFalse(dec._should_create_dcra())
 
     # ------------------------------------------------------------------
-    # Tests for _postprocess_monitoring_disable
+    # Tests for monitoring disable postprocessing (inlined in postprocessing_after_mc_created)
     # ------------------------------------------------------------------
-    def test_postprocess_monitoring_disable_calls_ensure_container_insights(self):
-        """_postprocess_monitoring_disable calls ensure_container_insights with remove_monitoring=True."""
+    def test_postprocessing_monitoring_disable_calls_ensure_container_insights(self):
+        """postprocessing_after_mc_created calls ensure_container_insights with remove_monitoring=True for disable."""
         dec = self._make_postprocessing_decorator({})
+        # Disable the enable path so only the disable path runs
+        dec.context.set_intermediate("monitoring_addon_enabled", False, overwrite_exists=True)
+        dec.context.set_intermediate("monitoring_addon_disable_postprocessing_required", True, overwrite_exists=True)
         # Mock client.get to return cluster with monitoring addon
         cluster_with_monitoring = self.models.ManagedCluster(
             location="test_location",
@@ -8589,14 +8595,16 @@ class AKSPreviewManagedClusterCreateDecoratorTestCase(unittest.TestCase):
         with patch.object(
             external_functions, "ensure_container_insights_for_monitoring", return_value=None
         ) as mock_ecifm:
-            dec._postprocess_monitoring_disable()
+            dec.postprocessing_after_mc_created(cluster_with_monitoring)
         mock_ecifm.assert_called_once()
         _, kwargs = mock_ecifm.call_args
         self.assertTrue(kwargs["remove_monitoring"])
 
-    def test_postprocess_monitoring_disable_no_addon_is_noop(self):
-        """_postprocess_monitoring_disable is a no-op when no monitoring addon on current cluster."""
+    def test_postprocessing_monitoring_disable_no_addon_is_noop(self):
+        """postprocessing_after_mc_created disable path is a no-op when no monitoring addon on current cluster."""
         dec = self._make_postprocessing_decorator({})
+        dec.context.set_intermediate("monitoring_addon_enabled", False, overwrite_exists=True)
+        dec.context.set_intermediate("monitoring_addon_disable_postprocessing_required", True, overwrite_exists=True)
         cluster_without_monitoring = self.models.ManagedCluster(location="test_location")
         dec.client = Mock()
         dec.client.get = Mock(return_value=cluster_without_monitoring)
@@ -8604,12 +8612,14 @@ class AKSPreviewManagedClusterCreateDecoratorTestCase(unittest.TestCase):
         with patch.object(
             external_functions, "ensure_container_insights_for_monitoring", return_value=None
         ) as mock_ecifm:
-            dec._postprocess_monitoring_disable()
+            dec.postprocessing_after_mc_created(cluster_without_monitoring)
         mock_ecifm.assert_not_called()
 
-    def test_postprocess_monitoring_disable_swallows_type_error(self):
-        """_postprocess_monitoring_disable should not raise on TypeError from ensure_container_insights."""
+    def test_postprocessing_monitoring_disable_swallows_type_error(self):
+        """postprocessing_after_mc_created disable path should not raise on TypeError."""
         dec = self._make_postprocessing_decorator({})
+        dec.context.set_intermediate("monitoring_addon_enabled", False, overwrite_exists=True)
+        dec.context.set_intermediate("monitoring_addon_disable_postprocessing_required", True, overwrite_exists=True)
         cluster_with_monitoring = self.models.ManagedCluster(
             location="test_location",
             addon_profiles={
@@ -8623,7 +8633,7 @@ class AKSPreviewManagedClusterCreateDecoratorTestCase(unittest.TestCase):
             external_functions, "ensure_container_insights_for_monitoring", side_effect=TypeError("test")
         ):
             # Should not raise
-            dec._postprocess_monitoring_disable()
+            dec.postprocessing_after_mc_created(cluster_with_monitoring)
 
     # ------------------------------------------------------------------
     # Tests for put_mc conditional postprocessing
@@ -11711,14 +11721,14 @@ class AKSPreviewManagedClusterUpdateDecoratorTestCase(unittest.TestCase):
         # Call _setup_azure_monitor_logs
         dec_1._setup_azure_monitor_logs(mc_1)
 
-        # Verify: The parent class normalizes addon keys to lowercase in-place,
-        # so "omsAgent" becomes "omsagent". The key point is no duplicate is created.
-        self.assertIn("omsagent", mc_1.addon_profiles)
-        self.assertNotIn("omsAgent", mc_1.addon_profiles)
+        # Verify: The existing key is preserved (no duplicate created).
+        # The implementation keeps the original casing ("omsAgent") found in addon_profiles.
         self.assertEqual(len([k for k in mc_1.addon_profiles if k.lower() == "omsagent"]), 1)  # No duplicate
-        self.assertTrue(mc_1.addon_profiles["omsagent"].enabled)
+        # Find the actual key used (could be normalized or preserved depending on parent behavior)
+        actual_key = next(k for k in mc_1.addon_profiles if k.lower() == "omsagent")
+        self.assertTrue(mc_1.addon_profiles[actual_key].enabled)
         self.assertEqual(
-            mc_1.addon_profiles["omsagent"].config["logAnalyticsWorkspaceResourceID"],
+            mc_1.addon_profiles[actual_key].config["logAnalyticsWorkspaceResourceID"],
             "/subscriptions/test/resourceGroups/test/providers/Microsoft.OperationalInsights/workspaces/test-workspace"
         )
 

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
@@ -16310,6 +16310,160 @@ class AKSPreviewManagedClusterUpdateDecoratorTestCase(unittest.TestCase):
         self.assertNotIn("enableRetinaNetworkFlags", addon_profile.config)
 
     # ------------------------------------------------------------------
+    # Tests for _setup_azure_monitor_logs workspace change detection
+    # ------------------------------------------------------------------
+    def test_setup_azure_monitor_logs_workspace_change_triggers_postprocessing(self):
+        """_setup_azure_monitor_logs sets monitoring_addon_postprocessing_required when workspace changes."""
+        old_ws = "/subscriptions/test/resourceGroups/test/providers/Microsoft.OperationalInsights/workspaces/old-ws"
+        new_ws = "/subscriptions/test/resourceGroups/test/providers/Microsoft.OperationalInsights/workspaces/new-ws"
+        dec = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "enable_azure_monitor_logs": True,
+                "workspace_resource_id": new_ws,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        mc = self.models.ManagedCluster(
+            location="test_location",
+            addon_profiles={
+                CONST_MONITORING_ADDON_NAME: self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                    config={
+                        "logAnalyticsWorkspaceResourceID": old_ws,
+                        "useAADAuth": "true",
+                    },
+                )
+            },
+        )
+        dec.context.attach_mc(mc)
+        dec.context.set_intermediate("subscription_id", "test-subscription-id")
+
+        with patch.object(
+            dec.context.external_functions,
+            "sanitize_loganalytics_ws_resource_id",
+            side_effect=lambda x: x,
+        ):
+            dec._setup_azure_monitor_logs(mc)
+
+        self.assertTrue(
+            dec.context.get_intermediate("monitoring_addon_postprocessing_required", default_value=False)
+        )
+        # Verify workspace was updated
+        actual_key = next(k for k in mc.addon_profiles if k.lower() == "omsagent")
+        self.assertEqual(mc.addon_profiles[actual_key].config["logAnalyticsWorkspaceResourceID"], new_ws)
+
+    def test_setup_azure_monitor_logs_same_workspace_no_postprocessing(self):
+        """_setup_azure_monitor_logs does NOT set monitoring_addon_postprocessing_required when workspace is unchanged."""
+        ws = "/subscriptions/test/resourceGroups/test/providers/Microsoft.OperationalInsights/workspaces/same-ws"
+        dec = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "enable_azure_monitor_logs": True,
+                "workspace_resource_id": ws,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        mc = self.models.ManagedCluster(
+            location="test_location",
+            addon_profiles={
+                CONST_MONITORING_ADDON_NAME: self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                    config={
+                        "logAnalyticsWorkspaceResourceID": ws,
+                        "useAADAuth": "true",
+                    },
+                )
+            },
+        )
+        dec.context.attach_mc(mc)
+        dec.context.set_intermediate("subscription_id", "test-subscription-id")
+
+        with patch.object(
+            dec.context.external_functions,
+            "sanitize_loganalytics_ws_resource_id",
+            side_effect=lambda x: x,
+        ):
+            dec._setup_azure_monitor_logs(mc)
+
+        self.assertFalse(
+            dec.context.get_intermediate("monitoring_addon_postprocessing_required", default_value=False)
+        )
+
+    def test_setup_azure_monitor_logs_workspace_change_case_insensitive(self):
+        """_setup_azure_monitor_logs compares workspaces case-insensitively (no false positives on casing)."""
+        ws_lower = "/subscriptions/test/resourcegroups/test/providers/microsoft.operationalinsights/workspaces/my-ws"
+        ws_mixed = "/subscriptions/test/resourceGroups/test/providers/Microsoft.OperationalInsights/workspaces/my-ws"
+        dec = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "enable_azure_monitor_logs": True,
+                "workspace_resource_id": ws_mixed,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        mc = self.models.ManagedCluster(
+            location="test_location",
+            addon_profiles={
+                CONST_MONITORING_ADDON_NAME: self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                    config={
+                        "logAnalyticsWorkspaceResourceID": ws_lower,
+                        "useAADAuth": "true",
+                    },
+                )
+            },
+        )
+        dec.context.attach_mc(mc)
+        dec.context.set_intermediate("subscription_id", "test-subscription-id")
+
+        with patch.object(
+            dec.context.external_functions,
+            "sanitize_loganalytics_ws_resource_id",
+            side_effect=lambda x: x,
+        ):
+            dec._setup_azure_monitor_logs(mc)
+
+        # Same workspace (different casing) should NOT trigger postprocessing
+        self.assertFalse(
+            dec.context.get_intermediate("monitoring_addon_postprocessing_required", default_value=False)
+        )
+
+    def test_setup_azure_monitor_logs_new_addon_no_postprocessing(self):
+        """_setup_azure_monitor_logs does NOT trigger postprocessing when there is no existing addon (fresh enable)."""
+        new_ws = "/subscriptions/test/resourceGroups/test/providers/Microsoft.OperationalInsights/workspaces/new-ws"
+        dec = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {
+                "enable_azure_monitor_logs": True,
+                "workspace_resource_id": new_ws,
+            },
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+        mc = self.models.ManagedCluster(
+            location="test_location",
+            addon_profiles={},
+        )
+        dec.context.attach_mc(mc)
+        dec.context.set_intermediate("subscription_id", "test-subscription-id")
+
+        with patch.object(
+            dec.context.external_functions,
+            "sanitize_loganalytics_ws_resource_id",
+            side_effect=lambda x: x,
+        ):
+            dec._setup_azure_monitor_logs(mc)
+
+        # Fresh enable — no old workspace to compare, should NOT trigger postprocessing
+        self.assertFalse(
+            dec.context.get_intermediate("monitoring_addon_postprocessing_required", default_value=False)
+        )
+
+    # ------------------------------------------------------------------
     # Tests for _disable_azure_monitor_logs disabling containerInsights
     # ------------------------------------------------------------------
     def test_disable_azure_monitor_logs_disables_container_insights_with_msi_auth(self):

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
@@ -4872,6 +4872,23 @@ class AKSPreviewManagedClusterContextTestCase(unittest.TestCase):
         result = ctx.get_enable_high_log_scale_mode()
         self.assertTrue(result)
 
+    def test_get_enable_high_log_scale_mode_flag_without_value_create(self):
+        """Test passing --enable-high-log-scale-mode without an explicit boolean value.
+
+        When using get_three_state_flag() and the user passes the flag without a value
+        (e.g. --enable-high-log-scale-mode), argparse sets it to True via nargs='?'.
+        This should behave identically to passing --enable-high-log-scale-mode true.
+        """
+        # get_three_state_flag uses nargs='?'; no value => True
+        ctx = AKSPreviewManagedClusterContext(
+            self.cmd,
+            AKSManagedClusterParamDict({"enable_high_log_scale_mode": True}),
+            self.models,
+            decorator_mode=DecoratorMode.CREATE,
+        )
+        result = ctx.get_enable_high_log_scale_mode()
+        self.assertTrue(result)
+
     def test_get_enable_high_log_scale_mode_auto_enable_with_container_network_logs(self):
         """Test auto-enable when container network logs are enabled with proper prerequisites."""
         ctx = AKSPreviewManagedClusterContext(
@@ -5034,6 +5051,31 @@ class AKSPreviewManagedClusterContextTestCase(unittest.TestCase):
         ctx.attach_mc(mc)
         with self.assertRaises(RequiredArgumentMissingError):
             ctx.get_enable_high_log_scale_mode()
+
+    def test_get_enable_high_log_scale_mode_flag_without_value_update(self):
+        """Test passing --enable-high-log-scale-mode without an explicit boolean in update mode.
+
+        When using get_three_state_flag() and the user passes the flag without a value
+        (e.g. --enable-high-log-scale-mode), argparse sets it to True via nargs='?'.
+        In update mode this should enable HLSM on the existing cluster.
+        """
+        ctx = AKSPreviewManagedClusterContext(
+            self.cmd,
+            AKSManagedClusterParamDict({"enable_high_log_scale_mode": True}),
+            self.models,
+            decorator_mode=DecoratorMode.UPDATE,
+        )
+        mc = self.models.ManagedCluster(
+            location="test_location",
+            addon_profiles={
+                "omsagent": self.models.ManagedClusterAddonProfile(
+                    enabled=True,
+                )
+            },
+        )
+        ctx.attach_mc(mc)
+        result = ctx.get_enable_high_log_scale_mode()
+        self.assertTrue(result)
 
     def test_get_container_network_logs_returns_none_when_not_specified(self):
         """Test get_container_network_logs returns None when neither enable nor disable is specified."""

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
@@ -8275,7 +8275,7 @@ class AKSPreviewManagedClusterCreateDecoratorTestCase(unittest.TestCase):
     def test_postprocessing_ensure_container_insights_not_called_without_relevant_flags(self):
         """ensure_container_insights_for_monitoring is NOT called when no relevant flags are set.
 
-        When neither enable_addons, enable-azure-monitor-logs, nor any CNL/HLSM flag is
+        When neither enable_addons, enable_azure_monitor_logs, nor any CNL/HLSM flag is
         present in raw_params, the outer elif is not entered.
         """
         dec = self._make_postprocessing_decorator({})
@@ -8436,6 +8436,23 @@ class AKSPreviewManagedClusterCreateDecoratorTestCase(unittest.TestCase):
         mock_ecifm.assert_called_once()
         _, kwargs = mock_ecifm.call_args
         self.assertTrue(kwargs["create_dcr"])
+
+    def test_postprocessing_create_dcr_false_when_enable_azure_monitor_logs(self):
+        """create_dcr=False when enable_azure_monitor_logs triggers ensure_container_insights_for_monitoring.
+
+        enable_azure_monitor_logs is in the outer _should_create_dcra condition but NOT in
+        _is_cnl_or_hlsm_changing, so create_dcr must be False.
+        """
+        dec = self._make_postprocessing_decorator({"enable_azure_monitor_logs": True})
+        cluster = self._make_cluster_with_monitoring()
+        external_functions = dec.context.external_functions
+        with patch.object(
+            external_functions, "ensure_container_insights_for_monitoring", return_value=None
+        ) as mock_ecifm:
+            dec.postprocessing_after_mc_created(cluster)
+        mock_ecifm.assert_called_once()
+        _, kwargs = mock_ecifm.call_args
+        self.assertFalse(kwargs["create_dcr"])
 
 
     def test_set_up_health_monitor_profile(self):

--- a/src/aks-preview/linter_exclusions.yml
+++ b/src/aks-preview/linter_exclusions.yml
@@ -1,5 +1,41 @@
+aks addon:
+  rule_exclusions:
+    - require_wait_command_if_no_wait
+aks extension:
+  rule_exclusions:
+    - require_wait_command_if_no_wait
+aks jwtauthenticator:
+  rule_exclusions:
+    - require_wait_command_if_no_wait
+aks machine:
+  rule_exclusions:
+    - require_wait_command_if_no_wait
+aks mesh upgrade:
+  rule_exclusions:
+    - require_wait_command_if_no_wait
+aks mesh:
+  rule_exclusions:
+    - require_wait_command_if_no_wait
+aks namespace:
+  rule_exclusions:
+    - require_wait_command_if_no_wait
+aks nodepool manual-scale:
+  rule_exclusions:
+    - require_wait_command_if_no_wait
+aks nodepool snapshot:
+  rule_exclusions:
+    - require_wait_command_if_no_wait
+aks nodepool:
+  rule_exclusions:
+    - require_wait_command_if_no_wait
+aks snapshot:
+  rule_exclusions:
+    - require_wait_command_if_no_wait
 aks create:
   parameters:
+    node_resource_group:
+      rule_exclusions:
+        - parameter_should_not_end_in_resource_group
     enable_sgxquotehelper:
       rule_exclusions:
         - option_length_too_long

--- a/src/aks-preview/setup.py
+++ b/src/aks-preview/setup.py
@@ -9,7 +9,7 @@ from codecs import open as open1
 
 from setuptools import find_packages, setup
 
-VERSION = "20.0.0b3"
+VERSION = "20.0.0b4"
 
 CLASSIFIERS = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
### Related command
`az aks create`, `az aks update`

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 

---

### Description

Fixes the `az aks create` and `az aks update` commands so that the Data Collection Rule (DCR) is properly created or updated when container network logs (CNL) or high log scale mode (HLSM) flags are passed. Previously, the DCR was not being created/updated in these scenarios, causing streams like `Microsoft-ContainerLogV2-HighScale` to be out of sync.

Also fixes `--disable-azure-monitor-logs` so it actually disables monitoring by setting `azureMonitorProfile.containerInsights.enabled = False` (the RP's source of truth), and handles `omsAgent` vs `omsagent` key casing inconsistencies from the Azure API.

#### Changes

**Shared utilities:**
- Added `_get_monitoring_addon_key()` helper to resolve the monitoring addon key from a cluster's `addon_profiles`, handling both `omsagent` and `omsAgent` key variants returned by the API.

**Context (`AKSPreviewManagedClusterContext`):**
- Fixed `get_enable_msi_auth_for_monitoring()` to detect MSI auth on clusters where `service_principal_profile.client_id` is `"msi"` by checking the addon's `useAADAuth` config instead of returning `False`.
- Fixed `get_container_network_logs()` and `get_enable_high_log_scale_mode()` to handle both `omsagent` and `omsAgent` addon key variants.
- Added validation: disabling HLSM while CNL is still enabled now raises a `MutuallyExclusiveArgumentError`.
- Added `enable_high_log_scale_mode` to the special parameter defaults list so standalone `--enable-high-log-scale-mode` passes the `check_raw_parameters` gate.

**Create path (`AKSPreviewManagedClusterCreateDecorator`):**
- Moved DCR creation from postprocessing to `_setup_azure_monitor_logs()` (pre-PUT), matching the base class `build_monitoring_addon_profile` pattern. DCRA is still created in postprocessing.
- Added `_should_create_dcra()` and `_is_cnl_or_hlsm_changing()` helpers to detect when CNL/HLSM flags require DCR/DCRA creation.
- Refactored `_postprocess_monitoring_enable()` and `_postprocess_monitoring_disable()` into reusable methods.

**Update path (`AKSPreviewManagedClusterUpdateDecorator`):**
- `update_monitoring_profile_flow_logs()`: Added base class delegation (`super().update_monitoring_profile_flow_logs(mc)`) for CLI >= 2.84.0 compatibility, and guarded the call site in `update_mc_profile_preview()` to avoid double execution.
- When `--enable-container-network-logs` or `--enable-retina-flow-logs` is passed, the `monitoring_addon_postprocessing_required` intermediate is now set, triggering the DCR update via `ensure_container_insights_for_monitoring`.
- Added validation for standalone `--enable-high-log-scale-mode`: requires the monitoring addon with MSI auth to be enabled, with an escape hatch when `--enable-azure-monitor-logs` is passed simultaneously.
- Added validation for `--enable-high-log-scale-mode false`: prevents disabling HLSM while CNL is still enabled.
- Fixed `_disable_azure_monitor_logs()`: now sets `mc.azure_monitor_profile.container_insights.enabled = False` (the RP source of truth) and uses `config = None` instead of `config = {}` to match the base CLI behavior.
- Fixed monitoring postprocessing to use `_get_monitoring_addon_key()` for correct key resolution.

**Tests:**
- 6 new live integration tests: `test_aks_create_with_azuremonitorlogs_and_cnl`, `test_aks_update_enable_azuremonitorlogs_with_hlsm`, `test_aks_create_with_retina_flow_logs_alias`, `test_aks_update_enable_cnl_via_azuremonitorlogs`, `test_aks_update_disable_azuremonitorlogs`, `test_aks_update_standalone_enable_high_log_scale_mode`.
- 38 new unit tests covering context methods, create decorator, update decorator, postprocessing, key casing, and validation error paths.

#### Testing

- Unit tests: `pytest src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py -k "container_network_logs or high_log_scale_mode or enable_container_network or standalone_high_log or disable_azure_monitor or postprocessing_create_dcr or update_monitoring_profile_flow_logs"`
- Live integration tests: `AZURE_TEST_RUN_LIVE=true pytest src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py -k "test_aks_create_with_azuremonitorlogs_and_cnl or test_aks_update_enable_azuremonitorlogs_with_hlsm or test_aks_create_with_retina_flow_logs_alias or test_aks_update_enable_cnl_via_azuremonitorlogs or test_aks_update_disable_azuremonitorlogs or test_aks_update_standalone_enable_high_log_scale_mode"`