### PR TITLE
[ManagedCleanroom] Add --subdirectory parameter for dataset publish

### DIFF
--- a/src/managedcleanroom/HISTORY.rst
+++ b/src/managedcleanroom/HISTORY.rst
@@ -73,3 +73,11 @@ Release History
   - Fixed schema_file parameter handling in dataset publish to support Azure CLI auto-loading (dict, string, and @file formats)
   - Fixed runhistory API endpoint method name
   - Fixed runresult API endpoint method name
+
+1.0.0b7
++++++++
+* Added: ``--subdirectory`` parameter to ``az managedcleanroom frontend analytics dataset publish``
+  to mount a specific subdirectory/prefix inside the storage container. Validation of
+  encryption-mode compatibility is enforced by the service.
+* SDK: ``analytics_frontend_api`` updated with the new ``store.subdirectory`` field
+  in the JSON dict templates (sync + async) to match the regenerated autorest output.

--- a/src/managedcleanroom/azext_managedcleanroom/_frontend_custom.py
+++ b/src/managedcleanroom/azext_managedcleanroom/_frontend_custom.py
@@ -253,6 +253,7 @@ def frontend_collaboration_dataset_publish(
     kek_keyvault_url=None,
     kek_secret_id=None,
     kek_maa_url=None,
+    subdirectory=None,
     api_version=None,
 ):
     """Publish a dataset
@@ -278,6 +279,7 @@ def frontend_collaboration_dataset_publish(
     :param kek_keyvault_url: KEK Key Vault URL (CPK mode)
     :param kek_secret_id: KEK secret ID (CPK mode)
     :param kek_maa_url: KEK MAA URL (CPK mode)
+    :param subdirectory: Optional subdirectory/prefix inside the storage container
     :param api_version: API version to use for this request
     :return: Publish result
     """
@@ -402,6 +404,8 @@ def frontend_collaboration_dataset_publish(
         "storageAccountType": storage_account_type,
         "encryptionMode": encryption_mode,
     }
