### PR TITLE
Update AFD security policy to 2026-04-01-preview

### DIFF
--- a/src/cdn/HISTORY.rst
+++ b/src/cdn/HISTORY.rst
@@ -5,7 +5,7 @@ Release History
 
 upcoming
 ++++++++
-* Update AFD security policy commands to API version 2026-04-01-preview for multilevel WAF support.
+* Add support for configuring profile-level Web Application Firewall policies and route associations on AFD security policies.
 * Update AFD/CDN AAZ-generated command models and tests to use native JSON support, including AFD rule action and condition subcommands.
 
 1.0.0b1

--- a/src/cdn/HISTORY.rst
+++ b/src/cdn/HISTORY.rst
@@ -5,6 +5,7 @@ Release History
 
 upcoming
 ++++++++
+* Update AFD security policy commands to API version 2026-04-01-preview for multilevel WAF support.
 * Update AFD/CDN AAZ-generated command models and tests to use native JSON support, including AFD rule action and condition subcommands.
 
 1.0.0b1

--- a/src/cdn/azext_cdn/aaz/latest/afd/security_policy/_create.py
+++ b/src/cdn/azext_cdn/aaz/latest/afd/security_policy/_create.py
@@ -22,9 +22,9 @@ class Create(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2025-09-01-preview",
+        "version": "2026-04-01-preview",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.cdn/profiles/{}/securitypolicies/{}", "2025-09-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.cdn/profiles/{}/securitypolicies/{}", "2026-04-01-preview"],
         ]
     }
 
@@ -71,427 +71,73 @@ class Create(AAZCommand):
             options=["--web-application-firewall"],
             arg_group="Parameters",
         )
-        _args_schema.web_application_firewall_embedded = AAZObjectArg(
-            options=["--web-application-firewall-embedded"],
-            arg_group="Parameters",
-        )
 
         web_application_firewall = cls._args_schema.web_application_firewall
         web_application_firewall.associations = AAZListArg(
             options=["associations"],
             help="Waf associations",
         )
-        web_application_firewall.waf_policy = AAZStrArg(
-            options=["waf-policy"],
-            help="The ID of Front Door WAF policy.",
+        web_application_firewall.is_profile_level = AAZBoolArg(
+            options=["is-profile-level"],
+            help="Indicates if this is a profile-level WAF policy.",
         )
+        web_application_firewall.waf_policy = AAZObjectArg(
+            options=["waf-policy"],
+            help="Resource ID.",
+        )
+        cls._build_args_resource_reference_create(web_application_firewall.waf_policy)
 
         associations = cls._args_schema.web_application_firewall.associations
         associations.Element = AAZObjectArg()
-        cls._build_args_security_policy_web_application_firewall_association_create(associations.Element)
 
-        web_application_firewall_embedded = cls._args_schema.web_application_firewall_embedded
-        web_application_firewall_embedded.associations = AAZListArg(
-            options=["associations"],
-            help="Waf associations",
-        )
-        web_application_firewall_embedded.waf_policy = AAZObjectArg(
-            options=["waf-policy"],
-            help="Properties of the web application firewall policy.",
-        )
-
-        associations = cls._args_schema.web_application_firewall_embedded.associations
-        associations.Element = AAZObjectArg()
-        cls._build_args_security_policy_web_application_firewall_association_create(associations.Element)
-
-        waf_policy = cls._args_schema.web_application_firewall_embedded.waf_policy
-        waf_policy.etag = AAZStrArg(
-            options=["etag"],
-            help="Gets a unique read-only string that changes whenever the resource is updated.",
-        )
-        waf_policy.custom_rules = AAZObjectArg(
-            options=["custom-rules"],
-            help="Describes custom rules inside the policy.",
-        )
-        waf_policy.managed_rules = AAZObjectArg(
-            options=["managed-rules"],
-            help="Describes managed rules inside the policy.",
-        )
-        waf_policy.policy_settings = AAZObjectArg(
-            options=["policy-settings"],
-            help="Describes settings for the policy.",
-        )
-        waf_policy.sku = AAZObjectArg(
-            options=["sku"],
-            help="The pricing tier of web application firewall policy. Defaults to Classic_AzureFrontDoor if not specified.",
-        )
-
-        custom_rules = cls._args_schema.web_application_firewall_embedded.waf_policy.custom_rules
-        custom_rules.rules = AAZListArg(
-            options=["rules"],
-            help="List of rules",
-        )
-
-        rules = cls._args_schema.web_application_firewall_embedded.waf_policy.custom_rules.rules
-        rules.Element = AAZObjectArg()
-
-        _element = cls._args_schema.web_application_firewall_embedded.waf_policy.custom_rules.rules.Element
-        _element.action = AAZStrArg(
-            options=["action"],
-            help="Describes what action to be applied when rule matches.",
-            required=True,
-            enum={"Allow": "Allow", "AnomalyScoring": "AnomalyScoring", "Block": "Block", "CAPTCHA": "CAPTCHA", "JSChallenge": "JSChallenge", "Log": "Log", "Redirect": "Redirect"},
-        )
-        _element.enabled_state = AAZStrArg(
-            options=["enabled-state"],
-            help="Describes if the custom rule is in enabled or disabled state. Defaults to Enabled if not specified.",
-            enum={"Disabled": "Disabled", "Enabled": "Enabled"},
-        )
-        _element.group_by = AAZListArg(
-            options=["group-by"],
-            help="Describes the list of variables to group the rate limit requests",
-        )
-        _element.match_conditions = AAZListArg(
-            options=["match-conditions"],
-            help="List of match conditions.",
-            required=True,
-        )
-        _element.name = AAZStrArg(
-            options=["name"],
-            help="Describes the name of the rule.",
-            fmt=AAZStrArgFormat(
-                max_length=128,
-            ),
-        )
-        _element.priority = AAZIntArg(
-            options=["priority"],
-            help="Describes priority of the rule. Rules with a lower value will be evaluated before rules with a higher value.",
-            required=True,
-        )
-        _element.rate_limit_duration_in_minutes = AAZIntArg(
-            options=["rate-limit-duration-in-minutes"],
-            help="Time window for resetting the rate limit count. Default is 1 minute.",
-            fmt=AAZIntArgFormat(
-                maximum=5,
-                minimum=0,
-            ),
-        )
-        _element.rate_limit_threshold = AAZIntArg(
-            options=["rate-limit-threshold"],
-            help="Number of allowed requests per client within the time window.",
-            fmt=AAZIntArgFormat(
-                minimum=0,
-            ),
-        )
-        _element.rule_type = AAZStrArg(
-            options=["rule-type"],
-            help="Describes type of rule.",
-            required=True,
-            enum={"MatchRule": "MatchRule", "RateLimitRule": "RateLimitRule"},
-        )
-
-        group_by = cls._args_schema.web_application_firewall_embedded.waf_policy.custom_rules.rules.Element.group_by
-        group_by.Element = AAZObjectArg()
-
-        _element = cls._args_schema.web_application_firewall_embedded.waf_policy.custom_rules.rules.Element.group_by.Element
-        _element.variable_name = AAZStrArg(
-            options=["variable-name"],
-            help="Describes the supported variable for group by",
-            required=True,
-            enum={"GeoLocation": "GeoLocation", "None": "None", "SocketAddr": "SocketAddr"},
-        )
-
-        match_conditions = cls._args_schema.web_application_firewall_embedded.waf_policy.custom_rules.rules.Element.match_conditions
-        match_conditions.Element = AAZObjectArg()
-
-        _element = cls._args_schema.web_application_firewall_embedded.waf_policy.custom_rules.rules.Element.match_conditions.Element
-        _element.match_value = AAZListArg(
-            options=["match-value"],
-            help="List of possible match values.",
-            required=True,
-        )
-        _element.match_variable = AAZStrArg(
-            options=["match-variable"],
-            help="Request variable to compare with.",
-            required=True,
-            enum={"ClientPort": "ClientPort", "Cookies": "Cookies", "HostName": "HostName", "HttpVersion": "HttpVersion", "IsDevice": "IsDevice", "PostArgs": "PostArgs", "QueryString": "QueryString", "RemoteAddress": "RemoteAddress", "RequestBody": "RequestBody", "RequestHeader": "RequestHeader", "RequestMethod": "RequestMethod", "RequestScheme": "RequestScheme", "RequestUri": "RequestUri", "ServerPort": "ServerPort", "SocketAddr": "SocketAddr", "SslProtocol": "SslProtocol", "UrlFileExtension": "UrlFileExtension", "UrlFileName": "UrlFileName", "UrlPath": "UrlPath"},
-        )
-        _element.negate_condition = AAZBoolArg(
-            options=["negate-condition"],
-            help="Describes if the result of this condition should be negated.",
-        )
-        _element.operator = AAZStrArg(
-            options=["operator"],
-            help="Comparison type to use for matching with the variable value.",
-            required=True,
-            enum={"Any": "Any", "BeginsWith": "BeginsWith", "Contains": "Contains", "EndsWith": "EndsWith", "Equal": "Equal", "GeoMatch": "GeoMatch", "GreaterThan": "GreaterThan", "GreaterThanOrEqual": "GreaterThanOrEqual", "IPMatch": "IPMatch", "LessThan": "LessThan", "LessThanOrEqual": "LessThanOrEqual", "RegEx": "RegEx"},
-        )
-        _element.selector = AAZStrArg(
-            options=["selector"],
-            help="Match against a specific key from the QueryString, PostArgs, RequestHeader or Cookies variables. Default is null.",
-        )
-        _element.transforms = AAZListArg(
-            options=["transforms"],
-            help="List of transforms.",
-        )
-
-        match_value = cls._args_schema.web_application_firewall_embedded.waf_policy.custom_rules.rules.Element.match_conditions.Element.match_value
-        match_value.Element = AAZStrArg()
-
-        transforms = cls._args_schema.web_application_firewall_embedded.waf_policy.custom_rules.rules.Element.match_conditions.Element.transforms
-        transforms.Element = AAZStrArg(
-            enum={"Lowercase": "Lowercase", "RemoveNulls": "RemoveNulls", "Trim": "Trim", "Uppercase": "Uppercase", "UrlDecode": "UrlDecode", "UrlEncode": "UrlEncode"},
-        )
-
-        managed_rules = cls._args_schema.web_application_firewall_embedded.waf_policy.managed_rules
-        managed_rules.managed_rule_sets = AAZListArg(
-            options=["managed-rule-sets"],
-            help="List of rule sets.",
-        )
-
-        managed_rule_sets = cls._args_schema.web_application_firewall_embedded.waf_policy.managed_rules.managed_rule_sets
-        managed_rule_sets.Element = AAZObjectArg()
-
-        _element = cls._args_schema.web_application_firewall_embedded.waf_policy.managed_rules.managed_rule_sets.Element
-        _element.exclusions = AAZListArg(
-            options=["exclusions"],
-            help="Describes the exclusions that are applied to all rules in the set.",
-        )
-        _element.rule_group_overrides = AAZListArg(
-            options=["rule-group-overrides"],
-            help="Defines the rule group overrides to apply to the rule set.",
-        )
-        _element.rule_set_action = AAZStrArg(
-            options=["rule-set-action"],
-            help="Defines the rule set action.",
-            enum={"Block": "Block", "Log": "Log", "Redirect": "Redirect"},
-        )
-        _element.rule_set_type = AAZStrArg(
-            options=["rule-set-type"],
-            help="Defines the rule set type to use.",
-            required=True,
-        )
-        _element.rule_set_version = AAZStrArg(
-            options=["rule-set-version"],
-            help="Defines the version of the rule set to use.",
-            required=True,
-        )
-
-        exclusions = cls._args_schema.web_application_firewall_embedded.waf_policy.managed_rules.managed_rule_sets.Element.exclusions
-        exclusions.Element = AAZObjectArg()
-        cls._build_args_managed_rule_exclusion_create(exclusions.Element)
-
-        rule_group_overrides = cls._args_schema.web_application_firewall_embedded.waf_policy.managed_rules.managed_rule_sets.Element.rule_group_overrides
-        rule_group_overrides.Element = AAZObjectArg()
-
-        _element = cls._args_schema.web_application_firewall_embedded.waf_policy.managed_rules.managed_rule_sets.Element.rule_group_overrides.Element
-        _element.exclusions = AAZListArg(
-            options=["exclusions"],
-            help="Describes the exclusions that are applied to all rules in the group.",
-        )
-        _element.rule_group_name = AAZStrArg(
-            options=["rule-group-name"],
-            help="Describes the managed rule group to override.",
-            required=True,
-        )
-        _element.rules = AAZListArg(
-            options=["rules"],
-            help="List of rules that will be disabled. If none specified, all rules in the group will be disabled.",
-        )
-
-        exclusions = cls._args_schema.web_application_firewall_embedded.waf_policy.managed_rules.managed_rule_sets.Element.rule_group_overrides.Element.exclusions
-        exclusions.Element = AAZObjectArg()
-        cls._build_args_managed_rule_exclusion_create(exclusions.Element)
-
-        rules = cls._args_schema.web_application_firewall_embedded.waf_policy.managed_rules.managed_rule_sets.Element.rule_group_overrides.Element.rules
-        rules.Element = AAZObjectArg()
-
-        _element = cls._args_schema.web_application_firewall_embedded.waf_policy.managed_rules.managed_rule_sets.Element.rule_group_overrides.Element.rules.Element
-        _element.action = AAZStrArg(
-            options=["action"],
-            help="Describes the override action to be applied when rule matches.",
-            enum={"Allow": "Allow", "AnomalyScoring": "AnomalyScoring", "Block": "Block", "CAPTCHA": "CAPTCHA", "JSChallenge": "JSChallenge", "Log": "Log", "Redirect": "Redirect"},
-        )
-        _element.enabled_state = AAZStrArg(
-            options=["enabled-state"],
-            help="Describes if the managed rule is in enabled or disabled state. Defaults to Disabled if not specified.",
-            enum={"Disabled": "Disabled", "Enabled": "Enabled"},
-        )
-        _element.exclusions = AAZListArg(
-            options=["exclusions"],
-            help="Describes the exclusions that are applied to this specific rule.",
-        )
-        _element.rule_id = AAZStrArg(
-            options=["rule-id"],
-            help="Identifier for the managed rule.",
-            required=True,
-        )
-
-        exclusions = cls._args_schema.web_application_firewall_embedded.waf_policy.managed_rules.managed_rule_sets.Element.rule_group_overrides.Element.rules.Element.exclusions
-        exclusions.Element = AAZObjectArg()
-        cls._build_args_managed_rule_exclusion_create(exclusions.Element)
-
-        policy_settings = cls._args_schema.web_application_firewall_embedded.waf_policy.policy_settings
-        policy_settings.captcha_expiration_in_minutes = AAZIntArg(
-            options=["captcha-expiration-in-minutes"],
-            help="Defines the Captcha cookie validity lifetime in minutes. This setting is only applicable to Premium_AzureFrontDoor. Value must be an integer between 5 and 1440 with the default value being 30.",
-            fmt=AAZIntArgFormat(
-                maximum=1440,
-                minimum=5,
-            ),
-        )
-        policy_settings.custom_block_response_body = AAZStrArg(
-            options=["custom-block-response-body"],
-            help="If the action type is block, customer can override the response body. The body must be specified in base64 encoding.",
-            fmt=AAZStrArgFormat(
-                pattern="^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
-            ),
-        )
-        policy_settings.custom_block_response_status_code = AAZIntArg(
-            options=["custom-block-response-status-code"],
-            help="If the action type is block, customer can override the response status code.",
-        )
-        policy_settings.enabled_state = AAZStrArg(
-            options=["enabled-state"],
-            help="Describes if the policy is in enabled or disabled state. Defaults to Enabled if not specified.",
-            enum={"Disabled": "Disabled", "Enabled": "Enabled"},
-        )
-        policy_settings.javascript_challenge_expiration_in_minutes = AAZIntArg(
-            options=["javascript-challenge-expiration-in-minutes"],
-            help="Defines the JavaScript challenge cookie validity lifetime in minutes. This setting is only applicable to Premium_AzureFrontDoor. Value must be an integer between 5 and 1440 with the default value being 30.",
-            fmt=AAZIntArgFormat(
-                maximum=1440,
-                minimum=5,
-            ),
-        )
-        policy_settings.scrubbing_rules = AAZListArg(
-            options=["scrubbing-rules"],
-            help="List of log scrubbing rules applied to the Web Application Firewall logs.",
-        )
-        policy_settings.state = AAZStrArg(
-            options=["state"],
-            help="State of the log scrubbing config. Default value is Enabled.",
-            enum={"Disabled": "Disabled", "Enabled": "Enabled"},
-        )
-        policy_settings.mode = AAZStrArg(
-            options=["mode"],
-            help="Describes if it is in detection mode or prevention mode at policy level.",
-            enum={"Detection": "Detection", "Prevention": "Prevention"},
-        )
-        policy_settings.redirect_url = AAZStrArg(
-            options=["redirect-url"],
-            help="If action type is redirect, this field represents redirect URL for the client.",
-        )
-        policy_settings.request_body_check = AAZStrArg(
-            options=["request-body-check"],
-            help="Describes if policy managed rules will inspect the request body content.",
-            enum={"Disabled": "Disabled", "Enabled": "Enabled"},
-        )
-
-        scrubbing_rules = cls._args_schema.web_application_firewall_embedded.waf_policy.policy_settings.scrubbing_rules
-        scrubbing_rules.Element = AAZObjectArg()
-
-        _element = cls._args_schema.web_application_firewall_embedded.waf_policy.policy_settings.scrubbing_rules.Element
-        _element.match_variable = AAZStrArg(
-            options=["match-variable"],
-            help="The variable to be scrubbed from the logs.",
-            required=True,
-            enum={"QueryStringArgNames": "QueryStringArgNames", "RequestBodyJsonArgNames": "RequestBodyJsonArgNames", "RequestBodyPostArgNames": "RequestBodyPostArgNames", "RequestCookieNames": "RequestCookieNames", "RequestHeaderNames": "RequestHeaderNames", "RequestIPAddress": "RequestIPAddress", "RequestUri": "RequestUri"},
-        )
-        _element.selector = AAZStrArg(
-            options=["selector"],
-            help="When matchVariable is a collection, operator used to specify which elements in the collection this rule applies to.",
-        )
-        _element.selector_match_operator = AAZStrArg(
-            options=["selector-match-operator"],
-            help="When matchVariable is a collection, operate on the selector to specify which elements in the collection this rule applies to.",
-            required=True,
-            enum={"Equals": "Equals", "EqualsAny": "EqualsAny"},
-        )
-        _element.state = AAZStrArg(
-            options=["state"],
-            help="Defines the state of a log scrubbing rule. Default value is enabled.",
-            enum={"Disabled": "Disabled", "Enabled": "Enabled"},
-        )
-
-        sku = cls._args_schema.web_application_firewall_embedded.waf_policy.sku
-        sku.name = AAZStrArg(
-            options=["name"],
-            help="Name of the pricing tier.",
-            enum={"Classic_AzureFrontDoor": "Classic_AzureFrontDoor", "Custom_Verizon": "Custom_Verizon", "Premium_AzureFrontDoor": "Premium_AzureFrontDoor", "Premium_Verizon": "Premium_Verizon", "StandardPlus_955BandWidth_ChinaCdn": "StandardPlus_955BandWidth_ChinaCdn", "StandardPlus_AvgBandWidth_ChinaCdn": "StandardPlus_AvgBandWidth_ChinaCdn", "StandardPlus_ChinaCdn": "StandardPlus_ChinaCdn", "Standard_955BandWidth_ChinaCdn": "Standard_955BandWidth_ChinaCdn", "Standard_Akamai": "Standard_Akamai", "Standard_AvgBandWidth_ChinaCdn": "Standard_AvgBandWidth_ChinaCdn", "Standard_AzureFrontDoor": "Standard_AzureFrontDoor", "Standard_ChinaCdn": "Standard_ChinaCdn", "Standard_Microsoft": "Standard_Microsoft", "Standard_Verizon": "Standard_Verizon"},
-        )
-        return cls._args_schema
-
-    _args_managed_rule_exclusion_create = None
-
-    @classmethod
-    def _build_args_managed_rule_exclusion_create(cls, _schema):
-        if cls._args_managed_rule_exclusion_create is not None:
-            _schema.match_variable = cls._args_managed_rule_exclusion_create.match_variable
-            _schema.selector = cls._args_managed_rule_exclusion_create.selector
-            _schema.selector_match_operator = cls._args_managed_rule_exclusion_create.selector_match_operator
-            return
-
-        cls._args_managed_rule_exclusion_create = AAZObjectArg()
-
-        managed_rule_exclusion_create = cls._args_managed_rule_exclusion_create
-        managed_rule_exclusion_create.match_variable = AAZStrArg(
-            options=["match-variable"],
-            help="The variable type to be excluded.",
-            required=True,
-            enum={"QueryStringArgNames": "QueryStringArgNames", "RequestBodyJsonArgNames": "RequestBodyJsonArgNames", "RequestBodyPostArgNames": "RequestBodyPostArgNames", "RequestCookieNames": "RequestCookieNames", "RequestHeaderNames": "RequestHeaderNames"},
-        )
-        managed_rule_exclusion_create.selector = AAZStrArg(
-            options=["selector"],
-            help="Selector value for which elements in the collection this exclusion applies to.",
-            required=True,
-        )
-        managed_rule_exclusion_create.selector_match_operator = AAZStrArg(
-            options=["selector-match-operator"],
-            help="Comparison operator to apply to the selector when specifying which elements in the collection this exclusion applies to.",
-            required=True,
-            enum={"Contains": "Contains", "EndsWith": "EndsWith", "Equals": "Equals", "EqualsAny": "EqualsAny", "StartsWith": "StartsWith"},
-        )
-
-        _schema.match_variable = cls._args_managed_rule_exclusion_create.match_variable
-        _schema.selector = cls._args_managed_rule_exclusion_create.selector
-        _schema.selector_match_operator = cls._args_managed_rule_exclusion_create.selector_match_operator
-
-    _args_security_policy_web_application_firewall_association_create = None
-
-    @classmethod
-    def _build_args_security_policy_web_application_firewall_association_create(cls, _schema):
-        if cls._args_security_policy_web_application_firewall_association_create is not None:
-            _schema.domains = cls._args_security_policy_web_application_firewall_association_create.domains
-            _schema.patterns_to_match = cls._args_security_policy_web_application_firewall_association_create.patterns_to_match
-            return
-
-        cls._args_security_policy_web_application_firewall_association_create = AAZObjectArg()
-
-        security_policy_web_application_firewall_association_create = cls._args_security_policy_web_application_firewall_association_create
-        security_policy_web_application_firewall_association_create.domains = AAZListArg(
+        _element = cls._args_schema.web_application_firewall.associations.Element
+        _element.domains = AAZListArg(
             options=["domains"],
             help="List of domains.",
         )
-        security_policy_web_application_firewall_association_create.patterns_to_match = AAZListArg(
+        _element.patterns_to_match = AAZListArg(
             options=["patterns-to-match"],
             help="List of paths",
         )
+        _element.routes = AAZListArg(
+            options=["routes"],
+            help="List of routes.",
+        )
 
-        domains = cls._args_security_policy_web_application_firewall_association_create.domains
+        domains = cls._args_schema.web_application_firewall.associations.Element.domains
         domains.Element = AAZObjectArg()
 
-        _element = cls._args_security_policy_web_application_firewall_association_create.domains.Element
+        _element = cls._args_schema.web_application_firewall.associations.Element.domains.Element
         _element.id = AAZStrArg(
             options=["id"],
             help="Resource ID.",
         )
 
-        patterns_to_match = cls._args_security_policy_web_application_firewall_association_create.patterns_to_match
+        patterns_to_match = cls._args_schema.web_application_firewall.associations.Element.patterns_to_match
         patterns_to_match.Element = AAZStrArg()
 
-        _schema.domains = cls._args_security_policy_web_application_firewall_association_create.domains
-        _schema.patterns_to_match = cls._args_security_policy_web_application_firewall_association_create.patterns_to_match
+        routes = cls._args_schema.web_application_firewall.associations.Element.routes
+        routes.Element = AAZObjectArg()
+        cls._build_args_resource_reference_create(routes.Element)
+        return cls._args_schema
+
+    _args_resource_reference_create = None
+
+    @classmethod
+    def _build_args_resource_reference_create(cls, _schema):
+        if cls._args_resource_reference_create is not None:
+            _schema.id = cls._args_resource_reference_create.id
+            return
+
+        cls._args_resource_reference_create = AAZObjectArg()
+
+        resource_reference_create = cls._args_resource_reference_create
+        resource_reference_create.id = AAZStrArg(
+            options=["id"],
+            help="Resource ID.",
+        )
+
+        _schema.id = cls._args_resource_reference_create.id
 
     def _execute_operations(self):
         self.pre_operations()
@@ -578,7 +224,7 @@ class Create(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2025-09-01-preview",
+                    "api-version", "2026-04-01-preview",
                     required=True,
                 ),
             }
@@ -612,173 +258,39 @@ class Create(AAZCommand):
             parameters = _builder.get(".properties.parameters")
             if parameters is not None:
                 parameters.set_const("type", "WebApplicationFirewall", AAZStrType, ".web_application_firewall", typ_kwargs={"flags": {"required": True}})
-                parameters.set_const("type", "WebApplicationFirewallEmbedded", AAZStrType, ".web_application_firewall_embedded", typ_kwargs={"flags": {"required": True}})
                 parameters.discriminate_by("type", "WebApplicationFirewall")
-                parameters.discriminate_by("type", "WebApplicationFirewallEmbedded")
 
             disc_web_application_firewall = _builder.get(".properties.parameters{type:WebApplicationFirewall}")
             if disc_web_application_firewall is not None:
                 disc_web_application_firewall.set_prop("associations", AAZListType, ".web_application_firewall.associations")
-                disc_web_application_firewall.set_prop("wafPolicy", AAZObjectType)
+                disc_web_application_firewall.set_prop("isProfileLevel", AAZBoolType, ".web_application_firewall.is_profile_level")
+                _CreateHelper._build_schema_resource_reference_create(disc_web_application_firewall.set_prop("wafPolicy", AAZObjectType, ".web_application_firewall.waf_policy"))
 
             associations = _builder.get(".properties.parameters{type:WebApplicationFirewall}.associations")
             if associations is not None:
-                _CreateHelper._build_schema_security_policy_web_application_firewall_association_create(associations.set_elements(AAZObjectType, "."))
+                associations.set_elements(AAZObjectType, ".")
 
-            waf_policy = _builder.get(".properties.parameters{type:WebApplicationFirewall}.wafPolicy")
-            if waf_policy is not None:
-                waf_policy.set_prop("id", AAZStrType, ".web_application_firewall.waf_policy")
-
-            disc_web_application_firewall_embedded = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}")
-            if disc_web_application_firewall_embedded is not None:
-                disc_web_application_firewall_embedded.set_prop("associations", AAZListType, ".web_application_firewall_embedded.associations")
-                disc_web_application_firewall_embedded.set_prop("wafPolicy", AAZObjectType, ".web_application_firewall_embedded.waf_policy")
-
-            associations = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.associations")
-            if associations is not None:
-                _CreateHelper._build_schema_security_policy_web_application_firewall_association_create(associations.set_elements(AAZObjectType, "."))
-
-            waf_policy = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy")
-            if waf_policy is not None:
-                waf_policy.set_prop("etag", AAZStrType, ".etag")
-                waf_policy.set_prop("properties", AAZObjectType, typ_kwargs={"flags": {"client_flatten": True}})
-                waf_policy.set_prop("sku", AAZObjectType, ".sku")
-
-            properties = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties")
-            if properties is not None:
-                properties.set_prop("customRules", AAZObjectType, ".custom_rules")
-                properties.set_prop("managedRules", AAZObjectType, ".managed_rules")
-                properties.set_prop("policySettings", AAZObjectType, ".policy_settings")
-
-            custom_rules = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.customRules")
-            if custom_rules is not None:
-                custom_rules.set_prop("rules", AAZListType, ".rules")
-
-            rules = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.customRules.rules")
-            if rules is not None:
-                rules.set_elements(AAZObjectType, ".")
-
-            _elements = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.customRules.rules[]")
+            _elements = _builder.get(".properties.parameters{type:WebApplicationFirewall}.associations[]")
             if _elements is not None:
-                _elements.set_prop("action", AAZStrType, ".action", typ_kwargs={"flags": {"required": True}})
-                _elements.set_prop("enabledState", AAZStrType, ".enabled_state")
-                _elements.set_prop("groupBy", AAZListType, ".group_by")
-                _elements.set_prop("matchConditions", AAZListType, ".match_conditions", typ_kwargs={"flags": {"required": True}})
-                _elements.set_prop("name", AAZStrType, ".name")
-                _elements.set_prop("priority", AAZIntType, ".priority", typ_kwargs={"flags": {"required": True}})
-                _elements.set_prop("rateLimitDurationInMinutes", AAZIntType, ".rate_limit_duration_in_minutes")
-                _elements.set_prop("rateLimitThreshold", AAZIntType, ".rate_limit_threshold")
-                _elements.set_prop("ruleType", AAZStrType, ".rule_type", typ_kwargs={"flags": {"required": True}})
+                _elements.set_prop("domains", AAZListType, ".domains")
+                _elements.set_prop("patternsToMatch", AAZListType, ".patterns_to_match")
+                _elements.set_prop("routes", AAZListType, ".routes")
 
-            group_by = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.customRules.rules[].groupBy")
-            if group_by is not None:
-                group_by.set_elements(AAZObjectType, ".")
+            domains = _builder.get(".properties.parameters{type:WebApplicationFirewall}.associations[].domains")
+            if domains is not None:
+                domains.set_elements(AAZObjectType, ".")
 
-            _elements = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.customRules.rules[].groupBy[]")
+            _elements = _builder.get(".properties.parameters{type:WebApplicationFirewall}.associations[].domains[]")
             if _elements is not None:
-                _elements.set_prop("variableName", AAZStrType, ".variable_name", typ_kwargs={"flags": {"required": True}})
+                _elements.set_prop("id", AAZStrType, ".id")
 
-            match_conditions = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.customRules.rules[].matchConditions")
-            if match_conditions is not None:
-                match_conditions.set_elements(AAZObjectType, ".")
+            patterns_to_match = _builder.get(".properties.parameters{type:WebApplicationFirewall}.associations[].patternsToMatch")
+            if patterns_to_match is not None:
+                patterns_to_match.set_elements(AAZStrType, ".")
 
-            _elements = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.customRules.rules[].matchConditions[]")
-            if _elements is not None:
-                _elements.set_prop("matchValue", AAZListType, ".match_value", typ_kwargs={"flags": {"required": True}})
-                _elements.set_prop("matchVariable", AAZStrType, ".match_variable", typ_kwargs={"flags": {"required": True}})
-                _elements.set_prop("negateCondition", AAZBoolType, ".negate_condition")
-                _elements.set_prop("operator", AAZStrType, ".operator", typ_kwargs={"flags": {"required": True}})
-                _elements.set_prop("selector", AAZStrType, ".selector")
-                _elements.set_prop("transforms", AAZListType, ".transforms")
-
-            match_value = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.customRules.rules[].matchConditions[].matchValue")
-            if match_value is not None:
-                match_value.set_elements(AAZStrType, ".")
-
-            transforms = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.customRules.rules[].matchConditions[].transforms")
-            if transforms is not None:
-                transforms.set_elements(AAZStrType, ".")
-
-            managed_rules = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.managedRules")
-            if managed_rules is not None:
-                managed_rules.set_prop("managedRuleSets", AAZListType, ".managed_rule_sets")
-
-            managed_rule_sets = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.managedRules.managedRuleSets")
-            if managed_rule_sets is not None:
-                managed_rule_sets.set_elements(AAZObjectType, ".")
-
-            _elements = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.managedRules.managedRuleSets[]")
-            if _elements is not None:
-                _elements.set_prop("exclusions", AAZListType, ".exclusions")
-                _elements.set_prop("ruleGroupOverrides", AAZListType, ".rule_group_overrides")
-                _elements.set_prop("ruleSetAction", AAZStrType, ".rule_set_action")
-                _elements.set_prop("ruleSetType", AAZStrType, ".rule_set_type", typ_kwargs={"flags": {"required": True}})
-                _elements.set_prop("ruleSetVersion", AAZStrType, ".rule_set_version", typ_kwargs={"flags": {"required": True}})
-
-            exclusions = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.managedRules.managedRuleSets[].exclusions")
-            if exclusions is not None:
-                _CreateHelper._build_schema_managed_rule_exclusion_create(exclusions.set_elements(AAZObjectType, "."))
-
-            rule_group_overrides = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.managedRules.managedRuleSets[].ruleGroupOverrides")
-            if rule_group_overrides is not None:
-                rule_group_overrides.set_elements(AAZObjectType, ".")
-
-            _elements = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.managedRules.managedRuleSets[].ruleGroupOverrides[]")
-            if _elements is not None:
-                _elements.set_prop("exclusions", AAZListType, ".exclusions")
-                _elements.set_prop("ruleGroupName", AAZStrType, ".rule_group_name", typ_kwargs={"flags": {"required": True}})
-                _elements.set_prop("rules", AAZListType, ".rules")
-
-            exclusions = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.managedRules.managedRuleSets[].ruleGroupOverrides[].exclusions")
-            if exclusions is not None:
-                _CreateHelper._build_schema_managed_rule_exclusion_create(exclusions.set_elements(AAZObjectType, "."))
-
-            rules = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.managedRules.managedRuleSets[].ruleGroupOverrides[].rules")
-            if rules is not None:
-                rules.set_elements(AAZObjectType, ".")
-
-            _elements = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.managedRules.managedRuleSets[].ruleGroupOverrides[].rules[]")
-            if _elements is not None:
-                _elements.set_prop("action", AAZStrType, ".action")
-                _elements.set_prop("enabledState", AAZStrType, ".enabled_state")
-                _elements.set_prop("exclusions", AAZListType, ".exclusions")
-                _elements.set_prop("ruleId", AAZStrType, ".rule_id", typ_kwargs={"flags": {"required": True}})
-
-            exclusions = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.managedRules.managedRuleSets[].ruleGroupOverrides[].rules[].exclusions")
-            if exclusions is not None:
-                _CreateHelper._build_schema_managed_rule_exclusion_create(exclusions.set_elements(AAZObjectType, "."))
-
-            policy_settings = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.policySettings")
-            if policy_settings is not None:
-                policy_settings.set_prop("captchaExpirationInMinutes", AAZIntType, ".captcha_expiration_in_minutes")
-                policy_settings.set_prop("customBlockResponseBody", AAZStrType, ".custom_block_response_body")
-                policy_settings.set_prop("customBlockResponseStatusCode", AAZIntType, ".custom_block_response_status_code")
-                policy_settings.set_prop("enabledState", AAZStrType, ".enabled_state")
-                policy_settings.set_prop("javascriptChallengeExpirationInMinutes", AAZIntType, ".javascript_challenge_expiration_in_minutes")
-                policy_settings.set_prop("logScrubbing", AAZObjectType, typ_kwargs={"flags": {"client_flatten": True}})
-                policy_settings.set_prop("mode", AAZStrType, ".mode")
-                policy_settings.set_prop("redirectUrl", AAZStrType, ".redirect_url")
-                policy_settings.set_prop("requestBodyCheck", AAZStrType, ".request_body_check")
-
-            log_scrubbing = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.policySettings.logScrubbing")
-            if log_scrubbing is not None:
-                log_scrubbing.set_prop("scrubbingRules", AAZListType, ".scrubbing_rules")
-                log_scrubbing.set_prop("state", AAZStrType, ".state")
-
-            scrubbing_rules = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.policySettings.logScrubbing.scrubbingRules")
-            if scrubbing_rules is not None:
-                scrubbing_rules.set_elements(AAZObjectType, ".")
-
-            _elements = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.policySettings.logScrubbing.scrubbingRules[]")
-            if _elements is not None:
-                _elements.set_prop("matchVariable", AAZStrType, ".match_variable", typ_kwargs={"flags": {"required": True}})
-                _elements.set_prop("selector", AAZStrType, ".selector")
-                _elements.set_prop("selectorMatchOperator", AAZStrType, ".selector_match_operator", typ_kwargs={"flags": {"required": True}})
-                _elements.set_prop("state", AAZStrType, ".state")
-
-            sku = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.sku")
-            if sku is not None:
-                sku.set_prop("name", AAZStrType, ".name")
+            routes = _builder.get(".properties.parameters{type:WebApplicationFirewall}.associations[].routes")
+            if routes is not None:
+                _CreateHelper._build_schema_resource_reference_create(routes.set_elements(AAZObjectType, "."))
 
             return self.serialize_content(_content_value)
 
@@ -807,93 +319,25 @@ class _CreateHelper:
     """Helper class for Create"""
 
     @classmethod
-    def _build_schema_managed_rule_exclusion_create(cls, _builder):
+    def _build_schema_resource_reference_create(cls, _builder):
         if _builder is None:
             return
-        _builder.set_prop("matchVariable", AAZStrType, ".match_variable", typ_kwargs={"flags": {"required": True}})
-        _builder.set_prop("selector", AAZStrType, ".selector", typ_kwargs={"flags": {"required": True}})
-        _builder.set_prop("selectorMatchOperator", AAZStrType, ".selector_match_operator", typ_kwargs={"flags": {"required": True}})
+        _builder.set_prop("id", AAZStrType, ".id")
+
+    _schema_resource_reference_read = None
 
     @classmethod
-    def _build_schema_security_policy_web_application_firewall_association_create(cls, _builder):
-        if _builder is None:
-            return
-        _builder.set_prop("domains", AAZListType, ".domains")
-        _builder.set_prop("patternsToMatch", AAZListType, ".patterns_to_match")
-
-        domains = _builder.get(".domains")
-        if domains is not None:
-            domains.set_elements(AAZObjectType, ".")
-
-        _elements = _builder.get(".domains[]")
-        if _elements is not None:
-            _elements.set_prop("id", AAZStrType, ".id")
-
-        patterns_to_match = _builder.get(".patternsToMatch")
-        if patterns_to_match is not None:
-            patterns_to_match.set_elements(AAZStrType, ".")
-
-    _schema_managed_rule_exclusion_read = None
-
-    @classmethod
-    def _build_schema_managed_rule_exclusion_read(cls, _schema):
-        if cls._schema_managed_rule_exclusion_read is not None:
-            _schema.match_variable = cls._schema_managed_rule_exclusion_read.match_variable
-            _schema.selector = cls._schema_managed_rule_exclusion_read.selector
-            _schema.selector_match_operator = cls._schema_managed_rule_exclusion_read.selector_match_operator
+    def _build_schema_resource_reference_read(cls, _schema):
+        if cls._schema_resource_reference_read is not None:
+            _schema.id = cls._schema_resource_reference_read.id
             return
 
-        cls._schema_managed_rule_exclusion_read = _schema_managed_rule_exclusion_read = AAZObjectType()
+        cls._schema_resource_reference_read = _schema_resource_reference_read = AAZObjectType()
 
-        managed_rule_exclusion_read = _schema_managed_rule_exclusion_read
-        managed_rule_exclusion_read.match_variable = AAZStrType(
-            serialized_name="matchVariable",
-            flags={"required": True},
-        )
-        managed_rule_exclusion_read.selector = AAZStrType(
-            flags={"required": True},
-        )
-        managed_rule_exclusion_read.selector_match_operator = AAZStrType(
-            serialized_name="selectorMatchOperator",
-            flags={"required": True},
-        )
+        resource_reference_read = _schema_resource_reference_read
+        resource_reference_read.id = AAZStrType()
 
-        _schema.match_variable = cls._schema_managed_rule_exclusion_read.match_variable
-        _schema.selector = cls._schema_managed_rule_exclusion_read.selector
-        _schema.selector_match_operator = cls._schema_managed_rule_exclusion_read.selector_match_operator
-
-    _schema_security_policy_web_application_firewall_association_read = None
-
-    @classmethod
-    def _build_schema_security_policy_web_application_firewall_association_read(cls, _schema):
-        if cls._schema_security_policy_web_application_firewall_association_read is not None:
-            _schema.domains = cls._schema_security_policy_web_application_firewall_association_read.domains
-            _schema.patterns_to_match = cls._schema_security_policy_web_application_firewall_association_read.patterns_to_match
-            return
-
-        cls._schema_security_policy_web_application_firewall_association_read = _schema_security_policy_web_application_firewall_association_read = AAZObjectType()
-
-        security_policy_web_application_firewall_association_read = _schema_security_policy_web_application_firewall_association_read
-        security_policy_web_application_firewall_association_read.domains = AAZListType()
-        security_policy_web_application_firewall_association_read.patterns_to_match = AAZListType(
-            serialized_name="patternsToMatch",
-        )
-
-        domains = _schema_security_policy_web_application_firewall_association_read.domains
-        domains.Element = AAZObjectType()
-
-        _element = _schema_security_policy_web_application_firewall_association_read.domains.Element
-        _element.id = AAZStrType()
-        _element.is_active = AAZBoolType(
-            serialized_name="isActive",
-            flags={"read_only": True},
-        )
-
-        patterns_to_match = _schema_security_policy_web_application_firewall_association_read.patterns_to_match
-        patterns_to_match.Element = AAZStrType()
-
-        _schema.domains = cls._schema_security_policy_web_application_firewall_association_read.domains
-        _schema.patterns_to_match = cls._schema_security_policy_web_application_firewall_association_read.patterns_to_match
+        _schema.id = cls._schema_resource_reference_read.id
 
     _schema_security_policy_read = None
 
@@ -923,7 +367,6 @@ class _CreateHelper:
             serialized_name="systemData",
             flags={"read_only": True},
         )
