### PR TITLE
remove depericated --location

### DIFF
--- a/src/quantum/HISTORY.rst
+++ b/src/quantum/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+1.0.0b15
++++++++++++++++
+* Removed deprecated ``--location``/``-l`` parameter from ``quantum execute``, ``quantum run``, ``quantum job submit``, ``quantum job cancel``, ``quantum job list``, ``quantum job output``, ``quantum job show``, ``quantum job wait``, ``quantum target list``, ``quantum workspace set``, and ``quantum workspace quotas`` commands.
+
 1.0.0b14
 +++++++++++++++
 * Updated control plane related commands to use latest API version 2025-12-15-preview

--- a/src/quantum/azext_quantum/_breaking_change.py
+++ b/src/quantum/azext_quantum/_breaking_change.py
@@ -2,4 +2,3 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
-

--- a/src/quantum/azext_quantum/_breaking_change.py
+++ b/src/quantum/azext_quantum/_breaking_change.py
@@ -2,16 +2,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
-from azure.cli.core.breaking_change import register_argument_deprecate
 
-register_argument_deprecate('quantum execute', '--location', target_version="May 2026")
-register_argument_deprecate('quantum run', '--location', target_version="May 2026")
-register_argument_deprecate('quantum job submit', '--location', target_version="May 2026")
-register_argument_deprecate('quantum job cancel', '--location', target_version="May 2026")
-register_argument_deprecate('quantum job list', '--location', target_version="May 2026")
-register_argument_deprecate('quantum job output', '--location', target_version="May 2026")
-register_argument_deprecate('quantum job show', '--location', target_version="May 2026")
-register_argument_deprecate('quantum job wait', '--location', target_version="May 2026")
-register_argument_deprecate('quantum target list', '--location', target_version="May 2026")
-register_argument_deprecate('quantum workspace set', '--location', target_version="May 2026")
-register_argument_deprecate('quantum workspace quotas', '--location', target_version="May 2026")

--- a/src/quantum/azext_quantum/_help.py
+++ b/src/quantum/azext_quantum/_help.py
@@ -17,17 +17,17 @@ helps['quantum execute'] = """
     examples:
       - name: Run QIR bitcode from a file in the current folder and wait for the result.
         text: |-
-            az quantum execute -g MyResourceGroup -w MyWorkspace -l MyLocation -t MyTarget \\
+            az quantum execute -g MyResourceGroup -w MyWorkspace -t MyTarget \\
                 --job-name MyJob --job-input-format qir.v1 --job-input-file MyQirBitcode.bc \\
                 --entry-point MyQirEntryPoint
       - name: Run a Quil pass-through job on the Rigetti simulator and wait for the result.
         text: |-
-            az quantum execute -g MyResourceGroup -w MyWorkspace -l MyLocation \\
+            az quantum execute -g MyResourceGroup -w MyWorkspace \\
                -t rigetti.sim.qvm --job-name MyJob --job-input-file MyProgram.quil \\
                --job-input-format rigetti.quil.v1 --job-output-format rigetti.quil-results.v1
       - name: Submit a Qiskit circuit to the IonQ simulator with job params and wait for the results.
         text: |-
-            az quantum execute -g MyResourceGroup -w MyWorkspace -l MyLocation \\
+            az quantum execute -g MyResourceGroup -w MyWorkspace \\
                -t ionq.simulator --job-name MyJobName --job-input-file MyCircuit.json \\
                --job-input-format ionq.circuit.v1 --job-output-format ionq.quantum-results.v1 \\
                --job-params count=100 content-type=application/json
@@ -40,17 +40,17 @@ helps['quantum run'] = """
     examples:
       - name: Run QIR bitcode from a file in the current folder and wait for the result.
         text: |-
-            az quantum run -g MyResourceGroup -w MyWorkspace -l MyLocation -t MyTarget \\
+            az quantum run -g MyResourceGroup -w MyWorkspace -t MyTarget \\
                 --job-name MyJob --job-input-format qir.v1 --job-input-file MyQirBitcode.bc \\
                 --entry-point MyQirEntryPoint
       - name: Run a Quil pass-through job on the Rigetti simulator and wait for the result.
         text: |-
