### PR TITLE
{CI} Fix update_index wheel filename + bump pinned azdev to latest

### DIFF
--- a/.azure-pipelines/templates/azdev_setup.yml
+++ b/.azure-pipelines/templates/azdev_setup.yml
@@ -11,14 +11,9 @@ steps:
       python -m venv env
       chmod +x env/bin/activate
       source ./env/bin/activate
-      # clone azure-cli
       git clone -q --single-branch -b dev https://github.com/Azure/azure-cli.git ../azure-cli
       python -m pip install -U pip
-      # azdev 0.2.11b1 (decouples extension metadata from wheel==0.30.0) tho it is not on PyPI yet.
-      # Pinned to a specific azure-cli-dev-tools commit (not @dev) for reproducible builds
-      # until the pre-release is published; then switch this back to:
-      # pip install --upgrade "azdev==0.2.11b1"
-      pip install --upgrade "git+https://github.com/Azure/azure-cli-dev-tools.git@49390f30c6a822620d2fbdf88889c4445d22666f#egg=azdev"
+      pip install --upgrade "azdev==0.2.12"
       azdev --version
       azdev setup -c $CLI_REPO_PATH -r $CLI_EXT_REPO_PATH --debug
       pip list -v

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@ This checklist is used to make sure that common guidelines for a pull request ar
 ### General Guidelines
 
 - [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
-- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`azdev` required; see `.azure-pipelines/templates/azdev_setup.yml` for the install command until `azdev==0.2.11b1` is on PyPI)
+- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install azdev` required)
 - [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)
 
 For new extensions:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,10 +80,8 @@ jobs:
       #!/usr/bin/env bash
       set -ev
       # test_index.py imports scripts/ci/util.py, which reads wheel metadata via azdev's
-      # pkginfo-based metadata module (decoupled from wheel==0.30.0), so azdev must be
-      # installed here. Install from the merged azure-cli-dev-tools source until azdev
-      # 0.2.11b1 is published to PyPI, then switch this to: pip install --upgrade "azdev==0.2.11b1"
-      pip install --upgrade "git+https://github.com/Azure/azure-cli-dev-tools.git@49390f30c6a822620d2fbdf88889c4445d22666f#egg=azdev"
+      # pkginfo-based metadata module (decoupled from wheel==0.30.0), so azdev must be installed here.
+      pip install --upgrade "azdev==0.2.12"
       pip install requests packaging setuptools
       export CI="ADO"
       python ./scripts/ci/test_index.py -v

--- a/scripts/ci/update_index.py
+++ b/scripts/ci/update_index.py
@@ -43,7 +43,11 @@ def main():
     ext_dir = tempfile.mkdtemp(dir=extensions_dir)
     whl_cache_dir = tempfile.mkdtemp()
     whl_cache = {}
-    ext_file = get_whl_from_url(whl_path, extension_name, whl_cache_dir, whl_cache)
+    # Download to the real wheel filename (ending in .whl): get_ext_metadata now
+    # reads metadata via pkginfo, which requires a .whl-named file. Passing the
+    # extension name (e.g. "ssh") produced an extension-less temp file that
+    # pkginfo rejects with "Not a known wheel archive format".
+    ext_file = get_whl_from_url(whl_path, whl_path.split('/')[-1], whl_cache_dir, whl_cache)
 
     with open('./src/index.json', 'r') as infile:
         curr_index = json.loads(infile.read())


### PR DESCRIPTION
Two follow-ups to #9922 so the decoupled (pkginfo) azdev path works end to end:

- scripts/ci/update_index.py saved the downloaded wheel as just the extension name, but pkginfo.Wheel needs a .whl-named file, so the publish index update failed with "Not a known wheel archive format". Use the real filename from the URL (as the entry already does).

- Bump the pinned azdev (azdev_setup.yml + azure-pipelines.yml) 49390f3 -> 644d296, the current dev commit that includes azdev's matching `extension update-index` fix. Stays pinned until azdev 0.2.11 is published to PyPI.