### PR TITLE
[aks-preview] Skip rollback auto-upgrade warning when only nodeOSUpgradeChannel is active for orchestrator-only rollback

### DIFF
--- a/src/aks-preview/azext_aks_preview/custom.py
+++ b/src/aks-preview/azext_aks_preview/custom.py
@@ -2298,13 +2298,21 @@ def aks_agentpool_rollback(cmd,   # pylint: disable=unused-argument
                 "unmanaged",
             ]
 
-            if upgrade_channel_enabled or node_os_channel_enabled:
+            if upgrade_channel_enabled:
                 logger.warning(
                     "Auto-upgrade is enabled on cluster '%s' (upgradeChannel=%s, nodeOSUpgradeChannel=%s). "
                     "Rollback will not succeed until auto-upgrade is disabled. Please disable auto-upgrade to roll back the node pool.",
                     cluster_name,
                     upgrade_channel or "none",
                     node_os_upgrade_channel or "Unmanaged",
+                )
+            if node_os_channel_enabled:
+                logger.warning(
+                    "nodeOSUpgradeChannel is enabled on cluster '%s' (nodeOSUpgradeChannel=%s). "
+                    "The orchestrator version rollback will proceed, but the node image rollback "
+                    "will not succeed. Please disable nodeOSUpgradeChannel if you want to roll back the node image.",
+                    cluster_name,
+                    node_os_upgrade_channel,
                 )
         except Exception as ex:  # pylint: disable=broad-except
             logger.debug("Unable to retrieve auto-upgrade configuration before rollback: %s", ex)


### PR DESCRIPTION
## Description

When rolling back a node pool via `az aks nodepool rollback`, the existing code shows the same "Rollback will not succeed" warning whenever **either** `upgradeChannel` or `nodeOSUpgradeChannel` is enabled. This is misleading when only `nodeOSUpgradeChannel` is active — the orchestrator version rollback will succeed fine since `nodeOSUpgradeChannel` only manages node OS images, not Kubernetes versions.

## Changes

Split the auto-upgrade warning in `aks_agentpool_rollback()` into two cases:

- **`upgradeChannel` enabled**: Keep the existing hard warning — _"Rollback will not succeed until auto-upgrade is disabled."_
- **Only `nodeOSUpgradeChannel` enabled**: Show an accurate warning — _"The orchestrator version rollback will proceed, but the node image rollback will not succeed. Please disable nodeOSUpgradeChannel if you want to roll back the node image."_
- **Neither enabled**: No warning (unchanged)

## Testing

Manual validation — this is a warning message update only, no change to rollback execution logic.