-        cls._build_schema_system_data_read(security_policy_read.system_data)
         security_policy_read.type = AAZStrType(
             flags={"read_only": True},
         )
@@ -950,337 +393,66 @@ class _CreateHelper:
 
         disc_web_application_firewall = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewall")
         disc_web_application_firewall.associations = AAZListType()
+        disc_web_application_firewall.is_profile_level = AAZBoolType(
+            serialized_name="isProfileLevel",
+        )
         disc_web_application_firewall.waf_policy = AAZObjectType(
             serialized_name="wafPolicy",
         )
+        cls._build_schema_resource_reference_read(disc_web_application_firewall.waf_policy)
 
         associations = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewall").associations
         associations.Element = AAZObjectType()
-        cls._build_schema_security_policy_web_application_firewall_association_read(associations.Element)
 
-        waf_policy = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewall").waf_policy
-        waf_policy.id = AAZStrType()
+        _element = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewall").associations.Element
+        _element.domains = AAZListType()
+        _element.patterns_to_match = AAZListType(
+            serialized_name="patternsToMatch",
+        )
+        _element.routes = AAZListType()
 
-        disc_web_application_firewall_embedded = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded")
-        disc_web_application_firewall_embedded.associations = AAZListType()
-        disc_web_application_firewall_embedded.waf_policy = AAZObjectType(
-            serialized_name="wafPolicy",
-        )
+        domains = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewall").associations.Element.domains
+        domains.Element = AAZObjectType()
 
