### PR TITLE
{AKS} Bump aks-preview to 20.0.0b5 for --control-plane-scaling-size release

### DIFF
--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -11,6 +11,9 @@ To release a new version, please select a new version number (usually plus 1 to 
 
 Pending
 +++++++
+
+20.0.0b5
++++++++
 * `az aks create`: Add `--control-plane-scaling-size` parameter to configure control plane scaling profile with available sizes 'H2', 'H4', and 'H8'.
 
 20.0.0b4

--- a/src/aks-preview/setup.py
+++ b/src/aks-preview/setup.py
@@ -9,7 +9,7 @@ from codecs import open as open1
 
 from setuptools import find_packages, setup
 
-VERSION = "20.0.0b4"
+VERSION = "20.0.0b5"
 
 CLASSIFIERS = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
## Summary

Bump `aks-preview` extension version from `20.0.0b4` to `20.0.0b5` to release the `--control-plane-scaling-size` parameter.

### Changes
- **setup.py**: Update `VERSION` from `20.0.0b4` to `20.0.0b5`
- **HISTORY.rst**: Move pending entry into new `20.0.0b5` section

### New feature in this release
- `az aks create`: Add `--control-plane-scaling-size` parameter to configure control plane scaling profile with available sizes 'H2', 'H4', and 'H8'.