-            az quantum run -g MyResourceGroup -w MyWorkspace -l MyLocation \\
+            az quantum run -g MyResourceGroup -w MyWorkspace \\
                -t rigetti.sim.qvm --job-name MyJob --job-input-file MyProgram.quil \\
                --job-input-format rigetti.quil.v1 --job-output-format rigetti.quil-results.v1
       - name: Submit a Qiskit circuit to the IonQ simulator with job params and wait for the results.
         text: |-
-            az quantum run -g MyResourceGroup -w MyWorkspace -l MyLocation \\
+            az quantum run -g MyResourceGroup -w MyWorkspace \\
                -t ionq.simulator --job-name MyJobName --job-input-file MyCircuit.json \\
                --job-input-format ionq.circuit.v1 --job-output-format ionq.quantum-results.v1 \\
                --job-params count=100 content-type=application/json
@@ -67,31 +67,31 @@ helps['quantum job list'] = """
     examples:
       - name: Get the list of jobs from an Azure Quantum workspace.
         text: |-
-            az quantum job list -g MyResourceGroup -w MyWorkspace -l MyLocation
+            az quantum job list -g MyResourceGroup -w MyWorkspace
       - name: List jobs that used the quantinuum provider.
         text: |-
-            az quantum job list -g MyResourceGroup -w MyWorkspace -l MyLocation --provider-id quantinuum
+            az quantum job list -g MyResourceGroup -w MyWorkspace --provider-id quantinuum
       - name: List jobs that ran on the ionq.simulator target.
         text: |-
-            az quantum job list -g MyResourceGroup -w MyWorkspace -l MyLocation --target-id ionq.simulator
+            az quantum job list -g MyResourceGroup -w MyWorkspace --target-id ionq.simulator
       - name: List jobs that completed successfully.
         text: |-
-            az quantum job list -g MyResourceGroup -w MyWorkspace -l MyLocation --status Succeeded
+            az quantum job list -g MyResourceGroup -w MyWorkspace --status Succeeded
       - name: List jobs created after January 15th, 2025.
         text: |-
-            az quantum job list -g MyResourceGroup -w MyWorkspace -l MyLocation --created-after 2025-01-15
+            az quantum job list -g MyResourceGroup -w MyWorkspace --created-after 2025-01-15
       - name: List jobs whose names start with "Generate...".
         text: |-
-            az quantum job list -g MyResourceGroup -w MyWorkspace -l MyLocation --job-name Generate
+            az quantum job list -g MyResourceGroup -w MyWorkspace --job-name Generate
       - name: Skip the first 50 jobs, start listing at the 51st job and list 10 jobs.
         text: |-
-            az quantum job list -g MyResourceGroup -w MyWorkspace -l MyLocation --skip 50 --top 10
+            az quantum job list -g MyResourceGroup -w MyWorkspace --skip 50 --top 10
       - name: Sort the job list by Target ID and display in tabular format.
         text: |-
-            az quantum job list -g MyResourceGroup -w MyWorkspace -l MyLocation --orderby Target -o table
+            az quantum job list -g MyResourceGroup -w MyWorkspace --orderby Target -o table
       - name: Sort the job list by Job Name in descending order, display in tabular format.
         text: |-
-            az quantum job list -g MyResourceGroup -w MyWorkspace -l MyLocation --orderby Name --order desc -o table
+            az quantum job list -g MyResourceGroup -w MyWorkspace --orderby Name --order desc -o table
 """
 
 helps['quantum job output'] = """
@@ -100,7 +100,7 @@ helps['quantum job output'] = """
     examples:
       - name: Print the results of a successful Azure Quantum job.
         text: |-
-            az quantum job output -g MyResourceGroup -w MyWorkspace -l MyLocation \\
+            az quantum job output -g MyResourceGroup -w MyWorkspace \\
                 -j yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy -o table
 """
 
@@ -110,7 +110,7 @@ helps['quantum job show'] = """
     examples:
       - name: Get the status of an Azure Quantum job.
         text: |-
-            az quantum job show -g MyResourceGroup -w MyWorkspace -l MyLocation \\
+            az quantum job show -g MyResourceGroup -w MyWorkspace \\
                 -j yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy --query status
 """
 
@@ -120,17 +120,17 @@ helps['quantum job submit'] = """
     examples:
       - name: Submit QIR bitcode from a file in the current folder.
         text: |-
