### PR TITLE
{CI} Update pipeline to use Python 3.14

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,7 +59,7 @@ jobs:
   - task: UsePythonVersion@0
     displayName: 'Use Python 3.14'
     inputs:
-      versionSpec: 3.14
+      versionSpec: '3.14'
   - template: .azure-pipelines/templates/azdev_setup.yml
   - bash: |
       #!/usr/bin/env bash
@@ -75,7 +75,7 @@ jobs:
   - task: UsePythonVersion@0
     displayName: 'Use Python 3.14'
     inputs:
-      versionSpec: 3.14
+      versionSpec: '3.14'
   - bash: |
       #!/usr/bin/env bash
       set -ev
@@ -137,7 +137,7 @@ jobs:
     - task: UsePythonVersion@0
       displayName: 'Use Python 3.14'
       inputs:
-        versionSpec: 3.14
+        versionSpec: '3.14'
     - template: .azure-pipelines/templates/azdev_setup.yml
     - bash: |
         #!/usr/bin/env bash
@@ -161,7 +161,7 @@ jobs:
     - task: UsePythonVersion@0
       displayName: 'Use Python 3.14'
       inputs:
-        versionSpec: 3.14
+        versionSpec: '3.14'
     - template: .azure-pipelines/templates/azdev_setup.yml
     - bash: |
         #!/usr/bin/env bash
@@ -186,7 +186,7 @@ jobs:
     - task: UsePythonVersion@0
       displayName: 'Use Python 3.11'
       inputs:
-        versionSpec: 3.11
+        versionSpec: '3.11'
     - template: .azure-pipelines/templates/azdev_setup.yml
     - bash: |
         #!/usr/bin/env bash
@@ -217,7 +217,7 @@ jobs:
     - task: UsePythonVersion@0
       displayName: 'Use Python 3.11'
       inputs:
-        versionSpec: 3.11
+        versionSpec: '3.11'
     - template: .azure-pipelines/templates/azdev_setup.yml
     - bash: |
         #!/usr/bin/env bash
@@ -246,7 +246,7 @@ jobs:
 #  - task: UsePythonVersion@0
 #    displayName: 'Use Python 3.14'
 #    inputs:
-#      versionSpec: 3.14
+#      versionSpec: '3.14'
 #  - bash: pip install wheel==0.30.0
 #    displayName: 'Install wheel==0.30.0'
 #  - task: Bash@3
@@ -263,6 +263,6 @@ jobs:
   - task: UsePythonVersion@0
     displayName: 'Use Python 3.x'
     inputs:
-      versionSpec: 3.x
+      versionSpec: '3.x'
   - bash: |
       python scripts/ci/test_init.py -v

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,9 +57,9 @@ jobs:
     name: ${{ variables.ubuntu_pool }}
   steps:
   - task: UsePythonVersion@0
-    displayName: 'Use Python 3.13'
+    displayName: 'Use Python 3.14'
     inputs:
-      versionSpec: 3.13
+      versionSpec: 3.14
   - template: .azure-pipelines/templates/azdev_setup.yml
   - bash: |
       #!/usr/bin/env bash
@@ -73,9 +73,9 @@ jobs:
     name: ${{ variables.ubuntu_pool }}
   steps:
   - task: UsePythonVersion@0
-    displayName: 'Use Python 3.13'
+    displayName: 'Use Python 3.14'
     inputs:
-      versionSpec: 3.13
+      versionSpec: 3.14
   - bash: |
       #!/usr/bin/env bash
       set -ev
@@ -98,6 +98,8 @@ jobs:
         python.version: '3.12'
       Python313:
         python.version: '3.13'
+      Python314:
+        python.version: '3.14'
   steps:
     - task: UsePythonVersion@0
       displayName: 'Use Python $(python.version)'
@@ -133,9 +135,9 @@ jobs:
     name: ${{ variables.ubuntu_pool }}
   steps:
     - task: UsePythonVersion@0
-      displayName: 'Use Python 3.13'
+      displayName: 'Use Python 3.14'
       inputs:
-        versionSpec: 3.13
+        versionSpec: 3.14
     - template: .azure-pipelines/templates/azdev_setup.yml
     - bash: |
         #!/usr/bin/env bash
@@ -157,9 +159,9 @@ jobs:
     name: ${{ variables.ubuntu_pool }}
   steps:
     - task: UsePythonVersion@0
-      displayName: 'Use Python 3.13'
+      displayName: 'Use Python 3.14'
       inputs:
-        versionSpec: 3.13
+        versionSpec: 3.14
     - template: .azure-pipelines/templates/azdev_setup.yml
     - bash: |
         #!/usr/bin/env bash
@@ -242,9 +244,9 @@ jobs:
 #    name: ${{ variables.ubuntu_pool }}
 #  steps:
 #  - task: UsePythonVersion@0
-#    displayName: 'Use Python 3.13'
+#    displayName: 'Use Python 3.14'
 #    inputs:
-#      versionSpec: 3.13
+#      versionSpec: 3.14
 #  - bash: pip install wheel==0.30.0
 #    displayName: 'Install wheel==0.30.0'
 #  - task: Bash@3


### PR DESCRIPTION
## Summary

Update CI to use Python 3.14 in the extensions pipeline.

## Changes

- switch existing single-version pipeline jobs from Python 3.13 to Python 3.14
- add Python 3.14 to the `SourceTests` matrix

## Validation

- CI only