-        associations = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").associations
-        associations.Element = AAZObjectType()
-        cls._build_schema_security_policy_web_application_firewall_association_read(associations.Element)
-
-        waf_policy = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy
-        waf_policy.etag = AAZStrType()
-        waf_policy.id = AAZStrType(
-            flags={"read_only": True},
-        )
-        waf_policy.name = AAZStrType(
-            flags={"read_only": True},
-        )
-        waf_policy.properties = AAZObjectType(
-            flags={"client_flatten": True},
-        )
-        waf_policy.sku = AAZObjectType()
-        waf_policy.system_data = AAZObjectType(
-            serialized_name="systemData",
-            flags={"read_only": True},
-        )
-        cls._build_schema_system_data_read(waf_policy.system_data)
-        waf_policy.type = AAZStrType(
+        _element = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewall").associations.Element.domains.Element
+        _element.id = AAZStrType()
+        _element.is_active = AAZBoolType(
+            serialized_name="isActive",
             flags={"read_only": True},
         )
 
-        properties = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties
-        properties.custom_rules = AAZObjectType(
-            serialized_name="customRules",
-        )
-        properties.frontend_endpoint_links = AAZListType(
-            serialized_name="frontendEndpointLinks",
-            flags={"read_only": True},
-        )
-        properties.managed_rules = AAZObjectType(
-            serialized_name="managedRules",
-        )
-        properties.policy_settings = AAZObjectType(
-            serialized_name="policySettings",
-        )
-        properties.provisioning_state = AAZStrType(
-            serialized_name="provisioningState",
-            flags={"read_only": True},
-        )
-        properties.resource_state = AAZStrType(
-            serialized_name="resourceState",
-            flags={"read_only": True},
-        )
-        properties.routing_rule_links = AAZListType(
-            serialized_name="routingRuleLinks",
-            flags={"read_only": True},
-        )
-        properties.security_policy_links = AAZListType(
-            serialized_name="securityPolicyLinks",
-            flags={"read_only": True},
-        )
+        patterns_to_match = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewall").associations.Element.patterns_to_match
+        patterns_to_match.Element = AAZStrType()
 
-        custom_rules = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules
-        custom_rules.rules = AAZListType()
+        routes = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewall").associations.Element.routes
+        routes.Element = AAZObjectType()
+        cls._build_schema_resource_reference_read(routes.Element)
 
-        rules = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules.rules
-        rules.Element = AAZObjectType()
-
-        _element = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules.rules.Element
-        _element.action = AAZStrType(
-            flags={"required": True},
+        system_data = _schema_security_policy_read.system_data
+        system_data.created_at = AAZStrType(
+            serialized_name="createdAt",
         )
-        _element.enabled_state = AAZStrType(
-            serialized_name="enabledState",
+        system_data.created_by = AAZStrType(
+            serialized_name="createdBy",
         )
-        _element.group_by = AAZListType(
-            serialized_name="groupBy",
+        system_data.created_by_type = AAZStrType(
+            serialized_name="createdByType",
         )
-        _element.match_conditions = AAZListType(
-            serialized_name="matchConditions",
-            flags={"required": True},
+        system_data.last_modified_at = AAZStrType(
+            serialized_name="lastModifiedAt",
         )
-        _element.name = AAZStrType()
-        _element.priority = AAZIntType(
-            flags={"required": True},
+        system_data.last_modified_by = AAZStrType(
+            serialized_name="lastModifiedBy",
         )
-        _element.rate_limit_duration_in_minutes = AAZIntType(
-            serialized_name="rateLimitDurationInMinutes",
+        system_data.last_modified_by_type = AAZStrType(
+            serialized_name="lastModifiedByType",
         )
-        _element.rate_limit_threshold = AAZIntType(
-            serialized_name="rateLimitThreshold",
-        )
-        _element.rule_type = AAZStrType(
-            serialized_name="ruleType",
-            flags={"required": True},
-        )
-
-        group_by = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules.rules.Element.group_by
-        group_by.Element = AAZObjectType()
-
-        _element = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules.rules.Element.group_by.Element
-        _element.variable_name = AAZStrType(
-            serialized_name="variableName",
-            flags={"required": True},
-        )
-
-        match_conditions = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules.rules.Element.match_conditions
-        match_conditions.Element = AAZObjectType()
-
-        _element = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules.rules.Element.match_conditions.Element
-        _element.match_value = AAZListType(
-            serialized_name="matchValue",
-            flags={"required": True},
-        )
-        _element.match_variable = AAZStrType(
-            serialized_name="matchVariable",
-            flags={"required": True},
-        )
-        _element.negate_condition = AAZBoolType(
-            serialized_name="negateCondition",
-        )
-        _element.operator = AAZStrType(
-            flags={"required": True},
-        )
-        _element.selector = AAZStrType()
-        _element.transforms = AAZListType()
-
-        match_value = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules.rules.Element.match_conditions.Element.match_value
-        match_value.Element = AAZStrType()
-
-        transforms = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules.rules.Element.match_conditions.Element.transforms
-        transforms.Element = AAZStrType()
-
-        frontend_endpoint_links = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.frontend_endpoint_links
-        frontend_endpoint_links.Element = AAZObjectType()
-
-        _element = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.frontend_endpoint_links.Element
-        _element.id = AAZStrType(
-            flags={"read_only": True},
-        )
-
-        managed_rules = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules
-        managed_rules.managed_rule_sets = AAZListType(
-            serialized_name="managedRuleSets",
-        )
-
-        managed_rule_sets = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets
-        managed_rule_sets.Element = AAZObjectType()
-
-        _element = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets.Element
-        _element.exclusions = AAZListType()
-        _element.rule_group_overrides = AAZListType(
-            serialized_name="ruleGroupOverrides",
-        )
-        _element.rule_set_action = AAZStrType(
-            serialized_name="ruleSetAction",
-        )
-        _element.rule_set_type = AAZStrType(
-            serialized_name="ruleSetType",
-            flags={"required": True},
-        )
-        _element.rule_set_version = AAZStrType(
-            serialized_name="ruleSetVersion",
-            flags={"required": True},
-        )
-
-        exclusions = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets.Element.exclusions
-        exclusions.Element = AAZObjectType()
-        cls._build_schema_managed_rule_exclusion_read(exclusions.Element)
-
-        rule_group_overrides = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets.Element.rule_group_overrides
-        rule_group_overrides.Element = AAZObjectType()
-
-        _element = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets.Element.rule_group_overrides.Element
-        _element.exclusions = AAZListType()
-        _element.rule_group_name = AAZStrType(
-            serialized_name="ruleGroupName",
-            flags={"required": True},
-        )
-        _element.rules = AAZListType()
-
-        exclusions = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets.Element.rule_group_overrides.Element.exclusions
-        exclusions.Element = AAZObjectType()
-        cls._build_schema_managed_rule_exclusion_read(exclusions.Element)
-
-        rules = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets.Element.rule_group_overrides.Element.rules
-        rules.Element = AAZObjectType()
-
-        _element = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets.Element.rule_group_overrides.Element.rules.Element
-        _element.action = AAZStrType()
-        _element.enabled_state = AAZStrType(
-            serialized_name="enabledState",
-        )
-        _element.exclusions = AAZListType()
-        _element.rule_id = AAZStrType(
-            serialized_name="ruleId",
-            flags={"required": True},
-        )
-
-        exclusions = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets.Element.rule_group_overrides.Element.rules.Element.exclusions
-        exclusions.Element = AAZObjectType()
-        cls._build_schema_managed_rule_exclusion_read(exclusions.Element)
-
-        policy_settings = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.policy_settings
-        policy_settings.captcha_expiration_in_minutes = AAZIntType(
-            serialized_name="captchaExpirationInMinutes",
-        )
-        policy_settings.custom_block_response_body = AAZStrType(
-            serialized_name="customBlockResponseBody",
-        )
-        policy_settings.custom_block_response_status_code = AAZIntType(
-            serialized_name="customBlockResponseStatusCode",
-        )
-        policy_settings.enabled_state = AAZStrType(
-            serialized_name="enabledState",
-        )
-        policy_settings.javascript_challenge_expiration_in_minutes = AAZIntType(
-            serialized_name="javascriptChallengeExpirationInMinutes",
-        )
-        policy_settings.log_scrubbing = AAZObjectType(
-            serialized_name="logScrubbing",
-            flags={"client_flatten": True},
-        )
-        policy_settings.mode = AAZStrType()
-        policy_settings.redirect_url = AAZStrType(
-            serialized_name="redirectUrl",
-        )
-        policy_settings.request_body_check = AAZStrType(
-            serialized_name="requestBodyCheck",
-        )
-
-        log_scrubbing = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.policy_settings.log_scrubbing
-        log_scrubbing.scrubbing_rules = AAZListType(
-            serialized_name="scrubbingRules",
-        )
-        log_scrubbing.state = AAZStrType()
-
-        scrubbing_rules = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.policy_settings.log_scrubbing.scrubbing_rules
-        scrubbing_rules.Element = AAZObjectType()
-
-        _element = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.policy_settings.log_scrubbing.scrubbing_rules.Element
-        _element.match_variable = AAZStrType(
-            serialized_name="matchVariable",
-            flags={"required": True},
-        )
-        _element.selector = AAZStrType()
-        _element.selector_match_operator = AAZStrType(
-            serialized_name="selectorMatchOperator",
-            flags={"required": True},
-        )
-        _element.state = AAZStrType()
-
-        routing_rule_links = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.routing_rule_links
-        routing_rule_links.Element = AAZObjectType()
-
-        _element = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.routing_rule_links.Element
-        _element.id = AAZStrType(
-            flags={"read_only": True},
-        )
-
-        security_policy_links = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.security_policy_links
-        security_policy_links.Element = AAZObjectType()
-
-        _element = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.security_policy_links.Element
-        _element.id = AAZStrType(
-            flags={"read_only": True},
-        )
-
-        sku = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.sku
-        sku.name = AAZStrType()
 
         _schema.id = cls._schema_security_policy_read.id
         _schema.name = cls._schema_security_policy_read.name
         _schema.properties = cls._schema_security_policy_read.properties
         _schema.system_data = cls._schema_security_policy_read.system_data
         _schema.type = cls._schema_security_policy_read.type
-
-    _schema_system_data_read = None
-
-    @classmethod
-    def _build_schema_system_data_read(cls, _schema):
-        if cls._schema_system_data_read is not None:
-            _schema.created_at = cls._schema_system_data_read.created_at
-            _schema.created_by = cls._schema_system_data_read.created_by
-            _schema.created_by_type = cls._schema_system_data_read.created_by_type
-            _schema.last_modified_at = cls._schema_system_data_read.last_modified_at
-            _schema.last_modified_by = cls._schema_system_data_read.last_modified_by
-            _schema.last_modified_by_type = cls._schema_system_data_read.last_modified_by_type
-            return
-
-        cls._schema_system_data_read = _schema_system_data_read = AAZObjectType(
-            flags={"read_only": True}
-        )
-
-        system_data_read = _schema_system_data_read
-        system_data_read.created_at = AAZStrType(
-            serialized_name="createdAt",
-        )
-        system_data_read.created_by = AAZStrType(
-            serialized_name="createdBy",
-        )
-        system_data_read.created_by_type = AAZStrType(
-            serialized_name="createdByType",
-        )
-        system_data_read.last_modified_at = AAZStrType(
-            serialized_name="lastModifiedAt",
-        )
-        system_data_read.last_modified_by = AAZStrType(
-            serialized_name="lastModifiedBy",
-        )
-        system_data_read.last_modified_by_type = AAZStrType(
-            serialized_name="lastModifiedByType",
-        )
-
-        _schema.created_at = cls._schema_system_data_read.created_at
-        _schema.created_by = cls._schema_system_data_read.created_by
-        _schema.created_by_type = cls._schema_system_data_read.created_by_type
-        _schema.last_modified_at = cls._schema_system_data_read.last_modified_at
-        _schema.last_modified_by = cls._schema_system_data_read.last_modified_by
-        _schema.last_modified_by_type = cls._schema_system_data_read.last_modified_by_type
 
 
 __all__ = ["Create"]

--- a/src/cdn/azext_cdn/aaz/latest/afd/security_policy/_delete.py
+++ b/src/cdn/azext_cdn/aaz/latest/afd/security_policy/_delete.py
@@ -23,9 +23,9 @@ class Delete(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2025-09-01-preview",
+        "version": "2026-04-01-preview",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.cdn/profiles/{}/securitypolicies/{}", "2025-09-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.cdn/profiles/{}/securitypolicies/{}", "2026-04-01-preview"],
         ]
     }
 
@@ -158,7 +158,7 @@ class Delete(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2025-09-01-preview",
+                    "api-version", "2026-04-01-preview",
                     required=True,
                 ),
             }

--- a/src/cdn/azext_cdn/aaz/latest/afd/security_policy/_list.py
+++ b/src/cdn/azext_cdn/aaz/latest/afd/security_policy/_list.py
@@ -22,9 +22,9 @@ class List(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2025-09-01-preview",
+        "version": "2026-04-01-preview",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.cdn/profiles/{}/securitypolicies", "2025-09-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.cdn/profiles/{}/securitypolicies", "2026-04-01-preview"],
         ]
     }
 
@@ -126,7 +126,7 @@ class List(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2025-09-01-preview",
+                    "api-version", "2026-04-01-preview",
                     required=True,
                 ),
             }
@@ -183,7 +183,6 @@ class List(AAZCommand):
                 serialized_name="systemData",
                 flags={"read_only": True},
             )
-            _ListHelper._build_schema_system_data_read(_element.system_data)
             _element.type = AAZStrType(
                 flags={"read_only": True},
             )
@@ -210,287 +209,60 @@ class List(AAZCommand):
 
             disc_web_application_firewall = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewall")
             disc_web_application_firewall.associations = AAZListType()
+            disc_web_application_firewall.is_profile_level = AAZBoolType(
+                serialized_name="isProfileLevel",
+            )
             disc_web_application_firewall.waf_policy = AAZObjectType(
                 serialized_name="wafPolicy",
             )
+            _ListHelper._build_schema_resource_reference_read(disc_web_application_firewall.waf_policy)
 
             associations = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewall").associations
             associations.Element = AAZObjectType()
-            _ListHelper._build_schema_security_policy_web_application_firewall_association_read(associations.Element)
 
-            waf_policy = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewall").waf_policy
-            waf_policy.id = AAZStrType()
+            _element = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewall").associations.Element
+            _element.domains = AAZListType()
+            _element.patterns_to_match = AAZListType(
+                serialized_name="patternsToMatch",
+            )
+            _element.routes = AAZListType()
 
-            disc_web_application_firewall_embedded = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded")
-            disc_web_application_firewall_embedded.associations = AAZListType()
-            disc_web_application_firewall_embedded.waf_policy = AAZObjectType(
-                serialized_name="wafPolicy",
-            )
+            domains = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewall").associations.Element.domains
+            domains.Element = AAZObjectType()
 
-            associations = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").associations
-            associations.Element = AAZObjectType()
-            _ListHelper._build_schema_security_policy_web_application_firewall_association_read(associations.Element)
-
-            waf_policy = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy
-            waf_policy.etag = AAZStrType()
-            waf_policy.id = AAZStrType(
-                flags={"read_only": True},
-            )
-            waf_policy.name = AAZStrType(
-                flags={"read_only": True},
-            )
-            waf_policy.properties = AAZObjectType(
-                flags={"client_flatten": True},
-            )
-            waf_policy.sku = AAZObjectType()
-            waf_policy.system_data = AAZObjectType(
-                serialized_name="systemData",
-                flags={"read_only": True},
-            )
-            _ListHelper._build_schema_system_data_read(waf_policy.system_data)
-            waf_policy.type = AAZStrType(
+            _element = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewall").associations.Element.domains.Element
+            _element.id = AAZStrType()
+            _element.is_active = AAZBoolType(
+                serialized_name="isActive",
                 flags={"read_only": True},
             )
 
-            properties = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties
-            properties.custom_rules = AAZObjectType(
-                serialized_name="customRules",
-            )
-            properties.frontend_endpoint_links = AAZListType(
-                serialized_name="frontendEndpointLinks",
-                flags={"read_only": True},
-            )
-            properties.managed_rules = AAZObjectType(
-                serialized_name="managedRules",
-            )
-            properties.policy_settings = AAZObjectType(
-                serialized_name="policySettings",
-            )
-            properties.provisioning_state = AAZStrType(
-                serialized_name="provisioningState",
-                flags={"read_only": True},
-            )
-            properties.resource_state = AAZStrType(
-                serialized_name="resourceState",
-                flags={"read_only": True},
-            )
-            properties.routing_rule_links = AAZListType(
-                serialized_name="routingRuleLinks",
-                flags={"read_only": True},
-            )
-            properties.security_policy_links = AAZListType(
-                serialized_name="securityPolicyLinks",
-                flags={"read_only": True},
-            )
+            patterns_to_match = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewall").associations.Element.patterns_to_match
+            patterns_to_match.Element = AAZStrType()
 
-            custom_rules = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules
-            custom_rules.rules = AAZListType()
+            routes = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewall").associations.Element.routes
+            routes.Element = AAZObjectType()
+            _ListHelper._build_schema_resource_reference_read(routes.Element)
 
-            rules = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules.rules
-            rules.Element = AAZObjectType()
-
-            _element = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules.rules.Element
-            _element.action = AAZStrType(
-                flags={"required": True},
+            system_data = cls._schema_on_200.value.Element.system_data
+            system_data.created_at = AAZStrType(
+                serialized_name="createdAt",
             )
-            _element.enabled_state = AAZStrType(
-                serialized_name="enabledState",
+            system_data.created_by = AAZStrType(
+                serialized_name="createdBy",
             )
-            _element.group_by = AAZListType(
-                serialized_name="groupBy",
+            system_data.created_by_type = AAZStrType(
+                serialized_name="createdByType",
             )
-            _element.match_conditions = AAZListType(
-                serialized_name="matchConditions",
-                flags={"required": True},
+            system_data.last_modified_at = AAZStrType(
+                serialized_name="lastModifiedAt",
             )
-            _element.name = AAZStrType()
-            _element.priority = AAZIntType(
-                flags={"required": True},
+            system_data.last_modified_by = AAZStrType(
+                serialized_name="lastModifiedBy",
             )
-            _element.rate_limit_duration_in_minutes = AAZIntType(
-                serialized_name="rateLimitDurationInMinutes",
+            system_data.last_modified_by_type = AAZStrType(
+                serialized_name="lastModifiedByType",
             )
-            _element.rate_limit_threshold = AAZIntType(
-                serialized_name="rateLimitThreshold",
-            )
-            _element.rule_type = AAZStrType(
-                serialized_name="ruleType",
-                flags={"required": True},
-            )
-
-            group_by = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules.rules.Element.group_by
-            group_by.Element = AAZObjectType()
-
-            _element = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules.rules.Element.group_by.Element
-            _element.variable_name = AAZStrType(
-                serialized_name="variableName",
-                flags={"required": True},
-            )
-
-            match_conditions = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules.rules.Element.match_conditions
-            match_conditions.Element = AAZObjectType()
-
-            _element = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules.rules.Element.match_conditions.Element
-            _element.match_value = AAZListType(
-                serialized_name="matchValue",
-                flags={"required": True},
-            )
-            _element.match_variable = AAZStrType(
-                serialized_name="matchVariable",
-                flags={"required": True},
-            )
-            _element.negate_condition = AAZBoolType(
-                serialized_name="negateCondition",
-            )
-            _element.operator = AAZStrType(
-                flags={"required": True},
-            )
-            _element.selector = AAZStrType()
-            _element.transforms = AAZListType()
-
-            match_value = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules.rules.Element.match_conditions.Element.match_value
-            match_value.Element = AAZStrType()
-
-            transforms = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules.rules.Element.match_conditions.Element.transforms
-            transforms.Element = AAZStrType()
-
-            frontend_endpoint_links = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.frontend_endpoint_links
-            frontend_endpoint_links.Element = AAZObjectType()
-
-            _element = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.frontend_endpoint_links.Element
-            _element.id = AAZStrType(
-                flags={"read_only": True},
-            )
-
-            managed_rules = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules
-            managed_rules.managed_rule_sets = AAZListType(
-                serialized_name="managedRuleSets",
-            )
-
-            managed_rule_sets = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets
-            managed_rule_sets.Element = AAZObjectType()
-
-            _element = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets.Element
-            _element.exclusions = AAZListType()
-            _element.rule_group_overrides = AAZListType(
-                serialized_name="ruleGroupOverrides",
-            )
-            _element.rule_set_action = AAZStrType(
-                serialized_name="ruleSetAction",
-            )
-            _element.rule_set_type = AAZStrType(
-                serialized_name="ruleSetType",
-                flags={"required": True},
-            )
-            _element.rule_set_version = AAZStrType(
-                serialized_name="ruleSetVersion",
-                flags={"required": True},
-            )
-
-            exclusions = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets.Element.exclusions
-            exclusions.Element = AAZObjectType()
-            _ListHelper._build_schema_managed_rule_exclusion_read(exclusions.Element)
-
-            rule_group_overrides = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets.Element.rule_group_overrides
-            rule_group_overrides.Element = AAZObjectType()
-
-            _element = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets.Element.rule_group_overrides.Element
-            _element.exclusions = AAZListType()
-            _element.rule_group_name = AAZStrType(
-                serialized_name="ruleGroupName",
-                flags={"required": True},
-            )
-            _element.rules = AAZListType()
-
-            exclusions = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets.Element.rule_group_overrides.Element.exclusions
-            exclusions.Element = AAZObjectType()
-            _ListHelper._build_schema_managed_rule_exclusion_read(exclusions.Element)
-
-            rules = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets.Element.rule_group_overrides.Element.rules
-            rules.Element = AAZObjectType()
-
-            _element = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets.Element.rule_group_overrides.Element.rules.Element
-            _element.action = AAZStrType()
-            _element.enabled_state = AAZStrType(
-                serialized_name="enabledState",
-            )
-            _element.exclusions = AAZListType()
-            _element.rule_id = AAZStrType(
-                serialized_name="ruleId",
-                flags={"required": True},
-            )
-
-            exclusions = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets.Element.rule_group_overrides.Element.rules.Element.exclusions
-            exclusions.Element = AAZObjectType()
-            _ListHelper._build_schema_managed_rule_exclusion_read(exclusions.Element)
-
-            policy_settings = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.policy_settings
-            policy_settings.captcha_expiration_in_minutes = AAZIntType(
-                serialized_name="captchaExpirationInMinutes",
-            )
-            policy_settings.custom_block_response_body = AAZStrType(
-                serialized_name="customBlockResponseBody",
-            )
-            policy_settings.custom_block_response_status_code = AAZIntType(
-                serialized_name="customBlockResponseStatusCode",
-            )
-            policy_settings.enabled_state = AAZStrType(
-                serialized_name="enabledState",
-            )
-            policy_settings.javascript_challenge_expiration_in_minutes = AAZIntType(
-                serialized_name="javascriptChallengeExpirationInMinutes",
-            )
-            policy_settings.log_scrubbing = AAZObjectType(
-                serialized_name="logScrubbing",
-                flags={"client_flatten": True},
-            )
-            policy_settings.mode = AAZStrType()
-            policy_settings.redirect_url = AAZStrType(
-                serialized_name="redirectUrl",
-            )
-            policy_settings.request_body_check = AAZStrType(
-                serialized_name="requestBodyCheck",
-            )
-
-            log_scrubbing = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.policy_settings.log_scrubbing
-            log_scrubbing.scrubbing_rules = AAZListType(
-                serialized_name="scrubbingRules",
-            )
-            log_scrubbing.state = AAZStrType()
-
-            scrubbing_rules = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.policy_settings.log_scrubbing.scrubbing_rules
-            scrubbing_rules.Element = AAZObjectType()
-
-            _element = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.policy_settings.log_scrubbing.scrubbing_rules.Element
-            _element.match_variable = AAZStrType(
-                serialized_name="matchVariable",
-                flags={"required": True},
-            )
-            _element.selector = AAZStrType()
-            _element.selector_match_operator = AAZStrType(
-                serialized_name="selectorMatchOperator",
-                flags={"required": True},
-            )
-            _element.state = AAZStrType()
-
-            routing_rule_links = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.routing_rule_links
-            routing_rule_links.Element = AAZObjectType()
-
-            _element = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.routing_rule_links.Element
-            _element.id = AAZStrType(
-                flags={"read_only": True},
-            )
-
-            security_policy_links = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.security_policy_links
-            security_policy_links.Element = AAZObjectType()
-
-            _element = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.security_policy_links.Element
-            _element.id = AAZStrType(
-                flags={"read_only": True},
-            )
-
-            sku = cls._schema_on_200.value.Element.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.sku
-            sku.name = AAZStrType()
 
             return cls._schema_on_200
 
@@ -498,111 +270,20 @@ class List(AAZCommand):
 class _ListHelper:
     """Helper class for List"""
 
-    _schema_managed_rule_exclusion_read = None
+    _schema_resource_reference_read = None
 
     @classmethod
-    def _build_schema_managed_rule_exclusion_read(cls, _schema):
-        if cls._schema_managed_rule_exclusion_read is not None:
-            _schema.match_variable = cls._schema_managed_rule_exclusion_read.match_variable
-            _schema.selector = cls._schema_managed_rule_exclusion_read.selector
-            _schema.selector_match_operator = cls._schema_managed_rule_exclusion_read.selector_match_operator
+    def _build_schema_resource_reference_read(cls, _schema):
+        if cls._schema_resource_reference_read is not None:
+            _schema.id = cls._schema_resource_reference_read.id
             return
 
-        cls._schema_managed_rule_exclusion_read = _schema_managed_rule_exclusion_read = AAZObjectType()
+        cls._schema_resource_reference_read = _schema_resource_reference_read = AAZObjectType()
 
-        managed_rule_exclusion_read = _schema_managed_rule_exclusion_read
-        managed_rule_exclusion_read.match_variable = AAZStrType(
-            serialized_name="matchVariable",
-            flags={"required": True},
-        )
-        managed_rule_exclusion_read.selector = AAZStrType(
-            flags={"required": True},
-        )
-        managed_rule_exclusion_read.selector_match_operator = AAZStrType(
-            serialized_name="selectorMatchOperator",
-            flags={"required": True},
-        )
+        resource_reference_read = _schema_resource_reference_read
+        resource_reference_read.id = AAZStrType()
 
-        _schema.match_variable = cls._schema_managed_rule_exclusion_read.match_variable
-        _schema.selector = cls._schema_managed_rule_exclusion_read.selector
-        _schema.selector_match_operator = cls._schema_managed_rule_exclusion_read.selector_match_operator
-
-    _schema_security_policy_web_application_firewall_association_read = None
-
-    @classmethod
-    def _build_schema_security_policy_web_application_firewall_association_read(cls, _schema):
-        if cls._schema_security_policy_web_application_firewall_association_read is not None:
-            _schema.domains = cls._schema_security_policy_web_application_firewall_association_read.domains
-            _schema.patterns_to_match = cls._schema_security_policy_web_application_firewall_association_read.patterns_to_match
-            return
-
-        cls._schema_security_policy_web_application_firewall_association_read = _schema_security_policy_web_application_firewall_association_read = AAZObjectType()
-
-        security_policy_web_application_firewall_association_read = _schema_security_policy_web_application_firewall_association_read
-        security_policy_web_application_firewall_association_read.domains = AAZListType()
-        security_policy_web_application_firewall_association_read.patterns_to_match = AAZListType(
-            serialized_name="patternsToMatch",
-        )
-
-        domains = _schema_security_policy_web_application_firewall_association_read.domains
-        domains.Element = AAZObjectType()
-
-        _element = _schema_security_policy_web_application_firewall_association_read.domains.Element
-        _element.id = AAZStrType()
-        _element.is_active = AAZBoolType(
-            serialized_name="isActive",
-            flags={"read_only": True},
-        )
-
-        patterns_to_match = _schema_security_policy_web_application_firewall_association_read.patterns_to_match
-        patterns_to_match.Element = AAZStrType()
-
-        _schema.domains = cls._schema_security_policy_web_application_firewall_association_read.domains
-        _schema.patterns_to_match = cls._schema_security_policy_web_application_firewall_association_read.patterns_to_match
-
-    _schema_system_data_read = None
-
-    @classmethod
-    def _build_schema_system_data_read(cls, _schema):
-        if cls._schema_system_data_read is not None:
-            _schema.created_at = cls._schema_system_data_read.created_at
-            _schema.created_by = cls._schema_system_data_read.created_by
-            _schema.created_by_type = cls._schema_system_data_read.created_by_type
-            _schema.last_modified_at = cls._schema_system_data_read.last_modified_at
-            _schema.last_modified_by = cls._schema_system_data_read.last_modified_by
-            _schema.last_modified_by_type = cls._schema_system_data_read.last_modified_by_type
-            return
-
-        cls._schema_system_data_read = _schema_system_data_read = AAZObjectType(
-            flags={"read_only": True}
-        )
-
-        system_data_read = _schema_system_data_read
-        system_data_read.created_at = AAZStrType(
-            serialized_name="createdAt",
-        )
-        system_data_read.created_by = AAZStrType(
-            serialized_name="createdBy",
-        )
-        system_data_read.created_by_type = AAZStrType(
-            serialized_name="createdByType",
-        )
-        system_data_read.last_modified_at = AAZStrType(
-            serialized_name="lastModifiedAt",
-        )
-        system_data_read.last_modified_by = AAZStrType(
-            serialized_name="lastModifiedBy",
-        )
-        system_data_read.last_modified_by_type = AAZStrType(
-            serialized_name="lastModifiedByType",
-        )
-
-        _schema.created_at = cls._schema_system_data_read.created_at
-        _schema.created_by = cls._schema_system_data_read.created_by
-        _schema.created_by_type = cls._schema_system_data_read.created_by_type
-        _schema.last_modified_at = cls._schema_system_data_read.last_modified_at
-        _schema.last_modified_by = cls._schema_system_data_read.last_modified_by
-        _schema.last_modified_by_type = cls._schema_system_data_read.last_modified_by_type
+        _schema.id = cls._schema_resource_reference_read.id
 
 
 __all__ = ["List"]

--- a/src/cdn/azext_cdn/aaz/latest/afd/security_policy/_show.py
+++ b/src/cdn/azext_cdn/aaz/latest/afd/security_policy/_show.py
@@ -22,9 +22,9 @@ class Show(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2025-09-01-preview",
+        "version": "2026-04-01-preview",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.cdn/profiles/{}/securitypolicies/{}", "2025-09-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.cdn/profiles/{}/securitypolicies/{}", "2026-04-01-preview"],
         ]
     }
 
@@ -135,7 +135,7 @@ class Show(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2025-09-01-preview",
+                    "api-version", "2026-04-01-preview",
                     required=True,
                 ),
             }
@@ -181,7 +181,6 @@ class Show(AAZCommand):
                 serialized_name="systemData",
                 flags={"read_only": True},
             )
-            _ShowHelper._build_schema_system_data_read(_schema_on_200.system_data)
             _schema_on_200.type = AAZStrType(
                 flags={"read_only": True},
             )
@@ -208,287 +207,60 @@ class Show(AAZCommand):
 
             disc_web_application_firewall = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewall")
             disc_web_application_firewall.associations = AAZListType()
+            disc_web_application_firewall.is_profile_level = AAZBoolType(
+                serialized_name="isProfileLevel",
+            )
             disc_web_application_firewall.waf_policy = AAZObjectType(
                 serialized_name="wafPolicy",
             )
+            _ShowHelper._build_schema_resource_reference_read(disc_web_application_firewall.waf_policy)
 
             associations = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewall").associations
             associations.Element = AAZObjectType()
-            _ShowHelper._build_schema_security_policy_web_application_firewall_association_read(associations.Element)
 
-            waf_policy = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewall").waf_policy
-            waf_policy.id = AAZStrType()
+            _element = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewall").associations.Element
+            _element.domains = AAZListType()
+            _element.patterns_to_match = AAZListType(
+                serialized_name="patternsToMatch",
+            )
+            _element.routes = AAZListType()
 
-            disc_web_application_firewall_embedded = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded")
-            disc_web_application_firewall_embedded.associations = AAZListType()
-            disc_web_application_firewall_embedded.waf_policy = AAZObjectType(
-                serialized_name="wafPolicy",
-            )
+            domains = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewall").associations.Element.domains
+            domains.Element = AAZObjectType()
 
-            associations = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").associations
-            associations.Element = AAZObjectType()
-            _ShowHelper._build_schema_security_policy_web_application_firewall_association_read(associations.Element)
-
-            waf_policy = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy
-            waf_policy.etag = AAZStrType()
-            waf_policy.id = AAZStrType(
-                flags={"read_only": True},
-            )
-            waf_policy.name = AAZStrType(
-                flags={"read_only": True},
-            )
-            waf_policy.properties = AAZObjectType(
-                flags={"client_flatten": True},
-            )
-            waf_policy.sku = AAZObjectType()
-            waf_policy.system_data = AAZObjectType(
-                serialized_name="systemData",
-                flags={"read_only": True},
-            )
-            _ShowHelper._build_schema_system_data_read(waf_policy.system_data)
-            waf_policy.type = AAZStrType(
+            _element = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewall").associations.Element.domains.Element
+            _element.id = AAZStrType()
+            _element.is_active = AAZBoolType(
+                serialized_name="isActive",
                 flags={"read_only": True},
             )
 
-            properties = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties
-            properties.custom_rules = AAZObjectType(
-                serialized_name="customRules",
-            )
-            properties.frontend_endpoint_links = AAZListType(
-                serialized_name="frontendEndpointLinks",
-                flags={"read_only": True},
-            )
-            properties.managed_rules = AAZObjectType(
-                serialized_name="managedRules",
-            )
-            properties.policy_settings = AAZObjectType(
-                serialized_name="policySettings",
-            )
-            properties.provisioning_state = AAZStrType(
-                serialized_name="provisioningState",
-                flags={"read_only": True},
-            )
-            properties.resource_state = AAZStrType(
-                serialized_name="resourceState",
-                flags={"read_only": True},
-            )
-            properties.routing_rule_links = AAZListType(
-                serialized_name="routingRuleLinks",
-                flags={"read_only": True},
-            )
-            properties.security_policy_links = AAZListType(
-                serialized_name="securityPolicyLinks",
-                flags={"read_only": True},
-            )
+            patterns_to_match = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewall").associations.Element.patterns_to_match
+            patterns_to_match.Element = AAZStrType()
 
-            custom_rules = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules
-            custom_rules.rules = AAZListType()
+            routes = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewall").associations.Element.routes
+            routes.Element = AAZObjectType()
+            _ShowHelper._build_schema_resource_reference_read(routes.Element)
 
-            rules = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules.rules
-            rules.Element = AAZObjectType()
-
-            _element = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules.rules.Element
-            _element.action = AAZStrType(
-                flags={"required": True},
+            system_data = cls._schema_on_200.system_data
+            system_data.created_at = AAZStrType(
+                serialized_name="createdAt",
             )
-            _element.enabled_state = AAZStrType(
-                serialized_name="enabledState",
+            system_data.created_by = AAZStrType(
+                serialized_name="createdBy",
             )
-            _element.group_by = AAZListType(
-                serialized_name="groupBy",
+            system_data.created_by_type = AAZStrType(
+                serialized_name="createdByType",
             )
-            _element.match_conditions = AAZListType(
-                serialized_name="matchConditions",
-                flags={"required": True},
+            system_data.last_modified_at = AAZStrType(
+                serialized_name="lastModifiedAt",
             )
-            _element.name = AAZStrType()
-            _element.priority = AAZIntType(
-                flags={"required": True},
+            system_data.last_modified_by = AAZStrType(
+                serialized_name="lastModifiedBy",
             )
-            _element.rate_limit_duration_in_minutes = AAZIntType(
-                serialized_name="rateLimitDurationInMinutes",
+            system_data.last_modified_by_type = AAZStrType(
+                serialized_name="lastModifiedByType",
             )
-            _element.rate_limit_threshold = AAZIntType(
-                serialized_name="rateLimitThreshold",
-            )
-            _element.rule_type = AAZStrType(
-                serialized_name="ruleType",
-                flags={"required": True},
-            )
-
-            group_by = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules.rules.Element.group_by
-            group_by.Element = AAZObjectType()
-
-            _element = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules.rules.Element.group_by.Element
-            _element.variable_name = AAZStrType(
-                serialized_name="variableName",
-                flags={"required": True},
-            )
-
-            match_conditions = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules.rules.Element.match_conditions
-            match_conditions.Element = AAZObjectType()
-
-            _element = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules.rules.Element.match_conditions.Element
-            _element.match_value = AAZListType(
-                serialized_name="matchValue",
-                flags={"required": True},
-            )
-            _element.match_variable = AAZStrType(
-                serialized_name="matchVariable",
-                flags={"required": True},
-            )
-            _element.negate_condition = AAZBoolType(
-                serialized_name="negateCondition",
-            )
-            _element.operator = AAZStrType(
-                flags={"required": True},
-            )
-            _element.selector = AAZStrType()
-            _element.transforms = AAZListType()
-
-            match_value = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules.rules.Element.match_conditions.Element.match_value
-            match_value.Element = AAZStrType()
-
-            transforms = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules.rules.Element.match_conditions.Element.transforms
-            transforms.Element = AAZStrType()
-
-            frontend_endpoint_links = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.frontend_endpoint_links
-            frontend_endpoint_links.Element = AAZObjectType()
-
-            _element = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.frontend_endpoint_links.Element
-            _element.id = AAZStrType(
-                flags={"read_only": True},
-            )
-
-            managed_rules = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules
-            managed_rules.managed_rule_sets = AAZListType(
-                serialized_name="managedRuleSets",
-            )
-
-            managed_rule_sets = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets
-            managed_rule_sets.Element = AAZObjectType()
-
-            _element = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets.Element
-            _element.exclusions = AAZListType()
-            _element.rule_group_overrides = AAZListType(
-                serialized_name="ruleGroupOverrides",
-            )
-            _element.rule_set_action = AAZStrType(
-                serialized_name="ruleSetAction",
-            )
-            _element.rule_set_type = AAZStrType(
-                serialized_name="ruleSetType",
-                flags={"required": True},
-            )
-            _element.rule_set_version = AAZStrType(
-                serialized_name="ruleSetVersion",
-                flags={"required": True},
-            )
-
-            exclusions = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets.Element.exclusions
-            exclusions.Element = AAZObjectType()
-            _ShowHelper._build_schema_managed_rule_exclusion_read(exclusions.Element)
-
-            rule_group_overrides = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets.Element.rule_group_overrides
-            rule_group_overrides.Element = AAZObjectType()
-
-            _element = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets.Element.rule_group_overrides.Element
-            _element.exclusions = AAZListType()
-            _element.rule_group_name = AAZStrType(
-                serialized_name="ruleGroupName",
-                flags={"required": True},
-            )
-            _element.rules = AAZListType()
-
-            exclusions = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets.Element.rule_group_overrides.Element.exclusions
-            exclusions.Element = AAZObjectType()
-            _ShowHelper._build_schema_managed_rule_exclusion_read(exclusions.Element)
-
-            rules = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets.Element.rule_group_overrides.Element.rules
-            rules.Element = AAZObjectType()
-
-            _element = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets.Element.rule_group_overrides.Element.rules.Element
-            _element.action = AAZStrType()
-            _element.enabled_state = AAZStrType(
-                serialized_name="enabledState",
-            )
-            _element.exclusions = AAZListType()
-            _element.rule_id = AAZStrType(
-                serialized_name="ruleId",
-                flags={"required": True},
-            )
-
-            exclusions = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets.Element.rule_group_overrides.Element.rules.Element.exclusions
-            exclusions.Element = AAZObjectType()
-            _ShowHelper._build_schema_managed_rule_exclusion_read(exclusions.Element)
-
-            policy_settings = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.policy_settings
-            policy_settings.captcha_expiration_in_minutes = AAZIntType(
-                serialized_name="captchaExpirationInMinutes",
-            )
-            policy_settings.custom_block_response_body = AAZStrType(
-                serialized_name="customBlockResponseBody",
-            )
-            policy_settings.custom_block_response_status_code = AAZIntType(
-                serialized_name="customBlockResponseStatusCode",
-            )
-            policy_settings.enabled_state = AAZStrType(
-                serialized_name="enabledState",
-            )
-            policy_settings.javascript_challenge_expiration_in_minutes = AAZIntType(
-                serialized_name="javascriptChallengeExpirationInMinutes",
-            )
-            policy_settings.log_scrubbing = AAZObjectType(
-                serialized_name="logScrubbing",
-                flags={"client_flatten": True},
-            )
-            policy_settings.mode = AAZStrType()
-            policy_settings.redirect_url = AAZStrType(
-                serialized_name="redirectUrl",
-            )
-            policy_settings.request_body_check = AAZStrType(
-                serialized_name="requestBodyCheck",
-            )
-
-            log_scrubbing = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.policy_settings.log_scrubbing
-            log_scrubbing.scrubbing_rules = AAZListType(
-                serialized_name="scrubbingRules",
-            )
-            log_scrubbing.state = AAZStrType()
-
-            scrubbing_rules = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.policy_settings.log_scrubbing.scrubbing_rules
-            scrubbing_rules.Element = AAZObjectType()
-
-            _element = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.policy_settings.log_scrubbing.scrubbing_rules.Element
-            _element.match_variable = AAZStrType(
-                serialized_name="matchVariable",
-                flags={"required": True},
-            )
-            _element.selector = AAZStrType()
-            _element.selector_match_operator = AAZStrType(
-                serialized_name="selectorMatchOperator",
-                flags={"required": True},
-            )
-            _element.state = AAZStrType()
-
-            routing_rule_links = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.routing_rule_links
-            routing_rule_links.Element = AAZObjectType()
-
-            _element = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.routing_rule_links.Element
-            _element.id = AAZStrType(
-                flags={"read_only": True},
-            )
-
-            security_policy_links = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.security_policy_links
-            security_policy_links.Element = AAZObjectType()
-
-            _element = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.security_policy_links.Element
-            _element.id = AAZStrType(
-                flags={"read_only": True},
-            )
-
-            sku = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.sku
-            sku.name = AAZStrType()
 
             return cls._schema_on_200
 
@@ -496,111 +268,20 @@ class Show(AAZCommand):
 class _ShowHelper:
     """Helper class for Show"""
 
-    _schema_managed_rule_exclusion_read = None
+    _schema_resource_reference_read = None
 
     @classmethod
-    def _build_schema_managed_rule_exclusion_read(cls, _schema):
-        if cls._schema_managed_rule_exclusion_read is not None:
-            _schema.match_variable = cls._schema_managed_rule_exclusion_read.match_variable
-            _schema.selector = cls._schema_managed_rule_exclusion_read.selector
-            _schema.selector_match_operator = cls._schema_managed_rule_exclusion_read.selector_match_operator
+    def _build_schema_resource_reference_read(cls, _schema):
+        if cls._schema_resource_reference_read is not None:
+            _schema.id = cls._schema_resource_reference_read.id
             return
 
-        cls._schema_managed_rule_exclusion_read = _schema_managed_rule_exclusion_read = AAZObjectType()
+        cls._schema_resource_reference_read = _schema_resource_reference_read = AAZObjectType()
 
-        managed_rule_exclusion_read = _schema_managed_rule_exclusion_read
-        managed_rule_exclusion_read.match_variable = AAZStrType(
-            serialized_name="matchVariable",
-            flags={"required": True},
-        )
-        managed_rule_exclusion_read.selector = AAZStrType(
-            flags={"required": True},
-        )
-        managed_rule_exclusion_read.selector_match_operator = AAZStrType(
-            serialized_name="selectorMatchOperator",
-            flags={"required": True},
-        )
+        resource_reference_read = _schema_resource_reference_read
+        resource_reference_read.id = AAZStrType()
 
-        _schema.match_variable = cls._schema_managed_rule_exclusion_read.match_variable
-        _schema.selector = cls._schema_managed_rule_exclusion_read.selector
-        _schema.selector_match_operator = cls._schema_managed_rule_exclusion_read.selector_match_operator
-
-    _schema_security_policy_web_application_firewall_association_read = None
-
-    @classmethod
-    def _build_schema_security_policy_web_application_firewall_association_read(cls, _schema):
-        if cls._schema_security_policy_web_application_firewall_association_read is not None:
-            _schema.domains = cls._schema_security_policy_web_application_firewall_association_read.domains
-            _schema.patterns_to_match = cls._schema_security_policy_web_application_firewall_association_read.patterns_to_match
-            return
-
-        cls._schema_security_policy_web_application_firewall_association_read = _schema_security_policy_web_application_firewall_association_read = AAZObjectType()
-
-        security_policy_web_application_firewall_association_read = _schema_security_policy_web_application_firewall_association_read
-        security_policy_web_application_firewall_association_read.domains = AAZListType()
-        security_policy_web_application_firewall_association_read.patterns_to_match = AAZListType(
-            serialized_name="patternsToMatch",
-        )
-
-        domains = _schema_security_policy_web_application_firewall_association_read.domains
-        domains.Element = AAZObjectType()
-
-        _element = _schema_security_policy_web_application_firewall_association_read.domains.Element
-        _element.id = AAZStrType()
-        _element.is_active = AAZBoolType(
-            serialized_name="isActive",
-            flags={"read_only": True},
-        )
-
-        patterns_to_match = _schema_security_policy_web_application_firewall_association_read.patterns_to_match
-        patterns_to_match.Element = AAZStrType()
-
-        _schema.domains = cls._schema_security_policy_web_application_firewall_association_read.domains
-        _schema.patterns_to_match = cls._schema_security_policy_web_application_firewall_association_read.patterns_to_match
-
-    _schema_system_data_read = None
-
-    @classmethod
-    def _build_schema_system_data_read(cls, _schema):
-        if cls._schema_system_data_read is not None:
-            _schema.created_at = cls._schema_system_data_read.created_at
-            _schema.created_by = cls._schema_system_data_read.created_by
-            _schema.created_by_type = cls._schema_system_data_read.created_by_type
-            _schema.last_modified_at = cls._schema_system_data_read.last_modified_at
-            _schema.last_modified_by = cls._schema_system_data_read.last_modified_by
-            _schema.last_modified_by_type = cls._schema_system_data_read.last_modified_by_type
-            return
-
-        cls._schema_system_data_read = _schema_system_data_read = AAZObjectType(
-            flags={"read_only": True}
-        )
-
-        system_data_read = _schema_system_data_read
-        system_data_read.created_at = AAZStrType(
-            serialized_name="createdAt",
-        )
-        system_data_read.created_by = AAZStrType(
-            serialized_name="createdBy",
-        )
-        system_data_read.created_by_type = AAZStrType(
-            serialized_name="createdByType",
-        )
-        system_data_read.last_modified_at = AAZStrType(
-            serialized_name="lastModifiedAt",
-        )
-        system_data_read.last_modified_by = AAZStrType(
-            serialized_name="lastModifiedBy",
-        )
-        system_data_read.last_modified_by_type = AAZStrType(
-            serialized_name="lastModifiedByType",
-        )
-
-        _schema.created_at = cls._schema_system_data_read.created_at
-        _schema.created_by = cls._schema_system_data_read.created_by
-        _schema.created_by_type = cls._schema_system_data_read.created_by_type
-        _schema.last_modified_at = cls._schema_system_data_read.last_modified_at
-        _schema.last_modified_by = cls._schema_system_data_read.last_modified_by
-        _schema.last_modified_by_type = cls._schema_system_data_read.last_modified_by_type
+        _schema.id = cls._schema_resource_reference_read.id
 
 
 __all__ = ["Show"]

--- a/src/cdn/azext_cdn/aaz/latest/afd/security_policy/_update.py
+++ b/src/cdn/azext_cdn/aaz/latest/afd/security_policy/_update.py
@@ -22,9 +22,9 @@ class Update(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2025-09-01-preview",
+        "version": "2026-04-01-preview",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.cdn/profiles/{}/securitypolicies/{}", "2025-09-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.cdn/profiles/{}/securitypolicies/{}", "2026-04-01-preview"],
         ]
     }
 
@@ -75,10 +75,6 @@ class Update(AAZCommand):
             options=["--web-application-firewall"],
             arg_group="Parameters",
         )
-        _args_schema.web_application_firewall_embedded = AAZObjectArg(
-            options=["--web-application-firewall-embedded"],
-            arg_group="Parameters",
-        )
 
         web_application_firewall = cls._args_schema.web_application_firewall
         web_application_firewall.associations = AAZListArg(
@@ -86,477 +82,84 @@ class Update(AAZCommand):
             help="Waf associations",
             nullable=True,
         )
-        web_application_firewall.waf_policy = AAZStrArg(
-            options=["waf-policy"],
-            help="The ID of Front Door WAF policy.",
+        web_application_firewall.is_profile_level = AAZBoolArg(
+            options=["is-profile-level"],
+            help="Indicates if this is a profile-level WAF policy.",
             nullable=True,
         )
+        web_application_firewall.waf_policy = AAZObjectArg(
+            options=["waf-policy"],
+            help="Resource ID.",
+            nullable=True,
+        )
+        cls._build_args_resource_reference_update(web_application_firewall.waf_policy)
 
         associations = cls._args_schema.web_application_firewall.associations
         associations.Element = AAZObjectArg(
             nullable=True,
         )
-        cls._build_args_security_policy_web_application_firewall_association_update(associations.Element)
 
-        web_application_firewall_embedded = cls._args_schema.web_application_firewall_embedded
-        web_application_firewall_embedded.associations = AAZListArg(
-            options=["associations"],
-            help="Waf associations",
-            nullable=True,
-        )
-        web_application_firewall_embedded.waf_policy = AAZObjectArg(
-            options=["waf-policy"],
-            help="Properties of the web application firewall policy.",
-            nullable=True,
-        )
-
-        associations = cls._args_schema.web_application_firewall_embedded.associations
-        associations.Element = AAZObjectArg(
-            nullable=True,
-        )
-        cls._build_args_security_policy_web_application_firewall_association_update(associations.Element)
-
-        waf_policy = cls._args_schema.web_application_firewall_embedded.waf_policy
-        waf_policy.etag = AAZStrArg(
-            options=["etag"],
-            help="Gets a unique read-only string that changes whenever the resource is updated.",
-            nullable=True,
-        )
-        waf_policy.custom_rules = AAZObjectArg(
-            options=["custom-rules"],
-            help="Describes custom rules inside the policy.",
-            nullable=True,
-        )
-        waf_policy.managed_rules = AAZObjectArg(
-            options=["managed-rules"],
-            help="Describes managed rules inside the policy.",
-            nullable=True,
-        )
-        waf_policy.policy_settings = AAZObjectArg(
-            options=["policy-settings"],
-            help="Describes settings for the policy.",
-            nullable=True,
-        )
-        waf_policy.sku = AAZObjectArg(
-            options=["sku"],
-            help="The pricing tier of web application firewall policy. Defaults to Classic_AzureFrontDoor if not specified.",
-            nullable=True,
-        )
-
-        custom_rules = cls._args_schema.web_application_firewall_embedded.waf_policy.custom_rules
-        custom_rules.rules = AAZListArg(
-            options=["rules"],
-            help="List of rules",
-            nullable=True,
-        )
-
-        rules = cls._args_schema.web_application_firewall_embedded.waf_policy.custom_rules.rules
-        rules.Element = AAZObjectArg(
-            nullable=True,
-        )
-
-        _element = cls._args_schema.web_application_firewall_embedded.waf_policy.custom_rules.rules.Element
-        _element.action = AAZStrArg(
-            options=["action"],
-            help="Describes what action to be applied when rule matches.",
-            enum={"Allow": "Allow", "AnomalyScoring": "AnomalyScoring", "Block": "Block", "CAPTCHA": "CAPTCHA", "JSChallenge": "JSChallenge", "Log": "Log", "Redirect": "Redirect"},
-        )
-        _element.enabled_state = AAZStrArg(
-            options=["enabled-state"],
-            help="Describes if the custom rule is in enabled or disabled state. Defaults to Enabled if not specified.",
-            nullable=True,
-            enum={"Disabled": "Disabled", "Enabled": "Enabled"},
-        )
-        _element.group_by = AAZListArg(
-            options=["group-by"],
-            help="Describes the list of variables to group the rate limit requests",
-            nullable=True,
-        )
-        _element.match_conditions = AAZListArg(
-            options=["match-conditions"],
-            help="List of match conditions.",
-        )
-        _element.name = AAZStrArg(
-            options=["name"],
-            help="Describes the name of the rule.",
-            nullable=True,
-            fmt=AAZStrArgFormat(
-                max_length=128,
-            ),
-        )
-        _element.priority = AAZIntArg(
-            options=["priority"],
-            help="Describes priority of the rule. Rules with a lower value will be evaluated before rules with a higher value.",
-        )
-        _element.rate_limit_duration_in_minutes = AAZIntArg(
-            options=["rate-limit-duration-in-minutes"],
-            help="Time window for resetting the rate limit count. Default is 1 minute.",
-            nullable=True,
-            fmt=AAZIntArgFormat(
-                maximum=5,
-                minimum=0,
-            ),
-        )
-        _element.rate_limit_threshold = AAZIntArg(
-            options=["rate-limit-threshold"],
-            help="Number of allowed requests per client within the time window.",
-            nullable=True,
-            fmt=AAZIntArgFormat(
-                minimum=0,
-            ),
-        )
-        _element.rule_type = AAZStrArg(
-            options=["rule-type"],
-            help="Describes type of rule.",
-            enum={"MatchRule": "MatchRule", "RateLimitRule": "RateLimitRule"},
-        )
-
-        group_by = cls._args_schema.web_application_firewall_embedded.waf_policy.custom_rules.rules.Element.group_by
-        group_by.Element = AAZObjectArg(
-            nullable=True,
-        )
-
-        _element = cls._args_schema.web_application_firewall_embedded.waf_policy.custom_rules.rules.Element.group_by.Element
-        _element.variable_name = AAZStrArg(
-            options=["variable-name"],
-            help="Describes the supported variable for group by",
-            enum={"GeoLocation": "GeoLocation", "None": "None", "SocketAddr": "SocketAddr"},
-        )
-
-        match_conditions = cls._args_schema.web_application_firewall_embedded.waf_policy.custom_rules.rules.Element.match_conditions
-        match_conditions.Element = AAZObjectArg(
-            nullable=True,
-        )
-
-        _element = cls._args_schema.web_application_firewall_embedded.waf_policy.custom_rules.rules.Element.match_conditions.Element
-        _element.match_value = AAZListArg(
-            options=["match-value"],
-            help="List of possible match values.",
-        )
-        _element.match_variable = AAZStrArg(
-            options=["match-variable"],
-            help="Request variable to compare with.",
-            enum={"ClientPort": "ClientPort", "Cookies": "Cookies", "HostName": "HostName", "HttpVersion": "HttpVersion", "IsDevice": "IsDevice", "PostArgs": "PostArgs", "QueryString": "QueryString", "RemoteAddress": "RemoteAddress", "RequestBody": "RequestBody", "RequestHeader": "RequestHeader", "RequestMethod": "RequestMethod", "RequestScheme": "RequestScheme", "RequestUri": "RequestUri", "ServerPort": "ServerPort", "SocketAddr": "SocketAddr", "SslProtocol": "SslProtocol", "UrlFileExtension": "UrlFileExtension", "UrlFileName": "UrlFileName", "UrlPath": "UrlPath"},
-        )
-        _element.negate_condition = AAZBoolArg(
-            options=["negate-condition"],
-            help="Describes if the result of this condition should be negated.",
-            nullable=True,
-        )
-        _element.operator = AAZStrArg(
-            options=["operator"],
-            help="Comparison type to use for matching with the variable value.",
-            enum={"Any": "Any", "BeginsWith": "BeginsWith", "Contains": "Contains", "EndsWith": "EndsWith", "Equal": "Equal", "GeoMatch": "GeoMatch", "GreaterThan": "GreaterThan", "GreaterThanOrEqual": "GreaterThanOrEqual", "IPMatch": "IPMatch", "LessThan": "LessThan", "LessThanOrEqual": "LessThanOrEqual", "RegEx": "RegEx"},
-        )
-        _element.selector = AAZStrArg(
-            options=["selector"],
-            help="Match against a specific key from the QueryString, PostArgs, RequestHeader or Cookies variables. Default is null.",
-            nullable=True,
-        )
-        _element.transforms = AAZListArg(
-            options=["transforms"],
-            help="List of transforms.",
-            nullable=True,
-        )
-
-        match_value = cls._args_schema.web_application_firewall_embedded.waf_policy.custom_rules.rules.Element.match_conditions.Element.match_value
-        match_value.Element = AAZStrArg(
-            nullable=True,
-        )
-
-        transforms = cls._args_schema.web_application_firewall_embedded.waf_policy.custom_rules.rules.Element.match_conditions.Element.transforms
-        transforms.Element = AAZStrArg(
-            nullable=True,
-            enum={"Lowercase": "Lowercase", "RemoveNulls": "RemoveNulls", "Trim": "Trim", "Uppercase": "Uppercase", "UrlDecode": "UrlDecode", "UrlEncode": "UrlEncode"},
-        )
-
-        managed_rules = cls._args_schema.web_application_firewall_embedded.waf_policy.managed_rules
-        managed_rules.managed_rule_sets = AAZListArg(
-            options=["managed-rule-sets"],
-            help="List of rule sets.",
-            nullable=True,
-        )
-
-        managed_rule_sets = cls._args_schema.web_application_firewall_embedded.waf_policy.managed_rules.managed_rule_sets
-        managed_rule_sets.Element = AAZObjectArg(
-            nullable=True,
-        )
-
-        _element = cls._args_schema.web_application_firewall_embedded.waf_policy.managed_rules.managed_rule_sets.Element
-        _element.exclusions = AAZListArg(
-            options=["exclusions"],
-            help="Describes the exclusions that are applied to all rules in the set.",
-            nullable=True,
-        )
-        _element.rule_group_overrides = AAZListArg(
-            options=["rule-group-overrides"],
-            help="Defines the rule group overrides to apply to the rule set.",
-            nullable=True,
-        )
-        _element.rule_set_action = AAZStrArg(
-            options=["rule-set-action"],
-            help="Defines the rule set action.",
-            nullable=True,
-            enum={"Block": "Block", "Log": "Log", "Redirect": "Redirect"},
-        )
-        _element.rule_set_type = AAZStrArg(
-            options=["rule-set-type"],
-            help="Defines the rule set type to use.",
-        )
-        _element.rule_set_version = AAZStrArg(
-            options=["rule-set-version"],
-            help="Defines the version of the rule set to use.",
-        )
-
-        exclusions = cls._args_schema.web_application_firewall_embedded.waf_policy.managed_rules.managed_rule_sets.Element.exclusions
-        exclusions.Element = AAZObjectArg(
-            nullable=True,
-        )
-        cls._build_args_managed_rule_exclusion_update(exclusions.Element)
-
-        rule_group_overrides = cls._args_schema.web_application_firewall_embedded.waf_policy.managed_rules.managed_rule_sets.Element.rule_group_overrides
-        rule_group_overrides.Element = AAZObjectArg(
-            nullable=True,
-        )
-
-        _element = cls._args_schema.web_application_firewall_embedded.waf_policy.managed_rules.managed_rule_sets.Element.rule_group_overrides.Element
-        _element.exclusions = AAZListArg(
-            options=["exclusions"],
-            help="Describes the exclusions that are applied to all rules in the group.",
-            nullable=True,
-        )
-        _element.rule_group_name = AAZStrArg(
-            options=["rule-group-name"],
-            help="Describes the managed rule group to override.",
-        )
-        _element.rules = AAZListArg(
-            options=["rules"],
-            help="List of rules that will be disabled. If none specified, all rules in the group will be disabled.",
-            nullable=True,
-        )
-
-        exclusions = cls._args_schema.web_application_firewall_embedded.waf_policy.managed_rules.managed_rule_sets.Element.rule_group_overrides.Element.exclusions
-        exclusions.Element = AAZObjectArg(
-            nullable=True,
-        )
-        cls._build_args_managed_rule_exclusion_update(exclusions.Element)
-
-        rules = cls._args_schema.web_application_firewall_embedded.waf_policy.managed_rules.managed_rule_sets.Element.rule_group_overrides.Element.rules
-        rules.Element = AAZObjectArg(
-            nullable=True,
-        )
-
-        _element = cls._args_schema.web_application_firewall_embedded.waf_policy.managed_rules.managed_rule_sets.Element.rule_group_overrides.Element.rules.Element
-        _element.action = AAZStrArg(
-            options=["action"],
-            help="Describes the override action to be applied when rule matches.",
-            nullable=True,
-            enum={"Allow": "Allow", "AnomalyScoring": "AnomalyScoring", "Block": "Block", "CAPTCHA": "CAPTCHA", "JSChallenge": "JSChallenge", "Log": "Log", "Redirect": "Redirect"},
-        )
-        _element.enabled_state = AAZStrArg(
-            options=["enabled-state"],
-            help="Describes if the managed rule is in enabled or disabled state. Defaults to Disabled if not specified.",
-            nullable=True,
-            enum={"Disabled": "Disabled", "Enabled": "Enabled"},
-        )
-        _element.exclusions = AAZListArg(
-            options=["exclusions"],
-            help="Describes the exclusions that are applied to this specific rule.",
-            nullable=True,
-        )
-        _element.rule_id = AAZStrArg(
-            options=["rule-id"],
-            help="Identifier for the managed rule.",
-        )
-
-        exclusions = cls._args_schema.web_application_firewall_embedded.waf_policy.managed_rules.managed_rule_sets.Element.rule_group_overrides.Element.rules.Element.exclusions
-        exclusions.Element = AAZObjectArg(
-            nullable=True,
-        )
-        cls._build_args_managed_rule_exclusion_update(exclusions.Element)
-
-        policy_settings = cls._args_schema.web_application_firewall_embedded.waf_policy.policy_settings
-        policy_settings.captcha_expiration_in_minutes = AAZIntArg(
-            options=["captcha-expiration-in-minutes"],
-            help="Defines the Captcha cookie validity lifetime in minutes. This setting is only applicable to Premium_AzureFrontDoor. Value must be an integer between 5 and 1440 with the default value being 30.",
-            nullable=True,
-            fmt=AAZIntArgFormat(
-                maximum=1440,
-                minimum=5,
-            ),
-        )
-        policy_settings.custom_block_response_body = AAZStrArg(
-            options=["custom-block-response-body"],
-            help="If the action type is block, customer can override the response body. The body must be specified in base64 encoding.",
-            nullable=True,
-            fmt=AAZStrArgFormat(
-                pattern="^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
-            ),
-        )
-        policy_settings.custom_block_response_status_code = AAZIntArg(
-            options=["custom-block-response-status-code"],
-            help="If the action type is block, customer can override the response status code.",
-            nullable=True,
-        )
-        policy_settings.enabled_state = AAZStrArg(
-            options=["enabled-state"],
-            help="Describes if the policy is in enabled or disabled state. Defaults to Enabled if not specified.",
-            nullable=True,
-            enum={"Disabled": "Disabled", "Enabled": "Enabled"},
-        )
-        policy_settings.javascript_challenge_expiration_in_minutes = AAZIntArg(
-            options=["javascript-challenge-expiration-in-minutes"],
-            help="Defines the JavaScript challenge cookie validity lifetime in minutes. This setting is only applicable to Premium_AzureFrontDoor. Value must be an integer between 5 and 1440 with the default value being 30.",
-            nullable=True,
-            fmt=AAZIntArgFormat(
-                maximum=1440,
-                minimum=5,
-            ),
-        )
-        policy_settings.scrubbing_rules = AAZListArg(
-            options=["scrubbing-rules"],
-            help="List of log scrubbing rules applied to the Web Application Firewall logs.",
-            nullable=True,
-        )
-        policy_settings.state = AAZStrArg(
-            options=["state"],
-            help="State of the log scrubbing config. Default value is Enabled.",
-            nullable=True,
-            enum={"Disabled": "Disabled", "Enabled": "Enabled"},
-        )
-        policy_settings.mode = AAZStrArg(
-            options=["mode"],
-            help="Describes if it is in detection mode or prevention mode at policy level.",
-            nullable=True,
-            enum={"Detection": "Detection", "Prevention": "Prevention"},
-        )
-        policy_settings.redirect_url = AAZStrArg(
-            options=["redirect-url"],
-            help="If action type is redirect, this field represents redirect URL for the client.",
-            nullable=True,
-        )
-        policy_settings.request_body_check = AAZStrArg(
-            options=["request-body-check"],
-            help="Describes if policy managed rules will inspect the request body content.",
-            nullable=True,
-            enum={"Disabled": "Disabled", "Enabled": "Enabled"},
-        )
-
-        scrubbing_rules = cls._args_schema.web_application_firewall_embedded.waf_policy.policy_settings.scrubbing_rules
-        scrubbing_rules.Element = AAZObjectArg(
-            nullable=True,
-        )
-
-        _element = cls._args_schema.web_application_firewall_embedded.waf_policy.policy_settings.scrubbing_rules.Element
-        _element.match_variable = AAZStrArg(
-            options=["match-variable"],
-            help="The variable to be scrubbed from the logs.",
-            enum={"QueryStringArgNames": "QueryStringArgNames", "RequestBodyJsonArgNames": "RequestBodyJsonArgNames", "RequestBodyPostArgNames": "RequestBodyPostArgNames", "RequestCookieNames": "RequestCookieNames", "RequestHeaderNames": "RequestHeaderNames", "RequestIPAddress": "RequestIPAddress", "RequestUri": "RequestUri"},
-        )
-        _element.selector = AAZStrArg(
-            options=["selector"],
-            help="When matchVariable is a collection, operator used to specify which elements in the collection this rule applies to.",
-            nullable=True,
-        )
-        _element.selector_match_operator = AAZStrArg(
-            options=["selector-match-operator"],
-            help="When matchVariable is a collection, operate on the selector to specify which elements in the collection this rule applies to.",
-            enum={"Equals": "Equals", "EqualsAny": "EqualsAny"},
-        )
-        _element.state = AAZStrArg(
-            options=["state"],
-            help="Defines the state of a log scrubbing rule. Default value is enabled.",
-            nullable=True,
-            enum={"Disabled": "Disabled", "Enabled": "Enabled"},
-        )
-
-        sku = cls._args_schema.web_application_firewall_embedded.waf_policy.sku
-        sku.name = AAZStrArg(
-            options=["name"],
-            help="Name of the pricing tier.",
-            nullable=True,
-            enum={"Classic_AzureFrontDoor": "Classic_AzureFrontDoor", "Custom_Verizon": "Custom_Verizon", "Premium_AzureFrontDoor": "Premium_AzureFrontDoor", "Premium_Verizon": "Premium_Verizon", "StandardPlus_955BandWidth_ChinaCdn": "StandardPlus_955BandWidth_ChinaCdn", "StandardPlus_AvgBandWidth_ChinaCdn": "StandardPlus_AvgBandWidth_ChinaCdn", "StandardPlus_ChinaCdn": "StandardPlus_ChinaCdn", "Standard_955BandWidth_ChinaCdn": "Standard_955BandWidth_ChinaCdn", "Standard_Akamai": "Standard_Akamai", "Standard_AvgBandWidth_ChinaCdn": "Standard_AvgBandWidth_ChinaCdn", "Standard_AzureFrontDoor": "Standard_AzureFrontDoor", "Standard_ChinaCdn": "Standard_ChinaCdn", "Standard_Microsoft": "Standard_Microsoft", "Standard_Verizon": "Standard_Verizon"},
-        )
-        return cls._args_schema
-
-    _args_managed_rule_exclusion_update = None
-
-    @classmethod
-    def _build_args_managed_rule_exclusion_update(cls, _schema):
-        if cls._args_managed_rule_exclusion_update is not None:
-            _schema.match_variable = cls._args_managed_rule_exclusion_update.match_variable
-            _schema.selector = cls._args_managed_rule_exclusion_update.selector
-            _schema.selector_match_operator = cls._args_managed_rule_exclusion_update.selector_match_operator
-            return
-
-        cls._args_managed_rule_exclusion_update = AAZObjectArg(
-            nullable=True,
-        )
-
-        managed_rule_exclusion_update = cls._args_managed_rule_exclusion_update
-        managed_rule_exclusion_update.match_variable = AAZStrArg(
-            options=["match-variable"],
-            help="The variable type to be excluded.",
-            enum={"QueryStringArgNames": "QueryStringArgNames", "RequestBodyJsonArgNames": "RequestBodyJsonArgNames", "RequestBodyPostArgNames": "RequestBodyPostArgNames", "RequestCookieNames": "RequestCookieNames", "RequestHeaderNames": "RequestHeaderNames"},
-        )
-        managed_rule_exclusion_update.selector = AAZStrArg(
-            options=["selector"],
-            help="Selector value for which elements in the collection this exclusion applies to.",
-        )
-        managed_rule_exclusion_update.selector_match_operator = AAZStrArg(
-            options=["selector-match-operator"],
-            help="Comparison operator to apply to the selector when specifying which elements in the collection this exclusion applies to.",
-            enum={"Contains": "Contains", "EndsWith": "EndsWith", "Equals": "Equals", "EqualsAny": "EqualsAny", "StartsWith": "StartsWith"},
-        )
-
-        _schema.match_variable = cls._args_managed_rule_exclusion_update.match_variable
-        _schema.selector = cls._args_managed_rule_exclusion_update.selector
-        _schema.selector_match_operator = cls._args_managed_rule_exclusion_update.selector_match_operator
-
-    _args_security_policy_web_application_firewall_association_update = None
-
-    @classmethod
-    def _build_args_security_policy_web_application_firewall_association_update(cls, _schema):
-        if cls._args_security_policy_web_application_firewall_association_update is not None:
-            _schema.domains = cls._args_security_policy_web_application_firewall_association_update.domains
-            _schema.patterns_to_match = cls._args_security_policy_web_application_firewall_association_update.patterns_to_match
-            return
-
-        cls._args_security_policy_web_application_firewall_association_update = AAZObjectArg(
-            nullable=True,
-        )
-
-        security_policy_web_application_firewall_association_update = cls._args_security_policy_web_application_firewall_association_update
-        security_policy_web_application_firewall_association_update.domains = AAZListArg(
+        _element = cls._args_schema.web_application_firewall.associations.Element
+        _element.domains = AAZListArg(
             options=["domains"],
             help="List of domains.",
             nullable=True,
         )
-        security_policy_web_application_firewall_association_update.patterns_to_match = AAZListArg(
+        _element.patterns_to_match = AAZListArg(
             options=["patterns-to-match"],
             help="List of paths",
             nullable=True,
         )
+        _element.routes = AAZListArg(
+            options=["routes"],
+            help="List of routes.",
+            nullable=True,
+        )
 
-        domains = cls._args_security_policy_web_application_firewall_association_update.domains
+        domains = cls._args_schema.web_application_firewall.associations.Element.domains
         domains.Element = AAZObjectArg(
             nullable=True,
         )
 
-        _element = cls._args_security_policy_web_application_firewall_association_update.domains.Element
+        _element = cls._args_schema.web_application_firewall.associations.Element.domains.Element
         _element.id = AAZStrArg(
             options=["id"],
             help="Resource ID.",
             nullable=True,
         )
 
-        patterns_to_match = cls._args_security_policy_web_application_firewall_association_update.patterns_to_match
+        patterns_to_match = cls._args_schema.web_application_firewall.associations.Element.patterns_to_match
         patterns_to_match.Element = AAZStrArg(
             nullable=True,
         )
 
-        _schema.domains = cls._args_security_policy_web_application_firewall_association_update.domains
-        _schema.patterns_to_match = cls._args_security_policy_web_application_firewall_association_update.patterns_to_match
+        routes = cls._args_schema.web_application_firewall.associations.Element.routes
+        routes.Element = AAZObjectArg(
+            nullable=True,
+        )
+        cls._build_args_resource_reference_update(routes.Element)
+        return cls._args_schema
+
+    _args_resource_reference_update = None
+
+    @classmethod
+    def _build_args_resource_reference_update(cls, _schema):
+        if cls._args_resource_reference_update is not None:
+            _schema.id = cls._args_resource_reference_update.id
+            return
+
+        cls._args_resource_reference_update = AAZObjectArg(
+            nullable=True,
+        )
+
+        resource_reference_update = cls._args_resource_reference_update
+        resource_reference_update.id = AAZStrArg(
+            options=["id"],
+            help="Resource ID.",
+            nullable=True,
+        )
+
+        _schema.id = cls._args_resource_reference_update.id
 
     def _execute_operations(self):
         self.pre_operations()
@@ -640,7 +243,7 @@ class Update(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2025-09-01-preview",
+                    "api-version", "2026-04-01-preview",
                     required=True,
                 ),
             }
@@ -743,7 +346,7 @@ class Update(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2025-09-01-preview",
+                    "api-version", "2026-04-01-preview",
                     required=True,
                 ),
             }
@@ -810,173 +413,39 @@ class Update(AAZCommand):
             parameters = _builder.get(".properties.parameters")
             if parameters is not None:
                 parameters.set_const("type", "WebApplicationFirewall", AAZStrType, ".web_application_firewall", typ_kwargs={"flags": {"required": True}})
-                parameters.set_const("type", "WebApplicationFirewallEmbedded", AAZStrType, ".web_application_firewall_embedded", typ_kwargs={"flags": {"required": True}})
                 parameters.discriminate_by("type", "WebApplicationFirewall")
-                parameters.discriminate_by("type", "WebApplicationFirewallEmbedded")
 
             disc_web_application_firewall = _builder.get(".properties.parameters{type:WebApplicationFirewall}")
             if disc_web_application_firewall is not None:
                 disc_web_application_firewall.set_prop("associations", AAZListType, ".web_application_firewall.associations")
-                disc_web_application_firewall.set_prop("wafPolicy", AAZObjectType)
+                disc_web_application_firewall.set_prop("isProfileLevel", AAZBoolType, ".web_application_firewall.is_profile_level")
+                _UpdateHelper._build_schema_resource_reference_update(disc_web_application_firewall.set_prop("wafPolicy", AAZObjectType, ".web_application_firewall.waf_policy"))
 
             associations = _builder.get(".properties.parameters{type:WebApplicationFirewall}.associations")
             if associations is not None:
-                _UpdateHelper._build_schema_security_policy_web_application_firewall_association_update(associations.set_elements(AAZObjectType, "."))
+                associations.set_elements(AAZObjectType, ".")
 
-            waf_policy = _builder.get(".properties.parameters{type:WebApplicationFirewall}.wafPolicy")
-            if waf_policy is not None:
-                waf_policy.set_prop("id", AAZStrType, ".web_application_firewall.waf_policy")
-
-            disc_web_application_firewall_embedded = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}")
-            if disc_web_application_firewall_embedded is not None:
-                disc_web_application_firewall_embedded.set_prop("associations", AAZListType, ".web_application_firewall_embedded.associations")
-                disc_web_application_firewall_embedded.set_prop("wafPolicy", AAZObjectType, ".web_application_firewall_embedded.waf_policy")
-
-            associations = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.associations")
-            if associations is not None:
-                _UpdateHelper._build_schema_security_policy_web_application_firewall_association_update(associations.set_elements(AAZObjectType, "."))
-
-            waf_policy = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy")
-            if waf_policy is not None:
-                waf_policy.set_prop("etag", AAZStrType, ".etag")
-                waf_policy.set_prop("properties", AAZObjectType, typ_kwargs={"flags": {"client_flatten": True}})
-                waf_policy.set_prop("sku", AAZObjectType, ".sku")
-
-            properties = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties")
-            if properties is not None:
-                properties.set_prop("customRules", AAZObjectType, ".custom_rules")
-                properties.set_prop("managedRules", AAZObjectType, ".managed_rules")
-                properties.set_prop("policySettings", AAZObjectType, ".policy_settings")
-
-            custom_rules = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.customRules")
-            if custom_rules is not None:
-                custom_rules.set_prop("rules", AAZListType, ".rules")
-
-            rules = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.customRules.rules")
-            if rules is not None:
-                rules.set_elements(AAZObjectType, ".")
-
-            _elements = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.customRules.rules[]")
+            _elements = _builder.get(".properties.parameters{type:WebApplicationFirewall}.associations[]")
             if _elements is not None:
-                _elements.set_prop("action", AAZStrType, ".action", typ_kwargs={"flags": {"required": True}})
-                _elements.set_prop("enabledState", AAZStrType, ".enabled_state")
-                _elements.set_prop("groupBy", AAZListType, ".group_by")
-                _elements.set_prop("matchConditions", AAZListType, ".match_conditions", typ_kwargs={"flags": {"required": True}})
-                _elements.set_prop("name", AAZStrType, ".name")
-                _elements.set_prop("priority", AAZIntType, ".priority", typ_kwargs={"flags": {"required": True}})
-                _elements.set_prop("rateLimitDurationInMinutes", AAZIntType, ".rate_limit_duration_in_minutes")
-                _elements.set_prop("rateLimitThreshold", AAZIntType, ".rate_limit_threshold")
-                _elements.set_prop("ruleType", AAZStrType, ".rule_type", typ_kwargs={"flags": {"required": True}})
+                _elements.set_prop("domains", AAZListType, ".domains")
+                _elements.set_prop("patternsToMatch", AAZListType, ".patterns_to_match")
+                _elements.set_prop("routes", AAZListType, ".routes")
 
-            group_by = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.customRules.rules[].groupBy")
-            if group_by is not None:
-                group_by.set_elements(AAZObjectType, ".")
+            domains = _builder.get(".properties.parameters{type:WebApplicationFirewall}.associations[].domains")
+            if domains is not None:
+                domains.set_elements(AAZObjectType, ".")
 
-            _elements = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.customRules.rules[].groupBy[]")
+            _elements = _builder.get(".properties.parameters{type:WebApplicationFirewall}.associations[].domains[]")
             if _elements is not None:
-                _elements.set_prop("variableName", AAZStrType, ".variable_name", typ_kwargs={"flags": {"required": True}})
+                _elements.set_prop("id", AAZStrType, ".id")
 
-            match_conditions = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.customRules.rules[].matchConditions")
-            if match_conditions is not None:
-                match_conditions.set_elements(AAZObjectType, ".")
+            patterns_to_match = _builder.get(".properties.parameters{type:WebApplicationFirewall}.associations[].patternsToMatch")
+            if patterns_to_match is not None:
+                patterns_to_match.set_elements(AAZStrType, ".")
 
-            _elements = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.customRules.rules[].matchConditions[]")
-            if _elements is not None:
-                _elements.set_prop("matchValue", AAZListType, ".match_value", typ_kwargs={"flags": {"required": True}})
-                _elements.set_prop("matchVariable", AAZStrType, ".match_variable", typ_kwargs={"flags": {"required": True}})
-                _elements.set_prop("negateCondition", AAZBoolType, ".negate_condition")
-                _elements.set_prop("operator", AAZStrType, ".operator", typ_kwargs={"flags": {"required": True}})
-                _elements.set_prop("selector", AAZStrType, ".selector")
-                _elements.set_prop("transforms", AAZListType, ".transforms")
-
-            match_value = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.customRules.rules[].matchConditions[].matchValue")
-            if match_value is not None:
-                match_value.set_elements(AAZStrType, ".")
-
-            transforms = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.customRules.rules[].matchConditions[].transforms")
-            if transforms is not None:
-                transforms.set_elements(AAZStrType, ".")
-
-            managed_rules = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.managedRules")
-            if managed_rules is not None:
-                managed_rules.set_prop("managedRuleSets", AAZListType, ".managed_rule_sets")
-
-            managed_rule_sets = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.managedRules.managedRuleSets")
-            if managed_rule_sets is not None:
-                managed_rule_sets.set_elements(AAZObjectType, ".")
-
-            _elements = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.managedRules.managedRuleSets[]")
-            if _elements is not None:
-                _elements.set_prop("exclusions", AAZListType, ".exclusions")
-                _elements.set_prop("ruleGroupOverrides", AAZListType, ".rule_group_overrides")
-                _elements.set_prop("ruleSetAction", AAZStrType, ".rule_set_action")
-                _elements.set_prop("ruleSetType", AAZStrType, ".rule_set_type", typ_kwargs={"flags": {"required": True}})
-                _elements.set_prop("ruleSetVersion", AAZStrType, ".rule_set_version", typ_kwargs={"flags": {"required": True}})
-
-            exclusions = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.managedRules.managedRuleSets[].exclusions")
-            if exclusions is not None:
-                _UpdateHelper._build_schema_managed_rule_exclusion_update(exclusions.set_elements(AAZObjectType, "."))
-
-            rule_group_overrides = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.managedRules.managedRuleSets[].ruleGroupOverrides")
-            if rule_group_overrides is not None:
-                rule_group_overrides.set_elements(AAZObjectType, ".")
-
-            _elements = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.managedRules.managedRuleSets[].ruleGroupOverrides[]")
-            if _elements is not None:
-                _elements.set_prop("exclusions", AAZListType, ".exclusions")
-                _elements.set_prop("ruleGroupName", AAZStrType, ".rule_group_name", typ_kwargs={"flags": {"required": True}})
-                _elements.set_prop("rules", AAZListType, ".rules")
-
-            exclusions = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.managedRules.managedRuleSets[].ruleGroupOverrides[].exclusions")
-            if exclusions is not None:
-                _UpdateHelper._build_schema_managed_rule_exclusion_update(exclusions.set_elements(AAZObjectType, "."))
-
-            rules = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.managedRules.managedRuleSets[].ruleGroupOverrides[].rules")
-            if rules is not None:
-                rules.set_elements(AAZObjectType, ".")
-
-            _elements = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.managedRules.managedRuleSets[].ruleGroupOverrides[].rules[]")
-            if _elements is not None:
-                _elements.set_prop("action", AAZStrType, ".action")
-                _elements.set_prop("enabledState", AAZStrType, ".enabled_state")
-                _elements.set_prop("exclusions", AAZListType, ".exclusions")
-                _elements.set_prop("ruleId", AAZStrType, ".rule_id", typ_kwargs={"flags": {"required": True}})
-
-            exclusions = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.managedRules.managedRuleSets[].ruleGroupOverrides[].rules[].exclusions")
-            if exclusions is not None:
-                _UpdateHelper._build_schema_managed_rule_exclusion_update(exclusions.set_elements(AAZObjectType, "."))
-
-            policy_settings = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.policySettings")
-            if policy_settings is not None:
-                policy_settings.set_prop("captchaExpirationInMinutes", AAZIntType, ".captcha_expiration_in_minutes")
-                policy_settings.set_prop("customBlockResponseBody", AAZStrType, ".custom_block_response_body")
-                policy_settings.set_prop("customBlockResponseStatusCode", AAZIntType, ".custom_block_response_status_code")
-                policy_settings.set_prop("enabledState", AAZStrType, ".enabled_state")
-                policy_settings.set_prop("javascriptChallengeExpirationInMinutes", AAZIntType, ".javascript_challenge_expiration_in_minutes")
-                policy_settings.set_prop("logScrubbing", AAZObjectType, typ_kwargs={"flags": {"client_flatten": True}})
-                policy_settings.set_prop("mode", AAZStrType, ".mode")
-                policy_settings.set_prop("redirectUrl", AAZStrType, ".redirect_url")
-                policy_settings.set_prop("requestBodyCheck", AAZStrType, ".request_body_check")
-
-            log_scrubbing = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.policySettings.logScrubbing")
-            if log_scrubbing is not None:
-                log_scrubbing.set_prop("scrubbingRules", AAZListType, ".scrubbing_rules")
-                log_scrubbing.set_prop("state", AAZStrType, ".state")
-
-            scrubbing_rules = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.policySettings.logScrubbing.scrubbingRules")
-            if scrubbing_rules is not None:
-                scrubbing_rules.set_elements(AAZObjectType, ".")
-
-            _elements = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.properties.policySettings.logScrubbing.scrubbingRules[]")
-            if _elements is not None:
-                _elements.set_prop("matchVariable", AAZStrType, ".match_variable", typ_kwargs={"flags": {"required": True}})
-                _elements.set_prop("selector", AAZStrType, ".selector")
-                _elements.set_prop("selectorMatchOperator", AAZStrType, ".selector_match_operator", typ_kwargs={"flags": {"required": True}})
-                _elements.set_prop("state", AAZStrType, ".state")
-
-            sku = _builder.get(".properties.parameters{type:WebApplicationFirewallEmbedded}.wafPolicy.sku")
-            if sku is not None:
-                sku.set_prop("name", AAZStrType, ".name")
+            routes = _builder.get(".properties.parameters{type:WebApplicationFirewall}.associations[].routes")
+            if routes is not None:
+                _UpdateHelper._build_schema_resource_reference_update(routes.set_elements(AAZObjectType, "."))
 
             return _instance_value
 
@@ -993,93 +462,25 @@ class _UpdateHelper:
     """Helper class for Update"""
 
     @classmethod
-    def _build_schema_managed_rule_exclusion_update(cls, _builder):
+    def _build_schema_resource_reference_update(cls, _builder):
         if _builder is None:
             return
-        _builder.set_prop("matchVariable", AAZStrType, ".match_variable", typ_kwargs={"flags": {"required": True}})
-        _builder.set_prop("selector", AAZStrType, ".selector", typ_kwargs={"flags": {"required": True}})
-        _builder.set_prop("selectorMatchOperator", AAZStrType, ".selector_match_operator", typ_kwargs={"flags": {"required": True}})
+        _builder.set_prop("id", AAZStrType, ".id")
+
+    _schema_resource_reference_read = None
 
     @classmethod
-    def _build_schema_security_policy_web_application_firewall_association_update(cls, _builder):
-        if _builder is None:
-            return
-        _builder.set_prop("domains", AAZListType, ".domains")
-        _builder.set_prop("patternsToMatch", AAZListType, ".patterns_to_match")
-
-        domains = _builder.get(".domains")
-        if domains is not None:
-            domains.set_elements(AAZObjectType, ".")
-
-        _elements = _builder.get(".domains[]")
-        if _elements is not None:
-            _elements.set_prop("id", AAZStrType, ".id")
-
-        patterns_to_match = _builder.get(".patternsToMatch")
-        if patterns_to_match is not None:
-            patterns_to_match.set_elements(AAZStrType, ".")
-
-    _schema_managed_rule_exclusion_read = None
-
-    @classmethod
-    def _build_schema_managed_rule_exclusion_read(cls, _schema):
-        if cls._schema_managed_rule_exclusion_read is not None:
-            _schema.match_variable = cls._schema_managed_rule_exclusion_read.match_variable
-            _schema.selector = cls._schema_managed_rule_exclusion_read.selector
-            _schema.selector_match_operator = cls._schema_managed_rule_exclusion_read.selector_match_operator
+    def _build_schema_resource_reference_read(cls, _schema):
+        if cls._schema_resource_reference_read is not None:
+            _schema.id = cls._schema_resource_reference_read.id
             return
 
-        cls._schema_managed_rule_exclusion_read = _schema_managed_rule_exclusion_read = AAZObjectType()
+        cls._schema_resource_reference_read = _schema_resource_reference_read = AAZObjectType()
 
-        managed_rule_exclusion_read = _schema_managed_rule_exclusion_read
-        managed_rule_exclusion_read.match_variable = AAZStrType(
-            serialized_name="matchVariable",
-            flags={"required": True},
-        )
-        managed_rule_exclusion_read.selector = AAZStrType(
-            flags={"required": True},
-        )
-        managed_rule_exclusion_read.selector_match_operator = AAZStrType(
-            serialized_name="selectorMatchOperator",
-            flags={"required": True},
-        )
+        resource_reference_read = _schema_resource_reference_read
+        resource_reference_read.id = AAZStrType()
 
-        _schema.match_variable = cls._schema_managed_rule_exclusion_read.match_variable
-        _schema.selector = cls._schema_managed_rule_exclusion_read.selector
-        _schema.selector_match_operator = cls._schema_managed_rule_exclusion_read.selector_match_operator
-
-    _schema_security_policy_web_application_firewall_association_read = None
-
-    @classmethod
-    def _build_schema_security_policy_web_application_firewall_association_read(cls, _schema):
-        if cls._schema_security_policy_web_application_firewall_association_read is not None:
-            _schema.domains = cls._schema_security_policy_web_application_firewall_association_read.domains
-            _schema.patterns_to_match = cls._schema_security_policy_web_application_firewall_association_read.patterns_to_match
-            return
-
-        cls._schema_security_policy_web_application_firewall_association_read = _schema_security_policy_web_application_firewall_association_read = AAZObjectType()
-
-        security_policy_web_application_firewall_association_read = _schema_security_policy_web_application_firewall_association_read
-        security_policy_web_application_firewall_association_read.domains = AAZListType()
-        security_policy_web_application_firewall_association_read.patterns_to_match = AAZListType(
-            serialized_name="patternsToMatch",
-        )
-
-        domains = _schema_security_policy_web_application_firewall_association_read.domains
-        domains.Element = AAZObjectType()
-
-        _element = _schema_security_policy_web_application_firewall_association_read.domains.Element
-        _element.id = AAZStrType()
-        _element.is_active = AAZBoolType(
-            serialized_name="isActive",
-            flags={"read_only": True},
-        )
-
-        patterns_to_match = _schema_security_policy_web_application_firewall_association_read.patterns_to_match
-        patterns_to_match.Element = AAZStrType()
-
-        _schema.domains = cls._schema_security_policy_web_application_firewall_association_read.domains
-        _schema.patterns_to_match = cls._schema_security_policy_web_application_firewall_association_read.patterns_to_match
+        _schema.id = cls._schema_resource_reference_read.id
 
     _schema_security_policy_read = None
 
@@ -1109,7 +510,6 @@ class _UpdateHelper:
             serialized_name="systemData",
             flags={"read_only": True},
         )
-        cls._build_schema_system_data_read(security_policy_read.system_data)
         security_policy_read.type = AAZStrType(
             flags={"read_only": True},
         )
@@ -1136,337 +536,66 @@ class _UpdateHelper:
 
         disc_web_application_firewall = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewall")
         disc_web_application_firewall.associations = AAZListType()
+        disc_web_application_firewall.is_profile_level = AAZBoolType(
+            serialized_name="isProfileLevel",
+        )
         disc_web_application_firewall.waf_policy = AAZObjectType(
             serialized_name="wafPolicy",
         )
+        cls._build_schema_resource_reference_read(disc_web_application_firewall.waf_policy)
 
         associations = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewall").associations
         associations.Element = AAZObjectType()
-        cls._build_schema_security_policy_web_application_firewall_association_read(associations.Element)
 
-        waf_policy = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewall").waf_policy
-        waf_policy.id = AAZStrType()
+        _element = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewall").associations.Element
+        _element.domains = AAZListType()
+        _element.patterns_to_match = AAZListType(
+            serialized_name="patternsToMatch",
+        )
+        _element.routes = AAZListType()
 
-        disc_web_application_firewall_embedded = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded")
-        disc_web_application_firewall_embedded.associations = AAZListType()
-        disc_web_application_firewall_embedded.waf_policy = AAZObjectType(
-            serialized_name="wafPolicy",
-        )
+        domains = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewall").associations.Element.domains
+        domains.Element = AAZObjectType()
 
-        associations = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").associations
-        associations.Element = AAZObjectType()
-        cls._build_schema_security_policy_web_application_firewall_association_read(associations.Element)
-
-        waf_policy = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy
-        waf_policy.etag = AAZStrType()
-        waf_policy.id = AAZStrType(
-            flags={"read_only": True},
-        )
-        waf_policy.name = AAZStrType(
-            flags={"read_only": True},
-        )
-        waf_policy.properties = AAZObjectType(
-            flags={"client_flatten": True},
-        )
-        waf_policy.sku = AAZObjectType()
-        waf_policy.system_data = AAZObjectType(
-            serialized_name="systemData",
-            flags={"read_only": True},
-        )
-        cls._build_schema_system_data_read(waf_policy.system_data)
-        waf_policy.type = AAZStrType(
+        _element = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewall").associations.Element.domains.Element
+        _element.id = AAZStrType()
+        _element.is_active = AAZBoolType(
+            serialized_name="isActive",
             flags={"read_only": True},
         )
 
-        properties = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties
-        properties.custom_rules = AAZObjectType(
-            serialized_name="customRules",
-        )
-        properties.frontend_endpoint_links = AAZListType(
-            serialized_name="frontendEndpointLinks",
-            flags={"read_only": True},
-        )
-        properties.managed_rules = AAZObjectType(
-            serialized_name="managedRules",
-        )
-        properties.policy_settings = AAZObjectType(
-            serialized_name="policySettings",
-        )
-        properties.provisioning_state = AAZStrType(
-            serialized_name="provisioningState",
-            flags={"read_only": True},
-        )
-        properties.resource_state = AAZStrType(
-            serialized_name="resourceState",
-            flags={"read_only": True},
-        )
-        properties.routing_rule_links = AAZListType(
-            serialized_name="routingRuleLinks",
-            flags={"read_only": True},
-        )
-        properties.security_policy_links = AAZListType(
-            serialized_name="securityPolicyLinks",
-            flags={"read_only": True},
-        )
+        patterns_to_match = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewall").associations.Element.patterns_to_match
+        patterns_to_match.Element = AAZStrType()
 
-        custom_rules = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules
-        custom_rules.rules = AAZListType()
+        routes = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewall").associations.Element.routes
+        routes.Element = AAZObjectType()
+        cls._build_schema_resource_reference_read(routes.Element)
 
-        rules = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules.rules
-        rules.Element = AAZObjectType()
-
-        _element = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules.rules.Element
-        _element.action = AAZStrType(
-            flags={"required": True},
+        system_data = _schema_security_policy_read.system_data
+        system_data.created_at = AAZStrType(
+            serialized_name="createdAt",
         )
-        _element.enabled_state = AAZStrType(
-            serialized_name="enabledState",
+        system_data.created_by = AAZStrType(
+            serialized_name="createdBy",
         )
-        _element.group_by = AAZListType(
-            serialized_name="groupBy",
+        system_data.created_by_type = AAZStrType(
+            serialized_name="createdByType",
         )
-        _element.match_conditions = AAZListType(
-            serialized_name="matchConditions",
-            flags={"required": True},
+        system_data.last_modified_at = AAZStrType(
+            serialized_name="lastModifiedAt",
         )
-        _element.name = AAZStrType()
-        _element.priority = AAZIntType(
-            flags={"required": True},
+        system_data.last_modified_by = AAZStrType(
+            serialized_name="lastModifiedBy",
         )
-        _element.rate_limit_duration_in_minutes = AAZIntType(
-            serialized_name="rateLimitDurationInMinutes",
+        system_data.last_modified_by_type = AAZStrType(
+            serialized_name="lastModifiedByType",
         )
-        _element.rate_limit_threshold = AAZIntType(
-            serialized_name="rateLimitThreshold",
-        )
-        _element.rule_type = AAZStrType(
-            serialized_name="ruleType",
-            flags={"required": True},
-        )
-
-        group_by = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules.rules.Element.group_by
-        group_by.Element = AAZObjectType()
-
-        _element = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules.rules.Element.group_by.Element
-        _element.variable_name = AAZStrType(
-            serialized_name="variableName",
-            flags={"required": True},
-        )
-
-        match_conditions = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules.rules.Element.match_conditions
-        match_conditions.Element = AAZObjectType()
-
-        _element = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules.rules.Element.match_conditions.Element
-        _element.match_value = AAZListType(
-            serialized_name="matchValue",
-            flags={"required": True},
-        )
-        _element.match_variable = AAZStrType(
-            serialized_name="matchVariable",
-            flags={"required": True},
-        )
-        _element.negate_condition = AAZBoolType(
-            serialized_name="negateCondition",
-        )
-        _element.operator = AAZStrType(
-            flags={"required": True},
-        )
-        _element.selector = AAZStrType()
-        _element.transforms = AAZListType()
-
-        match_value = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules.rules.Element.match_conditions.Element.match_value
-        match_value.Element = AAZStrType()
-
-        transforms = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules.rules.Element.match_conditions.Element.transforms
-        transforms.Element = AAZStrType()
-
-        frontend_endpoint_links = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.frontend_endpoint_links
-        frontend_endpoint_links.Element = AAZObjectType()
-
-        _element = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.frontend_endpoint_links.Element
-        _element.id = AAZStrType(
-            flags={"read_only": True},
-        )
-
-        managed_rules = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules
-        managed_rules.managed_rule_sets = AAZListType(
-            serialized_name="managedRuleSets",
-        )
-
-        managed_rule_sets = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets
-        managed_rule_sets.Element = AAZObjectType()
-
-        _element = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets.Element
-        _element.exclusions = AAZListType()
-        _element.rule_group_overrides = AAZListType(
-            serialized_name="ruleGroupOverrides",
-        )
-        _element.rule_set_action = AAZStrType(
-            serialized_name="ruleSetAction",
-        )
-        _element.rule_set_type = AAZStrType(
-            serialized_name="ruleSetType",
-            flags={"required": True},
-        )
-        _element.rule_set_version = AAZStrType(
-            serialized_name="ruleSetVersion",
-            flags={"required": True},
-        )
-
-        exclusions = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets.Element.exclusions
-        exclusions.Element = AAZObjectType()
-        cls._build_schema_managed_rule_exclusion_read(exclusions.Element)
-
-        rule_group_overrides = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets.Element.rule_group_overrides
-        rule_group_overrides.Element = AAZObjectType()
-
-        _element = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets.Element.rule_group_overrides.Element
-        _element.exclusions = AAZListType()
-        _element.rule_group_name = AAZStrType(
-            serialized_name="ruleGroupName",
-            flags={"required": True},
-        )
-        _element.rules = AAZListType()
-
-        exclusions = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets.Element.rule_group_overrides.Element.exclusions
-        exclusions.Element = AAZObjectType()
-        cls._build_schema_managed_rule_exclusion_read(exclusions.Element)
-
-        rules = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets.Element.rule_group_overrides.Element.rules
-        rules.Element = AAZObjectType()
-
-        _element = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets.Element.rule_group_overrides.Element.rules.Element
-        _element.action = AAZStrType()
-        _element.enabled_state = AAZStrType(
-            serialized_name="enabledState",
-        )
-        _element.exclusions = AAZListType()
-        _element.rule_id = AAZStrType(
-            serialized_name="ruleId",
-            flags={"required": True},
-        )
-
-        exclusions = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets.Element.rule_group_overrides.Element.rules.Element.exclusions
-        exclusions.Element = AAZObjectType()
-        cls._build_schema_managed_rule_exclusion_read(exclusions.Element)
-
-        policy_settings = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.policy_settings
-        policy_settings.captcha_expiration_in_minutes = AAZIntType(
-            serialized_name="captchaExpirationInMinutes",
-        )
-        policy_settings.custom_block_response_body = AAZStrType(
-            serialized_name="customBlockResponseBody",
-        )
-        policy_settings.custom_block_response_status_code = AAZIntType(
-            serialized_name="customBlockResponseStatusCode",
-        )
-        policy_settings.enabled_state = AAZStrType(
-            serialized_name="enabledState",
-        )
-        policy_settings.javascript_challenge_expiration_in_minutes = AAZIntType(
-            serialized_name="javascriptChallengeExpirationInMinutes",
-        )
-        policy_settings.log_scrubbing = AAZObjectType(
-            serialized_name="logScrubbing",
-            flags={"client_flatten": True},
-        )
-        policy_settings.mode = AAZStrType()
-        policy_settings.redirect_url = AAZStrType(
-            serialized_name="redirectUrl",
-        )
-        policy_settings.request_body_check = AAZStrType(
-            serialized_name="requestBodyCheck",
-        )
-
-        log_scrubbing = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.policy_settings.log_scrubbing
-        log_scrubbing.scrubbing_rules = AAZListType(
-            serialized_name="scrubbingRules",
-        )
-        log_scrubbing.state = AAZStrType()
-
-        scrubbing_rules = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.policy_settings.log_scrubbing.scrubbing_rules
-        scrubbing_rules.Element = AAZObjectType()
-
-        _element = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.policy_settings.log_scrubbing.scrubbing_rules.Element
-        _element.match_variable = AAZStrType(
-            serialized_name="matchVariable",
-            flags={"required": True},
-        )
-        _element.selector = AAZStrType()
-        _element.selector_match_operator = AAZStrType(
-            serialized_name="selectorMatchOperator",
-            flags={"required": True},
-        )
-        _element.state = AAZStrType()
-
-        routing_rule_links = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.routing_rule_links
-        routing_rule_links.Element = AAZObjectType()
-
-        _element = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.routing_rule_links.Element
-        _element.id = AAZStrType(
-            flags={"read_only": True},
-        )
-
-        security_policy_links = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.security_policy_links
-        security_policy_links.Element = AAZObjectType()
-
-        _element = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.security_policy_links.Element
-        _element.id = AAZStrType(
-            flags={"read_only": True},
-        )
-
-        sku = _schema_security_policy_read.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.sku
-        sku.name = AAZStrType()
 
         _schema.id = cls._schema_security_policy_read.id
         _schema.name = cls._schema_security_policy_read.name
         _schema.properties = cls._schema_security_policy_read.properties
         _schema.system_data = cls._schema_security_policy_read.system_data
         _schema.type = cls._schema_security_policy_read.type
-
-    _schema_system_data_read = None
-
-    @classmethod
-    def _build_schema_system_data_read(cls, _schema):
-        if cls._schema_system_data_read is not None:
-            _schema.created_at = cls._schema_system_data_read.created_at
-            _schema.created_by = cls._schema_system_data_read.created_by
-            _schema.created_by_type = cls._schema_system_data_read.created_by_type
-            _schema.last_modified_at = cls._schema_system_data_read.last_modified_at
-            _schema.last_modified_by = cls._schema_system_data_read.last_modified_by
-            _schema.last_modified_by_type = cls._schema_system_data_read.last_modified_by_type
-            return
-
-        cls._schema_system_data_read = _schema_system_data_read = AAZObjectType(
-            flags={"read_only": True}
-        )
-
-        system_data_read = _schema_system_data_read
-        system_data_read.created_at = AAZStrType(
-            serialized_name="createdAt",
-        )
-        system_data_read.created_by = AAZStrType(
-            serialized_name="createdBy",
-        )
-        system_data_read.created_by_type = AAZStrType(
-            serialized_name="createdByType",
-        )
-        system_data_read.last_modified_at = AAZStrType(
-            serialized_name="lastModifiedAt",
-        )
-        system_data_read.last_modified_by = AAZStrType(
-            serialized_name="lastModifiedBy",
-        )
-        system_data_read.last_modified_by_type = AAZStrType(
-            serialized_name="lastModifiedByType",
-        )
-
-        _schema.created_at = cls._schema_system_data_read.created_at
-        _schema.created_by = cls._schema_system_data_read.created_by
-        _schema.created_by_type = cls._schema_system_data_read.created_by_type
-        _schema.last_modified_at = cls._schema_system_data_read.last_modified_at
-        _schema.last_modified_by = cls._schema_system_data_read.last_modified_by
-        _schema.last_modified_by_type = cls._schema_system_data_read.last_modified_by_type
 
 
 __all__ = ["Update"]

--- a/src/cdn/azext_cdn/aaz/latest/afd/security_policy/_wait.py
+++ b/src/cdn/azext_cdn/aaz/latest/afd/security_policy/_wait.py
@@ -20,7 +20,7 @@ class Wait(AAZWaitCommand):
 
     _aaz_info = {
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.cdn/profiles/{}/securitypolicies/{}", "2025-09-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.cdn/profiles/{}/securitypolicies/{}", "2026-04-01-preview"],
         ]
     }
 
@@ -131,7 +131,7 @@ class Wait(AAZWaitCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2025-09-01-preview",
+                    "api-version", "2026-04-01-preview",
                     required=True,
                 ),
             }
@@ -177,7 +177,6 @@ class Wait(AAZWaitCommand):
                 serialized_name="systemData",
                 flags={"read_only": True},
             )
-            _WaitHelper._build_schema_system_data_read(_schema_on_200.system_data)
             _schema_on_200.type = AAZStrType(
                 flags={"read_only": True},
             )
@@ -204,287 +203,60 @@ class Wait(AAZWaitCommand):
 
             disc_web_application_firewall = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewall")
             disc_web_application_firewall.associations = AAZListType()
+            disc_web_application_firewall.is_profile_level = AAZBoolType(
+                serialized_name="isProfileLevel",
+            )
             disc_web_application_firewall.waf_policy = AAZObjectType(
                 serialized_name="wafPolicy",
             )
+            _WaitHelper._build_schema_resource_reference_read(disc_web_application_firewall.waf_policy)
 
             associations = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewall").associations
             associations.Element = AAZObjectType()
-            _WaitHelper._build_schema_security_policy_web_application_firewall_association_read(associations.Element)
 
-            waf_policy = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewall").waf_policy
-            waf_policy.id = AAZStrType()
+            _element = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewall").associations.Element
+            _element.domains = AAZListType()
+            _element.patterns_to_match = AAZListType(
+                serialized_name="patternsToMatch",
+            )
+            _element.routes = AAZListType()
 
-            disc_web_application_firewall_embedded = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded")
-            disc_web_application_firewall_embedded.associations = AAZListType()
-            disc_web_application_firewall_embedded.waf_policy = AAZObjectType(
-                serialized_name="wafPolicy",
-            )
+            domains = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewall").associations.Element.domains
+            domains.Element = AAZObjectType()
 
-            associations = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").associations
-            associations.Element = AAZObjectType()
-            _WaitHelper._build_schema_security_policy_web_application_firewall_association_read(associations.Element)
-
-            waf_policy = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy
-            waf_policy.etag = AAZStrType()
-            waf_policy.id = AAZStrType(
-                flags={"read_only": True},
-            )
-            waf_policy.name = AAZStrType(
-                flags={"read_only": True},
-            )
-            waf_policy.properties = AAZObjectType(
-                flags={"client_flatten": True},
-            )
-            waf_policy.sku = AAZObjectType()
-            waf_policy.system_data = AAZObjectType(
-                serialized_name="systemData",
-                flags={"read_only": True},
-            )
-            _WaitHelper._build_schema_system_data_read(waf_policy.system_data)
-            waf_policy.type = AAZStrType(
+            _element = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewall").associations.Element.domains.Element
+            _element.id = AAZStrType()
+            _element.is_active = AAZBoolType(
+                serialized_name="isActive",
                 flags={"read_only": True},
             )
 
-            properties = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties
-            properties.custom_rules = AAZObjectType(
-                serialized_name="customRules",
-            )
-            properties.frontend_endpoint_links = AAZListType(
-                serialized_name="frontendEndpointLinks",
-                flags={"read_only": True},
-            )
-            properties.managed_rules = AAZObjectType(
-                serialized_name="managedRules",
-            )
-            properties.policy_settings = AAZObjectType(
-                serialized_name="policySettings",
-            )
-            properties.provisioning_state = AAZStrType(
-                serialized_name="provisioningState",
-                flags={"read_only": True},
-            )
-            properties.resource_state = AAZStrType(
-                serialized_name="resourceState",
-                flags={"read_only": True},
-            )
-            properties.routing_rule_links = AAZListType(
-                serialized_name="routingRuleLinks",
-                flags={"read_only": True},
-            )
-            properties.security_policy_links = AAZListType(
-                serialized_name="securityPolicyLinks",
-                flags={"read_only": True},
-            )
+            patterns_to_match = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewall").associations.Element.patterns_to_match
+            patterns_to_match.Element = AAZStrType()
 
-            custom_rules = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules
-            custom_rules.rules = AAZListType()
+            routes = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewall").associations.Element.routes
+            routes.Element = AAZObjectType()
+            _WaitHelper._build_schema_resource_reference_read(routes.Element)
 
-            rules = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules.rules
-            rules.Element = AAZObjectType()
-
-            _element = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules.rules.Element
-            _element.action = AAZStrType(
-                flags={"required": True},
+            system_data = cls._schema_on_200.system_data
+            system_data.created_at = AAZStrType(
+                serialized_name="createdAt",
             )
-            _element.enabled_state = AAZStrType(
-                serialized_name="enabledState",
+            system_data.created_by = AAZStrType(
+                serialized_name="createdBy",
             )
-            _element.group_by = AAZListType(
-                serialized_name="groupBy",
+            system_data.created_by_type = AAZStrType(
+                serialized_name="createdByType",
             )
-            _element.match_conditions = AAZListType(
-                serialized_name="matchConditions",
-                flags={"required": True},
+            system_data.last_modified_at = AAZStrType(
+                serialized_name="lastModifiedAt",
             )
-            _element.name = AAZStrType()
-            _element.priority = AAZIntType(
-                flags={"required": True},
+            system_data.last_modified_by = AAZStrType(
+                serialized_name="lastModifiedBy",
             )
-            _element.rate_limit_duration_in_minutes = AAZIntType(
-                serialized_name="rateLimitDurationInMinutes",
+            system_data.last_modified_by_type = AAZStrType(
+                serialized_name="lastModifiedByType",
             )
-            _element.rate_limit_threshold = AAZIntType(
-                serialized_name="rateLimitThreshold",
-            )
-            _element.rule_type = AAZStrType(
-                serialized_name="ruleType",
-                flags={"required": True},
-            )
-
-            group_by = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules.rules.Element.group_by
-            group_by.Element = AAZObjectType()
-
-            _element = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules.rules.Element.group_by.Element
-            _element.variable_name = AAZStrType(
-                serialized_name="variableName",
-                flags={"required": True},
-            )
-
-            match_conditions = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules.rules.Element.match_conditions
-            match_conditions.Element = AAZObjectType()
-
-            _element = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules.rules.Element.match_conditions.Element
-            _element.match_value = AAZListType(
-                serialized_name="matchValue",
-                flags={"required": True},
-            )
-            _element.match_variable = AAZStrType(
-                serialized_name="matchVariable",
-                flags={"required": True},
-            )
-            _element.negate_condition = AAZBoolType(
-                serialized_name="negateCondition",
-            )
-            _element.operator = AAZStrType(
-                flags={"required": True},
-            )
-            _element.selector = AAZStrType()
-            _element.transforms = AAZListType()
-
-            match_value = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules.rules.Element.match_conditions.Element.match_value
-            match_value.Element = AAZStrType()
-
-            transforms = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.custom_rules.rules.Element.match_conditions.Element.transforms
-            transforms.Element = AAZStrType()
-
-            frontend_endpoint_links = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.frontend_endpoint_links
-            frontend_endpoint_links.Element = AAZObjectType()
-
-            _element = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.frontend_endpoint_links.Element
-            _element.id = AAZStrType(
-                flags={"read_only": True},
-            )
-
-            managed_rules = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules
-            managed_rules.managed_rule_sets = AAZListType(
-                serialized_name="managedRuleSets",
-            )
-
-            managed_rule_sets = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets
-            managed_rule_sets.Element = AAZObjectType()
-
-            _element = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets.Element
-            _element.exclusions = AAZListType()
-            _element.rule_group_overrides = AAZListType(
-                serialized_name="ruleGroupOverrides",
-            )
-            _element.rule_set_action = AAZStrType(
-                serialized_name="ruleSetAction",
-            )
-            _element.rule_set_type = AAZStrType(
-                serialized_name="ruleSetType",
-                flags={"required": True},
-            )
-            _element.rule_set_version = AAZStrType(
-                serialized_name="ruleSetVersion",
-                flags={"required": True},
-            )
-
-            exclusions = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets.Element.exclusions
-            exclusions.Element = AAZObjectType()
-            _WaitHelper._build_schema_managed_rule_exclusion_read(exclusions.Element)
-
-            rule_group_overrides = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets.Element.rule_group_overrides
-            rule_group_overrides.Element = AAZObjectType()
-
-            _element = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets.Element.rule_group_overrides.Element
-            _element.exclusions = AAZListType()
-            _element.rule_group_name = AAZStrType(
-                serialized_name="ruleGroupName",
-                flags={"required": True},
-            )
-            _element.rules = AAZListType()
-
-            exclusions = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets.Element.rule_group_overrides.Element.exclusions
-            exclusions.Element = AAZObjectType()
-            _WaitHelper._build_schema_managed_rule_exclusion_read(exclusions.Element)
-
-            rules = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets.Element.rule_group_overrides.Element.rules
-            rules.Element = AAZObjectType()
-
-            _element = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets.Element.rule_group_overrides.Element.rules.Element
-            _element.action = AAZStrType()
-            _element.enabled_state = AAZStrType(
-                serialized_name="enabledState",
-            )
-            _element.exclusions = AAZListType()
-            _element.rule_id = AAZStrType(
-                serialized_name="ruleId",
-                flags={"required": True},
-            )
-
-            exclusions = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.managed_rules.managed_rule_sets.Element.rule_group_overrides.Element.rules.Element.exclusions
-            exclusions.Element = AAZObjectType()
-            _WaitHelper._build_schema_managed_rule_exclusion_read(exclusions.Element)
-
-            policy_settings = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.policy_settings
-            policy_settings.captcha_expiration_in_minutes = AAZIntType(
-                serialized_name="captchaExpirationInMinutes",
-            )
-            policy_settings.custom_block_response_body = AAZStrType(
-                serialized_name="customBlockResponseBody",
-            )
-            policy_settings.custom_block_response_status_code = AAZIntType(
-                serialized_name="customBlockResponseStatusCode",
-            )
-            policy_settings.enabled_state = AAZStrType(
-                serialized_name="enabledState",
-            )
-            policy_settings.javascript_challenge_expiration_in_minutes = AAZIntType(
-                serialized_name="javascriptChallengeExpirationInMinutes",
-            )
-            policy_settings.log_scrubbing = AAZObjectType(
-                serialized_name="logScrubbing",
-                flags={"client_flatten": True},
-            )
-            policy_settings.mode = AAZStrType()
-            policy_settings.redirect_url = AAZStrType(
-                serialized_name="redirectUrl",
-            )
-            policy_settings.request_body_check = AAZStrType(
-                serialized_name="requestBodyCheck",
-            )
-
-            log_scrubbing = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.policy_settings.log_scrubbing
-            log_scrubbing.scrubbing_rules = AAZListType(
-                serialized_name="scrubbingRules",
-            )
-            log_scrubbing.state = AAZStrType()
-
-            scrubbing_rules = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.policy_settings.log_scrubbing.scrubbing_rules
-            scrubbing_rules.Element = AAZObjectType()
-
-            _element = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.policy_settings.log_scrubbing.scrubbing_rules.Element
-            _element.match_variable = AAZStrType(
-                serialized_name="matchVariable",
-                flags={"required": True},
-            )
-            _element.selector = AAZStrType()
-            _element.selector_match_operator = AAZStrType(
-                serialized_name="selectorMatchOperator",
-                flags={"required": True},
-            )
-            _element.state = AAZStrType()
-
-            routing_rule_links = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.routing_rule_links
-            routing_rule_links.Element = AAZObjectType()
-
-            _element = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.routing_rule_links.Element
-            _element.id = AAZStrType(
-                flags={"read_only": True},
-            )
-
-            security_policy_links = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.security_policy_links
-            security_policy_links.Element = AAZObjectType()
-
-            _element = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.properties.security_policy_links.Element
-            _element.id = AAZStrType(
-                flags={"read_only": True},
-            )
-
-            sku = cls._schema_on_200.properties.parameters.discriminate_by("type", "WebApplicationFirewallEmbedded").waf_policy.sku
-            sku.name = AAZStrType()
 
             return cls._schema_on_200
 
@@ -492,111 +264,20 @@ class Wait(AAZWaitCommand):
 class _WaitHelper:
     """Helper class for Wait"""
 
-    _schema_managed_rule_exclusion_read = None
+    _schema_resource_reference_read = None
 
     @classmethod
-    def _build_schema_managed_rule_exclusion_read(cls, _schema):
-        if cls._schema_managed_rule_exclusion_read is not None:
-            _schema.match_variable = cls._schema_managed_rule_exclusion_read.match_variable
-            _schema.selector = cls._schema_managed_rule_exclusion_read.selector
-            _schema.selector_match_operator = cls._schema_managed_rule_exclusion_read.selector_match_operator
+    def _build_schema_resource_reference_read(cls, _schema):
+        if cls._schema_resource_reference_read is not None:
+            _schema.id = cls._schema_resource_reference_read.id
             return
 
-        cls._schema_managed_rule_exclusion_read = _schema_managed_rule_exclusion_read = AAZObjectType()
+        cls._schema_resource_reference_read = _schema_resource_reference_read = AAZObjectType()
 
-        managed_rule_exclusion_read = _schema_managed_rule_exclusion_read
-        managed_rule_exclusion_read.match_variable = AAZStrType(
-            serialized_name="matchVariable",
-            flags={"required": True},
-        )
-        managed_rule_exclusion_read.selector = AAZStrType(
-            flags={"required": True},
-        )
-        managed_rule_exclusion_read.selector_match_operator = AAZStrType(
-            serialized_name="selectorMatchOperator",
-            flags={"required": True},
-        )
+        resource_reference_read = _schema_resource_reference_read
+        resource_reference_read.id = AAZStrType()
 
-        _schema.match_variable = cls._schema_managed_rule_exclusion_read.match_variable
-        _schema.selector = cls._schema_managed_rule_exclusion_read.selector
-        _schema.selector_match_operator = cls._schema_managed_rule_exclusion_read.selector_match_operator
-
-    _schema_security_policy_web_application_firewall_association_read = None
-
-    @classmethod
-    def _build_schema_security_policy_web_application_firewall_association_read(cls, _schema):
-        if cls._schema_security_policy_web_application_firewall_association_read is not None:
-            _schema.domains = cls._schema_security_policy_web_application_firewall_association_read.domains
-            _schema.patterns_to_match = cls._schema_security_policy_web_application_firewall_association_read.patterns_to_match
-            return
-
-        cls._schema_security_policy_web_application_firewall_association_read = _schema_security_policy_web_application_firewall_association_read = AAZObjectType()
-
-        security_policy_web_application_firewall_association_read = _schema_security_policy_web_application_firewall_association_read
-        security_policy_web_application_firewall_association_read.domains = AAZListType()
-        security_policy_web_application_firewall_association_read.patterns_to_match = AAZListType(
-            serialized_name="patternsToMatch",
-        )
-
-        domains = _schema_security_policy_web_application_firewall_association_read.domains
-        domains.Element = AAZObjectType()
-
-        _element = _schema_security_policy_web_application_firewall_association_read.domains.Element
-        _element.id = AAZStrType()
-        _element.is_active = AAZBoolType(
-            serialized_name="isActive",
-            flags={"read_only": True},
-        )
-
-        patterns_to_match = _schema_security_policy_web_application_firewall_association_read.patterns_to_match
-        patterns_to_match.Element = AAZStrType()
-
-        _schema.domains = cls._schema_security_policy_web_application_firewall_association_read.domains
-        _schema.patterns_to_match = cls._schema_security_policy_web_application_firewall_association_read.patterns_to_match
-
-    _schema_system_data_read = None
-
-    @classmethod
-    def _build_schema_system_data_read(cls, _schema):
-        if cls._schema_system_data_read is not None:
-            _schema.created_at = cls._schema_system_data_read.created_at
-            _schema.created_by = cls._schema_system_data_read.created_by
-            _schema.created_by_type = cls._schema_system_data_read.created_by_type
-            _schema.last_modified_at = cls._schema_system_data_read.last_modified_at
-            _schema.last_modified_by = cls._schema_system_data_read.last_modified_by
-            _schema.last_modified_by_type = cls._schema_system_data_read.last_modified_by_type
-            return
-
-        cls._schema_system_data_read = _schema_system_data_read = AAZObjectType(
-            flags={"read_only": True}
-        )
-
-        system_data_read = _schema_system_data_read
-        system_data_read.created_at = AAZStrType(
-            serialized_name="createdAt",
-        )
-        system_data_read.created_by = AAZStrType(
-            serialized_name="createdBy",
-        )
-        system_data_read.created_by_type = AAZStrType(
-            serialized_name="createdByType",
-        )
-        system_data_read.last_modified_at = AAZStrType(
-            serialized_name="lastModifiedAt",
-        )
-        system_data_read.last_modified_by = AAZStrType(
-            serialized_name="lastModifiedBy",
-        )
-        system_data_read.last_modified_by_type = AAZStrType(
-            serialized_name="lastModifiedByType",
-        )
-
-        _schema.created_at = cls._schema_system_data_read.created_at
-        _schema.created_by = cls._schema_system_data_read.created_by
-        _schema.created_by_type = cls._schema_system_data_read.created_by_type
-        _schema.last_modified_at = cls._schema_system_data_read.last_modified_at
-        _schema.last_modified_by = cls._schema_system_data_read.last_modified_by
-        _schema.last_modified_by_type = cls._schema_system_data_read.last_modified_by_type
+        _schema.id = cls._schema_resource_reference_read.id
 
 
 __all__ = ["Wait"]

--- a/src/cdn/azext_cdn/custom/custom_afdx.py
+++ b/src/cdn/azext_cdn/custom/custom_afdx.py
@@ -55,11 +55,23 @@ def _add_arg_option(arg, option):
         arg._options = [option, *arg._options]
 
 
+def _add_arg_option_if_exists(args_schema, arg_name, option):
+    arg = getattr(args_schema, '_fields', {}).get(arg_name)
+    if arg is not None:
+        _add_arg_option(arg, option)
+
+
 def _get_serialized_value(data, *keys):
     for key in keys:
         if key in data:
             return data[key]
     return None
+
+
+def _get_resource_reference_id(data):
+    if isinstance(data, dict):
+        return _get_serialized_value(data, "id")
+    return data
 
 
 def _update_action_argument_schema(args_schema):
@@ -359,7 +371,7 @@ class AFDSecurityPolicyCreate(_AFDSecurityPolicyCreate):
     @classmethod
     def _build_arguments_schema(cls, *args, **kwargs):
         args_schema = super()._build_arguments_schema(*args, **kwargs)
-        _add_arg_option(args_schema.web_application_firewall_embedded, "--waf-embedded")
+        _add_arg_option_if_exists(args_schema, 'web_application_firewall_embedded', "--waf-embedded")
         return args_schema
 
 
@@ -367,7 +379,7 @@ class AFDSecurityPolicyUpdate(_AFDSecurityPolicyUpdate):
     @classmethod
     def _build_arguments_schema(cls, *args, **kwargs):
         args_schema = super()._build_arguments_schema(*args, **kwargs)
-        _add_arg_option(args_schema.web_application_firewall_embedded, "--waf-embedded")
+        _add_arg_option_if_exists(args_schema, 'web_application_firewall_embedded', "--waf-embedded")
         return args_schema
 
     def post_instance_update(self, instance):
@@ -381,7 +393,7 @@ class AFDSecurityPolicyUpdate(_AFDSecurityPolicyUpdate):
                     parameters.associations = web_application_firewall.get("associations")
                 waf_policy = _get_serialized_value(web_application_firewall, "waf_policy", "waf-policy")
                 if waf_policy is not None:
-                    parameters.waf_policy.id = waf_policy
+                    parameters.waf_policy.id = _get_resource_reference_id(waf_policy)
 
     def _output(self, *args, **kwargs):
         result = super()._output(*args, **kwargs)
@@ -395,13 +407,18 @@ class AFDSecurityPolicyUpdate(_AFDSecurityPolicyUpdate):
                         {
                             "domains": association.get("domains"),
                             "patternsToMatch": _get_serialized_value(
-                                association, "patterns_to_match", "patterns-to-match", "patternsToMatch")
+                                association, "patterns_to_match", "patterns-to-match", "patternsToMatch"),
+                            "routes": association.get("routes")
                         }
                         for association in web_application_firewall.get("associations") or []
                     ]
+                if "is_profile_level" in web_application_firewall:
+                    parameters["isProfileLevel"] = web_application_firewall.get("is_profile_level")
+                if "is-profile-level" in web_application_firewall:
+                    parameters["isProfileLevel"] = web_application_firewall.get("is-profile-level")
                 waf_policy = _get_serialized_value(web_application_firewall, "waf_policy", "waf-policy")
                 if waf_policy is not None:
-                    parameters["wafPolicy"] = {"id": waf_policy}
+                    parameters["wafPolicy"] = {"id": _get_resource_reference_id(waf_policy)}
         return result
 
 

--- a/src/cdn/azext_cdn/tests/latest/afdx_scenario_mixin.py
+++ b/src/cdn/azext_cdn/tests/latest/afdx_scenario_mixin.py
@@ -375,14 +375,19 @@ class CdnAfdScenarioMixin:
         return self.cmd(command, checks)
 
     def afd_security_policy_create_cmd(self, resource_group_name, profile_name, security_policy_name, domains,
-                                       waf_policy, checks=None):
-        web_application_firewall = {
-            'waf-policy': waf_policy,
-            'associations': [{
-                'domains': [{'id': domain} for domain in domains],
-                'patterns-to-match': ['/*']
-            }]
+                                       waf_policy, checks=None, is_profile_level=None, routes=None):
+        association = {
+            'domains': [{'id': domain} for domain in domains],
+            'patterns-to-match': ['/*']
         }
+        if routes is not None:
+            association['routes'] = [{'id': route} for route in routes]
+        web_application_firewall = {
+            'waf-policy': {'id': waf_policy},
+            'associations': [association]
+        }
+        if is_profile_level is not None:
+            web_application_firewall['is-profile-level'] = is_profile_level
         cmd = f'afd security-policy create -g {resource_group_name} --profile-name {profile_name} ' \
               f'--security-policy-name {security_policy_name} ' \
               f'--web-application-firewall {_json_arg(web_application_firewall)}'
@@ -390,17 +395,23 @@ class CdnAfdScenarioMixin:
         return self.cmd(cmd, checks)
 
     def afd_security_policy_update_cmd(self, resource_group_name, profile_name, security_policy_name, domains=None,
-                                       waf_policy=None, checks=None):
+                                       waf_policy=None, checks=None, is_profile_level=None, routes=None):
         cmd = f'afd security-policy update -g {resource_group_name} --profile-name {profile_name} ' \
               f'--security-policy-name {security_policy_name}'
         web_application_firewall = {}
-        if domains:
-            web_application_firewall['associations'] = [{
-                'domains': [{'id': domain} for domain in domains],
+        if domains is not None or routes is not None:
+            association = {
                 'patterns-to-match': ['/*']
-            }]
+            }
+            if domains is not None:
+                association['domains'] = [{'id': domain} for domain in domains]
+            if routes is not None:
+                association['routes'] = [{'id': route} for route in routes]
+            web_application_firewall['associations'] = [association]
         if waf_policy:
-            web_application_firewall['waf-policy'] = waf_policy
+            web_application_firewall['waf-policy'] = {'id': waf_policy}
+        if is_profile_level is not None:
+            web_application_firewall['is-profile-level'] = is_profile_level
         if web_application_firewall:
             cmd += f' --web-application-firewall {_json_arg(web_application_firewall)}'
 

--- a/src/cdn/azext_cdn/tests/latest/recordings/test_afd_security_policy_crud.yaml
+++ b/src/cdn/azext_cdn/tests/latest/recordings/test_afd_security_policy_crud.yaml
@@ -13,9 +13,9 @@ interactions:
       ParameterSetName:
       - -g --profile-name
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.13.13 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/securityPolicies?api-version=2025-09-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/securityPolicies?api-version=2026-04-01-preview
   response:
     body:
       string: '{"error":{"code":"ParentResourceNotFound","message":"Failed to perform
@@ -30,7 +30,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 20 Apr 2026 08:50:09 GMT
+      - Thu, 18 Jun 2026 05:56:48 GMT
       expires:
       - '-1'
       pragma:
@@ -44,7 +44,7 @@ interactions:
       x-ms-failure-cause:
       - gateway
       x-msedge-ref:
-      - 'Ref A: A25A1068C1ED4B1880C68C5B7721A98D Ref B: SYD03EDGE1119 Ref C: 2026-04-20T08:50:08Z'
+      - 'Ref A: BB8999DD5D1C4ED29E0FB896C17B4293 Ref B: SYD03EDGE1717 Ref C: 2026-06-18T05:56:48Z'
     status:
       code: 404
       message: Not Found
@@ -62,7 +62,7 @@ interactions:
       ParameterSetName:
       - -g --profile-name --sku
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.13.13 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2024-11-01
   response:
@@ -76,7 +76,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 20 Apr 2026 08:50:10 GMT
+      - Thu, 18 Jun 2026 05:56:48 GMT
       expires:
       - '-1'
       pragma:
@@ -90,7 +90,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 1742FDB47D834A69965ADDF4D5DE7753 Ref B: SYD03EDGE1005 Ref C: 2026-04-20T08:50:10Z'
+      - 'Ref A: 78F42E23447F4417A2D3E4E32D16A50B Ref B: SYD03EDGE1311 Ref C: 2026-06-18T05:56:49Z'
     status:
       code: 200
       message: OK
@@ -112,23 +112,23 @@ interactions:
       ParameterSetName:
       - -g --profile-name --sku
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.13.13 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest?api-version=2025-09-01-preview
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest","type":"Microsoft.Cdn/profiles","name":"profilesecuritytest","location":"Global","kind":"frontdoor","tags":{},"sku":{"name":"Standard_AzureFrontDoor"},"properties":{"originResponseTimeoutSeconds":30,"logScrubbing":null,"frontDoorId":"6739e0a2-1011-43f5-aaa5-dcd82e6cb669","extendedProperties":{},"resourceState":"Creating","provisioningState":"Creating"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest","type":"Microsoft.Cdn/profiles","name":"profilesecuritytest","location":"Global","kind":"frontdoor","tags":{},"sku":{"name":"Standard_AzureFrontDoor"},"properties":{"originResponseTimeoutSeconds":30,"logScrubbing":null,"frontDoorId":"3ef79f7d-4b18-4dad-b151-99ecb0fb0997","extendedProperties":{},"enablePreviewDeployment":null,"resourceState":"Creating","provisioningState":"Creating"}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/a10dc4f3-b2bf-48e7-a826-23bc8648edb5?api-version=2025-09-01-preview&t=639122718135073251&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=Fyc07cWF9De0FRD56MHlsog62eq7mm01hQrQhOTM2r_sTeT01_DcqfvKKEx-GVTxqM1X5R89kBUw33-FCEtm2-e_THVXtX7V7nD-QdBChjcIsSQE_IQldqUvgG0kuaOWp8NniJDVyPcS2UwtWpbXy5cjxw1JMQVtcFmpZRDYHOE3a26c_xh-fzRdNm6dl6ZIo-uT4MZ3N-WRjSZCYHPanmMY_LO3jJEc-zUX_Y-VoeTEqwusfXJXGIXTwpb1PkHidy5a5ycP8q5yihKDyx_kBJwuYwATQSnJror1vDR3YdfC6Mvp-23b9opClLewPPNKTSPbUbbYdSmMmfzlXqk-sw&h=rbzjenZR93jD3spT-xew0-nfFc1OvQG-gLMWPxCqBkE
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/731181b6-174a-4759-bce0-a694a93252dd?api-version=2025-09-01-preview&t=639173590183337246&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=Y8FbuzwrwSO9PuvThzgAMlHhNzqC0cXAM8y1F1jNogZrYiOSTeysFwSDUP4NbuZysuYf_RlWGLVUYP81lTWni6mmWP4Ykhlk9gJav61faU0ALZ8VOR7B4BxTIq0Ooeg2jlvi9ErfNGO18aO3IjA5Lqe4g2usRjHxV3ZyHO1-qbAv5MqgCV9eQlgb0AjnhZ2f9OrF_gNUlIy6E3zwIXM_P0SoiSsvg2Ydjm6TDSpvdWExP9Tzyw6AfTkuFyFeF3ZCma47ufDVPx367_-UZENoDAIh4Ps9Lh4OPXiL2z0ybveytlYumb7BYt4KrC-tESXNtX8NDf8rU0cWMyukS1LqJQ&h=4qnSgB2b408LBmi6YfbN8xC0avw5iK44vKIedEZKT_M
       cache-control:
       - no-cache
       content-length:
-      - '500'
+      - '531'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 20 Apr 2026 08:50:12 GMT
+      - Thu, 18 Jun 2026 05:56:58 GMT
       expires:
       - '-1'
       pragma:
@@ -140,13 +140,13 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/77d533a8-ca1a-4105-994a-fb00d3a1546b
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/b5178f2b-1af6-4c45-9487-f82d76153c3b
       x-ms-ratelimit-remaining-subscription-global-writes:
-      - '11999'
+      - '12000'
       x-ms-ratelimit-remaining-subscription-writes:
-      - '799'
+      - '800'
       x-msedge-ref:
-      - 'Ref A: B5F555837B8240E090EFA1152461A6DE Ref B: SYD03EDGE0917 Ref C: 2026-04-20T08:50:11Z'
+      - 'Ref A: 21738D0CB2DD41B08688EE6A9B0ADC84 Ref B: SYD03EDGE1313 Ref C: 2026-06-18T05:56:50Z'
     status:
       code: 201
       message: Created
@@ -164,9 +164,9 @@ interactions:
       ParameterSetName:
       - -g --profile-name --sku
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.13.13 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/a10dc4f3-b2bf-48e7-a826-23bc8648edb5?api-version=2025-09-01-preview&t=639122718135073251&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=Fyc07cWF9De0FRD56MHlsog62eq7mm01hQrQhOTM2r_sTeT01_DcqfvKKEx-GVTxqM1X5R89kBUw33-FCEtm2-e_THVXtX7V7nD-QdBChjcIsSQE_IQldqUvgG0kuaOWp8NniJDVyPcS2UwtWpbXy5cjxw1JMQVtcFmpZRDYHOE3a26c_xh-fzRdNm6dl6ZIo-uT4MZ3N-WRjSZCYHPanmMY_LO3jJEc-zUX_Y-VoeTEqwusfXJXGIXTwpb1PkHidy5a5ycP8q5yihKDyx_kBJwuYwATQSnJror1vDR3YdfC6Mvp-23b9opClLewPPNKTSPbUbbYdSmMmfzlXqk-sw&h=rbzjenZR93jD3spT-xew0-nfFc1OvQG-gLMWPxCqBkE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/731181b6-174a-4759-bce0-a694a93252dd?api-version=2025-09-01-preview&t=639173590183337246&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=Y8FbuzwrwSO9PuvThzgAMlHhNzqC0cXAM8y1F1jNogZrYiOSTeysFwSDUP4NbuZysuYf_RlWGLVUYP81lTWni6mmWP4Ykhlk9gJav61faU0ALZ8VOR7B4BxTIq0Ooeg2jlvi9ErfNGO18aO3IjA5Lqe4g2usRjHxV3ZyHO1-qbAv5MqgCV9eQlgb0AjnhZ2f9OrF_gNUlIy6E3zwIXM_P0SoiSsvg2Ydjm6TDSpvdWExP9Tzyw6AfTkuFyFeF3ZCma47ufDVPx367_-UZENoDAIh4Ps9Lh4OPXiL2z0ybveytlYumb7BYt4KrC-tESXNtX8NDf8rU0cWMyukS1LqJQ&h=4qnSgB2b408LBmi6YfbN8xC0avw5iK44vKIedEZKT_M
   response:
     body:
       string: '{"status":"InProgress","error":{"code":"None","message":null}}'
@@ -178,7 +178,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 20 Apr 2026 08:50:15 GMT
+      - Thu, 18 Jun 2026 05:56:59 GMT
       expires:
       - '-1'
       pragma:
@@ -190,11 +190,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/australiaeast/e175e263-a5e6-43ef-9620-ea95b912e641
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/aaa212a1-b262-48c5-b981-213201ab1758
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: B2EE3C8DC7704A369DA65AB8E999D093 Ref B: SYD03EDGE2120 Ref C: 2026-04-20T08:50:14Z'
+      - 'Ref A: 4BEB2DFDBE5746B4BD8E3D1BFF0FC51F Ref B: SYD03EDGE1909 Ref C: 2026-06-18T05:56:59Z'
     status:
       code: 200
       message: OK
@@ -212,9 +212,9 @@ interactions:
       ParameterSetName:
       - -g --profile-name --sku
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.13.13 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/a10dc4f3-b2bf-48e7-a826-23bc8648edb5?api-version=2025-09-01-preview&t=639122718135073251&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=Fyc07cWF9De0FRD56MHlsog62eq7mm01hQrQhOTM2r_sTeT01_DcqfvKKEx-GVTxqM1X5R89kBUw33-FCEtm2-e_THVXtX7V7nD-QdBChjcIsSQE_IQldqUvgG0kuaOWp8NniJDVyPcS2UwtWpbXy5cjxw1JMQVtcFmpZRDYHOE3a26c_xh-fzRdNm6dl6ZIo-uT4MZ3N-WRjSZCYHPanmMY_LO3jJEc-zUX_Y-VoeTEqwusfXJXGIXTwpb1PkHidy5a5ycP8q5yihKDyx_kBJwuYwATQSnJror1vDR3YdfC6Mvp-23b9opClLewPPNKTSPbUbbYdSmMmfzlXqk-sw&h=rbzjenZR93jD3spT-xew0-nfFc1OvQG-gLMWPxCqBkE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/731181b6-174a-4759-bce0-a694a93252dd?api-version=2025-09-01-preview&t=639173590183337246&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=Y8FbuzwrwSO9PuvThzgAMlHhNzqC0cXAM8y1F1jNogZrYiOSTeysFwSDUP4NbuZysuYf_RlWGLVUYP81lTWni6mmWP4Ykhlk9gJav61faU0ALZ8VOR7B4BxTIq0Ooeg2jlvi9ErfNGO18aO3IjA5Lqe4g2usRjHxV3ZyHO1-qbAv5MqgCV9eQlgb0AjnhZ2f9OrF_gNUlIy6E3zwIXM_P0SoiSsvg2Ydjm6TDSpvdWExP9Tzyw6AfTkuFyFeF3ZCma47ufDVPx367_-UZENoDAIh4Ps9Lh4OPXiL2z0ybveytlYumb7BYt4KrC-tESXNtX8NDf8rU0cWMyukS1LqJQ&h=4qnSgB2b408LBmi6YfbN8xC0avw5iK44vKIedEZKT_M
   response:
     body:
       string: '{"status":"InProgress","error":{"code":"None","message":null}}'
@@ -226,7 +226,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 20 Apr 2026 08:50:47 GMT
+      - Thu, 18 Jun 2026 05:57:31 GMT
       expires:
       - '-1'
       pragma:
@@ -238,11 +238,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/australiaeast/5b156475-6d7d-4f95-8713-76e79afb70b2
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/d78b04da-c5a7-4609-a6ce-daf19ac1db69
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 7AF9C0ED65574F8595B4B3EDCA9AA981 Ref B: SYD03EDGE2010 Ref C: 2026-04-20T08:50:46Z'
+      - 'Ref A: 7FB1D147E8CB4B518EF91F47B62189CF Ref B: SYD03EDGE1421 Ref C: 2026-06-18T05:57:30Z'
     status:
       code: 200
       message: OK
@@ -260,9 +260,9 @@ interactions:
       ParameterSetName:
       - -g --profile-name --sku
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.13.13 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/a10dc4f3-b2bf-48e7-a826-23bc8648edb5?api-version=2025-09-01-preview&t=639122718135073251&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=Fyc07cWF9De0FRD56MHlsog62eq7mm01hQrQhOTM2r_sTeT01_DcqfvKKEx-GVTxqM1X5R89kBUw33-FCEtm2-e_THVXtX7V7nD-QdBChjcIsSQE_IQldqUvgG0kuaOWp8NniJDVyPcS2UwtWpbXy5cjxw1JMQVtcFmpZRDYHOE3a26c_xh-fzRdNm6dl6ZIo-uT4MZ3N-WRjSZCYHPanmMY_LO3jJEc-zUX_Y-VoeTEqwusfXJXGIXTwpb1PkHidy5a5ycP8q5yihKDyx_kBJwuYwATQSnJror1vDR3YdfC6Mvp-23b9opClLewPPNKTSPbUbbYdSmMmfzlXqk-sw&h=rbzjenZR93jD3spT-xew0-nfFc1OvQG-gLMWPxCqBkE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/731181b6-174a-4759-bce0-a694a93252dd?api-version=2025-09-01-preview&t=639173590183337246&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=Y8FbuzwrwSO9PuvThzgAMlHhNzqC0cXAM8y1F1jNogZrYiOSTeysFwSDUP4NbuZysuYf_RlWGLVUYP81lTWni6mmWP4Ykhlk9gJav61faU0ALZ8VOR7B4BxTIq0Ooeg2jlvi9ErfNGO18aO3IjA5Lqe4g2usRjHxV3ZyHO1-qbAv5MqgCV9eQlgb0AjnhZ2f9OrF_gNUlIy6E3zwIXM_P0SoiSsvg2Ydjm6TDSpvdWExP9Tzyw6AfTkuFyFeF3ZCma47ufDVPx367_-UZENoDAIh4Ps9Lh4OPXiL2z0ybveytlYumb7BYt4KrC-tESXNtX8NDf8rU0cWMyukS1LqJQ&h=4qnSgB2b408LBmi6YfbN8xC0avw5iK44vKIedEZKT_M
   response:
     body:
       string: '{"status":"Succeeded","error":{"code":"None","message":null}}'
@@ -274,7 +274,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 20 Apr 2026 08:51:18 GMT
+      - Thu, 18 Jun 2026 05:58:02 GMT
       expires:
       - '-1'
       pragma:
@@ -286,11 +286,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/1579791c-7c13-4c97-9087-cb98e4722ad4
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/67ec3e57-575c-40b0-a348-3267822bc4b0
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: D54C58C57C254EF0A74427EB4D4C0A45 Ref B: SYD03EDGE1416 Ref C: 2026-04-20T08:51:17Z'
+      - 'Ref A: EF1CC49864C6443F8B9A3B9411B6A34C Ref B: SYD03EDGE2109 Ref C: 2026-06-18T05:58:02Z'
     status:
       code: 200
       message: OK
@@ -308,21 +308,21 @@ interactions:
       ParameterSetName:
       - -g --profile-name --sku
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.13.13 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest?api-version=2025-09-01-preview
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest","type":"Microsoft.Cdn/profiles","name":"profilesecuritytest","location":"Global","kind":"frontdoor","tags":{},"sku":{"name":"Standard_AzureFrontDoor"},"properties":{"originResponseTimeoutSeconds":30,"logScrubbing":null,"frontDoorId":"6739e0a2-1011-43f5-aaa5-dcd82e6cb669","extendedProperties":{},"resourceState":"Active","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest","type":"Microsoft.Cdn/profiles","name":"profilesecuritytest","location":"Global","kind":"frontdoor","tags":{},"sku":{"name":"Standard_AzureFrontDoor"},"properties":{"originResponseTimeoutSeconds":30,"logScrubbing":null,"frontDoorId":"3ef79f7d-4b18-4dad-b151-99ecb0fb0997","extendedProperties":{},"enablePreviewDeployment":null,"resourceState":"Active","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '499'
+      - '530'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 20 Apr 2026 08:51:19 GMT
+      - Thu, 18 Jun 2026 05:58:04 GMT
       expires:
       - '-1'
       pragma:
@@ -336,7 +336,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 9C8ECB1FD16E4322BD41D504C32AED80 Ref B: SYD03EDGE1013 Ref C: 2026-04-20T08:51:19Z'
+      - 'Ref A: FAEAFD01F8DF4636B68EC568D8BBC7CB Ref B: SYD03EDGE1418 Ref C: 2026-06-18T05:58:03Z'
     status:
       code: 200
       message: OK
@@ -354,9 +354,9 @@ interactions:
       ParameterSetName:
       - -g --profile-name
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.13.13 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/securityPolicies?api-version=2025-09-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/securityPolicies?api-version=2026-04-01-preview
   response:
     body:
       string: '{"value":[]}'
@@ -368,7 +368,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 20 Apr 2026 08:51:21 GMT
+      - Thu, 18 Jun 2026 05:58:07 GMT
       expires:
       - '-1'
       pragma:
@@ -380,11 +380,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/8fc16038-983a-499f-be0e-2257229c2a80
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/8477a062-8011-4400-8b32-b8c0289f6fe4
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 7ECE9A039BCB43D6881FD1B5C9F5FC68 Ref B: SYD03EDGE0816 Ref C: 2026-04-20T08:51:20Z'
+      - 'Ref A: CE3EC4E82CC945399DD81914459D212E Ref B: SYD03EDGE1909 Ref C: 2026-06-18T05:58:06Z'
     status:
       code: 200
       message: OK
@@ -402,7 +402,7 @@ interactions:
       ParameterSetName:
       - -g --endpoint-name --profile-name --enabled-state
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.13.13 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2024-11-01
   response:
@@ -416,7 +416,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 20 Apr 2026 08:51:22 GMT
+      - Thu, 18 Jun 2026 05:58:09 GMT
       expires:
       - '-1'
       pragma:
@@ -430,7 +430,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 30E7E545BB624222B1729325485806CC Ref B: SYD03EDGE1916 Ref C: 2026-04-20T08:51:22Z'
+      - 'Ref A: 4269E66E54994F8A95ABA61575838537 Ref B: SYD03EDGE2115 Ref C: 2026-06-18T05:58:09Z'
     status:
       code: 200
       message: OK
@@ -452,15 +452,15 @@ interactions:
       ParameterSetName:
       - -g --endpoint-name --profile-name --enabled-state
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.13.13 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdEndpoints/endpoint1000002?api-version=2025-09-01-preview
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdendpoints/endpoint1000002","type":"Microsoft.Cdn/profiles/afdendpoints","name":"endpoint1000002","location":"Global","tags":{},"properties":{"hostName":"endpoint1000002-dme0d8g9frfeegat.z01.azurefd.net","autoGeneratedDomainNameLabelScope":null,"enabledState":"Enabled","enforceMtls":"Disabled","provisioningState":"Creating","deploymentStatus":"NotStarted"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdendpoints/endpoint1000002","type":"Microsoft.Cdn/profiles/afdendpoints","name":"endpoint1000002","location":"Global","tags":{},"properties":{"hostName":"endpoint1000002-f4fdh6f8eggba9ah.z01.azurefd.net","autoGeneratedDomainNameLabelScope":null,"enabledState":"Enabled","enforceMtls":"Disabled","provisioningState":"Creating","deploymentStatus":"NotStarted"}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/ec2db99b-a1fa-4e17-9a98-e55f818d619d?api-version=2025-09-01-preview&t=639122718852927892&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=o9MpNdoMZSXmqbN6iHDmmeNciWZeChQUu-IccYzIL8p6vb0qJZHEGQxxFi1Az0pvl3gpgp1DQoMgUVCcim7PNPaM9MhwIXSKrug28AkiCfi_kId-7CogTxWNqhnD98sdwnAL_Dd6Uxfiv45FQnjNV8PHjZBORpTXFPfWPSyT0D9Ha4JYvv68dFwR_6lUKugXuVrpIS4bOnBxany0hPa2QueDrRt5LaEtqbAAJhXcRxTkWlGTkLjRsAMWpWqhmKYLyRuAlxnh8-WEl0KIZw70tpIhMouREwnlFRj6OqCzX99Ih7nO7hrPiaKbCKWyIHvCdYj6S-p-eE6EpLJmtxWH3w&h=PpBd1s1VrhJ7zpHeGS71oLP0tqfU5OvQz9EgadakIOs
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/d992046a-e1a7-4aba-815e-2568422444e1?api-version=2025-09-01-preview&t=639173590922637594&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=Pb7HeBB4vpdq8YemlwFgljHnfggCB5komHYxfkCApRc2PlpsaqyIQmNFEIAT5hzXepuyutm66P6b0CC3B9C0wX7nPSMa41fB45cb4iLYOc2c3q8k1fd23JVZsA1s8Pqujkiig3TYtSzIGQYzNr4PzaLhQYVVygKy35SWMzjpS5J4gYmYmbBV9gGz6DPGh8HSyuMgceYbGzvze1oMmgNj0qFXUPdtqH6h_hKLG4s7IsnDXSWjDb-3tLxhpxOc9hz7q2enY3kFBTRwP9W1h58ZqfTLLLt6Myw1ilRzIBS8-DO_svKWn0hpcsjKchKGDLRbgLSCwcqRHpO7mYhEsdNThA&h=9Ng7gcSyQ8oiW5DatuRf9oagumY8NHazv4dzWYGKRp4
       cache-control:
       - no-cache
       content-length:
@@ -468,7 +468,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 20 Apr 2026 08:51:25 GMT
+      - Thu, 18 Jun 2026 05:58:11 GMT
       expires:
       - '-1'
       pragma:
@@ -480,13 +480,13 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/53655036-3c29-4de4-849e-3c03a77db305
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/33a0ccd5-b8fc-4d67-abe3-10c931bbae04
       x-ms-ratelimit-remaining-subscription-global-writes:
       - '11999'
       x-ms-ratelimit-remaining-subscription-writes:
       - '799'
       x-msedge-ref:
-      - 'Ref A: D71DF1CC69E04FECA7131C508EE8059B Ref B: SYD03EDGE0914 Ref C: 2026-04-20T08:51:23Z'
+      - 'Ref A: F69270BE4A3045559A8A5A0F734A2D5A Ref B: SYD03EDGE1309 Ref C: 2026-06-18T05:58:09Z'
     status:
       code: 201
       message: Created
@@ -504,9 +504,9 @@ interactions:
       ParameterSetName:
       - -g --endpoint-name --profile-name --enabled-state
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.13.13 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/ec2db99b-a1fa-4e17-9a98-e55f818d619d?api-version=2025-09-01-preview&t=639122718852927892&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=o9MpNdoMZSXmqbN6iHDmmeNciWZeChQUu-IccYzIL8p6vb0qJZHEGQxxFi1Az0pvl3gpgp1DQoMgUVCcim7PNPaM9MhwIXSKrug28AkiCfi_kId-7CogTxWNqhnD98sdwnAL_Dd6Uxfiv45FQnjNV8PHjZBORpTXFPfWPSyT0D9Ha4JYvv68dFwR_6lUKugXuVrpIS4bOnBxany0hPa2QueDrRt5LaEtqbAAJhXcRxTkWlGTkLjRsAMWpWqhmKYLyRuAlxnh8-WEl0KIZw70tpIhMouREwnlFRj6OqCzX99Ih7nO7hrPiaKbCKWyIHvCdYj6S-p-eE6EpLJmtxWH3w&h=PpBd1s1VrhJ7zpHeGS71oLP0tqfU5OvQz9EgadakIOs
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/d992046a-e1a7-4aba-815e-2568422444e1?api-version=2025-09-01-preview&t=639173590922637594&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=Pb7HeBB4vpdq8YemlwFgljHnfggCB5komHYxfkCApRc2PlpsaqyIQmNFEIAT5hzXepuyutm66P6b0CC3B9C0wX7nPSMa41fB45cb4iLYOc2c3q8k1fd23JVZsA1s8Pqujkiig3TYtSzIGQYzNr4PzaLhQYVVygKy35SWMzjpS5J4gYmYmbBV9gGz6DPGh8HSyuMgceYbGzvze1oMmgNj0qFXUPdtqH6h_hKLG4s7IsnDXSWjDb-3tLxhpxOc9hz7q2enY3kFBTRwP9W1h58ZqfTLLLt6Myw1ilRzIBS8-DO_svKWn0hpcsjKchKGDLRbgLSCwcqRHpO7mYhEsdNThA&h=9Ng7gcSyQ8oiW5DatuRf9oagumY8NHazv4dzWYGKRp4
   response:
     body:
       string: '{"status":"InProgress","error":{"code":"None","message":null}}'
@@ -518,7 +518,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 20 Apr 2026 08:51:25 GMT
+      - Thu, 18 Jun 2026 05:58:12 GMT
       expires:
       - '-1'
       pragma:
@@ -530,11 +530,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/f56a5bea-ecd1-4a73-bd90-6e21cfb56339
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/28b57aa6-04ab-479a-8d98-517c08e7e2b3
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: A046073B8C5D44C888932CD6B1449936 Ref B: SYD03EDGE1410 Ref C: 2026-04-20T08:51:25Z'
+      - 'Ref A: A0471CC9C0B2496BBD714C128DF59625 Ref B: SYD03EDGE2009 Ref C: 2026-06-18T05:58:12Z'
     status:
       code: 200
       message: OK
@@ -552,9 +552,9 @@ interactions:
       ParameterSetName:
       - -g --endpoint-name --profile-name --enabled-state
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.13.13 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/ec2db99b-a1fa-4e17-9a98-e55f818d619d?api-version=2025-09-01-preview&t=639122718852927892&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=o9MpNdoMZSXmqbN6iHDmmeNciWZeChQUu-IccYzIL8p6vb0qJZHEGQxxFi1Az0pvl3gpgp1DQoMgUVCcim7PNPaM9MhwIXSKrug28AkiCfi_kId-7CogTxWNqhnD98sdwnAL_Dd6Uxfiv45FQnjNV8PHjZBORpTXFPfWPSyT0D9Ha4JYvv68dFwR_6lUKugXuVrpIS4bOnBxany0hPa2QueDrRt5LaEtqbAAJhXcRxTkWlGTkLjRsAMWpWqhmKYLyRuAlxnh8-WEl0KIZw70tpIhMouREwnlFRj6OqCzX99Ih7nO7hrPiaKbCKWyIHvCdYj6S-p-eE6EpLJmtxWH3w&h=PpBd1s1VrhJ7zpHeGS71oLP0tqfU5OvQz9EgadakIOs
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/d992046a-e1a7-4aba-815e-2568422444e1?api-version=2025-09-01-preview&t=639173590922637594&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=Pb7HeBB4vpdq8YemlwFgljHnfggCB5komHYxfkCApRc2PlpsaqyIQmNFEIAT5hzXepuyutm66P6b0CC3B9C0wX7nPSMa41fB45cb4iLYOc2c3q8k1fd23JVZsA1s8Pqujkiig3TYtSzIGQYzNr4PzaLhQYVVygKy35SWMzjpS5J4gYmYmbBV9gGz6DPGh8HSyuMgceYbGzvze1oMmgNj0qFXUPdtqH6h_hKLG4s7IsnDXSWjDb-3tLxhpxOc9hz7q2enY3kFBTRwP9W1h58ZqfTLLLt6Myw1ilRzIBS8-DO_svKWn0hpcsjKchKGDLRbgLSCwcqRHpO7mYhEsdNThA&h=9Ng7gcSyQ8oiW5DatuRf9oagumY8NHazv4dzWYGKRp4
   response:
     body:
       string: '{"status":"Succeeded","error":{"code":"None","message":null}}'
@@ -566,7 +566,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 20 Apr 2026 08:51:57 GMT
+      - Thu, 18 Jun 2026 05:58:44 GMT
       expires:
       - '-1'
       pragma:
@@ -578,11 +578,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/c30a214f-8130-4ec9-9760-9b27a41e12f2
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/bd0b4335-22d5-4aff-89c4-eee828d97e30
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 80827935CE4942118E0ABC5776DFAF32 Ref B: SYD03EDGE1020 Ref C: 2026-04-20T08:51:57Z'
+      - 'Ref A: 7C15CEB78BEC42D791743CAAED5112C2 Ref B: SYD03EDGE1721 Ref C: 2026-06-18T05:58:44Z'
     status:
       code: 200
       message: OK
@@ -600,12 +600,12 @@ interactions:
       ParameterSetName:
       - -g --endpoint-name --profile-name --enabled-state
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.13.13 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdEndpoints/endpoint1000002?api-version=2025-09-01-preview
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdendpoints/endpoint1000002","type":"Microsoft.Cdn/profiles/afdendpoints","name":"endpoint1000002","location":"Global","tags":{},"properties":{"hostName":"endpoint1000002-dme0d8g9frfeegat.z01.azurefd.net","autoGeneratedDomainNameLabelScope":null,"enabledState":"Enabled","enforceMtls":"Disabled","provisioningState":"Succeeded","deploymentStatus":"NotStarted"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdendpoints/endpoint1000002","type":"Microsoft.Cdn/profiles/afdendpoints","name":"endpoint1000002","location":"Global","tags":{},"properties":{"hostName":"endpoint1000002-f4fdh6f8eggba9ah.z01.azurefd.net","autoGeneratedDomainNameLabelScope":null,"enabledState":"Enabled","enforceMtls":"Disabled","provisioningState":"Succeeded","deploymentStatus":"NotStarted"}}'
     headers:
       cache-control:
       - no-cache
@@ -614,7 +614,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 20 Apr 2026 08:51:58 GMT
+      - Thu, 18 Jun 2026 05:58:46 GMT
       expires:
       - '-1'
       pragma:
@@ -628,7 +628,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: AD3B169665514EF78ED74E2D85893B58 Ref B: SYD03EDGE0812 Ref C: 2026-04-20T08:51:58Z'
+      - 'Ref A: 12A711A7B9D046969794A3F2762DAC6F Ref B: SYD03EDGE2017 Ref C: 2026-06-18T05:58:46Z'
     status:
       code: 200
       message: OK
@@ -646,7 +646,7 @@ interactions:
       ParameterSetName:
       - -g --endpoint-name --profile-name --enabled-state
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.13.13 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2024-11-01
   response:
@@ -660,7 +660,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 20 Apr 2026 08:51:59 GMT
+      - Thu, 18 Jun 2026 05:58:47 GMT
       expires:
       - '-1'
       pragma:
@@ -674,7 +674,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 841394B3587B49E8898BAF6803BC249E Ref B: SYD03EDGE1317 Ref C: 2026-04-20T08:51:59Z'
+      - 'Ref A: F170D409A2164B7EA8F25BA80393577C Ref B: SYD03EDGE2111 Ref C: 2026-06-18T05:58:47Z'
     status:
       code: 200
       message: OK
@@ -696,15 +696,15 @@ interactions:
       ParameterSetName:
       - -g --endpoint-name --profile-name --enabled-state
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.13.13 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdEndpoints/endpoint2000003?api-version=2025-09-01-preview
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdendpoints/endpoint2000003","type":"Microsoft.Cdn/profiles/afdendpoints","name":"endpoint2000003","location":"Global","tags":{},"properties":{"hostName":"endpoint2000003-fwa8f0d9cncgfufm.z01.azurefd.net","autoGeneratedDomainNameLabelScope":null,"enabledState":"Enabled","enforceMtls":"Disabled","provisioningState":"Creating","deploymentStatus":"NotStarted"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdendpoints/endpoint2000003","type":"Microsoft.Cdn/profiles/afdendpoints","name":"endpoint2000003","location":"Global","tags":{},"properties":{"hostName":"endpoint2000003-gbh6etdrazgmfycq.z01.azurefd.net","autoGeneratedDomainNameLabelScope":null,"enabledState":"Enabled","enforceMtls":"Disabled","provisioningState":"Creating","deploymentStatus":"NotStarted"}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/1b24ee3b-3c80-4c64-8b45-f9b495e4675e?api-version=2025-09-01-preview&t=639122719235100016&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=ZBB037rolfNyJGaauX54DTdmJAnPit7UI0eqJuSnVfPF1kJnji6hkDUkC1iX1VT-N8Suva5OdPvU95jn17BbPyuHCTpIInCcBPPmPZlFpC4JN1bKxVuTQcU3LpDb_91gQ2eNEu4ZHBLD__hqttwLuniHY7ned5VT1u-HwKWPgQ1x5RTzFqt8dmqOLCp_PC6NNT30Hu2S3voXzeHUJpnGWYCwN3rUcsOuKV_UL5XNeJ02aQeqYRSyNcmHdSzvDEySD1o5ZvKUq5HC66o3IRNsAN4-06696lPBqVIWs7tqE3xzgXtBeysnUXJ_TQfw7U46kLpVejQ0ijI_dexJ0QIskw&h=DNXZfeG2TgRP-d64JXZZj68vlUl7gOEU_ax3nDAlQQo
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/d15b5130-b09f-4621-8562-39ccb52bc687?api-version=2025-09-01-preview&t=639173591312599997&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=i5tl34L9mQe7qkKKh3LMrKGgdnwS8SyM764QvrbubW2wmyHuyF0hIMMX0qRxYbXF8JMxWQp6LHnjj9dU2wV6zIfrA3L_8Zgim_IVcVQZBQm0O4dPT_bqqmPVS7ipI2xLTu7Kljs6dgPJpNxwtPa-3_79mH1a-zccvOUk82dz4ZUwFoXQJRNk5gsoVN8nQelTD7rsJPP2Fpu-dxe3l3HLOVczypi_WyIWKcPi_ORFb1B3_mmTjdv2EhiDcgW8kAnaFewZKfrCqQlMYFe1zCZDi8oyDJWUaeXScBeu3L6siTHCTWTLoEh7fl3RES9BxE0DIS7G0LYGXrq9_pf-Qdr8wQ&h=jAwIaUPNPrcwV_Jt3vw6VtvR-SeEt03rQ0mZz36Fm7o
       cache-control:
       - no-cache
       content-length:
@@ -712,7 +712,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 20 Apr 2026 08:52:03 GMT
+      - Thu, 18 Jun 2026 05:58:50 GMT
       expires:
       - '-1'
       pragma:
@@ -724,13 +724,13 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/95b570d7-749e-4334-a329-51bc9f2a578a
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/d15a15ec-ccb8-4456-9968-c3c05c133134
       x-ms-ratelimit-remaining-subscription-global-writes:
       - '11999'
       x-ms-ratelimit-remaining-subscription-writes:
       - '799'
       x-msedge-ref:
-      - 'Ref A: 3ABCDBD506604FA4A1EF3E223083CC58 Ref B: SYD03EDGE2116 Ref C: 2026-04-20T08:52:00Z'
+      - 'Ref A: 9EE56FEE70FF4C578FE7DC22D3356E3F Ref B: SYD03EDGE2110 Ref C: 2026-06-18T05:58:48Z'
     status:
       code: 201
       message: Created
@@ -748,9 +748,9 @@ interactions:
       ParameterSetName:
       - -g --endpoint-name --profile-name --enabled-state
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.13.13 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/1b24ee3b-3c80-4c64-8b45-f9b495e4675e?api-version=2025-09-01-preview&t=639122719235100016&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=ZBB037rolfNyJGaauX54DTdmJAnPit7UI0eqJuSnVfPF1kJnji6hkDUkC1iX1VT-N8Suva5OdPvU95jn17BbPyuHCTpIInCcBPPmPZlFpC4JN1bKxVuTQcU3LpDb_91gQ2eNEu4ZHBLD__hqttwLuniHY7ned5VT1u-HwKWPgQ1x5RTzFqt8dmqOLCp_PC6NNT30Hu2S3voXzeHUJpnGWYCwN3rUcsOuKV_UL5XNeJ02aQeqYRSyNcmHdSzvDEySD1o5ZvKUq5HC66o3IRNsAN4-06696lPBqVIWs7tqE3xzgXtBeysnUXJ_TQfw7U46kLpVejQ0ijI_dexJ0QIskw&h=DNXZfeG2TgRP-d64JXZZj68vlUl7gOEU_ax3nDAlQQo
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/d15b5130-b09f-4621-8562-39ccb52bc687?api-version=2025-09-01-preview&t=639173591312599997&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=i5tl34L9mQe7qkKKh3LMrKGgdnwS8SyM764QvrbubW2wmyHuyF0hIMMX0qRxYbXF8JMxWQp6LHnjj9dU2wV6zIfrA3L_8Zgim_IVcVQZBQm0O4dPT_bqqmPVS7ipI2xLTu7Kljs6dgPJpNxwtPa-3_79mH1a-zccvOUk82dz4ZUwFoXQJRNk5gsoVN8nQelTD7rsJPP2Fpu-dxe3l3HLOVczypi_WyIWKcPi_ORFb1B3_mmTjdv2EhiDcgW8kAnaFewZKfrCqQlMYFe1zCZDi8oyDJWUaeXScBeu3L6siTHCTWTLoEh7fl3RES9BxE0DIS7G0LYGXrq9_pf-Qdr8wQ&h=jAwIaUPNPrcwV_Jt3vw6VtvR-SeEt03rQ0mZz36Fm7o
   response:
     body:
       string: '{"status":"InProgress","error":{"code":"None","message":null}}'
@@ -762,7 +762,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 20 Apr 2026 08:52:04 GMT
+      - Thu, 18 Jun 2026 05:58:52 GMT
       expires:
       - '-1'
       pragma:
@@ -774,11 +774,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/c5815714-6f6c-4619-b9d5-9658349e4ed6
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/5b575336-e37a-46aa-a969-d28de694353f
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 257D573F7A5C4D6984546E6B37D781F8 Ref B: SYD03EDGE1920 Ref C: 2026-04-20T08:52:04Z'
+      - 'Ref A: 9BD3DAA023F04BDCB2D182E491FE7854 Ref B: SYD03EDGE1908 Ref C: 2026-06-18T05:58:52Z'
     status:
       code: 200
       message: OK
@@ -796,9 +796,9 @@ interactions:
       ParameterSetName:
       - -g --endpoint-name --profile-name --enabled-state
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.13.13 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/1b24ee3b-3c80-4c64-8b45-f9b495e4675e?api-version=2025-09-01-preview&t=639122719235100016&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=ZBB037rolfNyJGaauX54DTdmJAnPit7UI0eqJuSnVfPF1kJnji6hkDUkC1iX1VT-N8Suva5OdPvU95jn17BbPyuHCTpIInCcBPPmPZlFpC4JN1bKxVuTQcU3LpDb_91gQ2eNEu4ZHBLD__hqttwLuniHY7ned5VT1u-HwKWPgQ1x5RTzFqt8dmqOLCp_PC6NNT30Hu2S3voXzeHUJpnGWYCwN3rUcsOuKV_UL5XNeJ02aQeqYRSyNcmHdSzvDEySD1o5ZvKUq5HC66o3IRNsAN4-06696lPBqVIWs7tqE3xzgXtBeysnUXJ_TQfw7U46kLpVejQ0ijI_dexJ0QIskw&h=DNXZfeG2TgRP-d64JXZZj68vlUl7gOEU_ax3nDAlQQo
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/d15b5130-b09f-4621-8562-39ccb52bc687?api-version=2025-09-01-preview&t=639173591312599997&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=i5tl34L9mQe7qkKKh3LMrKGgdnwS8SyM764QvrbubW2wmyHuyF0hIMMX0qRxYbXF8JMxWQp6LHnjj9dU2wV6zIfrA3L_8Zgim_IVcVQZBQm0O4dPT_bqqmPVS7ipI2xLTu7Kljs6dgPJpNxwtPa-3_79mH1a-zccvOUk82dz4ZUwFoXQJRNk5gsoVN8nQelTD7rsJPP2Fpu-dxe3l3HLOVczypi_WyIWKcPi_ORFb1B3_mmTjdv2EhiDcgW8kAnaFewZKfrCqQlMYFe1zCZDi8oyDJWUaeXScBeu3L6siTHCTWTLoEh7fl3RES9BxE0DIS7G0LYGXrq9_pf-Qdr8wQ&h=jAwIaUPNPrcwV_Jt3vw6VtvR-SeEt03rQ0mZz36Fm7o
   response:
     body:
       string: '{"status":"Succeeded","error":{"code":"None","message":null}}'
@@ -810,7 +810,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 20 Apr 2026 08:52:35 GMT
+      - Thu, 18 Jun 2026 05:59:24 GMT
       expires:
       - '-1'
       pragma:
@@ -822,11 +822,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/98efd543-9ab3-45bc-83ed-8e3634182d30
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/d6bbce9c-5d23-4d4f-8fde-e31a460e5b9f
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 7AFF4F7A973E4B209FBFC66B81375B8D Ref B: SYD03EDGE2117 Ref C: 2026-04-20T08:52:35Z'
+      - 'Ref A: 3E26986D568543CD9FC4429D68715F99 Ref B: SYD03EDGE1718 Ref C: 2026-06-18T05:59:23Z'
     status:
       code: 200
       message: OK
@@ -844,12 +844,12 @@ interactions:
       ParameterSetName:
       - -g --endpoint-name --profile-name --enabled-state
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.13.13 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdEndpoints/endpoint2000003?api-version=2025-09-01-preview
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdendpoints/endpoint2000003","type":"Microsoft.Cdn/profiles/afdendpoints","name":"endpoint2000003","location":"Global","tags":{},"properties":{"hostName":"endpoint2000003-fwa8f0d9cncgfufm.z01.azurefd.net","autoGeneratedDomainNameLabelScope":null,"enabledState":"Enabled","enforceMtls":"Disabled","provisioningState":"Succeeded","deploymentStatus":"NotStarted"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdendpoints/endpoint2000003","type":"Microsoft.Cdn/profiles/afdendpoints","name":"endpoint2000003","location":"Global","tags":{},"properties":{"hostName":"endpoint2000003-gbh6etdrazgmfycq.z01.azurefd.net","autoGeneratedDomainNameLabelScope":null,"enabledState":"Enabled","enforceMtls":"Disabled","provisioningState":"Succeeded","deploymentStatus":"NotStarted"}}'
     headers:
       cache-control:
       - no-cache
@@ -858,7 +858,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 20 Apr 2026 08:52:36 GMT
+      - Thu, 18 Jun 2026 05:59:25 GMT
       expires:
       - '-1'
       pragma:
@@ -872,7 +872,577 @@ interactions:
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 143BC38406044BD79CD01815EC691D6E Ref B: SYD03EDGE0817 Ref C: 2026-04-20T08:52:36Z'
+      - 'Ref A: CAB000EEF29B410699AC41C6AD692281 Ref B: SYD03EDGE1416 Ref C: 2026-06-18T05:59:25Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"healthProbeSettings": {"probeIntervalInSeconds": 120,
+      "probePath": "/test1/azure.txt", "probeProtocol": "Http", "probeRequestType":
+      "GET"}, "loadBalancingSettings": {"additionalLatencyInMilliseconds": 50, "sampleSize":
+      4, "successfulSamplesRequired": 3}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - afd origin-group create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '272'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g --profile-name --origin-group-name --probe-request-type --probe-protocol
+        --probe-interval-in-seconds --probe-path --sample-size --successful-samples-required
+        --additional-latency-in-milliseconds
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/originGroups/og000004?api-version=2025-09-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/origingroups/og000004","type":"Microsoft.Cdn/profiles/origingroups","name":"og000004","properties":{"loadBalancingSettings":{"sampleSize":4,"successfulSamplesRequired":3,"additionalLatencyInMilliseconds":50,"capacityDistributionSettings":null},"healthProbeSettings":{"probePath":"/test1/azure.txt","probeRequestType":"GET","probeProtocol":"Http","probeIntervalInSeconds":120},"trafficRestorationTimeToHealedOrNewEndpointsInMinutes":null,"sessionAffinityState":"Disabled","authentication":null,"provisioningState":"Succeeded","deploymentStatus":"NotStarted"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '702'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Jun 2026 05:59:27 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/78a6c9ef-0751-482a-a59f-7472128520f2
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '11999'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: 0A559F6ABD9D465395F8C03B84FDBC79 Ref B: SYD03EDGE1412 Ref C: 2026-06-18T05:59:26Z'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"enabledState": "Enabled", "enforceCertificateNameCheck":
+      true, "hostName": "huaiyiztesthost1.blob.core.chinacloudapi.cn", "httpPort":
+      80, "httpsPort": 443, "originHostHeader": "huaiyiztesthost1.blob.core.chinacloudapi.cn",
+      "priority": 1, "weight": 1000}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - afd origin create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '271'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g --profile-name --origin-group-name --origin-name --host-name --origin-host-header
+        --priority --weight --http-port --https-port --enabled-state
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/originGroups/og000004/origins/origin000005?api-version=2025-09-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/origingroups/og000004/origins/origin000005","type":"Microsoft.Cdn/profiles/origingroups/origins","name":"origin000005","properties":{"originGroupName":"og000004","hostName":"huaiyiztesthost1.blob.core.chinacloudapi.cn","httpPort":80,"httpsPort":443,"originHostHeader":"huaiyiztesthost1.blob.core.chinacloudapi.cn","priority":1,"weight":1000,"enabledState":"Enabled","sharedPrivateLinkResource":null,"enforceCertificateNameCheck":true,"originCapacityResource":null,"provisioningState":"Creating","deploymentStatus":"NotStarted"}}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/f75d35fe-d9bb-4608-af64-a2772ebe4dd1?api-version=2025-09-01-preview&t=639173591709539696&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=LfzPCbQd-Wq7dPRyeWUZ4LSkc0DVwVo1Kcpp5gkOKqj7hJ_u3Jk8zxTnZEW4CCk_J2G5oSSCDEfnkkj5eAzjw5bKGoVmTuPyfrrMgl6J0SQ589nMjehlhxSVpPxB6tLoLU7dXyJ3Vrkx3efTXBpbPBvnsOQUUB9Z-bYDPzYyR76XBIi8dPCqwtwtg6r7d7jszGTE7KkVIU7ezFoc3hSdihpVH_rSHfO-lsX1ZNxxMhQdamVu6BiIiy2eamEp0C4tXMEjWdaXzNg8F4yjnxE1-pBAAfTZnGLGWgT2bHCDK4lrPov3aB7t4IAIKCqz_WoWoOTPAc1fnFop7zJ-yJ_8Ag&h=R2BzMnO1ZWN5eQ45hRtxHZj4ezDgm-rF7d33ni_pLIA
+      cache-control:
+      - no-cache
+      content-length:
+      - '672'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Jun 2026 05:59:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/a716af08-fcdb-45a4-a097-e56685a8f0e3
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '11999'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: A76D24831A12412780E0A22E26D77164 Ref B: SYD03EDGE2012 Ref C: 2026-06-18T05:59:29Z'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - afd origin create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --profile-name --origin-group-name --origin-name --host-name --origin-host-header
+        --priority --weight --http-port --https-port --enabled-state
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/f75d35fe-d9bb-4608-af64-a2772ebe4dd1?api-version=2025-09-01-preview&t=639173591709539696&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=LfzPCbQd-Wq7dPRyeWUZ4LSkc0DVwVo1Kcpp5gkOKqj7hJ_u3Jk8zxTnZEW4CCk_J2G5oSSCDEfnkkj5eAzjw5bKGoVmTuPyfrrMgl6J0SQ589nMjehlhxSVpPxB6tLoLU7dXyJ3Vrkx3efTXBpbPBvnsOQUUB9Z-bYDPzYyR76XBIi8dPCqwtwtg6r7d7jszGTE7KkVIU7ezFoc3hSdihpVH_rSHfO-lsX1ZNxxMhQdamVu6BiIiy2eamEp0C4tXMEjWdaXzNg8F4yjnxE1-pBAAfTZnGLGWgT2bHCDK4lrPov3aB7t4IAIKCqz_WoWoOTPAc1fnFop7zJ-yJ_8Ag&h=R2BzMnO1ZWN5eQ45hRtxHZj4ezDgm-rF7d33ni_pLIA
+  response:
+    body:
+      string: '{"status":"InProgress","error":{"code":"None","message":null}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '62'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Jun 2026 05:59:31 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/543db8bf-ed1b-41d6-ab93-591272c183e7
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 28FFBF9C41394D5A84A1C55EC5227F0D Ref B: SYD03EDGE1314 Ref C: 2026-06-18T05:59:31Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - afd origin create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --profile-name --origin-group-name --origin-name --host-name --origin-host-header
+        --priority --weight --http-port --https-port --enabled-state
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/f75d35fe-d9bb-4608-af64-a2772ebe4dd1?api-version=2025-09-01-preview&t=639173591709539696&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=LfzPCbQd-Wq7dPRyeWUZ4LSkc0DVwVo1Kcpp5gkOKqj7hJ_u3Jk8zxTnZEW4CCk_J2G5oSSCDEfnkkj5eAzjw5bKGoVmTuPyfrrMgl6J0SQ589nMjehlhxSVpPxB6tLoLU7dXyJ3Vrkx3efTXBpbPBvnsOQUUB9Z-bYDPzYyR76XBIi8dPCqwtwtg6r7d7jszGTE7KkVIU7ezFoc3hSdihpVH_rSHfO-lsX1ZNxxMhQdamVu6BiIiy2eamEp0C4tXMEjWdaXzNg8F4yjnxE1-pBAAfTZnGLGWgT2bHCDK4lrPov3aB7t4IAIKCqz_WoWoOTPAc1fnFop7zJ-yJ_8Ag&h=R2BzMnO1ZWN5eQ45hRtxHZj4ezDgm-rF7d33ni_pLIA
+  response:
+    body:
+      string: '{"status":"InProgress","error":{"code":"None","message":null}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '62'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Jun 2026 06:00:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/fa304ca7-403a-4454-98c3-481454453005
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 901350E2E6F44466B3DDD1A4E2AA4E5E Ref B: SYD03EDGE1721 Ref C: 2026-06-18T06:00:02Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - afd origin create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --profile-name --origin-group-name --origin-name --host-name --origin-host-header
+        --priority --weight --http-port --https-port --enabled-state
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/f75d35fe-d9bb-4608-af64-a2772ebe4dd1?api-version=2025-09-01-preview&t=639173591709539696&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=LfzPCbQd-Wq7dPRyeWUZ4LSkc0DVwVo1Kcpp5gkOKqj7hJ_u3Jk8zxTnZEW4CCk_J2G5oSSCDEfnkkj5eAzjw5bKGoVmTuPyfrrMgl6J0SQ589nMjehlhxSVpPxB6tLoLU7dXyJ3Vrkx3efTXBpbPBvnsOQUUB9Z-bYDPzYyR76XBIi8dPCqwtwtg6r7d7jszGTE7KkVIU7ezFoc3hSdihpVH_rSHfO-lsX1ZNxxMhQdamVu6BiIiy2eamEp0C4tXMEjWdaXzNg8F4yjnxE1-pBAAfTZnGLGWgT2bHCDK4lrPov3aB7t4IAIKCqz_WoWoOTPAc1fnFop7zJ-yJ_8Ag&h=R2BzMnO1ZWN5eQ45hRtxHZj4ezDgm-rF7d33ni_pLIA
+  response:
+    body:
+      string: '{"status":"Succeeded","error":{"code":"None","message":null}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '61'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Jun 2026 06:00:34 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/19f0d52b-e8e2-4a6f-8010-9fead89f3424
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: D6D05EE07C084E3BA07F999907F3A84F Ref B: SYD03EDGE1720 Ref C: 2026-06-18T06:00:34Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - afd origin create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --profile-name --origin-group-name --origin-name --host-name --origin-host-header
+        --priority --weight --http-port --https-port --enabled-state
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/originGroups/og000004/origins/origin000005?api-version=2025-09-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/origingroups/og000004/origins/origin000005","type":"Microsoft.Cdn/profiles/origingroups/origins","name":"origin000005","properties":{"originGroupName":"og000004","hostName":"huaiyiztesthost1.blob.core.chinacloudapi.cn","httpPort":80,"httpsPort":443,"originHostHeader":"huaiyiztesthost1.blob.core.chinacloudapi.cn","priority":1,"weight":1000,"enabledState":"Enabled","sharedPrivateLinkResource":null,"enforceCertificateNameCheck":true,"originCapacityResource":null,"provisioningState":"Succeeded","deploymentStatus":"NotStarted"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '673'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Jun 2026 06:00:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/739c6793-0ba2-4d65-81c6-ff14b658892b
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 0DD56DFC5BA245CA8685513D70AA379F Ref B: SYD03EDGE1314 Ref C: 2026-06-18T06:00:35Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"forwardingProtocol": "MatchRequest", "httpsRedirect":
+      "Enabled", "linkToDefaultDomain": "Enabled", "originGroup": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/originGroups/og000004"},
+      "supportedProtocols": ["Https", "Http"]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - afd route create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '342'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g --profile-name --endpoint-name --route-name --origin-group --supported-protocols
+        --link-to-default-domain --https-redirect --forwarding-protocol
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdEndpoints/endpoint1000002/routes/route000006?api-version=2025-09-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdendpoints/endpoint1000002/routes/route000006","type":"Microsoft.Cdn/profiles/afdendpoints/routes","name":"route000006","properties":{"cacheConfiguration":null,"customDomains":[],"grpcState":"Disabled","originGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/originGroups/og000004"},"originPath":null,"ruleSets":[],"supportedProtocols":["Https","Http"],"patternsToMatch":["/*"],"forwardingProtocol":"MatchRequest","linkToDefaultDomain":"Enabled","httpsRedirect":"Enabled","enabledState":"Enabled","provisioningState":"Creating","deploymentStatus":"NotStarted"}}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/4be0fb4c-8557-4fc2-8aed-12f78cf3a3ff?api-version=2025-09-01-preview&t=639173592402669565&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=At7ahfmRJHpbiqdtN0rfFYWqEJdXXDyyD9aqVHmDACo-JezfNUFGo7W8fx40eGe-QIadFr9ad921RAYixByCZRGJtdHJjTqQKAuIiAghIhaQ8zhQsDCc-275XEv4EdMwiAq1K6nOufN5y996AszPAY65Vi1wsbmOr3aEoXwJIm6anQ99jmQnjtwJkQrx2g0N8gaewkr4Xo4xbDE_iu5pwjaIcuajd25m4XDu9nfaw_04aO2e6qsTDaHy8eB6JCR7ndLmJtgGgTkGkWFTlYj3dH8oZ4JXK5XfokNev4ZMhaI_gZtDcW-1l_Zi_8BVccDQwvnPlYiVVzhQ5_5H9OjR8A&h=PWPzdy-K46qLlRrmME0Zn57gAEkub70-giKzZqgTWCQ
+      cache-control:
+      - no-cache
+      content-length:
+      - '808'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Jun 2026 06:00:39 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/43275c7d-285a-46cf-9cc4-798dcf7d803d
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '11999'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: 651B7B2B2AB9416C8BD35B5F15911B67 Ref B: SYD03EDGE2119 Ref C: 2026-06-18T06:00:37Z'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - afd route create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --profile-name --endpoint-name --route-name --origin-group --supported-protocols
+        --link-to-default-domain --https-redirect --forwarding-protocol
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/4be0fb4c-8557-4fc2-8aed-12f78cf3a3ff?api-version=2025-09-01-preview&t=639173592402669565&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=At7ahfmRJHpbiqdtN0rfFYWqEJdXXDyyD9aqVHmDACo-JezfNUFGo7W8fx40eGe-QIadFr9ad921RAYixByCZRGJtdHJjTqQKAuIiAghIhaQ8zhQsDCc-275XEv4EdMwiAq1K6nOufN5y996AszPAY65Vi1wsbmOr3aEoXwJIm6anQ99jmQnjtwJkQrx2g0N8gaewkr4Xo4xbDE_iu5pwjaIcuajd25m4XDu9nfaw_04aO2e6qsTDaHy8eB6JCR7ndLmJtgGgTkGkWFTlYj3dH8oZ4JXK5XfokNev4ZMhaI_gZtDcW-1l_Zi_8BVccDQwvnPlYiVVzhQ5_5H9OjR8A&h=PWPzdy-K46qLlRrmME0Zn57gAEkub70-giKzZqgTWCQ
+  response:
+    body:
+      string: '{"status":"InProgress","error":{"code":"None","message":null}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '62'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Jun 2026 06:00:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/4911ce81-9dc2-4bfa-8a7a-47f27412f470
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 304C68E9104444958BFFEFD8ABFCE3B1 Ref B: SYD03EDGE1921 Ref C: 2026-06-18T06:00:40Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - afd route create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --profile-name --endpoint-name --route-name --origin-group --supported-protocols
+        --link-to-default-domain --https-redirect --forwarding-protocol
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/4be0fb4c-8557-4fc2-8aed-12f78cf3a3ff?api-version=2025-09-01-preview&t=639173592402669565&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=At7ahfmRJHpbiqdtN0rfFYWqEJdXXDyyD9aqVHmDACo-JezfNUFGo7W8fx40eGe-QIadFr9ad921RAYixByCZRGJtdHJjTqQKAuIiAghIhaQ8zhQsDCc-275XEv4EdMwiAq1K6nOufN5y996AszPAY65Vi1wsbmOr3aEoXwJIm6anQ99jmQnjtwJkQrx2g0N8gaewkr4Xo4xbDE_iu5pwjaIcuajd25m4XDu9nfaw_04aO2e6qsTDaHy8eB6JCR7ndLmJtgGgTkGkWFTlYj3dH8oZ4JXK5XfokNev4ZMhaI_gZtDcW-1l_Zi_8BVccDQwvnPlYiVVzhQ5_5H9OjR8A&h=PWPzdy-K46qLlRrmME0Zn57gAEkub70-giKzZqgTWCQ
+  response:
+    body:
+      string: '{"status":"InProgress","error":{"code":"None","message":null}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '62'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Jun 2026 06:01:11 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/3d384695-172a-4456-86d0-50c0cf98d628
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 76DAD09571FD4B7C815FB081D60634F2 Ref B: SYD03EDGE1709 Ref C: 2026-06-18T06:01:11Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - afd route create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --profile-name --endpoint-name --route-name --origin-group --supported-protocols
+        --link-to-default-domain --https-redirect --forwarding-protocol
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/4be0fb4c-8557-4fc2-8aed-12f78cf3a3ff?api-version=2025-09-01-preview&t=639173592402669565&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=At7ahfmRJHpbiqdtN0rfFYWqEJdXXDyyD9aqVHmDACo-JezfNUFGo7W8fx40eGe-QIadFr9ad921RAYixByCZRGJtdHJjTqQKAuIiAghIhaQ8zhQsDCc-275XEv4EdMwiAq1K6nOufN5y996AszPAY65Vi1wsbmOr3aEoXwJIm6anQ99jmQnjtwJkQrx2g0N8gaewkr4Xo4xbDE_iu5pwjaIcuajd25m4XDu9nfaw_04aO2e6qsTDaHy8eB6JCR7ndLmJtgGgTkGkWFTlYj3dH8oZ4JXK5XfokNev4ZMhaI_gZtDcW-1l_Zi_8BVccDQwvnPlYiVVzhQ5_5H9OjR8A&h=PWPzdy-K46qLlRrmME0Zn57gAEkub70-giKzZqgTWCQ
+  response:
+    body:
+      string: '{"status":"Succeeded","error":{"code":"None","message":null}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '61'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Jun 2026 06:01:43 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/a17cb689-8f30-472e-b8eb-508b19f1ce81
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: B4685B5CDBDD49BB8D4709DC9535E2DA Ref B: SYD03EDGE1421 Ref C: 2026-06-18T06:01:43Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - afd route create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --profile-name --endpoint-name --route-name --origin-group --supported-protocols
+        --link-to-default-domain --https-redirect --forwarding-protocol
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdEndpoints/endpoint1000002/routes/route000006?api-version=2025-09-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdendpoints/endpoint1000002/routes/route000006","type":"Microsoft.Cdn/profiles/afdendpoints/routes","name":"route000006","properties":{"cacheConfiguration":null,"customDomains":[],"grpcState":"Disabled","originGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/originGroups/og000004"},"originPath":null,"ruleSets":[],"supportedProtocols":["Https","Http"],"patternsToMatch":["/*"],"forwardingProtocol":"MatchRequest","linkToDefaultDomain":"Enabled","httpsRedirect":"Enabled","enabledState":"Enabled","provisioningState":"Succeeded","deploymentStatus":"NotStarted"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '809'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Jun 2026 06:01:44 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/6b479981-d51e-4ec8-98e7-d06dc70a31b5
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: DC4AA1A866394A1393E24AF4E94174C3 Ref B: SYD03EDGE2118 Ref C: 2026-06-18T06:01:44Z'
     status:
       code: 200
       message: OK
@@ -895,25 +1465,24 @@ interactions:
       Content-Type:
       - application/json
       ParameterSetName:
-      - -g --profile-name --security-policy-name --waf-policy --domains
+      - -g --profile-name --security-policy-name --web-application-firewall
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.13.13 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/securityPolicies/security000004?api-version=2025-09-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/securityPolicies/security000007?api-version=2026-04-01-preview
   response:
     body:
       string: "{\n  \"error\": {\n    \"code\": \"BadRequest\",\n    \"message\":
-        \"Web Application Firewall Policy being attached to AFDX profile does not
-        exist.\"\n  }\n}"
+        \"Waf policy not found in AFD Data store\"\n  }\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '142'
+      - '102'
       content-type:
       - application/json
       date:
-      - Mon, 20 Apr 2026 08:52:41 GMT
+      - Thu, 18 Jun 2026 06:01:47 GMT
       expires:
       - '-1'
       pragma:
@@ -925,13 +1494,13 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/4fa83fea-85c5-4c57-af7b-2c6372684d16
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/50419220-9248-46f2-987d-b7b0db8800e0
       x-ms-ratelimit-remaining-subscription-global-writes:
       - '11999'
       x-ms-ratelimit-remaining-subscription-writes:
       - '799'
       x-msedge-ref:
-      - 'Ref A: FF2FE764CB4043508A1F5E361CF2E62E Ref B: SYD03EDGE0921 Ref C: 2026-04-20T08:52:39Z'
+      - 'Ref A: E67A3908325C4AD4A2A368FCCBDEBD4E Ref B: SYD03EDGE1718 Ref C: 2026-06-18T06:01:47Z'
     status:
       code: 400
       message: Bad Request
@@ -939,7 +1508,8 @@ interactions:
     body: '{"properties": {"parameters": {"type": "WebApplicationFirewall", "associations":
       [{"domains": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdEndpoints/endpoint1000002"},
       {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdEndpoints/endpoint2000003"}],
-      "patternsToMatch": ["/*"]}], "wafPolicy": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/CliDevReservedGroup/providers/Microsoft.Network/frontdoorwebapplicationfirewallpolicies/SampleStandard"}}}}'
+      "patternsToMatch": ["/*"], "routes": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdEndpoints/endpoint1000002/routes/route000006"}]}],
+      "isProfileLevel": false, "wafPolicy": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/CliDevReservedGroup/providers/Microsoft.Network/frontdoorwebapplicationfirewallpolicies/SampleStandard"}}}}'
     headers:
       Accept:
       - application/json
@@ -950,29 +1520,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '674'
+      - '907'
       Content-Type:
       - application/json
       ParameterSetName:
-      - -g --profile-name --security-policy-name --waf-policy --domains
+      - -g --profile-name --security-policy-name --web-application-firewall
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.13.13 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/securityPolicies/security000004?api-version=2025-09-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/securityPolicies/security000007?api-version=2026-04-01-preview
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/securitypolicies/security000004","type":"Microsoft.Cdn/profiles/securitypolicies","name":"security000004","properties":{"parameters":{"wafPolicy":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/CliDevReservedGroup/providers/Microsoft.Network/frontdoorwebapplicationfirewallpolicies/SampleStandard"},"type":"WebApplicationFirewall","associations":[{"domains":[{"isActive":true,"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdEndpoints/endpoint1000002"},{"isActive":true,"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdEndpoints/endpoint2000003"}],"patternsToMatch":["/*"]}]},"provisioningState":"Creating","deploymentStatus":"NotStarted"}}'
+      string: "{\n  \"error\": {\n    \"code\": \"BadRequest\",\n    \"message\":
+        \"Route level association is not allowed for 'Standard_AzureFrontDoor'. Use
+        'Premium_AzureFrontDoor' profile for route level association.\"\n  }\n}"
     headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/50bcfb4f-3ff1-4080-b227-c007cbb9a1e9?api-version=2020-09-01&t=639122719659916985&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=Zf5z4An8C2dfFFo_zjn3dsCAogzu908LSwV5o8WARrwCwCdIPUAi5JpBjFncOy2oHmy3aJzdG--iRIeb23rs4qY0zSkxnvdc1uTvZaceh8p4Lg5LzlwGfsEU7XJ_T-lLhCGKhCJfTfKPHMAVZBeAvnzHAiU8NmqZvjPRoGn7Xy0NVeoWeqmq6jstGL4qqSyQx2hgoATRLVoBiQ4pcjOlPViEA9RaMhxqOJizAwcghXjTE3kw_V2qBXbjso8VfA-QRr5uuScGoha72oyQNpLl1hGIGAKIW1qx6M6PoLs8eaziz-IBev2c6nQa5Rsbar2BN_kp-eMpizvxX-088sMrnQ&h=8Dm3W_yYrIZb3wBDDE8yKyEP6PeP5RoMcJeY_nc4py0
       cache-control:
       - no-cache
       content-length:
-      - '1004'
+      - '199'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Mon, 20 Apr 2026 08:52:45 GMT
+      - Thu, 18 Jun 2026 06:01:50 GMT
       expires:
       - '-1'
       pragma:
@@ -984,13 +1554,72 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/c0d12998-4354-40ea-b62e-f3a54e1b1e94
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/fec67602-ce10-4226-b6e3-3b28b576e3b9
       x-ms-ratelimit-remaining-subscription-global-writes:
       - '11999'
       x-ms-ratelimit-remaining-subscription-writes:
       - '799'
       x-msedge-ref:
-      - 'Ref A: 7703D3F49F354734807CD4DC86A525D6 Ref B: SYD03EDGE1015 Ref C: 2026-04-20T08:52:42Z'
+      - 'Ref A: 8EED61E52DDA46E3A7E32AB1C630008B Ref B: SYD03EDGE1717 Ref C: 2026-06-18T06:01:49Z'
+    status:
+      code: 400
+      message: Bad Request
+- request:
+    body: '{"properties": {"parameters": {"type": "WebApplicationFirewall", "associations":
+      [{"domains": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdEndpoints/endpoint1000002"},
+      {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdEndpoints/endpoint2000003"}],
+      "patternsToMatch": ["/*"]}], "isProfileLevel": false, "wafPolicy": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/CliDevReservedGroup/providers/Microsoft.Network/frontdoorwebapplicationfirewallpolicies/SampleStandard"}}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - afd security-policy create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '699'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g --profile-name --security-policy-name --web-application-firewall
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/securityPolicies/security000007?api-version=2026-04-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/securitypolicies/security000007","type":"Microsoft.Cdn/profiles/securitypolicies","name":"security000007","properties":{"parameters":{"wafPolicy":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/CliDevReservedGroup/providers/Microsoft.Network/frontdoorwebapplicationfirewallpolicies/SampleStandard"},"type":"WebApplicationFirewall","isProfileLevel":false,"associations":[{"domains":[{"isActive":true,"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdEndpoints/endpoint1000002"},{"isActive":true,"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdEndpoints/endpoint2000003"}],"routes":null,"patternsToMatch":["/*"]}]},"provisioningState":"Creating","deploymentStatus":"NotStarted"}}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/e0eed984-ac9d-46ff-b1b5-085ff48b0d19?api-version=2020-09-01&t=639173593145719611&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=ds9Rz2xnXr2OpcasFSTB6MLkKoHjge0YoWkAi5ENS6HHuHxan_B2btPq2faqzqhkRon79UFZ0o7xrbEseojjxzc827IrxcWLcRSUPJNN5Z-g-1S4LeEEJzhv0Vf_9mqak8CbhgGpHsuw9raMsmiERjigW6TNkL3m2DHTwG9Tj_cZboEM_NCOgyfKdo9XeJ1N1ceZTKUFB3mCLajmU8bPd4ymSFQxO9qghsag-0JyH2lhDrwyV9Ha9Gop6qKuoJKJ3Ixs-4yNhp7BrNtPzeSH8owt5mGIEK_KTIL3ZCbWcmE-HkxVP7306bxTvXLdfIGb3CBUPloTzsUbb_qA09_wDQ&h=mcHClJvFpEuIExuuNg2CdjCmlSrnooD4GVv_f5Aknjc
+      cache-control:
+      - no-cache
+      content-length:
+      - '1041'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 18 Jun 2026 06:01:54 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/e1ece317-35dd-489c-8934-af66af0ae951
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '11999'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: D86AF897187D40FAAD528AEAEB4D985F Ref B: SYD03EDGE2008 Ref C: 2026-06-18T06:01:51Z'
     status:
       code: 201
       message: Created
@@ -1006,11 +1635,11 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g --profile-name --security-policy-name --waf-policy --domains
+      - -g --profile-name --security-policy-name --web-application-firewall
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.13.13 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/50bcfb4f-3ff1-4080-b227-c007cbb9a1e9?api-version=2020-09-01&t=639122719659916985&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=Zf5z4An8C2dfFFo_zjn3dsCAogzu908LSwV5o8WARrwCwCdIPUAi5JpBjFncOy2oHmy3aJzdG--iRIeb23rs4qY0zSkxnvdc1uTvZaceh8p4Lg5LzlwGfsEU7XJ_T-lLhCGKhCJfTfKPHMAVZBeAvnzHAiU8NmqZvjPRoGn7Xy0NVeoWeqmq6jstGL4qqSyQx2hgoATRLVoBiQ4pcjOlPViEA9RaMhxqOJizAwcghXjTE3kw_V2qBXbjso8VfA-QRr5uuScGoha72oyQNpLl1hGIGAKIW1qx6M6PoLs8eaziz-IBev2c6nQa5Rsbar2BN_kp-eMpizvxX-088sMrnQ&h=8Dm3W_yYrIZb3wBDDE8yKyEP6PeP5RoMcJeY_nc4py0
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/e0eed984-ac9d-46ff-b1b5-085ff48b0d19?api-version=2020-09-01&t=639173593145719611&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=ds9Rz2xnXr2OpcasFSTB6MLkKoHjge0YoWkAi5ENS6HHuHxan_B2btPq2faqzqhkRon79UFZ0o7xrbEseojjxzc827IrxcWLcRSUPJNN5Z-g-1S4LeEEJzhv0Vf_9mqak8CbhgGpHsuw9raMsmiERjigW6TNkL3m2DHTwG9Tj_cZboEM_NCOgyfKdo9XeJ1N1ceZTKUFB3mCLajmU8bPd4ymSFQxO9qghsag-0JyH2lhDrwyV9Ha9Gop6qKuoJKJ3Ixs-4yNhp7BrNtPzeSH8owt5mGIEK_KTIL3ZCbWcmE-HkxVP7306bxTvXLdfIGb3CBUPloTzsUbb_qA09_wDQ&h=mcHClJvFpEuIExuuNg2CdjCmlSrnooD4GVv_f5Aknjc
   response:
     body:
       string: '{"status":"InProgress","error":{"code":"None","message":null}}'
@@ -1022,7 +1651,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 20 Apr 2026 08:52:47 GMT
+      - Thu, 18 Jun 2026 06:01:56 GMT
       expires:
       - '-1'
       pragma:
@@ -1034,11 +1663,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/80687228-961e-4a10-b778-e6ec9c303ee6
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/049a6523-01f0-4f28-92c0-83cf6f3dde6b
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 943FC7D0BAF4476991FD43B3B1FEB60B Ref B: SYD03EDGE0709 Ref C: 2026-04-20T08:52:46Z'
+      - 'Ref A: A1795E80AB39488D98E8355523A84312 Ref B: SYD03EDGE1311 Ref C: 2026-06-18T06:01:55Z'
     status:
       code: 200
       message: OK
@@ -1054,11 +1683,11 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g --profile-name --security-policy-name --waf-policy --domains
+      - -g --profile-name --security-policy-name --web-application-firewall
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.13.13 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/50bcfb4f-3ff1-4080-b227-c007cbb9a1e9?api-version=2020-09-01&t=639122719659916985&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=Zf5z4An8C2dfFFo_zjn3dsCAogzu908LSwV5o8WARrwCwCdIPUAi5JpBjFncOy2oHmy3aJzdG--iRIeb23rs4qY0zSkxnvdc1uTvZaceh8p4Lg5LzlwGfsEU7XJ_T-lLhCGKhCJfTfKPHMAVZBeAvnzHAiU8NmqZvjPRoGn7Xy0NVeoWeqmq6jstGL4qqSyQx2hgoATRLVoBiQ4pcjOlPViEA9RaMhxqOJizAwcghXjTE3kw_V2qBXbjso8VfA-QRr5uuScGoha72oyQNpLl1hGIGAKIW1qx6M6PoLs8eaziz-IBev2c6nQa5Rsbar2BN_kp-eMpizvxX-088sMrnQ&h=8Dm3W_yYrIZb3wBDDE8yKyEP6PeP5RoMcJeY_nc4py0
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/e0eed984-ac9d-46ff-b1b5-085ff48b0d19?api-version=2020-09-01&t=639173593145719611&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=ds9Rz2xnXr2OpcasFSTB6MLkKoHjge0YoWkAi5ENS6HHuHxan_B2btPq2faqzqhkRon79UFZ0o7xrbEseojjxzc827IrxcWLcRSUPJNN5Z-g-1S4LeEEJzhv0Vf_9mqak8CbhgGpHsuw9raMsmiERjigW6TNkL3m2DHTwG9Tj_cZboEM_NCOgyfKdo9XeJ1N1ceZTKUFB3mCLajmU8bPd4ymSFQxO9qghsag-0JyH2lhDrwyV9Ha9Gop6qKuoJKJ3Ixs-4yNhp7BrNtPzeSH8owt5mGIEK_KTIL3ZCbWcmE-HkxVP7306bxTvXLdfIGb3CBUPloTzsUbb_qA09_wDQ&h=mcHClJvFpEuIExuuNg2CdjCmlSrnooD4GVv_f5Aknjc
   response:
     body:
       string: '{"status":"InProgress","error":{"code":"None","message":null}}'
@@ -1070,7 +1699,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 20 Apr 2026 08:53:17 GMT
+      - Thu, 18 Jun 2026 06:02:27 GMT
       expires:
       - '-1'
       pragma:
@@ -1082,11 +1711,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/21fbaf62-f2df-47a6-bb9a-b76c3d03a531
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/7c8e973a-3911-42a8-a6d9-bfccd049b8d5
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: B6952B28023F4795AECC2CFE83D43FEE Ref B: SYD03EDGE0913 Ref C: 2026-04-20T08:53:17Z'
+      - 'Ref A: 43DDB9347CE942A59938DACCD37B81E8 Ref B: SYD03EDGE2120 Ref C: 2026-06-18T06:02:27Z'
     status:
       code: 200
       message: OK
@@ -1102,11 +1731,11 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g --profile-name --security-policy-name --waf-policy --domains
+      - -g --profile-name --security-policy-name --web-application-firewall
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.13.13 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/50bcfb4f-3ff1-4080-b227-c007cbb9a1e9?api-version=2020-09-01&t=639122719659916985&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=Zf5z4An8C2dfFFo_zjn3dsCAogzu908LSwV5o8WARrwCwCdIPUAi5JpBjFncOy2oHmy3aJzdG--iRIeb23rs4qY0zSkxnvdc1uTvZaceh8p4Lg5LzlwGfsEU7XJ_T-lLhCGKhCJfTfKPHMAVZBeAvnzHAiU8NmqZvjPRoGn7Xy0NVeoWeqmq6jstGL4qqSyQx2hgoATRLVoBiQ4pcjOlPViEA9RaMhxqOJizAwcghXjTE3kw_V2qBXbjso8VfA-QRr5uuScGoha72oyQNpLl1hGIGAKIW1qx6M6PoLs8eaziz-IBev2c6nQa5Rsbar2BN_kp-eMpizvxX-088sMrnQ&h=8Dm3W_yYrIZb3wBDDE8yKyEP6PeP5RoMcJeY_nc4py0
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/e0eed984-ac9d-46ff-b1b5-085ff48b0d19?api-version=2020-09-01&t=639173593145719611&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=ds9Rz2xnXr2OpcasFSTB6MLkKoHjge0YoWkAi5ENS6HHuHxan_B2btPq2faqzqhkRon79UFZ0o7xrbEseojjxzc827IrxcWLcRSUPJNN5Z-g-1S4LeEEJzhv0Vf_9mqak8CbhgGpHsuw9raMsmiERjigW6TNkL3m2DHTwG9Tj_cZboEM_NCOgyfKdo9XeJ1N1ceZTKUFB3mCLajmU8bPd4ymSFQxO9qghsag-0JyH2lhDrwyV9Ha9Gop6qKuoJKJ3Ixs-4yNhp7BrNtPzeSH8owt5mGIEK_KTIL3ZCbWcmE-HkxVP7306bxTvXLdfIGb3CBUPloTzsUbb_qA09_wDQ&h=mcHClJvFpEuIExuuNg2CdjCmlSrnooD4GVv_f5Aknjc
   response:
     body:
       string: '{"status":"Succeeded","error":{"code":"None","message":null}}'
@@ -1118,7 +1747,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 20 Apr 2026 08:53:48 GMT
+      - Thu, 18 Jun 2026 06:02:57 GMT
       expires:
       - '-1'
       pragma:
@@ -1130,11 +1759,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/3aec8a05-50c0-4ece-a285-43b2738945fc
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/2e4f3618-2896-4ab5-a1a7-b1dcad33bd30
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 7D0ECB5AAB5B4D2781AB488A0EE18CAD Ref B: SYD03EDGE2108 Ref C: 2026-04-20T08:53:48Z'
+      - 'Ref A: EC08FCFAEC4449BEA4BE14348DE672F4 Ref B: SYD03EDGE1308 Ref C: 2026-06-18T06:02:58Z'
     status:
       code: 200
       message: OK
@@ -1150,23 +1779,23 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g --profile-name --security-policy-name --waf-policy --domains
+      - -g --profile-name --security-policy-name --web-application-firewall
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.13.13 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/securityPolicies/security000004?api-version=2025-09-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/securityPolicies/security000007?api-version=2026-04-01-preview
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/securitypolicies/security000004","type":"Microsoft.Cdn/profiles/securitypolicies","name":"security000004","properties":{"parameters":{"wafPolicy":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/CliDevReservedGroup/providers/Microsoft.Network/frontdoorwebapplicationfirewallpolicies/SampleStandard"},"type":"WebApplicationFirewall","associations":[{"domains":[{"isActive":true,"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdEndpoints/endpoint1000002"},{"isActive":true,"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdEndpoints/endpoint2000003"}],"patternsToMatch":["/*"]}]},"provisioningState":"Succeeded","deploymentStatus":"NotStarted"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/securitypolicies/security000007","type":"Microsoft.Cdn/profiles/securitypolicies","name":"security000007","properties":{"parameters":{"wafPolicy":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/CliDevReservedGroup/providers/Microsoft.Network/frontdoorwebapplicationfirewallpolicies/SampleStandard"},"type":"WebApplicationFirewall","isProfileLevel":false,"associations":[{"domains":[{"isActive":true,"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdEndpoints/endpoint1000002"},{"isActive":true,"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdEndpoints/endpoint2000003"}],"routes":null,"patternsToMatch":["/*"]}]},"provisioningState":"Succeeded","deploymentStatus":"NotStarted"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1005'
+      - '1042'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 20 Apr 2026 08:53:51 GMT
+      - Thu, 18 Jun 2026 06:02:59 GMT
       expires:
       - '-1'
       pragma:
@@ -1178,11 +1807,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/245afaf1-374c-44c2-a7b3-ea5f6ebc2b7b
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/6a8e1058-64cb-4b01-94be-4283301101cb
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 582CA1A37ECE4FD5A318466E6F0E94BF Ref B: SYD03EDGE1915 Ref C: 2026-04-20T08:53:50Z'
+      - 'Ref A: 95BD8D5218D643218FD776A7BDC1AB79 Ref B: SYD03EDGE1422 Ref C: 2026-06-18T06:02:59Z'
     status:
       code: 200
       message: OK
@@ -1200,21 +1829,21 @@ interactions:
       ParameterSetName:
       - -g --profile-name --security-policy-name
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.13.13 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/securityPolicies/security000004?api-version=2025-09-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/securityPolicies/security000007?api-version=2026-04-01-preview
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/securitypolicies/security000004","type":"Microsoft.Cdn/profiles/securitypolicies","name":"security000004","properties":{"parameters":{"wafPolicy":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/CliDevReservedGroup/providers/Microsoft.Network/frontdoorwebapplicationfirewallpolicies/SampleStandard"},"type":"WebApplicationFirewall","associations":[{"domains":[{"isActive":true,"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdEndpoints/endpoint1000002"},{"isActive":true,"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdEndpoints/endpoint2000003"}],"patternsToMatch":["/*"]}]},"provisioningState":"Succeeded","deploymentStatus":"NotStarted"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/securitypolicies/security000007","type":"Microsoft.Cdn/profiles/securitypolicies","name":"security000007","properties":{"parameters":{"wafPolicy":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/CliDevReservedGroup/providers/Microsoft.Network/frontdoorwebapplicationfirewallpolicies/SampleStandard"},"type":"WebApplicationFirewall","isProfileLevel":false,"associations":[{"domains":[{"isActive":true,"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdEndpoints/endpoint1000002"},{"isActive":true,"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdEndpoints/endpoint2000003"}],"routes":null,"patternsToMatch":["/*"]}]},"provisioningState":"Succeeded","deploymentStatus":"NotStarted"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1005'
+      - '1042'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 20 Apr 2026 08:53:52 GMT
+      - Thu, 18 Jun 2026 06:03:01 GMT
       expires:
       - '-1'
       pragma:
@@ -1226,11 +1855,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/86ec7ba9-9eae-4967-8da0-11142e0c08b4
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/96056e57-218a-4c46-85ea-f68e34da6c8d
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: FC9EE903270243CB8FEEA0F63637413E Ref B: SYD03EDGE0713 Ref C: 2026-04-20T08:53:52Z'
+      - 'Ref A: 7F0610ED3AF24C95A084468C3E93AEF3 Ref B: SYD03EDGE1408 Ref C: 2026-06-18T06:03:01Z'
     status:
       code: 200
       message: OK
@@ -1248,21 +1877,21 @@ interactions:
       ParameterSetName:
       - -g --profile-name
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.13.13 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/securityPolicies?api-version=2025-09-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/securityPolicies?api-version=2026-04-01-preview
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/securitypolicies/security000004","type":"Microsoft.Cdn/profiles/securitypolicies","name":"security000004","properties":{"parameters":{"wafPolicy":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/CliDevReservedGroup/providers/Microsoft.Network/frontdoorwebapplicationfirewallpolicies/SampleStandard"},"type":"WebApplicationFirewall","associations":[{"domains":[{"isActive":true,"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdEndpoints/endpoint1000002"},{"isActive":true,"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdEndpoints/endpoint2000003"}],"patternsToMatch":["/*"]}]},"provisioningState":"Succeeded","deploymentStatus":"NotStarted"}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/securitypolicies/security000007","type":"Microsoft.Cdn/profiles/securitypolicies","name":"security000007","properties":{"parameters":{"wafPolicy":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/CliDevReservedGroup/providers/Microsoft.Network/frontdoorwebapplicationfirewallpolicies/SampleStandard"},"type":"WebApplicationFirewall","isProfileLevel":false,"associations":[{"domains":[{"isActive":true,"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdEndpoints/endpoint1000002"},{"isActive":true,"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdEndpoints/endpoint2000003"}],"routes":null,"patternsToMatch":["/*"]}]},"provisioningState":"Succeeded","deploymentStatus":"NotStarted"}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1017'
+      - '1054'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 20 Apr 2026 08:53:53 GMT
+      - Thu, 18 Jun 2026 06:03:03 GMT
       expires:
       - '-1'
       pragma:
@@ -1274,11 +1903,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/427e82c0-af05-4618-9d91-b2c4cecc2350
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/62e01dcc-9879-4cae-af4d-cf1983448be0
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 3851CEF765B64C21AA5EE112998B0919 Ref B: SYD03EDGE0805 Ref C: 2026-04-20T08:53:53Z'
+      - 'Ref A: E52F69A1281C49DB9EE3226E06A65D6C Ref B: SYD03EDGE2015 Ref C: 2026-06-18T06:03:03Z'
     status:
       code: 200
       message: OK
@@ -1294,23 +1923,23 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g --profile-name --security-policy-name --domains --waf-policy
+      - -g --profile-name --security-policy-name --web-application-firewall
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.13.13 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/securityPolicies/security000004?api-version=2025-09-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/securityPolicies/security000007?api-version=2026-04-01-preview
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/securitypolicies/security000004","type":"Microsoft.Cdn/profiles/securitypolicies","name":"security000004","properties":{"parameters":{"wafPolicy":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/CliDevReservedGroup/providers/Microsoft.Network/frontdoorwebapplicationfirewallpolicies/SampleStandard"},"type":"WebApplicationFirewall","associations":[{"domains":[{"isActive":true,"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdEndpoints/endpoint1000002"},{"isActive":true,"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdEndpoints/endpoint2000003"}],"patternsToMatch":["/*"]}]},"provisioningState":"Succeeded","deploymentStatus":"NotStarted"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/securitypolicies/security000007","type":"Microsoft.Cdn/profiles/securitypolicies","name":"security000007","properties":{"parameters":{"wafPolicy":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/CliDevReservedGroup/providers/Microsoft.Network/frontdoorwebapplicationfirewallpolicies/SampleStandard"},"type":"WebApplicationFirewall","isProfileLevel":false,"associations":[{"domains":[{"isActive":true,"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdEndpoints/endpoint1000002"},{"isActive":true,"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdEndpoints/endpoint2000003"}],"routes":null,"patternsToMatch":["/*"]}]},"provisioningState":"Succeeded","deploymentStatus":"NotStarted"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1005'
+      - '1042'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 20 Apr 2026 08:53:54 GMT
+      - Thu, 18 Jun 2026 06:03:05 GMT
       expires:
       - '-1'
       pragma:
@@ -1322,66 +1951,18 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/f9501547-c54f-489b-91d2-d39ed6a78429
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/15b92eec-9575-4081-81cc-2aa26364bee5
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 991D96CC48FE4695AADFD3B018DD48B2 Ref B: SYD03EDGE1419 Ref C: 2026-04-20T08:53:54Z'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - afd security-policy update
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --profile-name --security-policy-name --domains --waf-policy
-      User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.13.13 (Windows-11-10.0.26200-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/securityPolicies/security000004?api-version=2025-09-01-preview
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/securitypolicies/security000004","type":"Microsoft.Cdn/profiles/securitypolicies","name":"security000004","properties":{"parameters":{"wafPolicy":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/CliDevReservedGroup/providers/Microsoft.Network/frontdoorwebapplicationfirewallpolicies/SampleStandard"},"type":"WebApplicationFirewall","associations":[{"domains":[{"isActive":true,"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdEndpoints/endpoint1000002"},{"isActive":true,"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdEndpoints/endpoint2000003"}],"patternsToMatch":["/*"]}]},"provisioningState":"Succeeded","deploymentStatus":"NotStarted"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1005'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 20 Apr 2026 08:53:56 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-cache:
-      - CONFIG_NOCACHE
-      x-content-type-options:
-      - nosniff
-      x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/cc4a1235-0935-407b-b9a7-1259abf3d5fe
-      x-ms-ratelimit-remaining-subscription-global-reads:
-      - '16499'
-      x-msedge-ref:
-      - 'Ref A: 00F7AE9FD89F4D0493CD7B4E9F02DA44 Ref B: SYD03EDGE0906 Ref C: 2026-04-20T08:53:56Z'
+      - 'Ref A: 663028C6132B45218DC7780DF524C0ED Ref B: SYD03EDGE1913 Ref C: 2026-06-18T06:03:04Z'
     status:
       code: 200
       message: OK
 - request:
     body: '{"properties": {"parameters": {"type": "WebApplicationFirewall", "associations":
       [{"domains": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdEndpoints/endpoint2000003"}],
-      "patternsToMatch": ["/*"]}], "wafPolicy": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/CliDevReservedGroup/providers/Microsoft.Network/frontdoorwebapplicationfirewallpolicies/SampleStandard"}}}}'
+      "patternsToMatch": ["/*"]}], "isProfileLevel": false, "wafPolicy": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/CliDevReservedGroup/providers/Microsoft.Network/frontdoorwebapplicationfirewallpolicies/SampleStandard"}}}}'
     headers:
       Accept:
       - application/json
@@ -1392,33 +1973,33 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '497'
+      - '522'
       Content-Type:
       - application/json
       ParameterSetName:
-      - -g --profile-name --security-policy-name --domains --waf-policy
+      - -g --profile-name --security-policy-name --web-application-firewall
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.13.13 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/securityPolicies/security000004?api-version=2025-09-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/securityPolicies/security000007?api-version=2026-04-01-preview
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/securitypolicies/security000004","type":"Microsoft.Cdn/profiles/securitypolicies","name":"security000004","properties":{"parameters":{"wafPolicy":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/CliDevReservedGroup/providers/Microsoft.Network/frontdoorwebapplicationfirewallpolicies/SampleStandard"},"type":"WebApplicationFirewall","associations":[{"domains":[{"isActive":true,"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdEndpoints/endpoint2000003"}],"patternsToMatch":["/*"]}]},"provisioningState":"Updating","deploymentStatus":"NotStarted"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/securitypolicies/security000007","type":"Microsoft.Cdn/profiles/securitypolicies","name":"security000007","properties":{"parameters":{"wafPolicy":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/CliDevReservedGroup/providers/Microsoft.Network/frontdoorwebapplicationfirewallpolicies/SampleStandard"},"type":"WebApplicationFirewall","isProfileLevel":false,"associations":[{"domains":[{"isActive":true,"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdEndpoints/endpoint2000003"}],"routes":null,"patternsToMatch":["/*"]}]},"provisioningState":"Updating","deploymentStatus":"NotStarted"}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/1f571094-af19-4394-a4b0-2607ef93fdbe?api-version=2020-09-01&t=639122720405152037&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=pHffUSnu70gNQKIYyAvLjntkh_ngYJSt0UWdcXvQ_345HXVES7-x91jgVmosaqZir1F8_JGg8D8hWBCAESXBlOXNL5u4ddmlYRL1aTdbSOe8FfqRcFpCBLKFIgzsk7g1HFVGhmAQOXGikuDlfBBuLmOJieSR67UTn3AGOzHpT5vtwmMaoACfhg0ZXlepyZaaNgtEIi4cceDcvfHV_KdDk3I1ZJmH7qOq8_6SdWAecrwiPuQCZKHWN733PEDvMCg6lTtBANLkGoNsLks-yQk4NY6zZIMdzjbjPmzOWdnSGceO7C9NoCxaH7Gap34QdqdsDfJiqz9_4uueCDKIXn-ztQ&h=U6p7jwaCepmZZBDowAvDcFhnF20C7y4fcNUuliPpYyI
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/3708c182-0647-473f-ad87-7e4f7c8b49ce?api-version=2020-09-01&t=639173593881226612&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=U7568kf7MsLxwi-JwjGXOcQZ6Ux8-umb9nduy6qKJDvES6dvf6EGQmFt4nAnejQGFUrC6msmLNpENCPf1kEvmU7s4wWlpBiVSGJiWulAaxFdTT1_r6s9VuniqXpMcidB-inWY2rsTGafcCSrK35eS_DK4YVO8WKt8jF0YdxDHMwrmJYxQQoJeaKnTnjPjvzX3asODwIXnkraRWM0fRdypGyeTMKckWuP60t0-W_h4OFcmiwSZMq3XKILTjC5q0weDnAf58FidNIoDafInxCJFg-q8KAy8lgEVajoJR_yCwZqmj6UiRHHSmY3-T9fk9iHqilrUK-QfiOXrlDzqurNVg&h=FWVDb5EpzHxwOYP7NmNyR6EnS7KxQySGjk-FCYxmtaI
       cache-control:
       - no-cache
       content-length:
-      - '813'
+      - '850'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 20 Apr 2026 08:54:00 GMT
+      - Thu, 18 Jun 2026 06:03:07 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/1f571094-af19-4394-a4b0-2607ef93fdbe/profileresults/profilesecuritytest/securitypolicyresults/security000004?api-version=2020-09-01&t=639122720405152037&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=NjsRxO7Q6akU2iW7ihZLUrkeIRCdJhAUn5OhjenADarxcG2Tv2ellt8HeVZusgM4eRGK1Pg1p4S_WI_B-BbQSKKsiGE1dkju-pbOD4ubIqFOAAFpm2J653-OucanzqjQaYIDayUq92H6smpUsVeGs6DnOahurBaSSZE6aXaflz6t27v2MfQQQgkinETrdQrtsgvILe4TvK71JLGs_lrC_0hnMwfjwQ6d9wPfhyP-ZHLCfpcLBlJ88uOhPxp1-1MCjx2edAI5sa0FhuSCK7wX7aWES8_c75ZUKFddH7pwQX318agK7lVIq1L_KE8V41eeb5KXyjjL8PiOmPEGZIf3zQ&h=9sVienouPljjzzwWRzrck3PlUyirniECW_hGhv5--Qc
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/3708c182-0647-473f-ad87-7e4f7c8b49ce/profileresults/profilesecuritytest/securitypolicyresults/security000007?api-version=2020-09-01&t=639173593881226612&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=QlFEuriKXeLDCPGRYZdQ3VGpSOrxIUpFJV6jYZCXlqTdeeYgl_kauxzLx8yhA8TlSp2EGz1tTdhMWtyMc8h40uwL1wRoEt3U_ZHq8qqUbNYe_99paKTFLoF4ucqnBWAmnOK_9rtZrIBIXkjy9r6T0x79bh0PmwTvxPjXTsW53-NZkNp3HaY-Wx2Q1EYfVXVgyIPXrNXDr3gH8m3-tjQkJgAykXjXjQfm-uw9SHJsUHX8f3Vi49IMRcKoSi-Vd_PSy8bNdeP9AwnAo3H-tFz6hXvSBDOxdvQj7PaYOiZHHBySxOCeVobRavk5FN1YlkByR7PZ6bLQFfA3w_sndlSSMQ&h=um1uRAXE08S7jhU2pNFrt-qYsR-g1BCiEBauQdL3n74
       pragma:
       - no-cache
       strict-transport-security:
@@ -1428,13 +2009,13 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/8b25778c-36e5-42e8-b78b-ec920eb09f92
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/783b8508-49ab-4db6-a2fa-d86d5c608c20
       x-ms-ratelimit-remaining-subscription-global-writes:
       - '11999'
       x-ms-ratelimit-remaining-subscription-writes:
       - '799'
       x-msedge-ref:
-      - 'Ref A: AF83492DA13C4F52AF82DFBA75BF4C3D Ref B: SYD03EDGE1321 Ref C: 2026-04-20T08:53:57Z'
+      - 'Ref A: 2FD19EF0398F4FA4AE94848A46BFDA26 Ref B: SYD03EDGE2012 Ref C: 2026-06-18T06:03:06Z'
     status:
       code: 202
       message: Accepted
@@ -1450,11 +2031,11 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g --profile-name --security-policy-name --domains --waf-policy
+      - -g --profile-name --security-policy-name --web-application-firewall
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.13.13 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/1f571094-af19-4394-a4b0-2607ef93fdbe?api-version=2020-09-01&t=639122720405152037&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=pHffUSnu70gNQKIYyAvLjntkh_ngYJSt0UWdcXvQ_345HXVES7-x91jgVmosaqZir1F8_JGg8D8hWBCAESXBlOXNL5u4ddmlYRL1aTdbSOe8FfqRcFpCBLKFIgzsk7g1HFVGhmAQOXGikuDlfBBuLmOJieSR67UTn3AGOzHpT5vtwmMaoACfhg0ZXlepyZaaNgtEIi4cceDcvfHV_KdDk3I1ZJmH7qOq8_6SdWAecrwiPuQCZKHWN733PEDvMCg6lTtBANLkGoNsLks-yQk4NY6zZIMdzjbjPmzOWdnSGceO7C9NoCxaH7Gap34QdqdsDfJiqz9_4uueCDKIXn-ztQ&h=U6p7jwaCepmZZBDowAvDcFhnF20C7y4fcNUuliPpYyI
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/3708c182-0647-473f-ad87-7e4f7c8b49ce?api-version=2020-09-01&t=639173593881226612&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=U7568kf7MsLxwi-JwjGXOcQZ6Ux8-umb9nduy6qKJDvES6dvf6EGQmFt4nAnejQGFUrC6msmLNpENCPf1kEvmU7s4wWlpBiVSGJiWulAaxFdTT1_r6s9VuniqXpMcidB-inWY2rsTGafcCSrK35eS_DK4YVO8WKt8jF0YdxDHMwrmJYxQQoJeaKnTnjPjvzX3asODwIXnkraRWM0fRdypGyeTMKckWuP60t0-W_h4OFcmiwSZMq3XKILTjC5q0weDnAf58FidNIoDafInxCJFg-q8KAy8lgEVajoJR_yCwZqmj6UiRHHSmY3-T9fk9iHqilrUK-QfiOXrlDzqurNVg&h=FWVDb5EpzHxwOYP7NmNyR6EnS7KxQySGjk-FCYxmtaI
   response:
     body:
       string: '{"status":"InProgress","error":{"code":"None","message":null}}'
@@ -1466,7 +2047,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 20 Apr 2026 08:54:01 GMT
+      - Thu, 18 Jun 2026 06:03:09 GMT
       expires:
       - '-1'
       pragma:
@@ -1478,11 +2059,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/28cf8bea-80c8-49a5-ae68-1d96858f08d4
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/e1500588-fe64-4eca-9030-97e9837b7728
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 989D4F44A1064786B37A61AC3049AE22 Ref B: SYD03EDGE0716 Ref C: 2026-04-20T08:54:01Z'
+      - 'Ref A: 9B3A994E98AD48EDB7A482EA3D9253CA Ref B: SYD03EDGE1315 Ref C: 2026-06-18T06:03:08Z'
     status:
       code: 200
       message: OK
@@ -1498,11 +2079,11 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g --profile-name --security-policy-name --domains --waf-policy
+      - -g --profile-name --security-policy-name --web-application-firewall
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.13.13 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/1f571094-af19-4394-a4b0-2607ef93fdbe?api-version=2020-09-01&t=639122720405152037&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=pHffUSnu70gNQKIYyAvLjntkh_ngYJSt0UWdcXvQ_345HXVES7-x91jgVmosaqZir1F8_JGg8D8hWBCAESXBlOXNL5u4ddmlYRL1aTdbSOe8FfqRcFpCBLKFIgzsk7g1HFVGhmAQOXGikuDlfBBuLmOJieSR67UTn3AGOzHpT5vtwmMaoACfhg0ZXlepyZaaNgtEIi4cceDcvfHV_KdDk3I1ZJmH7qOq8_6SdWAecrwiPuQCZKHWN733PEDvMCg6lTtBANLkGoNsLks-yQk4NY6zZIMdzjbjPmzOWdnSGceO7C9NoCxaH7Gap34QdqdsDfJiqz9_4uueCDKIXn-ztQ&h=U6p7jwaCepmZZBDowAvDcFhnF20C7y4fcNUuliPpYyI
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/3708c182-0647-473f-ad87-7e4f7c8b49ce?api-version=2020-09-01&t=639173593881226612&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=U7568kf7MsLxwi-JwjGXOcQZ6Ux8-umb9nduy6qKJDvES6dvf6EGQmFt4nAnejQGFUrC6msmLNpENCPf1kEvmU7s4wWlpBiVSGJiWulAaxFdTT1_r6s9VuniqXpMcidB-inWY2rsTGafcCSrK35eS_DK4YVO8WKt8jF0YdxDHMwrmJYxQQoJeaKnTnjPjvzX3asODwIXnkraRWM0fRdypGyeTMKckWuP60t0-W_h4OFcmiwSZMq3XKILTjC5q0weDnAf58FidNIoDafInxCJFg-q8KAy8lgEVajoJR_yCwZqmj6UiRHHSmY3-T9fk9iHqilrUK-QfiOXrlDzqurNVg&h=FWVDb5EpzHxwOYP7NmNyR6EnS7KxQySGjk-FCYxmtaI
   response:
     body:
       string: '{"status":"InProgress","error":{"code":"None","message":null}}'
@@ -1514,7 +2095,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 20 Apr 2026 08:54:32 GMT
+      - Thu, 18 Jun 2026 06:03:40 GMT
       expires:
       - '-1'
       pragma:
@@ -1526,11 +2107,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/c97eae9b-9529-47d6-aaa8-1ac296211bc2
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/9d1b7080-69c5-4e4e-95a2-46d632ce9abf
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 3A169195121B44CE979B0DE8765A32E1 Ref B: SYD03EDGE0712 Ref C: 2026-04-20T08:54:32Z'
+      - 'Ref A: 78BE89155A064B1299C44AA402F8F2ED Ref B: SYD03EDGE1716 Ref C: 2026-06-18T06:03:40Z'
     status:
       code: 200
       message: OK
@@ -1546,11 +2127,11 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g --profile-name --security-policy-name --domains --waf-policy
+      - -g --profile-name --security-policy-name --web-application-firewall
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.13.13 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/1f571094-af19-4394-a4b0-2607ef93fdbe?api-version=2020-09-01&t=639122720405152037&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=pHffUSnu70gNQKIYyAvLjntkh_ngYJSt0UWdcXvQ_345HXVES7-x91jgVmosaqZir1F8_JGg8D8hWBCAESXBlOXNL5u4ddmlYRL1aTdbSOe8FfqRcFpCBLKFIgzsk7g1HFVGhmAQOXGikuDlfBBuLmOJieSR67UTn3AGOzHpT5vtwmMaoACfhg0ZXlepyZaaNgtEIi4cceDcvfHV_KdDk3I1ZJmH7qOq8_6SdWAecrwiPuQCZKHWN733PEDvMCg6lTtBANLkGoNsLks-yQk4NY6zZIMdzjbjPmzOWdnSGceO7C9NoCxaH7Gap34QdqdsDfJiqz9_4uueCDKIXn-ztQ&h=U6p7jwaCepmZZBDowAvDcFhnF20C7y4fcNUuliPpYyI
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/3708c182-0647-473f-ad87-7e4f7c8b49ce?api-version=2020-09-01&t=639173593881226612&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=U7568kf7MsLxwi-JwjGXOcQZ6Ux8-umb9nduy6qKJDvES6dvf6EGQmFt4nAnejQGFUrC6msmLNpENCPf1kEvmU7s4wWlpBiVSGJiWulAaxFdTT1_r6s9VuniqXpMcidB-inWY2rsTGafcCSrK35eS_DK4YVO8WKt8jF0YdxDHMwrmJYxQQoJeaKnTnjPjvzX3asODwIXnkraRWM0fRdypGyeTMKckWuP60t0-W_h4OFcmiwSZMq3XKILTjC5q0weDnAf58FidNIoDafInxCJFg-q8KAy8lgEVajoJR_yCwZqmj6UiRHHSmY3-T9fk9iHqilrUK-QfiOXrlDzqurNVg&h=FWVDb5EpzHxwOYP7NmNyR6EnS7KxQySGjk-FCYxmtaI
   response:
     body:
       string: '{"status":"Succeeded","error":{"code":"None","message":null}}'
@@ -1562,7 +2143,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 20 Apr 2026 08:55:03 GMT
+      - Thu, 18 Jun 2026 06:04:11 GMT
       expires:
       - '-1'
       pragma:
@@ -1574,11 +2155,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/1e9d8783-827e-4051-a730-03681778acaf
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/301452dd-612f-4007-8def-532047ff0f1b
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 6824D78F487649D5A683419A3BCBC7CF Ref B: SYD03EDGE2118 Ref C: 2026-04-20T08:55:03Z'
+      - 'Ref A: D72E5ED03A774378AE038C414C0DE90E Ref B: SYD03EDGE2117 Ref C: 2026-06-18T06:04:11Z'
     status:
       code: 200
       message: OK
@@ -1594,23 +2175,23 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g --profile-name --security-policy-name --domains --waf-policy
+      - -g --profile-name --security-policy-name --web-application-firewall
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.13.13 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/securityPolicies/security000004?api-version=2025-09-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/securityPolicies/security000007?api-version=2026-04-01-preview
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/securitypolicies/security000004","type":"Microsoft.Cdn/profiles/securitypolicies","name":"security000004","properties":{"parameters":{"wafPolicy":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/CliDevReservedGroup/providers/Microsoft.Network/frontdoorwebapplicationfirewallpolicies/SampleStandard"},"type":"WebApplicationFirewall","associations":[{"domains":[{"isActive":true,"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdEndpoints/endpoint2000003"}],"patternsToMatch":["/*"]}]},"provisioningState":"Succeeded","deploymentStatus":"NotStarted"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/securitypolicies/security000007","type":"Microsoft.Cdn/profiles/securitypolicies","name":"security000007","properties":{"parameters":{"wafPolicy":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/CliDevReservedGroup/providers/Microsoft.Network/frontdoorwebapplicationfirewallpolicies/SampleStandard"},"type":"WebApplicationFirewall","isProfileLevel":false,"associations":[{"domains":[{"isActive":true,"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/afdEndpoints/endpoint2000003"}],"routes":null,"patternsToMatch":["/*"]}]},"provisioningState":"Succeeded","deploymentStatus":"NotStarted"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '814'
+      - '851'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 20 Apr 2026 08:55:04 GMT
+      - Thu, 18 Jun 2026 06:04:12 GMT
       expires:
       - '-1'
       pragma:
@@ -1622,11 +2203,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/1d8305e0-81e8-4423-b70d-00761b0e6040
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/25b9aad3-92e4-4e86-8d5c-b3b2d15eb33c
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 67A15CCBAD024C7EBECAF059E170C2F4 Ref B: SYD03EDGE1015 Ref C: 2026-04-20T08:55:04Z'
+      - 'Ref A: 0745D3F40B2049E6B7F7647A86F53344 Ref B: SYD03EDGE1309 Ref C: 2026-06-18T06:04:12Z'
     status:
       code: 200
       message: OK
@@ -1646,25 +2227,25 @@ interactions:
       ParameterSetName:
       - -g --profile-name --security-policy-name --yes
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.13.13 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
     method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/securityPolicies/security000004?api-version=2025-09-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/securityPolicies/security000007?api-version=2026-04-01-preview
   response:
     body:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/79ca9ed9-42fb-48aa-873d-106edc14e9a8?api-version=2020-09-01&t=639122721078350782&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=ocRFpP6hJhVnwbwhA275Vm0fMBn5X5pKbQtbQMIyKvfmG385-t-VEn4sGrjSoSCLGoV6S7w3UiwMxWI3Ht5d_Mr_NO_TPOMCWUN9eBP05muFD6GDfBDbEkVx6J9MNSmXfkaEOlsGwatMji3gx93PL4kF7oKBA91O_aTVpTcJj04C1amf2Str7ehPKxwkLVisd86jzoTibhCGWd-9gzhV8NxnaQIjjikfsbSI8v2B3HOGzlQLWVV5Op1rs3EJ9WeiUKXm0F2z2srmt8fwkupukva6Wf3r0bxipbZ9gjcX9y1VLDDAQZjCmFXr8fa625sl4kZ1m6PAHIa-inkMkD5Mrw&h=YfD5xSNSRY6kj4BtDNwpIs5PJcYHeHTG2N7rQHWzDiI
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/b159949b-d6ea-4616-9a32-6c6c728f0a4f?api-version=2020-09-01&t=639173594559912369&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=d3z9AyDtINrj1whWfySe1-LfIlyR4AgHjenApDXEsDwrUqpibZfih-0HtklokYWQTSabn9kN1gX_j5bEnXZ1dXpY8KM3Xpnop4y64eZUcepuCBVq--vpJ23sXVs-BENzZ5y8U-uSicm_mVFKWb87ZgB7_lME2fufvJHXQ9kRKpXLEyc8UxAmYAZk0IIBX1HigKvtMRe0txqbwh02_V69r34CUTQ64E14RLJ9WbVqoGPC5uxPdblmCX22KjySSygdDIXdoW_KDTPcO_SIwPgfKj-6vtw3ApyhkADMuUm4M9vLbYndtj7jDjmSGizcna-RYwGb7jVYXYdlipcIVdEW2g&h=Tk-PIqYJr-1p1Mie8OsSCBOfS5BLWvBSq2ABvDqMJtE
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Mon, 20 Apr 2026 08:55:07 GMT
+      - Thu, 18 Jun 2026 06:04:15 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/79ca9ed9-42fb-48aa-873d-106edc14e9a8/profileresults/profilesecuritytest/securitypolicyresults/security000004?api-version=2020-09-01&t=639122721078350782&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=KziQ_74OZUu15fHFma9__HU_KA4AvG5Je6hiC57REAgzJ-594OlC7cZSCeaUHXLixToFIFp9ZRfIpGTPK4orCWg44G_NlWCF_DnJcfsC6UZrcTkyIoRljNd0ek3KnbvdlkmcS-oUpp-GMKWGGsmDtZ3YvET7QG-j0raAEOWde0L8SJXqb8OGlA8iSF2wP4Wmp7Ci9GPBDFY5aueAMT39GB22xwhIPWL3kVBh3-3pATuQm5zKYzXkDTzgeXAKvz3tp8kcZb5CwYUusfLSEOpxXwdwgJ52H8twFqc-5qH29_Btbwmz0FOwhqysCCfosfZlDWuAl46sfhOUb6zra6o2sA&h=nNKBI10XUmnT4NBBdRJW6ffd3_zxhPN-GNeS58GVTXo
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/b159949b-d6ea-4616-9a32-6c6c728f0a4f/profileresults/profilesecuritytest/securitypolicyresults/security000007?api-version=2020-09-01&t=639173594560068605&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=L0Sy3N8i9xMe5hgyRQSLAGQ2zwAcB1Kpv3-oxJdkOqkE0_VQIuEYmdeFni0e0fO6W6A6aEcHrLc82L1ni--2Pm4N0d1GPpQMZYGIxdlAvRszr6g_S9cdgiX8RxunDNvuIIDjXv8LS5y7nUFNCy2pNVOQfcwO9_Aw8j30W7UUMS6fsSnU_sP_-TjS3e8DHYlx13CP9Ga3r1M8dwutTCCLXseE2ycuR0oU6exgv7MYVDNW6ABEI0HcogpsWuhCI8VAHqKMOCdGjZoEAOaqaoo8NilEMMJwU07pBju6naDI8GaH63r1lTPbPQNE0a39-kkBq8yMgMPPkqVEKZi1Beg_4g&h=-8Zea9x_c9VCCFf1U3EBpBqxwIaXDMZMlpoywvubYPE
       pragma:
       - no-cache
       strict-transport-security:
@@ -1674,13 +2255,13 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/f98529cc-6221-4005-874b-8e285e8b7cf8
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/afff8469-876c-4b4d-bec7-f7497b54a9c1
       x-ms-ratelimit-remaining-subscription-deletes:
       - '799'
       x-ms-ratelimit-remaining-subscription-global-deletes:
       - '11999'
       x-msedge-ref:
-      - 'Ref A: 7D83D4E87B704A22B1F1648B3B7CA498 Ref B: SYD03EDGE0911 Ref C: 2026-04-20T08:55:06Z'
+      - 'Ref A: 74E3550A3E5A4A299ED3651DBF8C70C3 Ref B: SYD03EDGE1919 Ref C: 2026-06-18T06:04:14Z'
     status:
       code: 202
       message: Accepted
@@ -1698,9 +2279,9 @@ interactions:
       ParameterSetName:
       - -g --profile-name --security-policy-name --yes
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.13.13 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/79ca9ed9-42fb-48aa-873d-106edc14e9a8?api-version=2020-09-01&t=639122721078350782&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=ocRFpP6hJhVnwbwhA275Vm0fMBn5X5pKbQtbQMIyKvfmG385-t-VEn4sGrjSoSCLGoV6S7w3UiwMxWI3Ht5d_Mr_NO_TPOMCWUN9eBP05muFD6GDfBDbEkVx6J9MNSmXfkaEOlsGwatMji3gx93PL4kF7oKBA91O_aTVpTcJj04C1amf2Str7ehPKxwkLVisd86jzoTibhCGWd-9gzhV8NxnaQIjjikfsbSI8v2B3HOGzlQLWVV5Op1rs3EJ9WeiUKXm0F2z2srmt8fwkupukva6Wf3r0bxipbZ9gjcX9y1VLDDAQZjCmFXr8fa625sl4kZ1m6PAHIa-inkMkD5Mrw&h=YfD5xSNSRY6kj4BtDNwpIs5PJcYHeHTG2N7rQHWzDiI
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/b159949b-d6ea-4616-9a32-6c6c728f0a4f?api-version=2020-09-01&t=639173594559912369&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=d3z9AyDtINrj1whWfySe1-LfIlyR4AgHjenApDXEsDwrUqpibZfih-0HtklokYWQTSabn9kN1gX_j5bEnXZ1dXpY8KM3Xpnop4y64eZUcepuCBVq--vpJ23sXVs-BENzZ5y8U-uSicm_mVFKWb87ZgB7_lME2fufvJHXQ9kRKpXLEyc8UxAmYAZk0IIBX1HigKvtMRe0txqbwh02_V69r34CUTQ64E14RLJ9WbVqoGPC5uxPdblmCX22KjySSygdDIXdoW_KDTPcO_SIwPgfKj-6vtw3ApyhkADMuUm4M9vLbYndtj7jDjmSGizcna-RYwGb7jVYXYdlipcIVdEW2g&h=Tk-PIqYJr-1p1Mie8OsSCBOfS5BLWvBSq2ABvDqMJtE
   response:
     body:
       string: '{"status":"InProgress","error":{"code":"None","message":null}}'
@@ -1712,7 +2293,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 20 Apr 2026 08:55:08 GMT
+      - Thu, 18 Jun 2026 06:04:17 GMT
       expires:
       - '-1'
       pragma:
@@ -1724,11 +2305,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/2b47342a-62e9-438f-943c-e9bd99476963
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/8e0013d9-ca81-4330-bb68-7f5eb192cb9f
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 92B0978AE57749B397EDB0C94CB054F8 Ref B: SYD03EDGE1414 Ref C: 2026-04-20T08:55:08Z'
+      - 'Ref A: 3B2912CBFC0A4F2CBB81F2EBAD9EFE1D Ref B: SYD03EDGE1721 Ref C: 2026-06-18T06:04:16Z'
     status:
       code: 200
       message: OK
@@ -1746,9 +2327,9 @@ interactions:
       ParameterSetName:
       - -g --profile-name --security-policy-name --yes
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.13.13 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/79ca9ed9-42fb-48aa-873d-106edc14e9a8?api-version=2020-09-01&t=639122721078350782&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=ocRFpP6hJhVnwbwhA275Vm0fMBn5X5pKbQtbQMIyKvfmG385-t-VEn4sGrjSoSCLGoV6S7w3UiwMxWI3Ht5d_Mr_NO_TPOMCWUN9eBP05muFD6GDfBDbEkVx6J9MNSmXfkaEOlsGwatMji3gx93PL4kF7oKBA91O_aTVpTcJj04C1amf2Str7ehPKxwkLVisd86jzoTibhCGWd-9gzhV8NxnaQIjjikfsbSI8v2B3HOGzlQLWVV5Op1rs3EJ9WeiUKXm0F2z2srmt8fwkupukva6Wf3r0bxipbZ9gjcX9y1VLDDAQZjCmFXr8fa625sl4kZ1m6PAHIa-inkMkD5Mrw&h=YfD5xSNSRY6kj4BtDNwpIs5PJcYHeHTG2N7rQHWzDiI
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/b159949b-d6ea-4616-9a32-6c6c728f0a4f?api-version=2020-09-01&t=639173594559912369&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=d3z9AyDtINrj1whWfySe1-LfIlyR4AgHjenApDXEsDwrUqpibZfih-0HtklokYWQTSabn9kN1gX_j5bEnXZ1dXpY8KM3Xpnop4y64eZUcepuCBVq--vpJ23sXVs-BENzZ5y8U-uSicm_mVFKWb87ZgB7_lME2fufvJHXQ9kRKpXLEyc8UxAmYAZk0IIBX1HigKvtMRe0txqbwh02_V69r34CUTQ64E14RLJ9WbVqoGPC5uxPdblmCX22KjySSygdDIXdoW_KDTPcO_SIwPgfKj-6vtw3ApyhkADMuUm4M9vLbYndtj7jDjmSGizcna-RYwGb7jVYXYdlipcIVdEW2g&h=Tk-PIqYJr-1p1Mie8OsSCBOfS5BLWvBSq2ABvDqMJtE
   response:
     body:
       string: '{"status":"InProgress","error":{"code":"None","message":null}}'
@@ -1760,7 +2341,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 20 Apr 2026 08:55:40 GMT
+      - Thu, 18 Jun 2026 06:04:48 GMT
       expires:
       - '-1'
       pragma:
@@ -1772,11 +2353,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/a47486eb-0c90-4540-a6b4-4316b7997ca4
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/53f43391-fd31-46e7-ad39-990e7d565904
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: D4237CBFCDD944FD90DF6F9CC6ED9985 Ref B: SYD03EDGE0706 Ref C: 2026-04-20T08:55:39Z'
+      - 'Ref A: 25EDD450488344A997B8E02C08F5A91B Ref B: SYD03EDGE1410 Ref C: 2026-06-18T06:04:47Z'
     status:
       code: 200
       message: OK
@@ -1794,9 +2375,9 @@ interactions:
       ParameterSetName:
       - -g --profile-name --security-policy-name --yes
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.13.13 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/79ca9ed9-42fb-48aa-873d-106edc14e9a8?api-version=2020-09-01&t=639122721078350782&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=ocRFpP6hJhVnwbwhA275Vm0fMBn5X5pKbQtbQMIyKvfmG385-t-VEn4sGrjSoSCLGoV6S7w3UiwMxWI3Ht5d_Mr_NO_TPOMCWUN9eBP05muFD6GDfBDbEkVx6J9MNSmXfkaEOlsGwatMji3gx93PL4kF7oKBA91O_aTVpTcJj04C1amf2Str7ehPKxwkLVisd86jzoTibhCGWd-9gzhV8NxnaQIjjikfsbSI8v2B3HOGzlQLWVV5Op1rs3EJ9WeiUKXm0F2z2srmt8fwkupukva6Wf3r0bxipbZ9gjcX9y1VLDDAQZjCmFXr8fa625sl4kZ1m6PAHIa-inkMkD5Mrw&h=YfD5xSNSRY6kj4BtDNwpIs5PJcYHeHTG2N7rQHWzDiI
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Cdn/operationresults/b159949b-d6ea-4616-9a32-6c6c728f0a4f?api-version=2020-09-01&t=639173594559912369&c=MIIHlDCCBnygAwIBAgIQezb8rseFMm1IRs195n9vVzANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwNzIzNDE1NFoXDTI2MTAwMzA1NDE1NFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyN0RC1toIy0MUjNqRPJLB51RUbtwBvAu6pgWK5gw2lmci7lE7U6jMxMh_8ljqwlXFY90FwPHzKHdcfHD4M0Ma3DRUVgE-v0S1aUDhKodisph39p7biWkApcSmxbkzmQMB2D0u2Zm0IhszNnwquCfvJuftV7em4_XCA_NbUt5EYUpfjv1sYzkLLAA8_2geRJLmDRfZGZvSHhgN-bsErNiX7v-BdmAyt_5jYpEcuAWuKp_6DUtXPY_mbwCm-qkLcoXGR39z9dHcyaldZUrJJ6JYcAEG5QNboi3gR2R7bY7pVtxUqbJ9Gx2tDy1qzosxOu0hXflZnevb68ylv7B68Wu9AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQNw-Elcx5N6tZ9jh67WrWJYZxlnzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzM0L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMzQvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8zNC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBOslPK0kujtTlyxe5WOtpNbQRYZ8iSxYHILxKtavGf63w2nf7l5nX07MzYQqUYkw1ZLV81KZUWrAqmYoK0fTLgq7S_ePVqJ0Bi0EefpAOxc4Q7FtrTXk-2n80mtrwbcDH_jHtUGHd5gGv7MEFSu5Wa2iI3mNDsNSZrscWUqrBhKiZ2zF0slf8YMpHWflHomPT5wBh2LQC9ub-GLJKfkVDFxokxP2roGR1np3ATyRygILitspiTUM4Bcia0TOmYoYUqpLZTBiVNI-ehKyCyQXxR9eeBX0xmiPRji8kPKfC97Q_8KsB0icYO2jpcYUsIggTmm6Rz61nAEqF34O6kWVt8&s=d3z9AyDtINrj1whWfySe1-LfIlyR4AgHjenApDXEsDwrUqpibZfih-0HtklokYWQTSabn9kN1gX_j5bEnXZ1dXpY8KM3Xpnop4y64eZUcepuCBVq--vpJ23sXVs-BENzZ5y8U-uSicm_mVFKWb87ZgB7_lME2fufvJHXQ9kRKpXLEyc8UxAmYAZk0IIBX1HigKvtMRe0txqbwh02_V69r34CUTQ64E14RLJ9WbVqoGPC5uxPdblmCX22KjySSygdDIXdoW_KDTPcO_SIwPgfKj-6vtw3ApyhkADMuUm4M9vLbYndtj7jDjmSGizcna-RYwGb7jVYXYdlipcIVdEW2g&h=Tk-PIqYJr-1p1Mie8OsSCBOfS5BLWvBSq2ABvDqMJtE
   response:
     body:
       string: '{"status":"Succeeded","error":{"code":"None","message":null}}'
@@ -1808,7 +2389,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 20 Apr 2026 08:56:11 GMT
+      - Thu, 18 Jun 2026 06:05:19 GMT
       expires:
       - '-1'
       pragma:
@@ -1820,11 +2401,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/55a7e3e3-41bf-45ed-b053-7c36d4df7708
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/5d936657-9e2b-4132-84c1-48f7f036fd9d
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 48252A986B7940F28C290B35B9BCAC0A Ref B: SYD03EDGE1921 Ref C: 2026-04-20T08:56:10Z'
+      - 'Ref A: 74BBD9BAED8A4A6897775A7F6E9B40AE Ref B: SYD03EDGE1708 Ref C: 2026-06-18T06:05:19Z'
     status:
       code: 200
       message: OK
@@ -1842,9 +2423,9 @@ interactions:
       ParameterSetName:
       - -g --profile-name
       User-Agent:
-      - AZURECLI/2.85.0 azsdk-python-core/1.39.0 Python/3.13.13 (Windows-11-10.0.26200-SP0)
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.13.14 (Windows-11-10.0.26200-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/securityPolicies?api-version=2025-09-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Cdn/profiles/profilesecuritytest/securityPolicies?api-version=2026-04-01-preview
   response:
     body:
       string: '{"value":[]}'
@@ -1856,7 +2437,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 20 Apr 2026 08:56:13 GMT
+      - Thu, 18 Jun 2026 06:05:21 GMT
       expires:
       - '-1'
       pragma:
@@ -1868,11 +2449,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-operation-identifier:
-      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/b3c64cf0-5d3a-4eb3-b663-a24809ffde24
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=2e396a67-4dc1-43ae-afcc-c6747d291866/westus/bd1858e3-ff22-4521-a648-44bca56c1a44
       x-ms-ratelimit-remaining-subscription-global-reads:
       - '16499'
       x-msedge-ref:
-      - 'Ref A: 96B248EE47244D49812DCD6D9A6F22E7 Ref B: SYD03EDGE1315 Ref C: 2026-04-20T08:56:12Z'
+      - 'Ref A: EB7D8887FD9B43EEBC97702DD42B785C Ref B: SYD03EDGE1716 Ref C: 2026-06-18T06:05:21Z'
     status:
       code: 200
       message: OK

--- a/src/cdn/azext_cdn/tests/latest/test_afd_security_policy_scenarios.py
+++ b/src/cdn/azext_cdn/tests/latest/test_afd_security_policy_scenarios.py
@@ -36,6 +36,42 @@ class CdnAfdSecurityPolicyScenarioTest(CdnAfdScenarioMixin, ScenarioTest):
                                      endpoint2_name,
                                      enabled_state,
                                      checks=endpoint_checks)
+
+        origin_group_name = self.create_random_name(prefix='og', length=16)
+        self.afd_origin_group_create_cmd(resource_group,
+                                         profile_name,
+                                         origin_group_name,
+                                         "--probe-request-type GET --probe-protocol Http --probe-interval-in-seconds 120 --probe-path /test1/azure.txt "
+                                         "--sample-size 4 --successful-samples-required 3 --additional-latency-in-milliseconds 50")
+
+        origin_name = self.create_random_name(prefix='origin', length=16)
+        create_options = (
+            "--host-name huaiyiztesthost1.blob.core.chinacloudapi.cn "
+            "--origin-host-header huaiyiztesthost1.blob.core.chinacloudapi.cn "
+            "--priority 1 --weight 1000 --http-port 80 --https-port 443 --enabled-state Enabled"
+        )
+        self.afd_origin_create_cmd(resource_group,
+                                   profile_name,
+                                   origin_group_name,
+                                   origin_name,
+                                   create_options)
+
+        route_name = self.create_random_name(prefix='route', length=16)
+        route_id = (
+            f'/subscriptions/{self.get_subscription_id()}/resourcegroups/{resource_group}'
+            f'/providers/Microsoft.Cdn/profiles/{profile_name}/afdEndpoints/{endpoint1_name}'
+            f'/routes/{route_name}'
+        )
+        create_options = (
+            f"--origin-group {origin_group_name} "
+            "--supported-protocols Https Http --link-to-default-domain Enabled "
+            "--https-redirect Enabled --forwarding-protocol MatchRequest"
+        )
+        self.afd_route_create_cmd(resource_group,
+                                  profile_name,
+                                  endpoint1_name,
+                                  route_name,
+                                  create_options)
         
         security_policy_name = self.create_random_name(prefix='security', length=24)
         domain_ids = []
@@ -44,7 +80,9 @@ class CdnAfdSecurityPolicyScenarioTest(CdnAfdScenarioMixin, ScenarioTest):
         
         # Create a security policy with non-exisit waf should fail
         waf_policy_id = f'/subscriptions/{self.get_subscription_id()}/resourcegroups/CliDevReservedGroup/providers/Microsoft.Network/frontdoorwebapplicationfirewallpolicies/nonexist'
-        with self.assertRaisesRegex(HttpResponseError, "Web Application Firewall Policy being attached to AFDX profile does not exist"):
+        with self.assertRaisesRegex(HttpResponseError,
+                                    "Web Application Firewall Policy being attached to AFDX profile does not exist|"
+                                    "Waf policy not found in AFD Data store"):
             self.afd_security_policy_create_cmd(resource_group,
                                                 profile_name,
                                                 security_policy_name,
@@ -53,16 +91,27 @@ class CdnAfdSecurityPolicyScenarioTest(CdnAfdScenarioMixin, ScenarioTest):
         
         # Create a security policy
         waf_policy_id = f'/subscriptions/{self.get_subscription_id()}/resourcegroups/CliDevReservedGroup/providers/Microsoft.Network/frontdoorwebapplicationfirewallpolicies/SampleStandard'
+        with self.assertRaisesRegex(HttpResponseError, "Route level association is not allowed"):
+            self.afd_security_policy_create_cmd(resource_group,
+                                                profile_name,
+                                                security_policy_name,
+                                                domain_ids,
+                                                waf_policy_id,
+                                                is_profile_level=False,
+                                                routes=[route_id])
+
         checks = [JMESPathCheck('provisioningState', 'Succeeded')]
         self.afd_security_policy_create_cmd(resource_group,
                                             profile_name,
                                             security_policy_name,
                                             domain_ids,
                                             waf_policy_id,
-                                            checks=checks)
+                                            checks=checks,
+                                            is_profile_level=False)
 
         show_checks = [JMESPathCheck('name', security_policy_name),
                        JMESPathCheck('parameters.wafPolicy.id', waf_policy_id),
+                       JMESPathCheck('parameters.isProfileLevel', False),
                        JMESPathCheck('length(parameters.associations[0].domains)', 2),
                        JMESPathCheck('parameters.associations[0].domains[0].id', domain_ids[0]),
                        JMESPathCheck('parameters.associations[0].domains[1].id', domain_ids[1]),
@@ -77,6 +126,7 @@ class CdnAfdSecurityPolicyScenarioTest(CdnAfdScenarioMixin, ScenarioTest):
         # Update the security policy
         update_checks = [JMESPathCheck('name', security_policy_name),
                          JMESPathCheck('parameters.wafPolicy.id', waf_policy_id),
+                         JMESPathCheck('parameters.isProfileLevel', False),
                          JMESPathCheck('length(parameters.associations[0].domains)', 1),
                          JMESPathCheck('parameters.associations[0].domains[0].id', domain_ids[1]),
                          JMESPathCheck('provisioningState', 'Succeeded')]
@@ -85,7 +135,8 @@ class CdnAfdSecurityPolicyScenarioTest(CdnAfdScenarioMixin, ScenarioTest):
                                             security_policy_name,
                                             [domain_ids[1]],
                                             waf_policy_id,
-                                            checks=update_checks)
+                                            checks=update_checks,
+                                            is_profile_level=False)
 
         # Delete the security policy
         self.afd_security_policy_delete_cmd(resource_group, profile_name, security_policy_name)


### PR DESCRIPTION
## Summary
- Update generated AFD security policy commands to `2026-04-01-preview`
- Add support for security policy WAF `isProfileLevel` and route associations
- Keep `--waf-embedded` customization guarded because the embedded WAF model is no longer generated
- Update AFD security policy scenario test and recording for the new request shape

## Validation
- `aaz-dev command-model verify -a aaz -t afd`
- Python AST syntax check for changed custom/test files
- `azdev linter cdn` (all lint rules passed; local tool still exits with known `invalid git repo: None`)
- `azdev style cdn` (Pylint and Flake8 passed)
- `azdev test test_afd_security_policy_crud --profile latest --live` (1 passed)
