### PR TITLE
fix(serial-console): decode binary WebSocket frames as UTF-8

### DIFF
--- a/src/serial-console/HISTORY.rst
+++ b/src/serial-console/HISTORY.rst
@@ -1,7 +1,7 @@
 Release History
 ===============
 1.0.0b4
-++++++
++++++++
 * Fixed rendering of binary WebSocket frames by decoding them as UTF-8 so ANSI escapes and multi-byte characters display correctly instead of as ``repr()`` literals.
 
 1.0.0b3

--- a/src/serial-console/HISTORY.rst
+++ b/src/serial-console/HISTORY.rst
@@ -1,5 +1,9 @@
 Release History
 ===============
+1.0.0b4
+++++++
+* Fixed rendering of binary WebSocket frames by decoding them as UTF-8 so ANSI escapes and multi-byte characters display correctly instead of as ``repr()`` literals.
+
 1.0.0b3
 ++++++
 * Fixed an issue where admin commands were not being sent when the VM was using a custom boot diagnostics storage account.

--- a/src/serial-console/azext_serialconsole/custom.py
+++ b/src/serial-console/azext_serialconsole/custom.py
@@ -275,6 +275,19 @@ class Terminal:
                 termios.tcsetattr(fd, termios.TCSADRAIN, self.unix_original_mode)
 
 
+def _decode_ws_message(message):
+    """Decode a WebSocket message payload for terminal display.
+
+    Per RFC 6455, websocket-client delivers text-opcode frames as ``str``
+    and binary-opcode frames as ``bytes``/``bytearray``. The Serial Console
+    stream is semantically a text TTY regardless of the opcode, so decode
+    binary payloads as UTF-8 with replacement for any stray bytes.
+    """
+    if isinstance(message, (bytes, bytearray)):
+        return message.decode("utf-8", errors="replace")
+    return message
+
+
 class SerialConsole:
     def __init__(self, cmd, resource_group_name, vm_vmss_name, vmss_instanceid):
         _, storage_account_region = get_region_from_storage_account(cmd.cli_ctx, resource_group_name,
@@ -438,6 +451,7 @@ class SerialConsole:
                 GV.loading = False
                 PC.clear_screen()
             else:
+                message = _decode_ws_message(message)
                 PC.print(message)
 
         def on_error(*_):

--- a/src/serial-console/azext_serialconsole/tests/latest/test_decode_ws_message.py
+++ b/src/serial-console/azext_serialconsole/tests/latest/test_decode_ws_message.py
@@ -1,0 +1,49 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+"""Unit tests for `_decode_ws_message`.
+
+Covers the fix for rendering binary WebSocket frames from the Azure Serial
+Console stream: bytes must be decoded as UTF-8 so ANSI escape sequences and
+multi-byte characters render correctly instead of being emitted via `repr()`.
+"""
+
+import pytest
+
+from azext_serialconsole.custom import _decode_ws_message
+
+
+@pytest.mark.parametrize(
+    "message, expected",
+    [
+        # str passthrough (text-opcode frames).
+        pytest.param("hello", "hello", id="str-passthrough"),
+        pytest.param("", "", id="str-empty"),
+        # bytes / bytearray (binary-opcode frames) decoded as UTF-8.
+        pytest.param(b"", "", id="bytes-empty"),
+        pytest.param("héllo ✓".encode("utf-8"), "héllo ✓", id="bytes-utf8"),
+        pytest.param(
+            bytearray("héllo ✓".encode("utf-8")),
+            "héllo ✓",
+            id="bytearray-utf8",
+        ),
+        # Colored systemd boot output: escape sequence must survive intact.
+        pytest.param(
+            b"\x1b[0;32m  OK  \x1b[0m Finished something.\r\n",
+            "\x1b[0;32m  OK  \x1b[0m Finished something.\r\n",
+            id="ansi-escape-preserved",
+        ),
+        # cloud-init tables use UTF-8 box-drawing characters.
+        pytest.param(
+            "┌──────┐".encode("utf-8"), "┌──────┐", id="box-drawing"
+        ),
+        # errors="replace" keeps the session alive on stray bytes.
+        pytest.param(
+            b"ok \xff bad", "ok \ufffd bad", id="invalid-utf8-replaced"
+        ),
+    ],
+)
+def test_decode_ws_message(message, expected):
+    assert _decode_ws_message(message) == expected

--- a/src/serial-console/setup.py
+++ b/src/serial-console/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
-VERSION = '1.0.0b3'
+VERSION = '1.0.0b4'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
The `on_message` callback passed WebSocket messages directly to `PC.print`, which forwards to Python's built-in `print()`. Per RFC 6455, the `websocket-client` library delivers text-opcode frames as `str` and binary-opcode frames as `bytes`. When the server sends a binary frame, `print()` renders the `bytes` via `repr()` — emitting literals like `b'\x1b[0;32m  OK  \xe2\x80\xa6\r\r\n'` instead of interpreting ANSI escapes and UTF-8.

The Azure Serial Console stream is semantically text (a guest TTY), but the client shouldn't rely on the server's choice of opcode. Decode `bytes`/`bytearray` messages as UTF-8 (with `errors="replace"`) before printing so the terminal renders colors, box-drawing characters, and line endings correctly regardless of which opcode the server uses.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

`az serial-console connect -n $name -g $rg`

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 

# Example

Bad screenshot:

<img width="2560" height="1504" alt="console-broke" src="https://github.com/user-attachments/assets/3ab27ddc-dad8-493b-b0b4-7c9bb5e8d738" />

Fixed:

<img width="2560" height="1504" alt="console-fixed" src="https://github.com/user-attachments/assets/37d8eb5c-13c3-4193-9ce0-dc9f633b0900" />
