### PR TITLE
[aks-agent] Fix client mode when Microsoft Entra ID (keyless) provider is selected

### DIFF
--- a/src/aks-agent/HISTORY.rst
+++ b/src/aks-agent/HISTORY.rst
@@ -12,6 +12,10 @@ To release a new version, please select a new version number (usually plus 1 to 
 Pending
 +++++++
 
+1.0.0b23
+++++++++
+* Fix: client mode when Microsoft Entra ID (keyless) provider is selected
+
 1.0.0b22
 ++++++++
 * Bump aks-agent to v0.7.1

--- a/src/aks-agent/azext_aks_agent/agent/k8s/aks_agent_manager.py
+++ b/src/aks-agent/azext_aks_agent/agent/k8s/aks_agent_manager.py
@@ -1158,7 +1158,9 @@ class AKSAgentManagerClient(AKSAgentManagerLLMConfigBase):  # pylint: disable=to
             # When no API key is configured for an Azure model, enable Azure AD token authentication
             model_list = self.llm_config_manager.model_list
             if model_list and any(
-                "azure/" in model_name and not model_config.get("api_key")
+                "azure/" in model_name and (
+                    not model_config.get("api_key") or not model_config.get("api_key").strip()
+                )
                 for model_name, model_config in model_list.items()
             ):
                 env_vars.extend(["-e", "AZURE_AD_TOKEN_AUTH=True"])

--- a/src/aks-agent/azext_aks_agent/agent/k8s/aks_agent_manager.py
+++ b/src/aks-agent/azext_aks_agent/agent/k8s/aks_agent_manager.py
@@ -1155,6 +1155,14 @@ class AKSAgentManagerClient(AKSAgentManagerLLMConfigBase):  # pylint: disable=to
                 "-e", "AZURE_TOKEN_CREDENTIALS=AzureCLICredential"
             ]
 
+            # When no API key is configured for an Azure model, enable Azure AD token authentication
+            model_list = self.llm_config_manager.model_list
+            if model_list and any(
+                "azure/" in model_name and not model_config.get("api_key")
+                for model_name, model_config in model_list.items()
+            ):
+                env_vars.extend(["-e", "AZURE_AD_TOKEN_AUTH=True"])
+
             # Prepare the command
             exec_command = [
                 "docker", "run",

--- a/src/aks-agent/azext_aks_agent/tests/latest/test_aks_agent_manager.py
+++ b/src/aks-agent/azext_aks_agent/tests/latest/test_aks_agent_manager.py
@@ -369,6 +369,72 @@ class TestAKSAgentManagerClient(unittest.TestCase):
         expected = f"-n {self.cluster_name} -g {self.resource_group}"
         self.assertEqual(result, expected)
 
+    def _make_client_manager(self, model_list):
+        """Helper: create an AKSAgentManagerClient with a mocked llm_config_manager and config_dir."""
+        manager = AKSAgentManagerClient(
+            resource_group_name=self.resource_group,
+            cluster_name=self.cluster_name,
+            subscription_id=self.subscription_id,
+            kubeconfig_path=self.kubeconfig_path,
+        )
+        manager.llm_config_manager = MagicMock()
+        manager.llm_config_manager.model_list = model_list
+
+        # Make config_dir look like it exists and contains the required files
+        mock_config_dir = MagicMock()
+        mock_config_dir.exists.return_value = True
+        mock_file = MagicMock()
+        mock_file.exists.return_value = True
+        mock_config_dir.__truediv__ = lambda self, other: mock_file
+        manager.config_dir = mock_config_dir
+
+        return manager
+
+    @patch("subprocess.run")
+    @patch("os.path.exists", return_value=False)
+    def test_exec_aks_agent_sets_azure_ad_token_auth_when_no_api_key(self, _mock_exists, mock_run):
+        """AZURE_AD_TOKEN_AUTH=True must be injected when an azure/ model has no api_key."""
+        mock_run.return_value = MagicMock(returncode=0)
+
+        manager = self._make_client_manager({
+            "azure/gpt-4o": {"model": "azure/gpt-4o"}  # no api_key
+        })
+
+        manager.exec_aks_agent("")
+
+        docker_cmd = mock_run.call_args[0][0]
+        self.assertIn("AZURE_AD_TOKEN_AUTH=True", docker_cmd)
+
+    @patch("subprocess.run")
+    @patch("os.path.exists", return_value=False)
+    def test_exec_aks_agent_sets_azure_ad_token_auth_when_api_key_is_whitespace(self, _mock_exists, mock_run):
+        """AZURE_AD_TOKEN_AUTH=True must be injected when api_key is whitespace-only."""
+        mock_run.return_value = MagicMock(returncode=0)
+
+        manager = self._make_client_manager({
+            "azure/gpt-4o": {"model": "azure/gpt-4o", "api_key": "   "}
+        })
+
+        manager.exec_aks_agent("")
+
+        docker_cmd = mock_run.call_args[0][0]
+        self.assertIn("AZURE_AD_TOKEN_AUTH=True", docker_cmd)
+
+    @patch("subprocess.run")
+    @patch("os.path.exists", return_value=False)
+    def test_exec_aks_agent_omits_azure_ad_token_auth_when_api_key_present(self, _mock_exists, mock_run):
+        """AZURE_AD_TOKEN_AUTH must NOT be injected when a valid api_key is configured."""
+        mock_run.return_value = MagicMock(returncode=0)
+
+        manager = self._make_client_manager({
+            "azure/gpt-4o": {"model": "azure/gpt-4o", "api_key": "my-secret-key"}
+        })
+
+        manager.exec_aks_agent("")
+
+        docker_cmd = mock_run.call_args[0][0]
+        self.assertNotIn("AZURE_AD_TOKEN_AUTH=True", docker_cmd)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/aks-agent/setup.py
+++ b/src/aks-agent/setup.py
@@ -9,7 +9,7 @@ from codecs import open as open1
 
 from setuptools import find_packages, setup
 
-VERSION = "1.0.0b22"
+VERSION = "1.0.0b23"
 
 CLASSIFIERS = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
## Summary

- Fix client mode when Microsoft Entra ID (keyless) provider is selected by passing `AZURE_AD_TOKEN_AUTH=True` to the Docker container when no API key is configured for an Azure model
- Bump version to `1.0.0b23`

## Test plan

- [ ] Run `az aks agent-init` and select client mode with Microsoft Entra ID (keyless) provider
- [ ] Run `az aks agent` and verify the agent authenticates via Azure AD token