### PR TITLE
[vm-repair] Update --distro help text to list all supported distros

### DIFF
--- a/src/vm-repair/HISTORY.rst
+++ b/src/vm-repair/HISTORY.rst
@@ -2,6 +2,10 @@
 Release History
 ===============
 
+2.2.1
+++++++
+Updated `--distro` help text and examples to list all currently supported distros and document custom URN support
+
 2.2.0
 ++++++
 Adding `--tags` parameter to `vm repair create` and `vm repair repair-and-restore` commands to allow users to tag the repair VM for organizational requirements

--- a/src/vm-repair/azext_vm_repair/_help.py
+++ b/src/vm-repair/azext_vm_repair/_help.py
@@ -28,9 +28,12 @@ helps['vm repair create'] = """
         - name: Create a repair VM and set the VM authentication
           text: >
             az vm repair create -g MyResourceGroup -n myVM --repair-username username --repair-password password!234 --verbose
-        - name: Create a repair VM of a specific distro or a specific URN could also be provided
+        - name: Create a repair VM of a specific distro
           text: >
-            az vm repair create -g MyResourceGroup -n myVM --distro 'rhel7|rhel8|rhel9|rhel10|ubuntu20|ubuntu22|ubuntu24|centos6|centos7|centos8|oracle7|oracle8|oracle9|oracle10|sles12|sles15'
+            az vm repair create -g MyResourceGroup -n myVM --distro rhel9 --verbose
+        - name: Create a repair VM using a custom image URN
+          text: >
+            az vm repair create -g MyResourceGroup -n myVM --distro 'Publisher:Offer:Sku:Version' --verbose
         - name: Create a repair VM with a Private IP address
           text: >
             az vm repair create -g MyResourceGroup -n myVM --repair-username <username> --repair-password <password>

--- a/src/vm-repair/azext_vm_repair/_help.py
+++ b/src/vm-repair/azext_vm_repair/_help.py
@@ -30,7 +30,7 @@ helps['vm repair create'] = """
             az vm repair create -g MyResourceGroup -n myVM --repair-username username --repair-password password!234 --verbose
         - name: Create a repair VM of a specific distro or a specific URN could also be provided
           text: >
-            az vm repair create -g MyResourceGroup -n myVM --distro 'rhel7|sles12|ubuntu20|centos6|oracle8|sles15'
+            az vm repair create -g MyResourceGroup -n myVM --distro 'rhel7|rhel8|rhel9|rhel10|ubuntu20|ubuntu22|ubuntu24|centos6|centos7|centos8|oracle7|oracle8|oracle9|oracle10|sles12|sles15'
         - name: Create a repair VM with a Private IP address
           text: >
             az vm repair create -g MyResourceGroup -n myVM --repair-username <username> --repair-password <password>

--- a/src/vm-repair/azext_vm_repair/_params.py
+++ b/src/vm-repair/azext_vm_repair/_params.py
@@ -32,7 +32,7 @@ def load_arguments(self, _):
         c.argument('encrypt_recovery_key', help='Option to auto-unlock encrypted VMs using provided recovery password. The \'--unlock-encrypted-vm\' parameter must be used to use this parameter.')
         c.argument('enable_nested', help='enable nested hyperv.')
         c.argument('associate_public_ip', help='Option to create a repair vm with a public ip. If this parameter is not used, only a private ip will be made.')
-        c.argument('distro', help='Option to create repair vm from a specific linux distro (rhel7|rhel8|sles12|sles15|ubuntu20|centos7|centos8|oracle7)')
+        c.argument('distro', help='Option to create repair vm from a specific linux distro (rhel7|rhel8|rhel9|rhel10|ubuntu20|ubuntu22|ubuntu24|centos6|centos7|centos8|oracle7|oracle8|oracle9|oracle10|sles12|sles15). A custom URN can also be provided in the format Publisher:Offer:Sku:Version.')
         c.argument('disable_trusted_launch', help='Option to disable Trusted Launch security type on the repair vm by setting the security type to Standard.')
         c.argument('os_disk_type', help='Change the OS Disk storage type from the default of PremiumSSD_LRS to the given value.')
         c.argument('tags', help='Quoted string with space-separated key-value pairs in "key=value" format. Will be appended to the tags required for repair resources.')

--- a/src/vm-repair/setup.py
+++ b/src/vm-repair/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup, find_packages
 
-VERSION = "2.2.0"
+VERSION = "2.2.1"
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',


### PR DESCRIPTION
## Description

The `--distro` parameter help text in `_params.py` and the example in `_help.py` only listed a subset of the actually supported distros:
- **Old list:** `rhel7|rhel8|sles12|sles15|ubuntu20|centos7|centos8|oracle7`

However, the code in `repair_utils.py` (functions `_select_distro_linux`, `_select_distro_linux_gen2`, and `_select_distro_linux_Arm64`) supports many more:
- **Full list:** `rhel7|rhel8|rhel9|rhel10|ubuntu20|ubuntu22|ubuntu24|centos6|centos7|centos8|oracle7|oracle8|oracle9|oracle10|sles12|sles15`

## Changes

- **`_params.py`**: Updated the `--distro` argument help string to include all supported distros and documented that a custom URN (`Publisher:Offer:Sku:Version`) is also accepted.
- **`_help.py`**: Updated the example command to show all available distro keywords.

## Testing

Documentation-only change. No functional code modified.