### PR TITLE
[serial-console] Fix garbled console output by decoding binary websocket frames

### DIFF
--- a/.github/workflows/VersionCalPRComment.yml
+++ b/.github/workflows/VersionCalPRComment.yml
@@ -108,7 +108,7 @@ jobs:
           ls
       - name: Install azdev
         if: ${{ env.no_changed_mod == 'false' }}
-        run: | 
+        run: |
            python -m pip install --upgrade pip
            set -ev
            python -m venv env
@@ -118,6 +118,17 @@ jobs:
            azdev --version
            cd ../
            azdev setup -c azure-cli -r azure-cli-extensions --debug
+           # `azdev setup` installs azure-cli's pinned requirements which
+           # downgrade transitive dependencies that azdev itself relies on,
+           # leaving the environment in an inconsistent state:
+           #   - azure-cli-diff-tool 0.1.1 requires requests~=2.32.3,
+           #     but azure-cli's requirements pin requests==2.33.0
+           #   - tox 4.53.0 requires packaging>=26,
+           #     but azure-cli's requirements pin packaging==25.0
+           # Realign these so the subsequent metadata generation steps run
+           # against a consistent dependency set.
+           pip install --upgrade "requests~=2.32.3" "packaging>=26"
+           pip check || true
            az --version
            pip list -v
       - name: Gen Base and Diff Metadata

--- a/.github/workflows/VersionCalPRComment.yml
+++ b/.github/workflows/VersionCalPRComment.yml
@@ -108,7 +108,7 @@ jobs:
           ls
       - name: Install azdev
         if: ${{ env.no_changed_mod == 'false' }}
-        run: |
+        run: | 
            python -m pip install --upgrade pip
            set -ev
            python -m venv env
@@ -118,17 +118,6 @@ jobs:
            azdev --version
            cd ../
            azdev setup -c azure-cli -r azure-cli-extensions --debug
-           # `azdev setup` installs azure-cli's pinned requirements which
-           # downgrade transitive dependencies that azdev itself relies on,
-           # leaving the environment in an inconsistent state:
-           #   - azure-cli-diff-tool 0.1.1 requires requests~=2.32.3,
-           #     but azure-cli's requirements pin requests==2.33.0
-           #   - tox 4.53.0 requires packaging>=26,
-           #     but azure-cli's requirements pin packaging==25.0
-           # Realign these so the subsequent metadata generation steps run
-           # against a consistent dependency set.
-           pip install --upgrade "requests~=2.32.3" "packaging>=26"
-           pip check || true
            az --version
            pip list -v
       - name: Gen Base and Diff Metadata

--- a/src/serial-console/HISTORY.rst
+++ b/src/serial-console/HISTORY.rst
@@ -1,8 +1,8 @@
 Release History
 ===============
 1.0.0b4
-++++++
-* Fixed garbled console output where binary websocket frames were printed as a Python bytes repr (``b'...\\r\\n\\x1b[...]'``) instead of decoded text. Decode bytes to str in ``on_message`` so ANSI escapes and CR/LF are interpreted by the user's terminal.
++++++++
+* Fixed garbled console output where binary websocket frames were printed as a Python bytes repr (``b'...\r\n\x1b[...]'``) instead of decoded text. Decode bytes to str in ``on_message`` so ANSI escapes and CR/LF are interpreted by the user's terminal.
 * Bumped ``websocket-client`` dependency from ``==1.3.1`` to ``~=1.8.0`` to align with the version required by ``azure-cli`` and avoid a ``pkg_resources.ContextualVersionConflict`` at install time.
 
 1.0.0b3

--- a/src/serial-console/HISTORY.rst
+++ b/src/serial-console/HISTORY.rst
@@ -3,6 +3,7 @@ Release History
 1.0.0b4
 ++++++
 * Fixed garbled console output where binary websocket frames were printed as a Python bytes repr (``b'...\\r\\n\\x1b[...]'``) instead of decoded text. Decode bytes to str in ``on_message`` so ANSI escapes and CR/LF are interpreted by the user's terminal.
+* Bumped ``websocket-client`` dependency from ``==1.3.1`` to ``~=1.8.0`` to align with the version required by ``azure-cli`` and avoid a ``pkg_resources.ContextualVersionConflict`` at install time.
 
 1.0.0b3
 ++++++

--- a/src/serial-console/HISTORY.rst
+++ b/src/serial-console/HISTORY.rst
@@ -1,5 +1,9 @@
 Release History
 ===============
+1.0.0b4
+++++++
+* Fixed garbled console output where binary websocket frames were printed as a Python bytes repr (``b'...\\r\\n\\x1b[...]'``) instead of decoded text. Decode bytes to str in ``on_message`` so ANSI escapes and CR/LF are interpreted by the user's terminal.
+
 1.0.0b3
 ++++++
 * Fixed an issue where admin commands were not being sent when the VM was using a custom boot diagnostics storage account.

--- a/src/serial-console/azext_serialconsole/custom.py
+++ b/src/serial-console/azext_serialconsole/custom.py
@@ -432,6 +432,11 @@ class SerialConsole:
                 GV.websocket_instance.send(self.access_token)
 
         def on_message(_, message):
+            # Binary websocket frames arrive as bytes from websocket-client >= 1.0.
+            # Decode to str so that ANSI escapes and CR/LF are interpreted by the
+            # user's terminal instead of being printed as a bytes repr (b'...').
+            if isinstance(message, (bytes, bytearray)):
+                message = bytes(message).decode("utf-8", errors="replace")
             if GV.first_message:
                 GV.websocket_instance.send(self.access_token)
                 GV.first_message = False

