### PR TITLE
{CI} Add Azure Pipelines to trigger ADO extension release

### DIFF
--- a/.azure-pipelines/test-trigger-extension-release.yml
+++ b/.azure-pipelines/test-trigger-extension-release.yml
@@ -1,0 +1,87 @@
+name: Azure CLI Test Trigger Extension Release Pipeline
+
+trigger:
+  branches:
+    include:
+    - main
+
+pr: none
+
+resources:
+- repo: self
+
+variables:
+- template: ${{ variables.Pipeline.Workspace }}/.azure-pipelines/templates/variables.yml
+# - group: '<extension-release-variable-group>'  # provides ADO_ServiceConnection / ADO_ORGANIZATION / ADO_PROJECT / ADO_PIPELINE_ID (prod) / ADO_TEST_PIPELINE_ID (test)
+
+jobs:
+- job: TestTriggerExtensionRelease
+  displayName: 'Test Trigger ADO OneBranch Extension Release Pipeline'
+  timeoutInMinutes: 120
+  pool:
+    name: ${{ variables.ubuntu_pool }}
+  steps:
+  - checkout: none
+  - task: AzureCLI@2
+    displayName: 'Trigger ADO pipeline and wait for completion'
+    inputs:
+      azureSubscription: $(ADO_ServiceConnection)
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        echo "Triggering ADO pipeline..."
+        BUILD_RESULT=$(az pipelines build queue \
+          --definition-id "$ADO_PIPELINE_ID" \
+          --organization "$ADO_ORGANIZATION" \
+          --project "$ADO_PROJECT" \
+          --variables commit_id="$COMMIT_ID" \
+          --output json)
+
+        BUILD_ID=$(echo "$BUILD_RESULT" | jq -r '.id')
+        echo "Pipeline triggered with Build ID: $BUILD_ID"
+
+        if [ "$BUILD_ID" = "null" ] || [ -z "$BUILD_ID" ]; then
+          echo "Failed to get build ID from pipeline trigger"
+          exit 1
+        fi
+
+        echo "Waiting for build $BUILD_ID to complete..."
+        while true; do
+          BUILD_JSON=$(az pipelines build show \
+            --id "$BUILD_ID" \
+            --organization "$ADO_ORGANIZATION" \
+            --project "$ADO_PROJECT" \
+            --output json)
+
+          BUILD_STATUS=$(echo "$BUILD_JSON" | jq -r '.status')
+          BUILD_RESULT_STATUS=$(echo "$BUILD_JSON" | jq -r '.result // "none"')
+
+          echo "Current status: $BUILD_STATUS, Result: $BUILD_RESULT_STATUS"
+
+          if [ "$BUILD_STATUS" = "completed" ]; then
+            echo "Build completed with result: $BUILD_RESULT_STATUS"
+            if [ "$BUILD_RESULT_STATUS" = "succeeded" ]; then
+              echo "ADO pipeline build succeeded!"
+              exit 0
+            elif [ "$BUILD_RESULT_STATUS" = "partiallySucceeded" ]; then
+              echo "ADO pipeline build partially succeeded"
+              exit 1
+            else
+              echo "ADO pipeline build failed with result: $BUILD_RESULT_STATUS"
+              exit 1
+            fi
+          fi
+
+          if [ "$BUILD_STATUS" = "cancelling" ] || [ "$BUILD_STATUS" = "cancelled" ]; then
+            echo "ADO pipeline build was cancelled"
+            exit 1
+          fi
+
+          echo "Build still running... waiting 60 seconds"
+          sleep 60
+        done
+    env:
+      ADO_ORGANIZATION: $(ADO_ORGANIZATION)
+      ADO_PROJECT: $(ADO_PROJECT)
+      ADO_PIPELINE_ID: $(ADO_TEST_PIPELINE_ID)
+      COMMIT_ID: $(Build.SourceVersion)