-            az quantum job submit -g MyResourceGroup -w MyWorkspace -l MyLocation -t MyTarget \\
+            az quantum job submit -g MyResourceGroup -w MyWorkspace -t MyTarget \\
                 --job-name MyJob --job-input-format qir.v1 --job-input-file MyQirBitcode.bc \\
                 --entry-point MyQirEntryPoint
       - name: Submit a Quil pass-through job to the Rigetti simulator.
         text: |-
-            az quantum job submit -g MyResourceGroup -w MyWorkspace -l MyLocation \\
+            az quantum job submit -g MyResourceGroup -w MyWorkspace \\
                -t rigetti.sim.qvm --job-name MyJob --job-input-file MyProgram.quil \\
                --job-input-format rigetti.quil.v1 --job-output-format rigetti.quil-results.v1
       - name: Submit a IonQ JSON circuit to the IonQ simulator with job params.
         text: |-
-            az quantum job submit -g MyResourceGroup -w MyWorkspace -l MyLocation \\
+            az quantum job submit -g MyResourceGroup -w MyWorkspace \\
                -t ionq.simulator --job-name MyJobName --job-input-file MyCircuit.json \\
                --job-input-format ionq.circuit.v1 --job-output-format ionq.quantum-results.v1 \\
                --job-params count=100 content-type=application/json
@@ -142,7 +142,7 @@ helps['quantum job wait'] = """
     examples:
       - name: Wait for completion of a job, check at 60 second intervals.
         text: |-
-            az quantum job wait -g MyResourceGroup -w MyWorkspace -l MyLocation \\
+            az quantum job wait -g MyResourceGroup -w MyWorkspace \\
                 -j yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy --max-poll-wait-secs 60 -o table
 """
 
@@ -152,7 +152,7 @@ helps['quantum job cancel'] = """
     examples:
       - name: Cancel an Azure Quantum job by id.
         text: |-
-            az quantum job cancel -g MyResourceGroup -w MyWorkspace -l MyLocation \\
+            az quantum job cancel -g MyResourceGroup -w MyWorkspace \\
                 -j yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy
 """
 
@@ -211,7 +211,7 @@ helps['quantum target list'] = """
     examples:
       - name: Get the list of targets available in a Azure Quantum workspaces
         text: |-
-            az quantum target list -g MyResourceGroup -w MyWorkspace -l MyLocation
+            az quantum target list -g MyResourceGroup -w MyWorkspace
 """
 
 helps['quantum target set'] = """
@@ -288,9 +288,9 @@ helps['quantum workspace quotas'] = """
     type: command
     short-summary: List the quotas for the given (or current) Azure Quantum workspace.
     examples:
-      - name: List the quota information of a specified Azure Quantum workspace. If a default workspace has been set, the -g, -w, and -l parameters are not required.
+      - name: List the quota information of a specified Azure Quantum workspace. If a default workspace has been set, the -g and -w parameters are not required.
         text: |-
-            az quantum workspace quotas -g MyResourceGroup -w MyWorkspace -l MyLocation
+            az quantum workspace quotas -g MyResourceGroup -w MyWorkspace
 """
 
 helps['quantum workspace set'] = """
@@ -299,7 +299,7 @@ helps['quantum workspace set'] = """
     examples:
       - name: Set the default Azure Quantum workspace.
         text: |-
-            az quantum workspace set -g MyResourceGroup -w MyWorkspace -l MyLocation
+            az quantum workspace set -g MyResourceGroup -w MyWorkspace
 """
 
 helps['quantum workspace show'] = """

--- a/src/quantum/azext_quantum/operations/job.py
+++ b/src/quantum/azext_quantum/operations/job.py
@@ -46,7 +46,7 @@ logger = logging.getLogger(__name__)
 knack_logger = knack.log.get_logger(__name__)
 
 
-def list(cmd, resource_group_name, workspace_name, location=None, job_type=None, item_type=None, provider_id=None,
+def list(cmd, resource_group_name, workspace_name, job_type=None, item_type=None, provider_id=None,
          target_id=None, job_status=None, created_after=None, created_before=None, job_name=None,
          skip=None, top=None, orderby=None, order=None):
     """
