### PR TITLE
[AKS] Throw proper error message during HOBO to Base conversion when no AP

### DIFF
--- a/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
@@ -5692,12 +5692,23 @@ class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):
         self._ensure_mc(mc)
 
         # Preview-specific change: an AKS ManagedCluster of automatic
-        # cluster with hosted system components may not have agent pools
-        # When transitioning from hosted to non-hosted automatic clusters,
-        # customers must first add a system node pool before disabling
-        # the hosted system profile.
+        # cluster with hosted system components may not have agent pools.
+        # When converting from automatic to base SKU, customers must first
+        # add a system node pool before changing the SKU.
         if not mc.agent_pool_profiles:
             if mc.hosted_system_profile and mc.hosted_system_profile.enabled:
+                return mc
+            if mc.sku and mc.sku.name and mc.sku.name.lower() == "automatic":
+                # Check if the user is explicitly requesting a conversion to base SKU
+                requested_sku = self.context.raw_param.get("sku")
+                if requested_sku is not None and requested_sku.lower() == CONST_MANAGED_CLUSTER_SKU_NAME_BASE:
+                    raise RequiredArgumentMissingError(
+                        "The cluster does not have any agent pool profiles. "
+                        "Please add a system node pool to the cluster before converting to base SKU. "
+                        "You can add a system node pool by running "
+                        "'az aks nodepool add --cluster-name <cluster-name> -g <resource-group> "
+                        "-n <nodepool-name> --mode System'."
+                    )
                 return mc
             raise UnknownError(
                 "Encounter an unexpected error while getting agent pool profiles from the cluster in the process of "

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_managed_cluster_decorator.py
@@ -14515,6 +14515,51 @@ class AKSPreviewManagedClusterUpdateDecoratorTestCase(unittest.TestCase):
         with self.assertRaises(UnknownError):
             dec_3.update_agentpool_profile(mc_3)
 
+    def test_update_agentpool_profile_with_none_agent_pool_profiles_automatic_sku(self):
+        """Test update_agentpool_profile passes through for automatic SKU cluster with no agent pools when not converting to base"""
+        dec = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {},
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+
+        # Create an automatic SKU cluster with None agent_pool_profiles and no hosted system profile
+        mc = self.models.ManagedCluster(
+            location="test_location",
+            agent_pool_profiles=None,
+            hosted_system_profile=None,
+            sku=self.models.ManagedClusterSKU(name="Automatic", tier="Standard"),
+        )
+        dec.context.attach_mc(mc)
+
+        # Should return the MC unchanged (no --sku base requested)
+        result = dec.update_agentpool_profile(mc)
+        self.assertEqual(result, mc)
+        self.assertIsNone(result.agent_pool_profiles)
+
+    def test_update_agentpool_profile_automatic_to_base_no_agent_pools(self):
+        """Test update_agentpool_profile raises RequiredArgumentMissingError when converting automatic to base with no agent pools"""
+        dec = AKSPreviewManagedClusterUpdateDecorator(
+            self.cmd,
+            self.client,
+            {"sku": "base"},
+            CUSTOM_MGMT_AKS_PREVIEW,
+        )
+
+        # Create an automatic SKU cluster with None agent_pool_profiles
+        mc = self.models.ManagedCluster(
+            location="test_location",
+            agent_pool_profiles=None,
+            hosted_system_profile=None,
+            sku=self.models.ManagedClusterSKU(name="Automatic", tier="Standard"),
+        )
+        dec.context.attach_mc(mc)
+
+        # Should raise RequiredArgumentMissingError asking user to add a system node pool first
+        with self.assertRaises(RequiredArgumentMissingError):
+            dec.update_agentpool_profile(mc)
+
     def test_update_agentpool_profile_with_empty_agent_pool_profiles(self):
         """Test update_agentpool_profile raises UnknownError for empty agent_pool_profiles list"""
         # Test case 4: Empty agent_pool_profiles list (should raise UnknownError)


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
az aks update -n "${RESOURCE_NAME}" -g "${RESOURCE_GROUP}" --sku base


### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
