### PR TITLE
Fix for Fairfax ExtType calls landing on Prod ARM URL

### DIFF
--- a/src/k8s-extension/azext_k8s_extension/vendored_sdks/_source_control_configuration_client.py
+++ b/src/k8s-extension/azext_k8s_extension/vendored_sdks/_source_control_configuration_client.py
@@ -233,8 +233,6 @@ class SourceControlConfigurationClient(MultiApiClientMixin, _SDKClient):
         else:
             raise ValueError("API version {} does not have operation group 'extension_types'".format(api_version))
         self._config.api_version = api_version
-        # Remove this after testing is done for 2023-05-01-preview
-        self._client._base_url = "https://management.azure.com"
         return OperationClass(self._client, self._config, Serializer(self._models_dict(api_version)), Deserializer(self._models_dict(api_version)))
 
     @property


### PR DESCRIPTION
Fixes an issue where az k8s-extension extension-types commands in Fairfax are routed to public ARM URL

This checklist is used to make sure that common guidelines for a pull request are followed.



### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)
