### PR TITLE
{AKS} `az aks bastion`: Fix `--subscription` not being passed to internal `az network bastion tunnel` and bastion discovery commands

### DIFF
--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -11,6 +11,7 @@ To release a new version, please select a new version number (usually plus 1 to 
 
 Pending
 +++++++
+* `az aks bastion`: Fix `--subscription` not being passed to internal `az network bastion tunnel` and bastion discovery commands.
 
 21.0.0b2
 ++++++++

--- a/src/aks-preview/azext_aks_preview/bastion/bastion.py
+++ b/src/aks-preview/azext_aks_preview/bastion/bastion.py
@@ -36,7 +36,7 @@ class BastionResource:
 
 
 def aks_bastion_parse_bastion_resource(
-    bastion: str, resource_groups: List[str]
+    bastion: str, resource_groups: List[str], subscription_id: str = None
 ) -> BastionResource:
     """Get the bastion resource name from the provided name or node resource group."""
 
@@ -55,18 +55,21 @@ def aks_bastion_parse_bastion_resource(
                     resource_group,
                 )
                 # check if the bastion exists in the provided resource group
+                show_cmd = [
+                    "network",
+                    "bastion",
+                    "show",
+                    "--resource-group",
+                    resource_group,
+                    "--name",
+                    bastion,
+                    "--output",
+                    "json",
+                ]
+                if subscription_id:
+                    show_cmd.extend(["--subscription", subscription_id])
                 result = run_az_cmd(
-                    [
-                        "network",
-                        "bastion",
-                        "show",
-                        "--resource-group",
-                        resource_group,
-                        "--name",
-                        bastion,
-                        "--output",
-                        "json",
-                    ],
+                    show_cmd,
                     out_file=TextIO(),
                 )
                 if result.exit_code != 0:
@@ -92,16 +95,19 @@ def aks_bastion_parse_bastion_resource(
     # list bastions in the provided resource groups
     for resource_group in resource_groups:
         logger.debug("Searching for bastion in resource group '%s'.", resource_group)
+        list_cmd = [
+            "network",
+            "bastion",
+            "list",
+            "--resource-group",
+            resource_group,
+            "--output",
+            "json",
+        ]
+        if subscription_id:
+            list_cmd.extend(["--subscription", subscription_id])
         result = run_az_cmd(
-            [
-                "network",
-                "bastion",
-                "list",
-                "--resource-group",
-                resource_group,
-                "--output",
-                "json",
-            ],
+            list_cmd,
             out_file=TextIO(),
         )
         if result.exit_code != 0:
@@ -243,12 +249,12 @@ def aks_bastion_set_kubeconfig(kubeconfig_path, port, cluster_name=None):
 
 
 async def aks_bastion_runner(
-    bastion_resource, port, mc_id, kubeconfig_path, test_hook=None
+    bastion_resource, port, mc_id, kubeconfig_path, subscription_id=None, test_hook=None
 ):
     """Run the bastion tunnel and subshell in parallel, cancelling the other if one completes."""
 
     task1 = asyncio.create_task(
-        _aks_bastion_launch_tunnel(bastion_resource, port, mc_id)
+        _aks_bastion_launch_tunnel(bastion_resource, port, mc_id, subscription_id)
     )
     if test_hook:
         task2 = asyncio.create_task(
@@ -468,7 +474,7 @@ async def _aks_bastion_launch_subshell(kubeconfig_path, port):
             logger.warning("Subshell was cancelled before it could be launched.")
 
 
-async def _aks_bastion_launch_tunnel(bastion_resource, port, mc_id):
+async def _aks_bastion_launch_tunnel(bastion_resource, port, mc_id, subscription_id=None):
     """Launch the bastion tunnel using the provided parameters."""
 
     tunnel_proces = None
@@ -478,6 +484,8 @@ async def _aks_bastion_launch_tunnel(bastion_resource, port, mc_id):
             f"{az_cmd_name} network bastion tunnel --resource-group {bastion_resource.resource_group} "
             f"--name {bastion_resource.name} --port {port} --target-resource-id {mc_id} --resource-port 443"
         )
+        if subscription_id:
+            cmd += f" --subscription {subscription_id}"
         logger.warning("Creating bastion tunnel with command: '%s'", cmd)
 
         # Use start_new_session on Unix to create a new process group

--- a/src/aks-preview/azext_aks_preview/custom.py
+++ b/src/aks-preview/azext_aks_preview/custom.py
@@ -5539,10 +5539,11 @@ def aks_bastion(cmd, client, resource_group_name, name, bastion=None, port=None,
         kubeconfig_path = os.path.join(temp_dir, ".kube", "config")
 
     try:
+        subscription_id = get_subscription_id(cmd.cli_ctx)
         mc = client.get(resource_group_name, name)
         mc_id = mc.id
         nrg = mc.node_resource_group
-        bastion_resource = aks_bastion_parse_bastion_resource(bastion, [nrg])
+        bastion_resource = aks_bastion_parse_bastion_resource(bastion, [nrg], subscription_id)
         port = aks_bastion_get_local_port(port)
 
         # Fetch credentials only if kubeconfig not provided
@@ -5574,6 +5575,7 @@ def aks_bastion(cmd, client, resource_group_name, name, bastion=None, port=None,
                 port,
                 mc_id,
                 kubeconfig_path,
+                subscription_id=subscription_id,
                 test_hook=os.getenv("AKS_BASTION_TEST_HOOK"),
             )
         )


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

`az aks bastion`

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
