### PR TITLE
Remove readOnly from nodeImageVersion in aks-preview agent pool models to unblock rollback

### DIFF
--- a/src/aks-preview/azext_aks_preview/vendored_sdks/azure_mgmt_preview_aks/models/_models_py3.py
+++ b/src/aks-preview/azext_aks_preview/vendored_sdks/azure_mgmt_preview_aks/models/_models_py3.py
@@ -556,6 +556,8 @@ class AgentPool(ProxyResource):
         "e_tag": {"readonly": True},
         "os_disk_size_gb": {"maximum": 2048, "minimum": 0},
         "current_orchestrator_version": {"readonly": True},
+        # NOTE: node_image_version readonly intentionally removed to support agentpool rollback.
+        # See: azure-rest-api-specs#37229 (original removal), #38641 (regression), #41598 (upstream fix).
         "provisioning_state": {"readonly": True},
     }
 
@@ -6517,6 +6519,8 @@ class ManagedClusterAgentPoolProfileProperties(_serialization.Model):
         "e_tag": {"readonly": True},
         "os_disk_size_gb": {"maximum": 2048, "minimum": 0},
         "current_orchestrator_version": {"readonly": True},
+        # NOTE: node_image_version readonly intentionally removed to support agentpool rollback.
+        # See: azure-rest-api-specs#37229 (original removal), #38641 (regression), #41598 (upstream fix).
         "provisioning_state": {"readonly": True},
     }
 
@@ -7173,6 +7177,8 @@ class ManagedClusterAgentPoolProfile(ManagedClusterAgentPoolProfileProperties):
         "e_tag": {"readonly": True},
         "os_disk_size_gb": {"maximum": 2048, "minimum": 0},
         "current_orchestrator_version": {"readonly": True},
+        # NOTE: node_image_version readonly intentionally removed to support agentpool rollback.
+        # See: azure-rest-api-specs#37229 (original removal), #38641 (regression), #41598 (upstream fix).
         "provisioning_state": {"readonly": True},
         "name": {"required": True, "pattern": r"^[a-z][a-z0-9]{0,11}$"},
     }


### PR DESCRIPTION
## Description

The TypeSpec conversion in [Azure/azure-rest-api-specs#38641](https://github.com/Azure/azure-rest-api-specs/pull/38641) incorrectly re-added `readOnly` to the `nodeImageVersion` field in agent pool models. This was intentionally removed in [Azure/azure-rest-api-specs#37229](https://github.com/Azure/azure-rest-api-specs/pull/37229) to enable agentpool rollback functionality.

The upstream spec fix is tracked in [Azure/azure-rest-api-specs#41598](https://github.com/Azure/azure-rest-api-specs/pull/41598), but vendoring into the CLI may take a week or more. This is a temporary SDK-level workaround to unblock the rollback feature that is already in preview for customers.

## Changes

Removes `"node_image_version": {"readonly": True}` from the vendored SDK `_validation` dict in:
- `AgentPool`
- `ManagedClusterAgentPoolProfileProperties`
- `ManagedClusterAgentPoolProfile`

`MachineProperties` and `Snapshot` retain `readonly` — `nodeImageVersion` is genuinely read-only on those resources.

## Impact

Without this fix, the serializer strips `nodeImageVersion` from the PUT request body during agentpool rollback, causing the rollback to only update the orchestrator version while silently ignoring the node image version.

## Related PRs
- Upstream spec fix: [Azure/azure-rest-api-specs#41598](https://github.com/Azure/azure-rest-api-specs/pull/41598)
- Original readOnly removal: [Azure/azure-rest-api-specs#37229](https://github.com/Azure/azure-rest-api-specs/pull/37229)
- Regression introduced by: [Azure/azure-rest-api-specs#38641](https://github.com/Azure/azure-rest-api-specs/pull/38641)