@@ -141,7 +141,7 @@ def _construct_orderby_expression(orderby, order):
     return orderby_expression
 
 
-def get(cmd, job_id, resource_group_name=None, workspace_name=None, location=None):
+def get(cmd, job_id, resource_group_name=None, workspace_name=None):
     """
     Get the job's status and details.
     """
@@ -173,7 +173,7 @@ def _convert_numeric_params(job_params):
                     pass
 
 
-def submit(cmd, resource_group_name, workspace_name, target_id, job_input_file, job_input_format, location=None,
+def submit(cmd, resource_group_name, workspace_name, target_id, job_input_file, job_input_format,
            job_name=None, shots=None, storage=None, job_params=None, target_capability=None,
            job_output_format=None, entry_point=None):
     """
@@ -354,7 +354,7 @@ def submit(cmd, resource_group_name, workspace_name, target_id, job_input_file, 
     return client.create(ws_info.subscription, ws_info.resource_group, ws_info.name, job_id, job_details).as_dict()
 
 
-def output(cmd, job_id, resource_group_name, workspace_name, location=None):
+def output(cmd, job_id, resource_group_name, workspace_name):
     """
     Get the results of running a job.
     """
@@ -371,7 +371,7 @@ def output(cmd, job_id, resource_group_name, workspace_name, location=None):
     return _get_job_output(job)
 
 
-def wait(cmd, job_id, resource_group_name, workspace_name, location=None, max_poll_wait_secs=5):
+def wait(cmd, job_id, resource_group_name, workspace_name, max_poll_wait_secs=5):
     """
     Place the CLI in a waiting state until the job finishes running.
     """
@@ -400,7 +400,7 @@ def wait(cmd, job_id, resource_group_name, workspace_name, location=None, max_po
     return job.as_dict()
 
 
-def job_show(cmd, job_id, resource_group_name, workspace_name, location=None):
+def job_show(cmd, job_id, resource_group_name, workspace_name):
     """
     Get the job's status and details.
     """
@@ -410,13 +410,13 @@ def job_show(cmd, job_id, resource_group_name, workspace_name, location=None):
     return job.as_dict()
 
 
-def run(cmd, resource_group_name, workspace_name, target_id, job_input_file, job_input_format, location=None,
+def run(cmd, resource_group_name, workspace_name, target_id, job_input_file, job_input_format,
         job_name=None, shots=None, storage=None, job_params=None, target_capability=None,
         job_output_format=None, entry_point=None):
     """
     Submit a job to run on Azure Quantum, and wait for the result.
     """
-    job = submit(cmd, resource_group_name, workspace_name, target_id, job_input_file, job_input_format, location,
+    job = submit(cmd, resource_group_name, workspace_name, target_id, job_input_file, job_input_format,
                  job_name, shots, storage, job_params, target_capability,
                  job_output_format, entry_point)
     logger.warning("Job id: %s", job["id"])
@@ -428,7 +428,7 @@ def run(cmd, resource_group_name, workspace_name, target_id, job_input_file, job
     return output(cmd, job["id"], resource_group_name, workspace_name)
 
 
-def cancel(cmd, job_id, resource_group_name, workspace_name, location=None):
+def cancel(cmd, job_id, resource_group_name, workspace_name):
     """
     Request to cancel a job on Azure Quantum if it hasn't completed.
     """

--- a/src/quantum/azext_quantum/operations/target.py
+++ b/src/quantum/azext_quantum/operations/target.py
@@ -49,7 +49,7 @@ def set(cmd, target_id):
     return info
 
 
-def list(cmd, resource_group_name, workspace_name, location=None):
+def list(cmd, resource_group_name, workspace_name):
     """
     Get the list of providers and their targets in an Azure Quantum workspace.
     """

--- a/src/quantum/azext_quantum/operations/workspace.py
+++ b/src/quantum/azext_quantum/operations/workspace.py
@@ -348,7 +348,7 @@ def get(cmd, resource_group_name=None, workspace_name=None):
     return ws
 
 
-def quotas(cmd, resource_group_name, workspace_name, location=None):
+def quotas(cmd, resource_group_name, workspace_name):
     """
     List the quotas for the given (or current) Azure Quantum workspace.
     """
@@ -358,7 +358,7 @@ def quotas(cmd, resource_group_name, workspace_name, location=None):
     return repack_response_json(response)
 
 
-def set(cmd, workspace_name, resource_group_name, location=None):
+def set(cmd, workspace_name, resource_group_name):
     """
     Set the default Azure Quantum workspace.
     """

--- a/src/quantum/azext_quantum/tests/latest/test_quantum_jobs.py
+++ b/src/quantum/azext_quantum/tests/latest/test_quantum_jobs.py
@@ -33,7 +33,7 @@ class QuantumJobsScenarioTest(ScenarioTest):
     @live_only()
     def test_jobs(self):
         # set current workspace:
-        self.cmd(f'az quantum workspace set -g {get_test_resource_group()} -w {get_test_workspace()} -l {get_test_workspace_location()}')
+        self.cmd(f'az quantum workspace set -g {get_test_resource_group()} -w {get_test_workspace()}')
 
         # list
         targets = self.cmd('az quantum target list -o json').get_output_in_json()
@@ -45,10 +45,10 @@ class QuantumJobsScenarioTest(ScenarioTest):
     # # See "TODO" in issue_cmd_with_param_missing un utils.py
 
     def test_job_errors(self):
-        issue_cmd_with_param_missing(self, "az quantum job cancel", "az quantum job cancel -g MyResourceGroup -w MyWorkspace -l MyLocation -j yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy\nCancel an Azure Quantum job by id.")
-        issue_cmd_with_param_missing(self, "az quantum job output", "az quantum job output -g MyResourceGroup -w MyWorkspace -l MyLocation -j yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy -o table\nPrint the results of a successful Azure Quantum job.")
-        issue_cmd_with_param_missing(self, "az quantum job show", "az quantum job show -g MyResourceGroup -w MyWorkspace -l MyLocation -j yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy --query status\nGet the status of an Azure Quantum job.")
-        issue_cmd_with_param_missing(self, "az quantum job wait", "az quantum job wait -g MyResourceGroup -w MyWorkspace -l MyLocation -j yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy --max-poll-wait-secs 60 -o table\nWait for completion of a job, check at 60 second intervals.")
+        issue_cmd_with_param_missing(self, "az quantum job cancel", "az quantum job cancel -g MyResourceGroup -w MyWorkspace -j yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy\nCancel an Azure Quantum job by id.")
+        issue_cmd_with_param_missing(self, "az quantum job output", "az quantum job output -g MyResourceGroup -w MyWorkspace -j yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy -o table\nPrint the results of a successful Azure Quantum job.")
+        issue_cmd_with_param_missing(self, "az quantum job show", "az quantum job show -g MyResourceGroup -w MyWorkspace -j yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy --query status\nGet the status of an Azure Quantum job.")
+        issue_cmd_with_param_missing(self, "az quantum job wait", "az quantum job wait -g MyResourceGroup -w MyWorkspace -j yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy --max-poll-wait-secs 60 -o table\nWait for completion of a job, check at 60 second intervals.")
 
     def test_transform_output(self):
         # Call with a good histogram
@@ -203,7 +203,7 @@ class QuantumJobsScenarioTest(ScenarioTest):
         # Wait for role assignments to propagate so the new workspace can access the storage account
         time.sleep(60)
         
-        self.cmd(f"az quantum workspace set -g {test_resource_group} -w {test_workspace_temp} -l {test_location}")
+        self.cmd(f"az quantum workspace set -g {test_resource_group} -w {test_workspace_temp}")
 
         # Submit a job to Rigetti and look for SAS tokens in URIs in the output
         results = self.cmd("az quantum job submit -t rigetti.sim.qvm --job-input-format rigetti.quil.v1 --job-input-file src/quantum/azext_quantum/tests/latest/input_data/bell-state.quil --job-output-format rigetti.quil-results.v1 -o json").get_output_in_json()
@@ -267,7 +267,7 @@ class QuantumJobsScenarioTest(ScenarioTest):
         storage_info = self.cmd(f"az storage account show -g {test_resource_group} -n {test_storage_temp} -o json").get_output_in_json()
         self.assertFalse(storage_info["allowSharedKeyAccess"], "Access keys should be disabled on the newly created storage account for new workspace")
 
-        self.cmd(f"az quantum workspace set -g {test_resource_group} -w {test_workspace_temp} -l {test_location}")
+        self.cmd(f"az quantum workspace set -g {test_resource_group} -w {test_workspace_temp}")
         time.sleep(60) # wait for role assignments to propagate so the new workspace can access the storage account
 
         # Test that job submission works with disabled access keys on linked storage (/sasUri returns user delegation SAS)

--- a/src/quantum/azext_quantum/tests/latest/test_quantum_targets.py
+++ b/src/quantum/azext_quantum/tests/latest/test_quantum_targets.py
@@ -23,7 +23,7 @@ class QuantumTargetsScenarioTest(ScenarioTest):
     @live_only()
     def test_targets(self):
         # set current workspace:
-        self.cmd(f'az quantum workspace set -g {get_test_resource_group()} -w {get_test_workspace()} -l {get_test_workspace_location()}')
+        self.cmd(f'az quantum workspace set -g {get_test_resource_group()} -w {get_test_workspace()}')
 
         # clear current target
         self.cmd('az quantum target clear')

--- a/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
+++ b/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
@@ -78,7 +78,7 @@ class QuantumWorkspacesScenarioTest(ScenarioTest):
         ])
 
         # set
-        self.cmd(f'az quantum workspace set -g {test_resource_group} -w {test_workspace} -l {test_location} -o json', checks=[
+        self.cmd(f'az quantum workspace set -g {test_resource_group} -w {test_workspace} -o json', checks=[
             self.check("name", test_workspace)
         ])
 
@@ -108,7 +108,7 @@ class QuantumWorkspacesScenarioTest(ScenarioTest):
             ])
 
             # set
-            self.cmd(f'az quantum workspace set -g {test_resource_group} -w {test_workspace_temp} -l {test_location} -o json', checks=[
+            self.cmd(f'az quantum workspace set -g {test_resource_group} -w {test_workspace_temp} -o json', checks=[
                 self.check("name", test_workspace_temp)
             ])
 
@@ -204,7 +204,7 @@ class QuantumWorkspacesScenarioTest(ScenarioTest):
         ])
 
         # set
-        self.cmd(f'az quantum workspace set -g {test_resource_group} -w {test_workspace_temp} -l {test_location} -o json', checks=[
+        self.cmd(f'az quantum workspace set -g {test_resource_group} -w {test_workspace_temp} -o json', checks=[
             self.check("name", test_workspace_temp)
         ])
 

--- a/src/quantum/setup.py
+++ b/src/quantum/setup.py
@@ -17,7 +17,7 @@ except ImportError:
 # This version should match the latest entry in HISTORY.rst
 # Also, when updating this, please review the version used by the extension to
 # submit requests, which can be found at './azext_quantum/__init__.py'
-VERSION = '1.0.0b14'
+VERSION = '1.0.0b15'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
## Summary

Adds `--workspace-kind` parameter to `az quantum workspace create`, allowing users to specify whether to create a V1 or V2 Azure Quantum workspace.

## Motivation

V2 workspaces have a different architecture and must be explicitly requested at creation time. The service already supports this via the `workspaceKind` field in the REST API, but there was no way to set it from the CLI — users had to use the portal or call the API directly.

## Changes

- Added `--workspace-kind` (`V1` or `V2`) argument to `az quantum workspace create` in `_params.py`.
- Updated `operations/workspace.py` to pass `workspace_kind` through both code paths: the direct API path (`--skip-role-assignment`) sets it on `WorkspaceResourceProperties`, and the ARM template path includes it as a `workspaceKind` parameter.
- Updated the ARM template `create-workspace-and-assign-role.json` to accept and forward `workspaceKind` to the workspace resource properties
- Added V2 example to `az quantum workspace create` help text.
- Bumped extension version

## Testing

- All offline unit tests pass locally 
- New Unit test added that verifies previous behavior for no breaking changes and checks new workspaces are created with the right workspaceKind field by serializing the JSON.
- Manually verified end-to-end via `test_v2_workspace_temp.py`: created a V2 workspace and confirmed workspaceKind is V2 on azure
