### PR TITLE
aks-preview: Fix V2 NAT gateway params rejected on update without --outbound-type

### DIFF
--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -11,10 +11,14 @@ To release a new version, please select a new version number (usually plus 1 to 
 
 Pending
 +++++++
+
+20.0.0b2
++++++++
 * `az aks nodepool update`: clean up some useless code in the update managed gpu function. 
 * `az aks machine add`: Add `--spot-max-price` flag support to set the max price (in US Dollars) you are willing to pay for spot instances on a machine.
 * `az aks machine add`: Add `--eviction-policy` flag support to set the eviction policy for a machine.
 * `az aks machine add`: Add `--enable-ultra-ssd` flag support to enable ultra ssd on a machine.
+* `az aks update`: Fix V2-only NAT gateway params (e.g. `--nat-gateway-managed-outbound-ipv6-count`) being rejected on update when `--outbound-type` is not re-specified for an already-V2 cluster.
 
 20.0.0b1
 +++++++

--- a/src/aks-preview/azext_aks_preview/_validators.py
+++ b/src/aks-preview/azext_aks_preview/_validators.py
@@ -1168,7 +1168,11 @@ def validate_nat_gateway_managed_outbound_ipv6_count(namespace):
 
 
 def validate_nat_gateway_v2_params(namespace):
-    """Validate that V2-only NAT gateway params require managedNATGatewayV2."""
+    """Validate that V2-only NAT gateway params require managedNATGatewayV2.
+
+    On update, --outbound-type may not be specified if the cluster is already V2.
+    Only reject when --outbound-type is explicitly set to a non-V2 value.
+    """
     v2_params = [
         getattr(namespace, 'nat_gateway_managed_outbound_ipv6_count', None),
         getattr(namespace, 'nat_gateway_outbound_ip_ids', None),
@@ -1176,7 +1180,7 @@ def validate_nat_gateway_v2_params(namespace):
     ]
     if any(p is not None for p in v2_params):
         outbound_type = getattr(namespace, 'outbound_type', None)
-        if outbound_type != 'managedNATGatewayV2':
+        if outbound_type is not None and outbound_type != 'managedNATGatewayV2':
             raise InvalidArgumentValueError(
                 "--nat-gateway-managed-outbound-ipv6-count, "
                 "--nat-gateway-outbound-ips, and "

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_natgateway.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_natgateway.py
@@ -235,5 +235,55 @@ class TestIsNatGatewayV2ProfileProvided(unittest.TestCase):
         self.assertFalse(result)
 
 
+class TestValidateNatGatewayV2Params(unittest.TestCase):
+    """Test the cross-parameter validator for V2-only params."""
+
+    def _make_namespace(self, **kwargs):
+        from types import SimpleNamespace
+        defaults = {
+            'nat_gateway_managed_outbound_ipv6_count': None,
+            'nat_gateway_outbound_ip_ids': None,
+            'nat_gateway_outbound_ip_prefix_ids': None,
+            'outbound_type': None,
+        }
+        defaults.update(kwargs)
+        return SimpleNamespace(**defaults)
+
+    def test_v2_params_allowed_when_outbound_type_is_v2(self):
+        from azext_aks_preview._validators import validate_nat_gateway_v2_params
+        ns = self._make_namespace(
+            nat_gateway_managed_outbound_ipv6_count=4,
+            outbound_type='managedNATGatewayV2',
+        )
+        # Should not raise
+        validate_nat_gateway_v2_params(ns)
+
+    def test_v2_params_allowed_when_outbound_type_not_specified(self):
+        """On update, outbound_type may be None if cluster is already V2."""
+        from azext_aks_preview._validators import validate_nat_gateway_v2_params
+        ns = self._make_namespace(
+            nat_gateway_managed_outbound_ipv6_count=3,
+            outbound_type=None,
+        )
+        # Should not raise — let RP validate
+        validate_nat_gateway_v2_params(ns)
+
+    def test_v2_params_rejected_when_outbound_type_is_non_v2(self):
+        from azure.cli.core.azclierror import InvalidArgumentValueError
+        from azext_aks_preview._validators import validate_nat_gateway_v2_params
+        ns = self._make_namespace(
+            nat_gateway_managed_outbound_ipv6_count=4,
+            outbound_type='loadBalancer',
+        )
+        with self.assertRaises(InvalidArgumentValueError):
+            validate_nat_gateway_v2_params(ns)
+
+    def test_no_v2_params_passes_always(self):
+        from azext_aks_preview._validators import validate_nat_gateway_v2_params
+        ns = self._make_namespace(outbound_type='loadBalancer')
+        # No V2 params set, should not raise
+        validate_nat_gateway_v2_params(ns)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/src/aks-preview/setup.py
+++ b/src/aks-preview/setup.py
@@ -9,7 +9,7 @@ from codecs import open as open1
 
 from setuptools import find_packages, setup
 
-VERSION = "20.0.0b1"
+VERSION = "20.0.0b2"
 
 CLASSIFIERS = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
The validate_nat_gateway_v2_params validator required --outbound-type managedNATGatewayV2 to be explicitly passed even on updates where the cluster is already V2. Users had to re-specify --outbound-type on every update that used V2-only params like --nat-gateway-managed-outbound-ipv6-count.

Fix: Only reject V2 params when --outbound-type is explicitly set to a non-V2 value. When --outbound-type is not specified (None), allow the request through and let the RP validate.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [X] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [X] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [X] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
