### PR TITLE
Add --driver-type to machine commands

### DIFF
--- a/src/aks-preview/azext_aks_preview/_help.py
+++ b/src/aks-preview/azext_aks_preview/_help.py
@@ -2889,6 +2889,9 @@ helps['aks machine add'] = """
        - name: --eviction-policy
          type: string
          short-summary: The eviction policy for machine. This cannot be specified unless the priority is 'Spot'. If not specified, the default is 'Delete'.
+       - name: --driver-type
+         type: string
+         short-summary: Specify the type of GPU driver to install when creating Windows machines. Valid values are "GRID" and "CUDA". If not provided, AKS selects the driver based on system compatibility.
 """
 
 helps['aks machine update'] = """

--- a/src/aks-preview/azext_aks_preview/_params.py
+++ b/src/aks-preview/azext_aks_preview/_params.py
@@ -202,6 +202,7 @@ from azext_aks_preview._validators import (
     validate_defender_config_parameter,
     validate_defender_disable_and_enable_parameters,
     validate_disable_windows_outbound_nat,
+    validate_driver_type,
     validate_asm_egress_name,
     validate_eviction_policy,
     validate_grafanaresourceid,
@@ -2599,6 +2600,13 @@ def load_arguments(self, _):
             "eviction_policy",
             arg_type=get_enum_type(node_eviction_policies),
             validator=validate_eviction_policy,
+        )
+        # gpu setting
+        c.argument(
+            "driver_type",
+            arg_type=get_enum_type(gpu_driver_types),
+            is_preview=True,
+            validator=validate_driver_type,
         )
 
     with self.argument_context("aks machine update") as c:

--- a/src/aks-preview/azext_aks_preview/_validators.py
+++ b/src/aks-preview/azext_aks_preview/_validators.py
@@ -799,6 +799,14 @@ def validate_disable_windows_outbound_nat(namespace):
                 '--disable-windows-outbound-nat can only be set for Windows nodepools')
 
 
+def validate_driver_type(namespace):
+    """Validates driver_type can only be used with Windows os-type."""
+    if namespace.driver_type:
+        if hasattr(namespace, 'os_type') and str(namespace.os_type).lower() != "windows":
+            raise ArgumentUsageError(
+                '--driver-type can only be set for Windows nodes')
+
+
 def validate_defender_config_parameter(namespace):
     if namespace.defender_config and not namespace.enable_defender:
         raise RequiredArgumentMissingError("Please specify --enable-defnder")

--- a/src/aks-preview/azext_aks_preview/custom.py
+++ b/src/aks-preview/azext_aks_preview/custom.py
@@ -2967,6 +2967,7 @@ def aks_machine_add(
     spot_max_price=float("nan"),
     enable_ultra_ssd=False,
     eviction_policy=None,
+    driver_type=None,
 ):
     existedMachine = None
     try:

--- a/src/aks-preview/azext_aks_preview/machine.py
+++ b/src/aks-preview/azext_aks_preview/machine.py
@@ -125,6 +125,18 @@ def set_machine_hardware_profile(cmd, raw_parameters):
         vm_size=vm_size,
         ultra_ssd_enabled=enable_ultra_ssd
     )
+
+    driver_type = raw_parameters.get("driver_type")
+    if driver_type is not None:
+        GPUProfile = cmd.get_models(
+            "GPUProfile",
+            resource_type=CUSTOM_MGMT_AKS_PREVIEW,
+            operation_group="machines"
+        )
+        machine_hardware_profile.gpu_profile = GPUProfile(
+            driver_type=driver_type
+        )
+
     return machine_hardware_profile
 
 
@@ -201,6 +213,7 @@ def set_machine_os_profile(cmd, raw_parameters):
         os_sku=os_sku,
         enable_fips=enable_fips
     )
+
     return machineOSProfile
 
 

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -2866,6 +2866,91 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
     @AKSCustomResourceGroupPreparer(
         random_name_length=17, name_prefix="clitest", location="westus2"
     )
+    def test_aks_machine_add_windows_params(self, resource_group, resource_group_location):
+        aks_name = self.create_random_name("cliakstest", 16)
+        nodepool_name = self.create_random_name("c", 6)
+        self.kwargs.update(
+            {
+                "resource_group": resource_group,
+                "location": resource_group_location,
+                "name": aks_name,
+                "ssh_key_value": self.generate_ssh_keys(),
+                "nodepool_name": nodepool_name,
+                "machine_name": "machinetest1",
+                "vm_size": "Standard_D4s_v3",
+            }
+        )
+
+        # create aks cluster
+        self.cmd(
+            "aks create "
+            "--resource-group={resource_group} "
+            "--name={name} "
+            "--ssh-key-value={ssh_key_value}",
+            checks=[
+                self.check("provisioningState", "Succeeded"),
+            ],
+        )
+
+        # add machines nodepool
+        self.cmd(
+            "aks nodepool add "
+            "--resource-group={resource_group}"
+            " --cluster-name={name} "
+            "--name={nodepool_name} "
+            "--mode=Machines",
+            checks=[
+                self.check("provisioningState", "Succeeded"),
+                self.check("mode", "Machines"),
+            ],
+        )
+
+        # add machine with Windows os-type and driver-type
+        self.cmd(
+            "aks machine add "
+            " --resource-group={resource_group} "
+            " --cluster-name={name} "
+            " --nodepool-name={nodepool_name} "
+            " --machine-name={machine_name} "
+            " --vm-size={vm_size} "
+            " --os-type Windows "
+            " --driver-type CUDA"
+        )
+
+        # show the machine and verify Windows-specific settings
+        show_cmd = (
+            "aks machine show "
+            " --resource-group={resource_group} "
+            " --cluster-name={name} "
+            " --nodepool-name={nodepool_name} "
+            " --machine-name={machine_name} -o json"
+        )
+        machine_show = self.cmd(show_cmd).get_output_in_json()
+        assert machine_show["properties"]["hardware"]["gpuProfile"]["driverType"] == "CUDA"
+
+        # negative test: --driver-type with Linux os-type should fail
+        self.cmd(
+            "aks machine add "
+            " --resource-group={resource_group} "
+            " --cluster-name={name} "
+            " --nodepool-name={nodepool_name} "
+            " --machine-name=machinelinux1 "
+            " --vm-size={vm_size} "
+            " --os-type Linux "
+            " --driver-type CUDA",
+            expect_failure=True,
+        )
+
+        # delete AKS cluster
+        self.cmd(
+            "aks delete -g {resource_group} -n {name} --yes --no-wait",
+            checks=[self.is_empty()],
+        )
+
+    @AllowLargeResponse()
+    @AKSCustomResourceGroupPreparer(
+        random_name_length=17, name_prefix="clitest", location="westus2"
+    )
     def test_aks_operations_cmds(self, resource_group, resource_group_location):
         aks_name = self.create_random_name("cliakstest", 16)
         self.kwargs.update(

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_validators.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_validators.py
@@ -149,6 +149,12 @@ class DisableWindowsOutboundNatNamespace:
         self.disable_windows_outbound_nat = disable_windows_outbound_nat
 
 
+class DriverTypeNamespace:
+    def __init__(self, os_type, driver_type):
+        self.os_type = os_type
+        self.driver_type = driver_type
+
+
 class ArtifactStreamingNamespace:
     def __init__(self, os_type, enable_artifact_streaming=False, disable_artifact_streaming=False):
         self.os_type = os_type
@@ -387,6 +393,40 @@ class TestDisableWindowsOutboundNAT(unittest.TestCase):
             )
         self.assertTrue(
             "--disable-windows-outbound-nat can only be set for Windows nodepools"
+            in str(cm.exception),
+            msg=str(cm.exception),
+        )
+
+
+class TestDriverType(unittest.TestCase):
+    def test_pass_if_os_type_windows(self):
+        validators.validate_driver_type(
+            DriverTypeNamespace("Windows", "CUDA")
+        )
+
+    def test_pass_if_driver_type_none(self):
+        validators.validate_driver_type(
+            DriverTypeNamespace("Linux", None)
+        )
+
+    def test_fail_if_os_type_linux(self):
+        with self.assertRaises(CLIError) as cm:
+            validators.validate_driver_type(
+                DriverTypeNamespace("Linux", "CUDA")
+            )
+        self.assertTrue(
+            "--driver-type can only be set for Windows nodes"
+            in str(cm.exception),
+            msg=str(cm.exception),
+        )
+
+    def test_fail_if_os_type_invalid(self):
+        with self.assertRaises(CLIError) as cm:
+            validators.validate_driver_type(
+                DriverTypeNamespace("invalid", "GRID")
+            )
+        self.assertTrue(
+            "--driver-type can only be set for Windows nodes"
             in str(cm.exception),
             msg=str(cm.exception),
         )


### PR DESCRIPTION

The Machine CLI was missing two Windows-related parameters that are already supported in the Nodepool CLI:  --driver-type (for specifying GPU driver type CUDA/GRID). This adds parameter to `az aks machine add` for Windows support.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`azdev` required; see `.azure-pipelines/templates/azdev_setup.yml` for the install command until `azdev==0.2.11b1` is on PyPI)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