--- a/src/serial-console/azext_serialconsole/tests/latest/recordings/test_check_resource_VM.yaml
+++ b/src/serial-console/azext_serialconsole/tests/latest/recordings/test_check_resource_VM.yaml
@@ -150,7 +150,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.4
     method: GET
-    uri: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/arm-compute/quickstart-templates/aliases.json
+    uri: https://azcliprod.blob.core.windows.net/cli/vm/aliases.json
   response:
     body:
       string: "{\n  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json\",\n
@@ -429,7 +429,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.4
     method: GET
-    uri: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/arm-compute/quickstart-templates/aliases.json
+    uri: https://azcliprod.blob.core.windows.net/cli/vm/aliases.json
   response:
     body:
       string: "{\n  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json\",\n

--- a/src/serial-console/azext_serialconsole/tests/latest/recordings/test_check_resource_VMSS.yaml
+++ b/src/serial-console/azext_serialconsole/tests/latest/recordings/test_check_resource_VMSS.yaml
@@ -150,7 +150,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.4
     method: GET
-    uri: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/arm-compute/quickstart-templates/aliases.json
+    uri: https://azcliprod.blob.core.windows.net/cli/vm/aliases.json
   response:
     body:
       string: "{\n  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json\",\n
@@ -429,7 +429,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.4
     method: GET
-    uri: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/arm-compute/quickstart-templates/aliases.json
+    uri: https://azcliprod.blob.core.windows.net/cli/vm/aliases.json
   response:
     body:
       string: "{\n  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json\",\n

--- a/src/serial-console/setup.py
+++ b/src/serial-console/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
-VERSION = '1.0.0b3'
+VERSION = '1.0.0b4'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/src/serial-console/setup.py
+++ b/src/serial-console/setup.py
@@ -33,7 +33,7 @@ CLASSIFIERS = [
 ]
 
 # TODO: Add any additional SDK dependencies here
-DEPENDENCIES = ["websocket-client==1.3.1"]
+DEPENDENCIES = ["websocket-client~=1.8.0"]
 
 with open('README.md', 'r', encoding='utf-8') as f:
     README = f.read()


### PR DESCRIPTION
### Related command

`az serial-console connect`

### Description

Fixes #9796.

The `serial-console` extension's `on_message` callback in `SerialConsole.connect()` assumed websocket frames were always `str`. Newer versions of `websocket-client` (>= 1.0) return `bytes` for binary frames, which the extension passed straight into Python's built-in `print()` — producing a `bytes` repr (`b'...\r\n\x1b[0;32m...'`) in the user's terminal instead of decoded text. This makes the serial console unusable on recent Python / websocket-client combinations (reliably reproduced on Python 3.13).

Sample of the broken output before this fix:

```
b'\r\n[ 2135.909432] cloud-init[3293]: The system is finally up...\r\n\x1b[0;32m  OK  \x1b[0m] Finished cloud-init...'
```

### Runtime fix

In `src/serial-console/azext_serialconsole/custom.py`, decode `bytes`/`bytearray` to `str` (UTF-8 with `errors="replace"` for safety) before forwarding the message to `PC.print`. After this change, ANSI escapes and CR/LF are interpreted by the user's terminal as intended and the serial console renders normally.

```python
def on_message(_, message):
    if isinstance(message, (bytes, bytearray)):
        message = bytes(message).decode("utf-8", errors="replace")
    ...
```

### Dependency widening (required for clean install)

The `websocket-client` requirement is widened from `==1.3.1` to `~=1.8.0`. Current `azure-cli` requires `websocket-client~=1.8.0` (`src/azure-cli/setup.py`, pinned to `1.8.0` in `requirements.py3.Linux.txt`), so the existing `==1.3.1` pin produces a `pkg_resources.ContextualVersionConflict` when the extension is added against current `azure-cli`:

```
pkg_resources.ContextualVersionConflict: (websocket-client 1.3.1 ...,
    Requirement.parse('websocket-client~=1.8.0'), {'azure-cli'})
Exception: Error when adding serial-console from source
    https://azcliprod.blob.core.windows.net/cli-extensions/serial_console-1.0.0b3-py3-none-any.whl
```

This blocks `version-cal` in CI and means published `1.0.0b3` is currently uninstallable on a fresh azure-cli. The runtime API used by this extension (`WebSocketApp.on_message`) is stable across the 1.x line, so widening to `~=1.8.0` is safe.

### Test cassette refresh

Both VCR cassettes (`test_check_resource_VM.yaml`, `test_check_resource_VMSS.yaml`) had stale `aliases.json` request URIs (`raw.githubusercontent.com/.../aliases.json`). `azure-cli` now fetches that file from `azcliprod.blob.core.windows.net/cli/vm/aliases.json`, so the cassette URIs were swapped to match. Response bodies and headers are unchanged. Without this, `Build Tests Python3.10–3.13` fail with VCR `Can't overwrite existing cassette`. Same change pattern already landed in `src/scheduled-query/` cassettes.

### Versioning

- Bumps `serial-console` from `1.0.0b3` to `1.0.0b4`.
- Adds a `HISTORY.rst` entry covering the runtime fix and the dependency change.

### Testing

- Repro before fix: `az serial-console connect --resource-group <rg> --name <vmss> --instance-id <id>` shows literal `b'...'` blob instead of console output.
- After applying this patch (and clearing `__pycache__`), the same command renders the cloud-init / login boot log normally with proper newlines and colors.
- Verified on:
  - macOS 15 (Apple Silicon), Homebrew `azure-cli 2.85.0`, Python 3.13.12
  - Connecting to a Linux VMSS instance with serial console enabled

### Notes

- The runtime fix itself is minimal and behavior-preserving (no API changes).
- Pinning `websocket-client < 1.0` would also "fix" the bytes-decode symptom but is not future-proof and conflicts with `azure-cli`'s own pinning.