### PR TITLE
Quantum: workspace create and set related bug fixes

### DIFF
--- a/src/quantum/HISTORY.rst
+++ b/src/quantum/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+1.0.0b15
++++++++++++++++
+* Fixed bug where workspace providers were appended to wrong property causing workspace creation to fail
+* Improved error handling for `az quantum workspace set` to provide a clear error message when a workspace is not yet fully provisioned
+
 1.0.0b14
 +++++++++++++++
 * Updated control plane related commands to use latest API version 2025-12-15-preview

--- a/src/quantum/azext_quantum/operations/workspace.py
+++ b/src/quantum/azext_quantum/operations/workspace.py
@@ -362,8 +362,14 @@ def set(cmd, workspace_name, resource_group_name, location=None):
     client = cf_workspaces(cmd.cli_ctx)
     info = WorkspaceInfo(cmd, resource_group_name, workspace_name)
     ws = client.get(info.resource_group, info.name)
-    if ws:
-        info.save(cmd, ws.properties.endpoint_uri)
+    if not ws or not ws.properties.endpoint_uri:
+        provisioning_state = ws.properties.provisioning_state if ws and ws.properties else 'unknown'
+        raise InvalidArgumentValueError(
+            f"Workspace '{workspace_name}' is not ready (current state: '{provisioning_state}'). "
+            "Only workspaces in 'Succeeded' state can be set as default. "
+            "Please wait for the workspace to finish provisioning and try again."
+        )
+    info.save(cmd, ws.properties.endpoint_uri)
     return ws
 
 

--- a/src/quantum/azext_quantum/operations/workspace.py
+++ b/src/quantum/azext_quantum/operations/workspace.py
@@ -140,7 +140,7 @@ def _autoadd_providers(cmd, providers_in_region, providers_selected, workspace_l
                     providers_selected.append(provider_selected)
 
 
-def _add_quantum_providers(cmd, workspace, providers, auto_accept, skip_autoadd):
+def _add_quantum_providers(cmd, workspace: QuantumWorkspace, providers, auto_accept, skip_autoadd):
     providers_in_region_paged = cf_offerings(cmd.cli_ctx).list(location_name=workspace.location)
     providers_in_region = [item for item in providers_in_region_paged]
     providers_selected = []
@@ -183,7 +183,7 @@ def _add_quantum_providers(cmd, workspace, providers, auto_accept, skip_autoadd)
         p = Provider()
         p.provider_id = provider['provider_id']
         p.provider_sku = provider['sku']
-        workspace.providers.append(p)
+        workspace.properties.providers.append(p)
 
 
 def _validate_storage_account(tier_or_kind_msg_text, tier_or_kind, supported_tiers_or_kinds):
@@ -209,15 +209,12 @@ def create(cmd, resource_group_name, workspace_name, location, storage_account, 
     info = WorkspaceInfo(cmd, resource_group_name, workspace_name)
     if not info.resource_group:
         raise ResourceNotFoundError("Please run 'az quantum workspace set' first to select a default resource group.")
-    quantum_workspace = _get_basic_quantum_workspace(location, info, storage_account)
+    quantum_workspace: QuantumWorkspace = _get_basic_quantum_workspace(location, info, storage_account)
 
     # Until the "--skip-role-assignment" parameter is deprecated, use the old non-ARM code to create a workspace without doing a role assignment
     if skip_role_assignment:
         _add_quantum_providers(cmd, quantum_workspace, provider_sku_list, auto_accept, skip_autoadd)
-        properties = WorkspaceResourceProperties()
-        properties.providers = quantum_workspace.providers
-        properties.api_key_enabled = True
-        quantum_workspace.properties = properties
+        quantum_workspace.properties.api_key_enabled = True
         poller = client.begin_create_or_update(info.resource_group, info.name, quantum_workspace, polling=False)
         while not poller.done():
             time.sleep(POLLING_TIME_DURATION)
@@ -232,7 +229,7 @@ def create(cmd, resource_group_name, workspace_name, location, storage_account, 
 
     _add_quantum_providers(cmd, quantum_workspace, provider_sku_list, auto_accept, skip_autoadd)
     validated_providers = []
-    for provider in quantum_workspace.providers:
+    for provider in quantum_workspace.properties.providers:
         validated_providers.append({"providerId": provider.provider_id, "providerSku": provider.provider_sku})
 
     # Set default storage account parameters in case the storage account does not exist yet

--- a/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
+++ b/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
@@ -107,12 +107,12 @@ class QuantumWorkspacesScenarioTest(ScenarioTest):
                 self.check("properties.provisioningState", "Accepted")  # Status is accepted since we're not linking the storage account.
             ])
 
+            time.sleep(10)  # Wait for the workspace to be provisioned
+
             # set
             self.cmd(f'az quantum workspace set -g {test_resource_group} -w {test_workspace_temp} -l {test_location} -o json', checks=[
                 self.check("name", test_workspace_temp)
             ])
-
-            time.sleep(10)  # Wait for the workspace to be created before fetching quotas
 
             # list quotas
             results = self.cmd('az quantum workspace quotas -o json').get_output_in_json()

--- a/src/quantum/setup.py
+++ b/src/quantum/setup.py
@@ -17,7 +17,7 @@ except ImportError:
 # This version should match the latest entry in HISTORY.rst
 # Also, when updating this, please review the version used by the extension to
 # submit requests, which can be found at './azext_quantum/__init__.py'
-VERSION = '1.0.0b14'
+VERSION = '1.0.0b15'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
## Description:
* Fixed bug where workspace providers were appended to wrong property causing workspace creation to fail
* Improved error handling for `az quantum workspace set` to provide a clear error message when a workspace is not yet fully provisioned
* Added timeout after workspace creation in e2e test

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