--- a/.azure-pipelines/trigger-extension-release.yml
+++ b/.azure-pipelines/trigger-extension-release.yml
@@ -1,0 +1,87 @@
+name: Azure CLI Trigger Extension Release Pipeline
+
+trigger:
+  branches:
+    include:
+    - main
+
+pr: none
+
+resources:
+- repo: self
+
+variables:
+- template: ${{ variables.Pipeline.Workspace }}/.azure-pipelines/templates/variables.yml
+# - group: '<extension-release-variable-group>'  # provides ADO_ServiceConnection / ADO_ORGANIZATION / ADO_PROJECT / ADO_PIPELINE_ID (prod) / ADO_TEST_PIPELINE_ID (test)
+
+jobs:
+- job: TriggerExtensionRelease
+  displayName: 'Trigger ADO OneBranch Extension Release Pipeline'
+  timeoutInMinutes: 120
+  pool:
+    name: ${{ variables.ubuntu_pool }}
+  steps:
+  - checkout: none
+  - task: AzureCLI@2
+    displayName: 'Trigger ADO pipeline and wait for completion'
+    inputs:
+      azureSubscription: $(ADO_ServiceConnection)
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        echo "Triggering ADO pipeline..."
+        BUILD_RESULT=$(az pipelines build queue \
+          --definition-id "$ADO_PIPELINE_ID" \
+          --organization "$ADO_ORGANIZATION" \
+          --project "$ADO_PROJECT" \
+          --variables commit_id="$COMMIT_ID" \
+          --output json)
+
+        BUILD_ID=$(echo "$BUILD_RESULT" | jq -r '.id')
+        echo "Pipeline triggered with Build ID: $BUILD_ID"
+
+        if [ "$BUILD_ID" = "null" ] || [ -z "$BUILD_ID" ]; then
+          echo "Failed to get build ID from pipeline trigger"
+          exit 1
+        fi
+
+        echo "Waiting for build $BUILD_ID to complete..."
+        while true; do
+          BUILD_JSON=$(az pipelines build show \
+            --id "$BUILD_ID" \
+            --organization "$ADO_ORGANIZATION" \
+            --project "$ADO_PROJECT" \
+            --output json)
+
+          BUILD_STATUS=$(echo "$BUILD_JSON" | jq -r '.status')
+          BUILD_RESULT_STATUS=$(echo "$BUILD_JSON" | jq -r '.result // "none"')
+
+          echo "Current status: $BUILD_STATUS, Result: $BUILD_RESULT_STATUS"
+
+          if [ "$BUILD_STATUS" = "completed" ]; then
+            echo "Build completed with result: $BUILD_RESULT_STATUS"
+            if [ "$BUILD_RESULT_STATUS" = "succeeded" ]; then
+              echo "ADO pipeline build succeeded!"
+              exit 0
+            elif [ "$BUILD_RESULT_STATUS" = "partiallySucceeded" ]; then
+              echo "ADO pipeline build partially succeeded"
+              exit 1
+            else
+              echo "ADO pipeline build failed with result: $BUILD_RESULT_STATUS"
+              exit 1
+            fi
+          fi
+
+          if [ "$BUILD_STATUS" = "cancelling" ] || [ "$BUILD_STATUS" = "cancelled" ]; then
+            echo "ADO pipeline build was cancelled"
+            exit 1
+          fi
+
+          echo "Build still running... waiting 60 seconds"
+          sleep 60
+        done
+    env:
+      ADO_ORGANIZATION: $(ADO_ORGANIZATION)
+      ADO_PROJECT: $(ADO_PROJECT)
+      ADO_PIPELINE_ID: $(ADO_PIPELINE_ID)
+      COMMIT_ID: $(Build.SourceVersion)


### PR DESCRIPTION
## What

Add two Azure Pipelines under `.azure-pipelines/` to trigger the ADO OneBranch Extension Release pipeline, replacing the GitHub Actions that authenticate with a GitHub Corp-tenant Federated Identity Credential (FIC):

- `trigger-extension-release.yml` (prod)
- `test-trigger-extension-release.yml` (test)

## Why

The GitHub Corp-tenant FIC used by `azure/login` in the existing Actions is being removed. These pipelines move the trigger into ADO and authenticate with a Workload Identity Federation (WIF) service connection instead — no Corp FIC, no stored secret.

## How it works

- CI trigger on push to `main` (same as the Actions' `on: push: branches: [main]`).
- `AzureCLI@2` (WIF service connection) queues the target release pipeline, then polls `az pipelines build show` until completion and exits with the build result — the same "trigger + wait for completion" behavior as the Actions.
- The pipeline's success/failure is reported back to the commit via the Azure Pipelines GitHub App, replacing the Action's status check.
- A job-level `timeoutInMinutes` bounds the wait so a stuck/failing downstream build can't hang the run forever (tune to your release duration).

## Variables

Provide via a single variable group (uncomment the `- group:` line):

- `ADO_ServiceConnection` — the WIF service connection name
- `ADO_ORGANIZATION` / `ADO_PROJECT` — target ADO org/project
- `ADO_PIPELINE_ID` — prod release pipeline definition id
- `ADO_TEST_PIPELINE_ID` — test release pipeline definition id (default `396380`)

Variables are passed via `env:` and referenced as `"$VAR"` in the script (instead of inline interpolation) to avoid injection.

## Follow-ups (not in this PR)

- Create the WIF service connection (manual) and authorize it for these pipelines.
- Register both pipelines in ADO and provide the variable group values.
- Validate on the test pipeline first, then remove the two GitHub Actions.

The existing GitHub Actions are kept until the new pipelines are validated.
