### PR TITLE
[vm-repair] Fix unlock failure on Ubuntu 24.04 ADE-encrypted VMs

### DIFF
--- a/src/vm-repair/azext_vm_repair/scripts/linux-mount-encrypted-disk.sh
+++ b/src/vm-repair/azext_vm_repair/scripts/linux-mount-encrypted-disk.sh
@@ -95,7 +95,11 @@ data_os_lvm_check () {
 	then
 		#Updaing the below command to use lsblk instead of fdisk for accounting for different distros
 		#export root_part=`fdisk -l ${data_disk} 2>&1 | grep ^/ |awk '$4 > 60000000{print $1}'` >> ${logpath}/${logfile}
-		export root_part=`lsblk ${data_disk} -l -n -p -b 2>&1 | grep -w -v ${data_disk} |awk '$4 > 600000000{print $1}'` >> ${logpath}/${logfile}
+		# Select the largest partition on the data disk (root is always the largest).
+		# Using sort+head instead of a size threshold to avoid matching /boot partitions
+		# that exceed 600MB (e.g. Ubuntu 24.04 has a ~913MB /boot on partition 16).
+		root_part=$(lsblk "${data_disk}" -l -n -p -b 2>>"${logpath}/${logfile}" | grep -w -v "${data_disk}" | sort -k4 -rn | awk 'NR==1{print $1}')
+		export root_part
 		echo "`date` LVM not found on the data disk" >> ${logpath}/${logfile}
 		echo "`date` The OS partition on the data drive is ${root_part}" >> ${logpath}/${logfile}
 	else


### PR DESCRIPTION
## Description

Fix `az vm repair create --unlock-encrypted-vm` failing on **Ubuntu 24.04** ADE-encrypted VMs.

### Problem

The `data_os_lvm_check` function in `linux-mount-encrypted-disk.sh` identifies the root partition by filtering partitions larger than 600MB:

```bash
export root_part=lsblk ${data_disk} -l -n -p -b 2>&1 | grep -w -v ${data_disk} | awk '$4 > 600000000{print $1}'`
```

Ubuntu 24.04 introduced a **~913MB /boot partition** (partition 16, ext4, LABEL=BOOT). This partition exceeds the 600MB threshold, causing `root_part` to capture **two values** instead of one:

```
root_part=/dev/sdb1\n/dev/sdb16
```

When `unlock_root` passes this to `cryptsetup`, the command becomes:

```bash
cryptsetup luksOpen --key-file ... --header ... /dev/sdb1 /dev/sdb16 osencrypt
```

Where `/dev/sdb16` is interpreted as the mapper name instead of `osencrypt`, producing:

```
Device sdb16 not found
Cannot use device /dev/sdb16, name is invalid or still in use.
```

### Partition layout comparison

| Ubuntu version | Boot partition | Size | Exceeds 600MB? |
|---|---|---|---|
| 20.04 | sdX2 (ext2) | ~248MB | No |
| 22.04 | sdX2 (ext2) | ~248MB | No |
| **24.04** | **sdX16 (ext4)** | **~913MB** | **Yes** |

### Fix

Replace the fixed-threshold filter with a sort-by-size approach that selects only the **largest partition** (always root):

```bash
export root_part=lsblk ${data_disk} -l -n -p -b 2>&1 | grep -w -v ${data_disk} | sort -k4 -rn | awk 'NR==1{print $1}'`
```

This is future-proof against boot partition size changes in newer distro versions.

### Testing

- **Ubuntu 24.04 Gen 1 + ADE**: unlock now **succeeds** (was failing before)
- **Ubuntu 22.04 Gen 1/Gen 2 + ADE**: no regression (verified)
- **Ubuntu 20.04 Gen 1/Gen 2 + ADE**: no regression (verified)
- **RHEL 7/8/9 LVM + ADE**: not affected (uses LVM branch, not this code path)

### Affected file

`src/vm-repair/azext_vm_repair/scripts/linux-mount-encrypted-disk.sh`