### PR TITLE
{AKS} `az aks create/update`: Update container network logs error message to mention portal enablement of ACNS

### DIFF
--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -12,6 +12,10 @@ To release a new version, please select a new version number (usually plus 1 to 
 Pending
 +++++++
 
+20.0.0b6
++++++++
+* `az aks create/update`: Improve error message for container network logs validation when ACNS is not enabled to provide clearer guidance.
+
 20.0.0b5
 +++++++
 * `az aks update`: Fix acceleration mode getting wiped out when modifying unrelated parameters in an ACNS enabled cluster.

--- a/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
@@ -1083,8 +1083,10 @@ class AKSPreviewManagedClusterContext(AKSManagedClusterContext):
             monitoring_enabled = monitoring_being_enabled or monitoring_already_enabled
             if not acns_enabled or not monitoring_enabled:
                 raise InvalidArgumentValueError(
-                    "Container network logs requires '--enable-acns', advanced networking "
-                    "to be enabled, and the monitoring addon to be enabled."
+                    "Container network logs require Advanced Container Networking Services to be enabled. "
+                    "Activate this service through the portal or use the CLI with --enable-acns flag. "
+                    "Additionally, the monitoring addon must be enabled and the cilium network dataplane "
+                    "is required."
                 )
         enable_cnl = bool(enable_cnl) if enable_cnl is not None else False
         disable_cnl = bool(disable_cnl) if disable_cnl is not None else False

--- a/src/aks-preview/setup.py
+++ b/src/aks-preview/setup.py
@@ -9,7 +9,7 @@ from codecs import open as open1
 
 from setuptools import find_packages, setup
 
-VERSION = "20.0.0b5"
+VERSION = "20.0.0b6"
 
 CLASSIFIERS = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command

`az aks create`, `az aks update`

### General Guidelines

- [X] Have you run `azdev style aks-preview` locally? (`pip install azdev` required)
- [X] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

### Description

Improves the error message for container network logs (CNL) validation when ACNS is not enabled.
The previous message was terse and did not guide users on how to resolve the issue. The new message
clearly states that Advanced Container Networking Services must be enabled, explains how to activate
it (via portal or CLI with --enable-acns), and notes the additional requirements (monitoring addon
and cilium network dataplane).