+    if subdirectory:
+        store["subdirectory"] = subdirectory
 
     # Build identity
     identity = {

--- a/src/managedcleanroom/azext_managedcleanroom/_help.py
+++ b/src/managedcleanroom/azext_managedcleanroom/_help.py
@@ -411,6 +411,9 @@ helps['managedcleanroom frontend analytics dataset publish'] = """
         - name: --kek-maa-url
           type: string
           short-summary: MAA URL for KEK (CPK mode only)
+        - name: --subdirectory
+          type: string
+          short-summary: Optional subdirectory/prefix inside the storage container to mount
     examples:
         - name: Publish a dataset using SSE encryption with individual parameters
           text: |
@@ -454,6 +457,22 @@ helps['managedcleanroom frontend analytics dataset publish'] = """
               --collaboration-id my-collab-123 \
               --document-id my-dataset \
               --body @dataset-config.json
+        - name: Publish a dataset mounted at a subdirectory
+          text: |
+            az managedcleanroom frontend analytics dataset publish \
+              --collaboration-id my-collab-123 \
+              --document-id my-dataset \
+              --storage-account-url https://mystorageaccount.blob.core.windows.net \
+              --container-name datasets \
+              --storage-account-type AzureStorageAccount \
+              --encryption-mode SSE \
+              --schema-file @schema.json \
+              --access-mode ReadWrite \
+              --identity-name northwind-identity \
+              --identity-client-id fb907136-1234-5678-9abc-def012345678 \
+              --identity-tenant-id 72f988bf-1234-5678-9abc-def012345678 \
+              --identity-issuer-url https://oidc.example.com/issuer \
+              --subdirectory year=2026/month=05
 """
 
 

--- a/src/managedcleanroom/azext_managedcleanroom/_params.py
+++ b/src/managedcleanroom/azext_managedcleanroom/_params.py
@@ -204,6 +204,10 @@ def load_arguments(self, _):  # pylint: disable=unused-argument
             'kek_maa_url',
             options_list=['--kek-maa-url'],
             help='MAA URL for KEK (CPK mode only)')
+        c.argument(
+            'subdirectory',
+            options_list=['--subdirectory'],
+            help='Optional subdirectory/prefix inside the storage container to mount.')
 
     # Dataset queries context
     with self.argument_context('managedcleanroom frontend analytics dataset queries') as c:

--- a/src/managedcleanroom/azext_managedcleanroom/analytics_frontend_api/aio/operations/_operations.py
+++ b/src/managedcleanroom/azext_managedcleanroom/analytics_frontend_api/aio/operations/_operations.py
@@ -1304,7 +1304,8 @@ class CollaborationOperations:  # pylint: disable=too-many-public-methods
                             "encryptionMode": "str",
                             "storageAccountType": "str",
                             "storageAccountUrl": "str",
-                            "awsCgsSecretId": "str"
+                            "awsCgsSecretId": "str",
+                            "subdirectory": ""
                         },
                         "dek": {
                             "keyVaultUrl": "str",
@@ -1441,7 +1442,8 @@ class CollaborationOperations:  # pylint: disable=too-many-public-methods
                         "encryptionMode": "str",
                         "storageAccountType": "str",
                         "storageAccountUrl": "str",
-                        "awsCgsSecretId": "str"
+                        "awsCgsSecretId": "str",
+                        "subdirectory": ""
                     },
                     "dek": {
                         "keyVaultUrl": "str",
@@ -1555,7 +1557,8 @@ class CollaborationOperations:  # pylint: disable=too-many-public-methods
                         "encryptionMode": "str",
                         "storageAccountType": "str",
                         "storageAccountUrl": "str",
-                        "awsCgsSecretId": "str"
+                        "awsCgsSecretId": "str",
+                        "subdirectory": ""
                     },
                     "dek": {
                         "keyVaultUrl": "str",

--- a/src/managedcleanroom/azext_managedcleanroom/analytics_frontend_api/operations/_operations.py
+++ b/src/managedcleanroom/azext_managedcleanroom/analytics_frontend_api/operations/_operations.py
@@ -2247,7 +2247,8 @@ class CollaborationOperations:  # pylint: disable=too-many-public-methods
                             "encryptionMode": "str",
                             "storageAccountType": "str",
                             "storageAccountUrl": "str",
-                            "awsCgsSecretId": "str"
+                            "awsCgsSecretId": "str",
+                            "subdirectory": ""
                         },
                         "dek": {
                             "keyVaultUrl": "str",
@@ -2384,7 +2385,8 @@ class CollaborationOperations:  # pylint: disable=too-many-public-methods
                         "encryptionMode": "str",
                         "storageAccountType": "str",
                         "storageAccountUrl": "str",
-                        "awsCgsSecretId": "str"
+                        "awsCgsSecretId": "str",
+                        "subdirectory": ""
                     },
                     "dek": {
                         "keyVaultUrl": "str",
@@ -2498,7 +2500,8 @@ class CollaborationOperations:  # pylint: disable=too-many-public-methods
                         "encryptionMode": "str",
                         "storageAccountType": "str",
                         "storageAccountUrl": "str",
-                        "awsCgsSecretId": "str"
+                        "awsCgsSecretId": "str",
+                        "subdirectory": ""
                     },
                     "dek": {
                         "keyVaultUrl": "str",

--- a/src/managedcleanroom/azext_managedcleanroom/tests/latest/test_frontend_dataset.py
+++ b/src/managedcleanroom/azext_managedcleanroom/tests/latest/test_frontend_dataset.py
@@ -336,6 +336,71 @@ class TestFrontendDataset(unittest.TestCase):
                 "CPK encryption mode requires", str(
                     context.exception))
 
+    @patch("azext_managedcleanroom._frontend_custom.get_frontend_client")
+    def test_publish_dataset_with_subdirectory(self, mock_get_client):
+        """Test that --subdirectory propagates into the request body's store"""
+        mock_publish_response = {"datasetId": "test-dataset-sub", "status": "published"}
+        mock_client = Mock()
+        mock_client.collaboration.analytics_datasets_document_id_publish_post.return_value = mock_publish_response
+        mock_get_client.return_value = mock_client
+
+        test_schema = {"fields": [], "format": "Delta"}
+
+        with patch("builtins.open", unittest.mock.mock_open(read_data=json.dumps(test_schema))):
+            frontend_collaboration_dataset_publish(
+                cmd=Mock(),
+                collaboration_id="test-collab-123",
+                document_id="test-dataset-sub",
+                body=None,
+                storage_account_url="https://mystorageaccount.blob.core.windows.net",
+                container_name="datasets",
+                storage_account_type="AzureStorageAccount",
+                encryption_mode="SSE",
+                schema_file="@schema.json",
+                access_mode="ReadWrite",
+                identity_name="northwind-identity",
+                identity_client_id="fb907136-1234-5678-9abc-def012345678",
+                identity_tenant_id="72f988bf-1234-5678-9abc-def012345678",
+                identity_issuer_url="https://oidc.example.com/issuer",
+                subdirectory="year=2026/month=05",
+            )
+
+        call_args = mock_client.collaboration.analytics_datasets_document_id_publish_post.call_args
+        body = call_args[0][2]
+        self.assertEqual(body["store"]["subdirectory"], "year=2026/month=05")
+
+    @patch("azext_managedcleanroom._frontend_custom.get_frontend_client")
+    def test_publish_dataset_subdirectory_default_omitted(self, mock_get_client):
+        """Test that subdirectory key is omitted from store when not provided"""
+        mock_publish_response = {"datasetId": "test-dataset-nosub", "status": "published"}
+        mock_client = Mock()
+        mock_client.collaboration.analytics_datasets_document_id_publish_post.return_value = mock_publish_response
+        mock_get_client.return_value = mock_client
+
+        test_schema = {"fields": [], "format": "Delta"}
+
+        with patch("builtins.open", unittest.mock.mock_open(read_data=json.dumps(test_schema))):
+            frontend_collaboration_dataset_publish(
+                cmd=Mock(),
+                collaboration_id="test-collab-123",
+                document_id="test-dataset-nosub",
+                body=None,
+                storage_account_url="https://mystorageaccount.blob.core.windows.net",
+                container_name="datasets",
+                storage_account_type="AzureStorageAccount",
+                encryption_mode="SSE",
+                schema_file="@schema.json",
+                access_mode="ReadWrite",
+                identity_name="northwind-identity",
+                identity_client_id="fb907136-1234-5678-9abc-def012345678",
+                identity_tenant_id="72f988bf-1234-5678-9abc-def012345678",
+                identity_issuer_url="https://oidc.example.com/issuer",
+            )
+
+        call_args = mock_client.collaboration.analytics_datasets_document_id_publish_post.call_args
+        body = call_args[0][2]
+        self.assertNotIn("subdirectory", body["store"])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/managedcleanroom/setup.py
+++ b/src/managedcleanroom/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 
 
 # HISTORY.rst entry.
-VERSION = '1.0.0b6'
+VERSION = '1.0.0b7'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
### Related command
`az managedcleanroom frontend analytics dataset publish`

### Description
Adds a new --subdirectory parameter to the dataset publish command, providing parity with the upstream cleanroom extension's blobfuse subdirectory feature. The new field lets data owners restrict the mounted blobfuse view to a subtree of the storage container (e.g. year=2026/month=05) instead of mounting the entire container.

#### Changes
- **`_params.py`** — Adds the --subdirectory argument to the managedcleanroom frontend analytics dataset publish argument context.
- **`_frontend_custom.py`** — Accepts the new parameter and propagates it into the request body's store.subdirectory property when set. Encryption-mode compatibility is enforced by the service, so no CLI-side restriction is added — this keeps the CLI forward-compatible with future service-side relaxations without requiring an extension update.
- **`_help.py`** — Documents the new parameter and adds an example showing dataset publish with --subdirectory.
- **`analytics_frontend_api/operations/_operations.py`** + **`aio/operations/_operations.py`** — Auto-generated SDK updated to include `subdirectory` in the `store` JSON dict templates (sync + async). The change matches what a fresh autorest regen produces from the updated upstream `frontend.yaml`; only the substantive subdirectory delta is included to avoid unrelated cosmetic churn from the team's SDK post-processing.
- **`tests/latest/test_frontend_dataset.py`** —  Two new unit tests:
test_publish_dataset_with_subdirectory — verifies subdirectory propagation into the request body's store.
test_publish_dataset_subdirectory_default_omitted — verifies the field is omitted when not provided.
- **`HISTORY.rst`** — Added `1.0.0b6` changelog entry.
- **`setup.py`** — Bumped extension version `1.0.0b5` → `1.0.0b6`.

#### Validation
- ✅ `azdev style managedcleanroom` — Pylint + Flake8 PASSED
- ✅ `python scripts/ci/test_index.py -q` — OK
- ✅ All 56 unit tests pass (54 existing + 2 new)

### General Guidelines
- [x] Have you run `azdev style <YOUR_EXT>` locally? *(pip install azdev required)*
- [x] Have you run `python scripts/ci/test_index.py -q` locally? *(pip install wheel==0.30.0 required)*

### About CLI version requirement
- [ ] Does the PR requires a new CLI core version? *(No — uses existing `analytics_frontend_api` SDK with raw JSON request body path)*
- [ ] If yes, do you have a label of `CLI Version Required` and have you updated `azext_metadata.json` in your extension to refer to a new CLI core version?

### About Extension Publish

- [x] Have you updated the version of `setup.py`?
- [x] Have you updated `HISTORY.rst`?
- [ ] Note: `src/index.json` is auto-updated post-merge — not modified in this PR.
