### PR TITLE
[HORIZONDB] Add private endpoint CLI commands

### DIFF
--- a/src/horizondb/HISTORY.rst
+++ b/src/horizondb/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+1.0.0b6
++++++++
+* Add private endpoint connection commands: `az horizondb private-endpoint-connection list/show/approve/reject/delete`.
+* Add private link resource commands: `az horizondb private-link-resource list/show`.
+
 1.0.0b5
 +++++++
 * Add support for configuring public access on HorizonDB clusters through `az horizondb create --public-access` and `az horizondb update --public-access`. Supplying an IP address or range automatically creates a firewall rule.

--- a/src/horizondb/README.md
+++ b/src/horizondb/README.md
@@ -19,3 +19,20 @@ az extension add --name horizondb
 - `az horizondb create`: Create a new Azure HorizonDB cluster.
 - `az horizondb delete`: Delete an Azure HorizonDB cluster.
 - `az horizondb show`: Show details of an Azure HorizonDB cluster.
+
+### HorizonDB Private Endpoint Connections
+
+*Commands:*
+
+- `az horizondb private-endpoint-connection list`: List private endpoint connections for a HorizonDB cluster.
+- `az horizondb private-endpoint-connection show`: Show details of a HorizonDB private endpoint connection.
+- `az horizondb private-endpoint-connection approve`: Approve a HorizonDB private endpoint connection.
+- `az horizondb private-endpoint-connection reject`: Reject a HorizonDB private endpoint connection.
+- `az horizondb private-endpoint-connection delete`: Delete a HorizonDB private endpoint connection.
+
+### HorizonDB Private Link Resources
+
+*Commands:*
+
+- `az horizondb private-link-resource list`: List private link resources for a HorizonDB cluster.
+- `az horizondb private-link-resource show`: Show details of a HorizonDB private link resource.

--- a/src/horizondb/azext_horizondb/_client_factory.py
+++ b/src/horizondb/azext_horizondb/_client_factory.py
@@ -40,3 +40,11 @@ def cf_horizondb_clusters(cli_ctx, _):
 
 def cf_horizondb_firewall_rules(cli_ctx, _):
     return get_horizondb_management_client(cli_ctx).horizon_db_firewall_rules
+
+
+def cf_horizondb_private_endpoint_connections(cli_ctx, _):
+    return get_horizondb_management_client(cli_ctx).horizon_db_private_endpoint_connections
+
+
+def cf_horizondb_private_link_resources(cli_ctx, _):
+    return get_horizondb_management_client(cli_ctx).horizon_db_private_link_resources

--- a/src/horizondb/azext_horizondb/_help.py
+++ b/src/horizondb/azext_horizondb/_help.py
@@ -130,3 +130,86 @@ examples:
   - name: Delete a firewall rule.
     text: az horizondb firewall-rule delete --resource-group exampleresourcegroup --cluster-name examplecluster --name allowclientip
 """
+
+
+helps['horizondb private-endpoint-connection'] = """
+type: group
+short-summary: Manage HorizonDB private endpoint connections.
+"""
+
+
+helps['horizondb private-endpoint-connection list'] = """
+type: command
+short-summary: List private endpoint connections for a HorizonDB cluster.
+examples:
+  - name: List private endpoint connections for a HorizonDB cluster.
+    text: az horizondb private-endpoint-connection list --resource-group exampleresourcegroup --name examplecluster
+"""
+
+
+helps['horizondb private-endpoint-connection show'] = """
+type: command
+short-summary: Show details of a HorizonDB private endpoint connection.
+examples:
+  - name: Show a private endpoint connection by cluster and connection name.
+    text: az horizondb private-endpoint-connection show --resource-group exampleresourcegroup --name examplecluster --connection-name exampleconnection
+  - name: Show a private endpoint connection by resource ID.
+    text: az horizondb private-endpoint-connection show --id /subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.HorizonDb/clusters/{clusterName}/privateEndpointConnections/{connectionName}
+"""
+
+
+helps['horizondb private-endpoint-connection approve'] = """
+type: command
+short-summary: Approve a HorizonDB private endpoint connection.
+examples:
+  - name: Approve a private endpoint connection by cluster and connection name.
+    text: az horizondb private-endpoint-connection approve --resource-group exampleresourcegroup --name examplecluster --connection-name exampleconnection --description "Approved"
+  - name: Approve a private endpoint connection by resource ID.
+    text: az horizondb private-endpoint-connection approve --id /subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.HorizonDb/clusters/{clusterName}/privateEndpointConnections/{connectionName} --description "Approved"
+"""
+
+
+helps['horizondb private-endpoint-connection reject'] = """
+type: command
+short-summary: Reject a HorizonDB private endpoint connection.
+examples:
+  - name: Reject a private endpoint connection by cluster and connection name.
+    text: az horizondb private-endpoint-connection reject --resource-group exampleresourcegroup --name examplecluster --connection-name exampleconnection --description "Rejected"
+  - name: Reject a private endpoint connection by resource ID.
+    text: az horizondb private-endpoint-connection reject --id /subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.HorizonDb/clusters/{clusterName}/privateEndpointConnections/{connectionName} --description "Rejected"
+"""
+
+
+helps['horizondb private-endpoint-connection delete'] = """
+type: command
+short-summary: Delete a HorizonDB private endpoint connection.
+examples:
+  - name: Delete a private endpoint connection by cluster and connection name.
+    text: az horizondb private-endpoint-connection delete --resource-group exampleresourcegroup --name examplecluster --connection-name exampleconnection
+  - name: Delete a private endpoint connection by resource ID.
+    text: az horizondb private-endpoint-connection delete --id /subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.HorizonDb/clusters/{clusterName}/privateEndpointConnections/{connectionName}
+"""
+
+
+helps['horizondb private-link-resource'] = """
+type: group
+short-summary: Manage HorizonDB private link resources.
+"""
+
+
+helps['horizondb private-link-resource list'] = """
+type: command
+short-summary: List private link resources for a HorizonDB cluster.
+examples:
+  - name: List private link resources for a HorizonDB cluster.
+    text: az horizondb private-link-resource list --resource-group exampleresourcegroup --name examplecluster
+"""
+
+
+helps['horizondb private-link-resource show'] = """
+type: command
+short-summary: Show details of a HorizonDB private link resource.
+examples:
+  - name: Show a private link resource by group name.
+    text: az horizondb private-link-resource show --resource-group exampleresourcegroup --name examplecluster --group-name DefaultPool
+"""

--- a/src/horizondb/azext_horizondb/_help.py
+++ b/src/horizondb/azext_horizondb/_help.py
@@ -143,7 +143,7 @@ type: command
 short-summary: List private endpoint connections for a HorizonDB cluster.
 examples:
   - name: List private endpoint connections for a HorizonDB cluster.
-    text: az horizondb private-endpoint-connection list --resource-group exampleresourcegroup --name examplecluster
+    text: az horizondb private-endpoint-connection list --resource-group exampleresourcegroup --cluster-name examplecluster
 """
 
 
@@ -152,7 +152,7 @@ type: command
 short-summary: Show details of a HorizonDB private endpoint connection.
 examples:
   - name: Show a private endpoint connection by cluster and connection name.
-    text: az horizondb private-endpoint-connection show --resource-group exampleresourcegroup --name examplecluster --connection-name exampleconnection
+    text: az horizondb private-endpoint-connection show --resource-group exampleresourcegroup --cluster-name examplecluster --name exampleconnection
   - name: Show a private endpoint connection by resource ID.
     text: az horizondb private-endpoint-connection show --id /subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.HorizonDb/clusters/{clusterName}/privateEndpointConnections/{connectionName}
 """
@@ -163,7 +163,7 @@ type: command
 short-summary: Approve a HorizonDB private endpoint connection.
 examples:
   - name: Approve a private endpoint connection by cluster and connection name.
-    text: az horizondb private-endpoint-connection approve --resource-group exampleresourcegroup --name examplecluster --connection-name exampleconnection --description "Approved"
+    text: az horizondb private-endpoint-connection approve --resource-group exampleresourcegroup --cluster-name examplecluster --name exampleconnection --description "Approved"
   - name: Approve a private endpoint connection by resource ID.
     text: az horizondb private-endpoint-connection approve --id /subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.HorizonDb/clusters/{clusterName}/privateEndpointConnections/{connectionName} --description "Approved"
 """
@@ -174,7 +174,7 @@ type: command
 short-summary: Reject a HorizonDB private endpoint connection.
 examples:
   - name: Reject a private endpoint connection by cluster and connection name.
-    text: az horizondb private-endpoint-connection reject --resource-group exampleresourcegroup --name examplecluster --connection-name exampleconnection --description "Rejected"
+    text: az horizondb private-endpoint-connection reject --resource-group exampleresourcegroup --cluster-name examplecluster --name exampleconnection --description "Rejected"
   - name: Reject a private endpoint connection by resource ID.
     text: az horizondb private-endpoint-connection reject --id /subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.HorizonDb/clusters/{clusterName}/privateEndpointConnections/{connectionName} --description "Rejected"
 """
@@ -185,7 +185,7 @@ type: command
 short-summary: Delete a HorizonDB private endpoint connection.
 examples:
   - name: Delete a private endpoint connection by cluster and connection name.
-    text: az horizondb private-endpoint-connection delete --resource-group exampleresourcegroup --name examplecluster --connection-name exampleconnection
+    text: az horizondb private-endpoint-connection delete --resource-group exampleresourcegroup --cluster-name examplecluster --name exampleconnection
   - name: Delete a private endpoint connection by resource ID.
     text: az horizondb private-endpoint-connection delete --id /subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.HorizonDb/clusters/{clusterName}/privateEndpointConnections/{connectionName}
 """
@@ -202,7 +202,7 @@ type: command
 short-summary: List private link resources for a HorizonDB cluster.
 examples:
   - name: List private link resources for a HorizonDB cluster.
-    text: az horizondb private-link-resource list --resource-group exampleresourcegroup --name examplecluster
+    text: az horizondb private-link-resource list --resource-group exampleresourcegroup --cluster-name examplecluster
 """
 
 
@@ -211,5 +211,5 @@ type: command
 short-summary: Show details of a HorizonDB private link resource.
 examples:
   - name: Show a private link resource by group name.
-    text: az horizondb private-link-resource show --resource-group exampleresourcegroup --name examplecluster --group-name DefaultPool
+    text: az horizondb private-link-resource show --resource-group exampleresourcegroup --cluster-name examplecluster --group-name DefaultPool
 """

--- a/src/horizondb/azext_horizondb/_params.py
+++ b/src/horizondb/azext_horizondb/_params.py
@@ -40,16 +40,6 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
                 name='cluster_name',
                 actions=[LocalContextAction.SET, LocalContextAction.GET],
                 scopes=['horizondb']))
-        cluster_name_no_id_arg_type = CLIArgumentType(
-            metavar='NAME',
-            options_list=['--name', '-n'],
-            id_part=None,
-            help="Name of the cluster. The name can contain only lowercase letters, numbers, and the hyphen (-) character. Minimum 3 characters and maximum 63 characters.",
-            local_context_attribute=LocalContextAttribute(
-                name='cluster_name',
-                actions=[LocalContextAction.SET, LocalContextAction.GET],
-                scopes=['horizondb']))
-
         administrator_login_arg_type = CLIArgumentType(
             options_list=['--administrator-login', '-u'],
             help='The administrator login name for the cluster.',

--- a/src/horizondb/azext_horizondb/_params.py
+++ b/src/horizondb/azext_horizondb/_params.py
@@ -73,6 +73,29 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
         parameter_group_arg_type = CLIArgumentType(
             options_list=['--parameter-group'],
             help='The resource ID of the parameter group.')
+        cluster_name_resource_arg_type = CLIArgumentType(
+            metavar='NAME',
+            options_list=['--cluster-name', '-c'],
+            id_part=None,
+            help="Name of the cluster. The name can contain only lowercase letters, numbers, and the hyphen (-) character. Minimum 3 characters and maximum 63 characters.",
+            local_context_attribute=LocalContextAttribute(
+                name='cluster_name',
+                actions=[LocalContextAction.SET, LocalContextAction.GET],
+                scopes=['horizondb']))
+        private_endpoint_connection_name_arg_type = CLIArgumentType(
+            options_list=['--name', '-n'],
+            help='The name of the private endpoint connection associated with the HorizonDB cluster. '
+                 'Required if --id is not specified.')
+        private_endpoint_connection_id_arg_type = CLIArgumentType(
+            options_list=['--id'],
+            help='The resource ID of the private endpoint connection associated with the HorizonDB cluster. '
+                 'If specified --cluster-name/-c and --name/-n, this should be omitted.')
+        private_endpoint_connection_description_arg_type = CLIArgumentType(
+            options_list=['--description', '-d'],
+            help='Comments for the approval or rejection.')
+        private_link_resource_group_name_arg_type = CLIArgumentType(
+            options_list=['--group-name'],
+            help='The private link resource group name. For HorizonDB this is the pool name, for example DefaultPool.')
 
         public_access_create_arg_type = CLIArgumentType(
             options_list=['--public-access'],
@@ -160,5 +183,30 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
 
         with self.argument_context('horizondb firewall-rule delete') as c:
             c.argument('yes', arg_type=yes_arg_type)
+
+        for scope in ['show', 'delete', 'approve', 'reject']:
+            with self.argument_context('horizondb private-endpoint-connection {}'.format(scope)) as c:
+                c.argument('resource_group_name', arg_type=resource_group_name_type, required=False)
+                c.argument('cluster_name', arg_type=cluster_name_resource_arg_type, required=False)
+                c.argument('private_endpoint_connection_name',
+                           arg_type=private_endpoint_connection_name_arg_type,
+                           required=False)
+                c.extra('connection_id',
+                        arg_type=private_endpoint_connection_id_arg_type,
+                        required=False)
+                if scope in ['approve', 'reject']:
+                    c.argument('description',
+                               arg_type=private_endpoint_connection_description_arg_type,
+                               required=True)
+
+        with self.argument_context('horizondb private-endpoint-connection list') as c:
+            c.argument('cluster_name', arg_type=cluster_name_resource_arg_type)
+
+        with self.argument_context('horizondb private-link-resource list') as c:
+            c.argument('cluster_name', arg_type=cluster_name_resource_arg_type)
+
+        with self.argument_context('horizondb private-link-resource show') as c:
+            c.argument('cluster_name', arg_type=cluster_name_resource_arg_type)
+            c.argument('group_name', arg_type=private_link_resource_group_name_arg_type, required=True)
 
     _horizondb_params()

--- a/src/horizondb/azext_horizondb/_params.py
+++ b/src/horizondb/azext_horizondb/_params.py
@@ -40,6 +40,15 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
                 name='cluster_name',
                 actions=[LocalContextAction.SET, LocalContextAction.GET],
                 scopes=['horizondb']))
+        cluster_name_no_id_arg_type = CLIArgumentType(
+            metavar='NAME',
+            options_list=['--name', '-n'],
+            id_part=None,
+            help="Name of the cluster. The name can contain only lowercase letters, numbers, and the hyphen (-) character. Minimum 3 characters and maximum 63 characters.",
+            local_context_attribute=LocalContextAttribute(
+                name='cluster_name',
+                actions=[LocalContextAction.SET, LocalContextAction.GET],
+                scopes=['horizondb']))
 
         administrator_login_arg_type = CLIArgumentType(
             options_list=['--administrator-login', '-u'],

--- a/src/horizondb/azext_horizondb/cluster_commands.py
+++ b/src/horizondb/azext_horizondb/cluster_commands.py
@@ -47,7 +47,6 @@ def load_command_table(self, _):
         g.custom_command('delete', 'horizondb_cluster_delete')
         g.custom_command('list', 'horizondb_cluster_list')
         g.show_command('show', 'get')
-        g.wait_command('wait')
 
     with self.command_group('horizondb firewall-rule', firewall_rule_custom,
                             custom_command_type=firewall_rule_custom,

--- a/src/horizondb/azext_horizondb/cluster_commands.py
+++ b/src/horizondb/azext_horizondb/cluster_commands.py
@@ -6,9 +6,13 @@
 from azure.cli.core.commands import CliCommandType
 from azext_horizondb._client_factory import (
     cf_horizondb_clusters,
-    cf_horizondb_firewall_rules)
+    cf_horizondb_firewall_rules,
+    cf_horizondb_private_endpoint_connections,
+    cf_horizondb_private_link_resources)
 from azext_horizondb.utils._transformers import (
     table_transform_output)
+from azext_horizondb.utils.validators import (
+    validate_private_endpoint_connection_id)
 
 
 # pylint: disable=too-many-locals, too-many-statements, line-too-long
@@ -24,6 +28,16 @@ def load_command_table(self, _):
     firewall_rule_custom = CliCommandType(
         operations_tmpl='azext_horizondb.commands.firewall_rule_commands#{}',
         client_factory=cf_horizondb_firewall_rules)
+    private_endpoint_commands = CliCommandType(
+        operations_tmpl='azext_horizondb.commands.private_endpoint_commands#{}')
+    horizondb_private_endpoint_connections_sdk = CliCommandType(
+        operations_tmpl='azext_horizondb.vendored_sdks.operations#HorizonDbPrivateEndpointConnectionsOperations.{}',
+        client_factory=cf_horizondb_private_endpoint_connections
+    )
+    horizondb_private_link_resources_sdk = CliCommandType(
+        operations_tmpl='azext_horizondb.vendored_sdks.operations#HorizonDbPrivateLinkResourcesOperations.{}',
+        client_factory=cf_horizondb_private_link_resources
+    )
 
     with self.command_group('horizondb', horizondb_clusters_sdk,
                             custom_command_type=custom_commands,
@@ -42,3 +56,22 @@ def load_command_table(self, _):
         g.custom_command('delete', 'horizondb_firewall_rule_delete')
         g.custom_show_command('show', 'horizondb_firewall_rule_get')
         g.custom_command('list', 'horizondb_firewall_rule_list')
+
+    with self.command_group('horizondb private-endpoint-connection',
+                            horizondb_private_endpoint_connections_sdk,
+                            custom_command_type=private_endpoint_commands,
+                            client_factory=cf_horizondb_private_endpoint_connections) as g:
+        g.command('list', 'list')
+        g.show_command('show', 'get', validator=validate_private_endpoint_connection_id)
+        g.command('delete', 'begin_delete', validator=validate_private_endpoint_connection_id)
+        g.custom_command('approve', 'horizondb_approve_private_endpoint_connection',
+                         validator=validate_private_endpoint_connection_id)
+        g.custom_command('reject', 'horizondb_reject_private_endpoint_connection',
+                         validator=validate_private_endpoint_connection_id)
+
+    with self.command_group('horizondb private-link-resource',
+                            horizondb_private_link_resources_sdk,
+                            custom_command_type=private_endpoint_commands,
+                            client_factory=cf_horizondb_private_link_resources) as g:
+        g.command('list', 'list')
+        g.custom_show_command('show', 'horizondb_private_link_resource_get')

--- a/src/horizondb/azext_horizondb/cluster_commands.py
+++ b/src/horizondb/azext_horizondb/cluster_commands.py
@@ -47,6 +47,7 @@ def load_command_table(self, _):
         g.custom_command('delete', 'horizondb_cluster_delete')
         g.custom_command('list', 'horizondb_cluster_list')
         g.show_command('show', 'get')
+        g.wait_command('wait')
 
     with self.command_group('horizondb firewall-rule', firewall_rule_custom,
                             custom_command_type=firewall_rule_custom,
@@ -61,7 +62,7 @@ def load_command_table(self, _):
                             horizondb_private_endpoint_connections_sdk,
                             custom_command_type=private_endpoint_commands,
                             client_factory=cf_horizondb_private_endpoint_connections) as g:
-        g.command('list', 'list')
+        g.custom_command('list', 'horizondb_private_endpoint_connection_list')
         g.show_command('show', 'get', validator=validate_private_endpoint_connection_id)
         g.command('delete', 'begin_delete', validator=validate_private_endpoint_connection_id)
         g.custom_command('approve', 'horizondb_approve_private_endpoint_connection',
@@ -73,5 +74,5 @@ def load_command_table(self, _):
                             horizondb_private_link_resources_sdk,
                             custom_command_type=private_endpoint_commands,
                             client_factory=cf_horizondb_private_link_resources) as g:
-        g.command('list', 'list')
+        g.custom_command('list', 'horizondb_private_link_resource_list')
         g.custom_show_command('show', 'horizondb_private_link_resource_get')

--- a/src/horizondb/azext_horizondb/commands/private_endpoint_commands.py
+++ b/src/horizondb/azext_horizondb/commands/private_endpoint_commands.py
@@ -1,0 +1,59 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+
+def horizondb_approve_private_endpoint_connection(
+        cmd, client, resource_group_name, cluster_name, private_endpoint_connection_name,
+        description=None):
+    return _update_private_endpoint_connection_status(
+        cmd, client, resource_group_name, cluster_name, private_endpoint_connection_name,
+        is_approved=True, description=description)
+
+
+def horizondb_reject_private_endpoint_connection(
+        cmd, client, resource_group_name, cluster_name, private_endpoint_connection_name,
+        description=None):
+    return _update_private_endpoint_connection_status(
+        cmd, client, resource_group_name, cluster_name, private_endpoint_connection_name,
+        is_approved=False, description=description)
+
+
+def _update_private_endpoint_connection_status(
+        cmd, client, resource_group_name, cluster_name, private_endpoint_connection_name,
+        is_approved=True, description=None):  # pylint: disable=unused-argument
+    from azext_horizondb._client_factory import cf_horizondb_private_endpoint_connections
+    from azext_horizondb.vendored_sdks.models import (
+        OptionalPropertiesUpdateableProperties,
+        PrivateEndpointConnectionUpdate,
+        PrivateLinkServiceConnectionState,
+    )
+
+    private_endpoint_connections_client = cf_horizondb_private_endpoint_connections(cmd.cli_ctx, None)
+    private_endpoint_connections_client.get(
+        resource_group_name=resource_group_name,
+        cluster_name=cluster_name,
+        private_endpoint_connection_name=private_endpoint_connection_name)
+
+    new_status = 'Approved' if is_approved else 'Rejected'
+    state = PrivateLinkServiceConnectionState(
+        status=new_status,
+        description=description)
+    update = PrivateEndpointConnectionUpdate(
+        properties=OptionalPropertiesUpdateableProperties(
+            private_link_service_connection_state=state))
+
+    return client.begin_update(
+        resource_group_name=resource_group_name,
+        cluster_name=cluster_name,
+        private_endpoint_connection_name=private_endpoint_connection_name,
+        properties=update)
+
+
+def horizondb_private_link_resource_get(
+        client, resource_group_name, cluster_name, group_name):
+    return client.get(
+        resource_group_name=resource_group_name,
+        cluster_name=cluster_name,
+        group_name=group_name)

--- a/src/horizondb/azext_horizondb/commands/private_endpoint_commands.py
+++ b/src/horizondb/azext_horizondb/commands/private_endpoint_commands.py
@@ -5,36 +5,29 @@
 
 
 def horizondb_approve_private_endpoint_connection(
-        cmd, client, resource_group_name, cluster_name, private_endpoint_connection_name,
+        client, resource_group_name, cluster_name, private_endpoint_connection_name,
         description=None):
     return _update_private_endpoint_connection_status(
-        cmd, client, resource_group_name, cluster_name, private_endpoint_connection_name,
+        client, resource_group_name, cluster_name, private_endpoint_connection_name,
         is_approved=True, description=description)
 
 
 def horizondb_reject_private_endpoint_connection(
-        cmd, client, resource_group_name, cluster_name, private_endpoint_connection_name,
+        client, resource_group_name, cluster_name, private_endpoint_connection_name,
         description=None):
     return _update_private_endpoint_connection_status(
-        cmd, client, resource_group_name, cluster_name, private_endpoint_connection_name,
+        client, resource_group_name, cluster_name, private_endpoint_connection_name,
         is_approved=False, description=description)
 
 
 def _update_private_endpoint_connection_status(
-        cmd, client, resource_group_name, cluster_name, private_endpoint_connection_name,
-        is_approved=True, description=None):  # pylint: disable=unused-argument
-    from azext_horizondb._client_factory import cf_horizondb_private_endpoint_connections
+        client, resource_group_name, cluster_name, private_endpoint_connection_name,
+        is_approved=True, description=None):
     from azext_horizondb.vendored_sdks.models import (
         OptionalPropertiesUpdateableProperties,
         PrivateEndpointConnectionUpdate,
         PrivateLinkServiceConnectionState,
     )
-
-    private_endpoint_connections_client = cf_horizondb_private_endpoint_connections(cmd.cli_ctx, None)
-    private_endpoint_connections_client.get(
-        resource_group_name=resource_group_name,
-        cluster_name=cluster_name,
-        private_endpoint_connection_name=private_endpoint_connection_name)
 
     new_status = 'Approved' if is_approved else 'Rejected'
     state = PrivateLinkServiceConnectionState(
@@ -49,6 +42,20 @@ def _update_private_endpoint_connection_status(
         cluster_name=cluster_name,
         private_endpoint_connection_name=private_endpoint_connection_name,
         properties=update)
+
+
+def horizondb_private_endpoint_connection_list(
+        client, resource_group_name, cluster_name):
+    return client.list(
+        resource_group_name=resource_group_name,
+        cluster_name=cluster_name)
+
+
+def horizondb_private_link_resource_list(
+        client, resource_group_name, cluster_name):
+    return client.list(
+        resource_group_name=resource_group_name,
+        cluster_name=cluster_name)
 
 
 def horizondb_private_link_resource_get(

--- a/src/horizondb/azext_horizondb/tests/latest/recordings/test_horizondb_private_endpoint_command_scenario.yaml
+++ b/src/horizondb/azext_horizondb/tests/latest/recordings/test_horizondb_private_endpoint_command_scenario.yaml
@@ -1,0 +1,164 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      CommandName:
+      - horizondb private-link-resource list
+      ParameterSetName:
+      - -g --cluster-name
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.HorizonDb/clusters/horizondbclitest-000002/privateLinkResources?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.HorizonDb/clusters/horizondbclitest-000002/privateLinkResources/DefaultPool","name":"DefaultPool","type":"Microsoft.HorizonDb/clusters/privateLinkResources","properties":{"groupId":"DefaultPool","requiredMembers":["rw","ro"],"requiredZoneNames":["privatelink.horizondb.azure.com"]}}]}'
+    headers:
+      content-type:
+      - application/json; charset=utf-8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      CommandName:
+      - horizondb private-link-resource show
+      ParameterSetName:
+      - -g --cluster-name --group-name
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.HorizonDb/clusters/horizondbclitest-000002/privateLinkResources/DefaultPool?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.HorizonDb/clusters/horizondbclitest-000002/privateLinkResources/DefaultPool","name":"DefaultPool","type":"Microsoft.HorizonDb/clusters/privateLinkResources","properties":{"groupId":"DefaultPool","requiredMembers":["rw","ro"],"requiredZoneNames":["privatelink.horizondb.azure.com"]}}'
+    headers:
+      content-type:
+      - application/json; charset=utf-8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      CommandName:
+      - horizondb private-endpoint-connection list
+      ParameterSetName:
+      - -g --cluster-name
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.HorizonDb/clusters/horizondbclitest-000002/privateEndpointConnections?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.HorizonDb/clusters/horizondbclitest-000002/privateEndpointConnections/test-connection","name":"test-connection","type":"Microsoft.HorizonDb/clusters/privateEndpointConnections","properties":{"groupIds":["DefaultPool"],"privateEndpoint":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/privateEndpoints/test-private-endpoint"},"privateLinkServiceConnectionState":{"status":"Pending","description":"Requested","actionsRequired":"None"},"provisioningState":"Succeeded"}}]}'
+    headers:
+      content-type:
+      - application/json; charset=utf-8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      CommandName:
+      - horizondb private-endpoint-connection show
+      ParameterSetName:
+      - -g --cluster-name --name
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.HorizonDb/clusters/horizondbclitest-000002/privateEndpointConnections/test-connection?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.HorizonDb/clusters/horizondbclitest-000002/privateEndpointConnections/test-connection","name":"test-connection","type":"Microsoft.HorizonDb/clusters/privateEndpointConnections","properties":{"groupIds":["DefaultPool"],"privateEndpoint":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/privateEndpoints/test-private-endpoint"},"privateLinkServiceConnectionState":{"status":"Pending","description":"Requested","actionsRequired":"None"},"provisioningState":"Succeeded"}}'
+    headers:
+      content-type:
+      - application/json; charset=utf-8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      CommandName:
+      - horizondb private-endpoint-connection show
+      ParameterSetName:
+      - --id
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.HorizonDb/clusters/horizondbclitest-000002/privateEndpointConnections/test-connection?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.HorizonDb/clusters/horizondbclitest-000002/privateEndpointConnections/test-connection","name":"test-connection","type":"Microsoft.HorizonDb/clusters/privateEndpointConnections","properties":{"groupIds":["DefaultPool"],"privateEndpoint":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/privateEndpoints/test-private-endpoint"},"privateLinkServiceConnectionState":{"status":"Pending","description":"Requested","actionsRequired":"None"},"provisioningState":"Succeeded"}}'
+    headers:
+      content-type:
+      - application/json; charset=utf-8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"privateLinkServiceConnectionState": {"status": "Approved", "description": "Approved"}}}'
+    headers:
+      Accept:
+      - application/json
+      CommandName:
+      - horizondb private-endpoint-connection approve
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g --cluster-name --name --description
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.HorizonDb/clusters/horizondbclitest-000002/privateEndpointConnections/test-connection?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.HorizonDb/clusters/horizondbclitest-000002/privateEndpointConnections/test-connection","name":"test-connection","type":"Microsoft.HorizonDb/clusters/privateEndpointConnections","properties":{"groupIds":["DefaultPool"],"privateEndpoint":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/privateEndpoints/test-private-endpoint"},"privateLinkServiceConnectionState":{"status":"Approved","description":"Approved","actionsRequired":"None"},"provisioningState":"Succeeded"}}'
+    headers:
+      content-type:
+      - application/json; charset=utf-8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"privateLinkServiceConnectionState": {"status": "Rejected", "description": "Rejected"}}}'
+    headers:
+      Accept:
+      - application/json
+      CommandName:
+      - horizondb private-endpoint-connection reject
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - --id --description
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.HorizonDb/clusters/horizondbclitest-000002/privateEndpointConnections/test-connection?api-version=2026-01-20-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.HorizonDb/clusters/horizondbclitest-000002/privateEndpointConnections/test-connection","name":"test-connection","type":"Microsoft.HorizonDb/clusters/privateEndpointConnections","properties":{"groupIds":["DefaultPool"],"privateEndpoint":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/privateEndpoints/test-private-endpoint"},"privateLinkServiceConnectionState":{"status":"Rejected","description":"Rejected","actionsRequired":"None"},"provisioningState":"Succeeded"}}'
+    headers:
+      content-type:
+      - application/json; charset=utf-8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      CommandName:
+      - horizondb private-endpoint-connection delete
+      ParameterSetName:
+      - --id
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.HorizonDb/clusters/horizondbclitest-000002/privateEndpointConnections/test-connection?api-version=2026-01-20-preview
+  response:
+    body:
+      string: ''
+    headers: {}
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/src/horizondb/azext_horizondb/tests/latest/test_horizondb_private_endpoint_commands.py
+++ b/src/horizondb/azext_horizondb/tests/latest/test_horizondb_private_endpoint_commands.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from unittest.mock import Mock
 
 from azure.cli.core import get_default_cli
+from azure.cli.testsdk import ScenarioTest
 from knack.util import CLIError
 
 from azext_horizondb import HorizonDBCommandsLoader
@@ -17,6 +18,58 @@ from azext_horizondb.utils.validators import validate_private_endpoint_connectio
 from azext_horizondb.vendored_sdks.operations._operations import (
     build_horizon_db_private_endpoint_connections_delete_request,
     build_horizon_db_private_endpoint_connections_update_request)
+
+
+class HorizonDBPrivateEndpointScenarioTest(ScenarioTest):
+
+    def test_horizondb_private_endpoint_command_scenario(self):
+        resource_group = 'clitest.rg000001'
+        cluster_name = 'horizondbclitest-000002'
+        group_name = 'DefaultPool'
+        connection_name = 'test-connection'
+        pec_id = (
+            '/subscriptions/00000000-0000-0000-0000-000000000000'
+            '/resourceGroups/{}/providers/Microsoft.HorizonDb/clusters/{}'
+            '/privateEndpointConnections/{}').format(resource_group, cluster_name, connection_name)
+
+        self.cmd('horizondb private-link-resource list -g {} --cluster-name {}'.format(
+            resource_group, cluster_name), checks=[
+                self.check('length(@)', 1),
+                self.check('[0].properties.groupId', group_name),
+                self.check('[0].properties.requiredMembers', ['rw', 'ro'])
+            ])
+        self.cmd('horizondb private-link-resource show -g {} --cluster-name {} --group-name {}'.format(
+            resource_group, cluster_name, group_name), checks=[
+                self.check('properties.groupId', group_name),
+                self.check('properties.requiredZoneNames[0]', 'privatelink.horizondb.azure.com')
+            ])
+
+        self.cmd('horizondb private-endpoint-connection list -g {} --cluster-name {}'.format(
+            resource_group, cluster_name), checks=[
+                self.check('length(@)', 1),
+                self.check('[0].id', pec_id),
+                self.check('[0].properties.privateLinkServiceConnectionState.status', 'Pending')
+            ])
+        self.cmd('horizondb private-endpoint-connection show -g {} --cluster-name {} --name {}'.format(
+            resource_group, cluster_name, connection_name), checks=[
+                self.check('id', pec_id),
+                self.check('properties.privateLinkServiceConnectionState.status', 'Pending')
+            ])
+        self.cmd('horizondb private-endpoint-connection show --id {}'.format(pec_id), checks=[
+            self.check('id', pec_id),
+            self.check('properties.privateLinkServiceConnectionState.status', 'Pending')
+        ])
+
+        self.cmd('horizondb private-endpoint-connection approve -g {} --cluster-name {} --name {} '
+                 '--description "Approved"'.format(resource_group, cluster_name, connection_name), checks=[
+                     self.check('properties.privateLinkServiceConnectionState.status', 'Approved'),
+                     self.check('properties.privateLinkServiceConnectionState.description', 'Approved')
+                 ])
+        self.cmd('horizondb private-endpoint-connection reject --id {} --description "Rejected"'.format(pec_id), checks=[
+            self.check('properties.privateLinkServiceConnectionState.status', 'Rejected'),
+            self.check('properties.privateLinkServiceConnectionState.description', 'Rejected')
+        ])
+        self.cmd('horizondb private-endpoint-connection delete --id {}'.format(pec_id))
 
 
 class HorizonDBPrivateEndpointCommandTests(unittest.TestCase):
@@ -37,7 +90,11 @@ class HorizonDBPrivateEndpointCommandTests(unittest.TestCase):
             loader.load_arguments(None)
 
             resource_group_arg = loader.argument_registry.arguments[command]['resource_group_name']
+            cluster_name_arg = loader.argument_registry.arguments[command]['cluster_name']
+            connection_name_arg = loader.argument_registry.arguments[command]['private_endpoint_connection_name']
             self.assertFalse(resource_group_arg.settings['required'], command)
+            self.assertEqual(['--cluster-name', '-c'], cluster_name_arg.settings['options_list'])
+            self.assertEqual(['--name', '-n'], connection_name_arg.settings['options_list'])
 
     def test_child_list_commands_do_not_register_generic_ids_arguments(self):
         commands = [

--- a/src/horizondb/azext_horizondb/tests/latest/test_horizondb_private_endpoint_commands.py
+++ b/src/horizondb/azext_horizondb/tests/latest/test_horizondb_private_endpoint_commands.py
@@ -5,7 +5,7 @@
 
 import unittest
 from types import SimpleNamespace
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 from azure.cli.core import get_default_cli
 from knack.util import CLIError
@@ -38,6 +38,22 @@ class HorizonDBPrivateEndpointCommandTests(unittest.TestCase):
 
             resource_group_arg = loader.argument_registry.arguments[command]['resource_group_name']
             self.assertFalse(resource_group_arg.settings['required'], command)
+
+    def test_child_list_commands_do_not_register_generic_ids_arguments(self):
+        commands = [
+            'horizondb private-endpoint-connection list',
+            'horizondb private-link-resource list',
+        ]
+
+        for command in commands:
+            cli = get_default_cli()
+            cli.invocation = SimpleNamespace(data={'command_string': command})
+            loader = HorizonDBCommandsLoader(cli_ctx=cli)
+            loader.load_command_table(None)
+            loader.load_arguments(None)
+
+            cluster_name_arg = loader.argument_registry.arguments[command]['cluster_name']
+            self.assertIsNone(cluster_name_arg.settings.get('id_part'), command)
 
     def test_update_request_is_cluster_scoped_put(self):
         request = build_horizon_db_private_endpoint_connections_update_request(
@@ -131,26 +147,17 @@ class HorizonDBPrivateEndpointCommandTests(unittest.TestCase):
             validate_private_endpoint_connection_id(None, namespace)
 
     def test_approve_private_endpoint_connection_uses_cluster_scoped_update(self):
-        get_client = Mock()
         update_client = Mock()
         update_client.begin_update.return_value = 'poller'
-        cmd = SimpleNamespace(cli_ctx=object())
 
-        with patch('azext_horizondb._client_factory.cf_horizondb_private_endpoint_connections',
-                   return_value=get_client):
-            result = horizondb_approve_private_endpoint_connection(
-                cmd,
-                update_client,
-                resource_group_name='rg1',
-                cluster_name='cluster1',
-                private_endpoint_connection_name='pec1',
-                description='Approved')
-
-        self.assertEqual('poller', result)
-        get_client.get.assert_called_once_with(
+        result = horizondb_approve_private_endpoint_connection(
+            update_client,
             resource_group_name='rg1',
             cluster_name='cluster1',
-            private_endpoint_connection_name='pec1')
+            private_endpoint_connection_name='pec1',
+            description='Approved')
+
+        self.assertEqual('poller', result)
         update_client.begin_update.assert_called_once()
         kwargs = update_client.begin_update.call_args.kwargs
         self.assertEqual('rg1', kwargs['resource_group_name'])

--- a/src/horizondb/azext_horizondb/tests/latest/test_horizondb_private_endpoint_commands.py
+++ b/src/horizondb/azext_horizondb/tests/latest/test_horizondb_private_endpoint_commands.py
@@ -1,0 +1,168 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from azure.cli.core import get_default_cli
+from knack.util import CLIError
+
+from azext_horizondb import HorizonDBCommandsLoader
+from azext_horizondb.commands.private_endpoint_commands import (
+    horizondb_approve_private_endpoint_connection)
+from azext_horizondb.utils.validators import validate_private_endpoint_connection_id
+from azext_horizondb.vendored_sdks.operations._operations import (
+    build_horizon_db_private_endpoint_connections_delete_request,
+    build_horizon_db_private_endpoint_connections_update_request)
+
+
+class HorizonDBPrivateEndpointCommandTests(unittest.TestCase):
+
+    def test_private_endpoint_connection_id_commands_do_not_require_resource_group_at_parse_time(self):
+        commands = [
+            'horizondb private-endpoint-connection show',
+            'horizondb private-endpoint-connection approve',
+            'horizondb private-endpoint-connection reject',
+            'horizondb private-endpoint-connection delete',
+        ]
+
+        for command in commands:
+            cli = get_default_cli()
+            cli.invocation = SimpleNamespace(data={'command_string': command})
+            loader = HorizonDBCommandsLoader(cli_ctx=cli)
+            loader.load_command_table(None)
+            loader.load_arguments(None)
+
+            resource_group_arg = loader.argument_registry.arguments[command]['resource_group_name']
+            self.assertFalse(resource_group_arg.settings['required'], command)
+
+    def test_update_request_is_cluster_scoped_put(self):
+        request = build_horizon_db_private_endpoint_connections_update_request(
+            resource_group_name='rg1',
+            cluster_name='cluster1',
+            private_endpoint_connection_name='pec1',
+            subscription_id='00000000-0000-0000-0000-000000000000')
+
+        self.assertEqual('PUT', request.method)
+        self.assertIn('/providers/Microsoft.HorizonDb/clusters/cluster1/privateEndpointConnections/pec1',
+                      request.url)
+        self.assertNotIn('/providers/Microsoft.HorizonDb/privateEndpointConnections/pec1',
+                         request.url)
+
+    def test_delete_request_is_cluster_scoped(self):
+        request = build_horizon_db_private_endpoint_connections_delete_request(
+            resource_group_name='rg1',
+            cluster_name='cluster1',
+            private_endpoint_connection_name='pec1',
+            subscription_id='00000000-0000-0000-0000-000000000000')
+
+        self.assertEqual('DELETE', request.method)
+        self.assertIn('/providers/Microsoft.HorizonDb/clusters/cluster1/privateEndpointConnections/pec1',
+                      request.url)
+
+    def test_validate_private_endpoint_connection_id_parses_horizondb_cluster_id(self):
+        connection_id = (
+            '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1'
+            '/providers/Microsoft.HorizonDb/clusters/cluster1/privateEndpointConnections/pec1')
+        namespace = SimpleNamespace(
+            connection_id=connection_id,
+            resource_group_name=None,
+            cluster_name=None,
+            private_endpoint_connection_name=None)
+
+        validate_private_endpoint_connection_id(None, namespace)
+
+        self.assertEqual('rg1', namespace.resource_group_name)
+        self.assertEqual('cluster1', namespace.cluster_name)
+        self.assertEqual('pec1', namespace.private_endpoint_connection_name)
+        self.assertFalse(hasattr(namespace, 'connection_id'))
+
+    def test_validate_private_endpoint_connection_id_rejects_non_horizondb_id(self):
+        connection_id = (
+            '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1'
+            '/providers/Microsoft.Storage/storageAccounts/account1/privateEndpointConnections/pec1')
+        namespace = SimpleNamespace(
+            connection_id=connection_id,
+            resource_group_name=None,
+            cluster_name=None,
+            private_endpoint_connection_name=None)
+
+        with self.assertRaises(CLIError):
+            validate_private_endpoint_connection_id(None, namespace)
+
+    def test_validate_private_endpoint_connection_id_rejects_non_pec_child_id(self):
+        connection_id = (
+            '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1'
+            '/providers/Microsoft.HorizonDb/clusters/cluster1/privateLinkResources/DefaultPool')
+        namespace = SimpleNamespace(
+            connection_id=connection_id,
+            resource_group_name=None,
+            cluster_name=None,
+            private_endpoint_connection_name=None)
+
+        with self.assertRaises(CLIError):
+            validate_private_endpoint_connection_id(None, namespace)
+
+    def test_validate_private_endpoint_connection_id_rejects_malformed_id(self):
+        namespace = SimpleNamespace(
+            connection_id='foo',
+            resource_group_name=None,
+            cluster_name=None,
+            private_endpoint_connection_name=None)
+
+        with self.assertRaises(CLIError):
+            validate_private_endpoint_connection_id(None, namespace)
+
+    def test_validate_private_endpoint_connection_id_rejects_extra_child_id(self):
+        connection_id = (
+            '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1'
+            '/providers/Microsoft.HorizonDb/clusters/cluster1/privateEndpointConnections/pec1'
+            '/extra/name')
+        namespace = SimpleNamespace(
+            connection_id=connection_id,
+            resource_group_name=None,
+            cluster_name=None,
+            private_endpoint_connection_name=None)
+
+        with self.assertRaises(CLIError):
+            validate_private_endpoint_connection_id(None, namespace)
+
+    def test_approve_private_endpoint_connection_uses_cluster_scoped_update(self):
+        get_client = Mock()
+        update_client = Mock()
+        update_client.begin_update.return_value = 'poller'
+        cmd = SimpleNamespace(cli_ctx=object())
+
+        with patch('azext_horizondb._client_factory.cf_horizondb_private_endpoint_connections',
+                   return_value=get_client):
+            result = horizondb_approve_private_endpoint_connection(
+                cmd,
+                update_client,
+                resource_group_name='rg1',
+                cluster_name='cluster1',
+                private_endpoint_connection_name='pec1',
+                description='Approved')
+
+        self.assertEqual('poller', result)
+        get_client.get.assert_called_once_with(
+            resource_group_name='rg1',
+            cluster_name='cluster1',
+            private_endpoint_connection_name='pec1')
+        update_client.begin_update.assert_called_once()
+        kwargs = update_client.begin_update.call_args.kwargs
+        self.assertEqual('rg1', kwargs['resource_group_name'])
+        self.assertEqual('cluster1', kwargs['cluster_name'])
+        self.assertEqual('pec1', kwargs['private_endpoint_connection_name'])
+        self.assertEqual(
+            'Approved',
+            kwargs['properties'].properties.private_link_service_connection_state.status)
+        self.assertEqual(
+            'Approved',
+            kwargs['properties'].properties.private_link_service_connection_state.description)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/horizondb/azext_horizondb/utils/validators.py
+++ b/src/horizondb/azext_horizondb/utils/validators.py
@@ -154,4 +154,3 @@ def validate_private_endpoint_connection_id(cmd, namespace):  # pylint: disable=
             '--resource-group <resource-group>.')
     if hasattr(namespace, 'connection_id'):
         del namespace.connection_id
-        del namespace.connection_id

--- a/src/horizondb/azext_horizondb/utils/validators.py
+++ b/src/horizondb/azext_horizondb/utils/validators.py
@@ -8,6 +8,7 @@ from knack.util import CLIError
 from azure.cli.core.azclierror import ArgumentUsageError
 from azure.cli.core.commands.validators import (
     get_default_location_from_resource_group, validate_tags)
+from azure.cli.core.util import parse_proxy_resource_id
 from typing import Any, Dict, Iterable, Optional
 
 
@@ -127,3 +128,30 @@ def _valid_range(addr_range):
     if addr_range.isdigit() and 0 <= int(addr_range) <= 255:
         return True
     return False
+
+
+def validate_private_endpoint_connection_id(cmd, namespace):  # pylint: disable=unused-argument
+    if getattr(namespace, 'connection_id', None):
+        result = parse_proxy_resource_id(namespace.connection_id)
+        provider_type = '{}/{}'.format(result.get('namespace'), result.get('type')).lower() if result else ''
+        child_type = (result.get('child_type_1') or '').lower() if result else ''
+        if (not result or
+                provider_type != 'microsoft.horizondb/clusters' or
+                child_type != 'privateendpointconnections' or
+                result.get('last_child_num') != 1):
+            raise CLIError('The --id value must be a HorizonDB cluster private endpoint connection resource ID.')
+        namespace.resource_group_name = result.get('resource_group')
+        namespace.cluster_name = result.get('name')
+        namespace.private_endpoint_connection_name = result.get('child_name_1')
+
+    if not all([
+            getattr(namespace, 'resource_group_name', None),
+            getattr(namespace, 'cluster_name', None),
+            getattr(namespace, 'private_endpoint_connection_name', None)]):
+        raise CLIError(
+            'Specify either --id <private-endpoint-connection-id> or '
+            '--name <private-endpoint-connection-name> --cluster-name <cluster-name> '
+            '--resource-group <resource-group>.')
+    if hasattr(namespace, 'connection_id'):
+        del namespace.connection_id
+        del namespace.connection_id

--- a/src/horizondb/azext_horizondb/vendored_sdks/aio/operations/_operations.py
+++ b/src/horizondb/azext_horizondb/vendored_sdks/aio/operations/_operations.py
@@ -2894,6 +2894,7 @@ class HorizonDbPrivateEndpointConnectionsOperations:  # pylint: disable=name-too
     async def _update_initial(
         self,
         resource_group_name: str,
+        cluster_name: str,
         private_endpoint_connection_name: str,
         properties: Union[_models.PrivateEndpointConnectionUpdate, JSON, IO[bytes]],
         **kwargs: Any
@@ -2921,6 +2922,7 @@ class HorizonDbPrivateEndpointConnectionsOperations:  # pylint: disable=name-too
 
         _request = build_horizon_db_private_endpoint_connections_update_request(
             resource_group_name=resource_group_name,
+            cluster_name=cluster_name,
             private_endpoint_connection_name=private_endpoint_connection_name,
             subscription_id=self._config.subscription_id,
             content_type=content_type,
@@ -2970,6 +2972,7 @@ class HorizonDbPrivateEndpointConnectionsOperations:  # pylint: disable=name-too
     async def begin_update(
         self,
         resource_group_name: str,
+        cluster_name: str,
         private_endpoint_connection_name: str,
         properties: _models.PrivateEndpointConnectionUpdate,
         *,
@@ -2981,6 +2984,8 @@ class HorizonDbPrivateEndpointConnectionsOperations:  # pylint: disable=name-too
         :param resource_group_name: The name of the resource group. The name is case insensitive.
          Required.
         :type resource_group_name: str
+        :param cluster_name: The name of the HorizonDb cluster. Required.
+        :type cluster_name: str
         :param private_endpoint_connection_name: The name of the private endpoint connection associated
          with the Azure resource. Required.
         :type private_endpoint_connection_name: str
@@ -3000,6 +3005,7 @@ class HorizonDbPrivateEndpointConnectionsOperations:  # pylint: disable=name-too
     async def begin_update(
         self,
         resource_group_name: str,
+        cluster_name: str,
         private_endpoint_connection_name: str,
         properties: JSON,
         *,
@@ -3011,6 +3017,8 @@ class HorizonDbPrivateEndpointConnectionsOperations:  # pylint: disable=name-too
         :param resource_group_name: The name of the resource group. The name is case insensitive.
          Required.
         :type resource_group_name: str
+        :param cluster_name: The name of the HorizonDb cluster. Required.
+        :type cluster_name: str
         :param private_endpoint_connection_name: The name of the private endpoint connection associated
          with the Azure resource. Required.
         :type private_endpoint_connection_name: str
@@ -3030,6 +3038,7 @@ class HorizonDbPrivateEndpointConnectionsOperations:  # pylint: disable=name-too
     async def begin_update(
         self,
         resource_group_name: str,
+        cluster_name: str,
         private_endpoint_connection_name: str,
         properties: IO[bytes],
         *,
@@ -3041,6 +3050,8 @@ class HorizonDbPrivateEndpointConnectionsOperations:  # pylint: disable=name-too
         :param resource_group_name: The name of the resource group. The name is case insensitive.
          Required.
         :type resource_group_name: str
+        :param cluster_name: The name of the HorizonDb cluster. Required.
+        :type cluster_name: str
         :param private_endpoint_connection_name: The name of the private endpoint connection associated
          with the Azure resource. Required.
         :type private_endpoint_connection_name: str
@@ -3060,6 +3071,7 @@ class HorizonDbPrivateEndpointConnectionsOperations:  # pylint: disable=name-too
     async def begin_update(
         self,
         resource_group_name: str,
+        cluster_name: str,
         private_endpoint_connection_name: str,
         properties: Union[_models.PrivateEndpointConnectionUpdate, JSON, IO[bytes]],
         **kwargs: Any
@@ -3069,6 +3081,8 @@ class HorizonDbPrivateEndpointConnectionsOperations:  # pylint: disable=name-too
         :param resource_group_name: The name of the resource group. The name is case insensitive.
          Required.
         :type resource_group_name: str
+        :param cluster_name: The name of the HorizonDb cluster. Required.
+        :type cluster_name: str
         :param private_endpoint_connection_name: The name of the private endpoint connection associated
          with the Azure resource. Required.
         :type private_endpoint_connection_name: str
@@ -3093,6 +3107,7 @@ class HorizonDbPrivateEndpointConnectionsOperations:  # pylint: disable=name-too
         if cont_token is None:
             raw_result = await self._update_initial(
                 resource_group_name=resource_group_name,
+                cluster_name=cluster_name,
                 private_endpoint_connection_name=private_endpoint_connection_name,
                 properties=properties,
                 content_type=content_type,
@@ -3135,7 +3150,7 @@ class HorizonDbPrivateEndpointConnectionsOperations:  # pylint: disable=name-too
         )
 
     async def _delete_initial(
-        self, resource_group_name: str, private_endpoint_connection_name: str, **kwargs: Any
+        self, resource_group_name: str, cluster_name: str, private_endpoint_connection_name: str, **kwargs: Any
     ) -> AsyncIterator[bytes]:
         error_map: MutableMapping = {
             401: ClientAuthenticationError,
@@ -3152,6 +3167,7 @@ class HorizonDbPrivateEndpointConnectionsOperations:  # pylint: disable=name-too
 
         _request = build_horizon_db_private_endpoint_connections_delete_request(
             resource_group_name=resource_group_name,
+            cluster_name=cluster_name,
             private_endpoint_connection_name=private_endpoint_connection_name,
             subscription_id=self._config.subscription_id,
             api_version=self._config.api_version,
@@ -3200,13 +3216,15 @@ class HorizonDbPrivateEndpointConnectionsOperations:  # pylint: disable=name-too
 
     @distributed_trace_async
     async def begin_delete(
-        self, resource_group_name: str, private_endpoint_connection_name: str, **kwargs: Any
+        self, resource_group_name: str, cluster_name: str, private_endpoint_connection_name: str, **kwargs: Any
     ) -> AsyncLROPoller[None]:
         """Deletes a private endpoint connection.
 
         :param resource_group_name: The name of the resource group. The name is case insensitive.
          Required.
         :type resource_group_name: str
+        :param cluster_name: The name of the HorizonDb cluster. Required.
+        :type cluster_name: str
         :param private_endpoint_connection_name: The name of the private endpoint connection associated
          with the Azure resource. Required.
         :type private_endpoint_connection_name: str
@@ -3224,6 +3242,7 @@ class HorizonDbPrivateEndpointConnectionsOperations:  # pylint: disable=name-too
         if cont_token is None:
             raw_result = await self._delete_initial(
                 resource_group_name=resource_group_name,
+                cluster_name=cluster_name,
                 private_endpoint_connection_name=private_endpoint_connection_name,
                 cls=lambda x, y, z: x,
                 headers=_headers,

--- a/src/horizondb/azext_horizondb/vendored_sdks/operations/_operations.py
+++ b/src/horizondb/azext_horizondb/vendored_sdks/operations/_operations.py
@@ -631,7 +631,11 @@ def build_horizon_db_private_endpoint_connections_list_request(  # pylint: disab
 
 
 def build_horizon_db_private_endpoint_connections_update_request(  # pylint: disable=name-too-long
-    resource_group_name: str, private_endpoint_connection_name: str, subscription_id: str, **kwargs: Any
+    resource_group_name: str,
+    cluster_name: str,
+    private_endpoint_connection_name: str,
+    subscription_id: str,
+    **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
@@ -641,10 +645,11 @@ def build_horizon_db_private_endpoint_connections_update_request(  # pylint: dis
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
-    _url = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HorizonDb/privateEndpointConnections/{privateEndpointConnectionName}"
+    _url = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HorizonDb/clusters/{clusterName}/privateEndpointConnections/{privateEndpointConnectionName}"
     path_format_arguments = {
         "subscriptionId": _SERIALIZER.url("subscription_id", subscription_id, "str"),
         "resourceGroupName": _SERIALIZER.url("resource_group_name", resource_group_name, "str"),
+        "clusterName": _SERIALIZER.url("cluster_name", cluster_name, "str"),
         "privateEndpointConnectionName": _SERIALIZER.url(
             "private_endpoint_connection_name", private_endpoint_connection_name, "str"
         ),
@@ -660,20 +665,25 @@ def build_horizon_db_private_endpoint_connections_update_request(  # pylint: dis
         _headers["Content-Type"] = _SERIALIZER.header("content_type", content_type, "str")
     _headers["Accept"] = _SERIALIZER.header("accept", accept, "str")
 
-    return HttpRequest(method="PATCH", url=_url, params=_params, headers=_headers, **kwargs)
+    return HttpRequest(method="PUT", url=_url, params=_params, headers=_headers, **kwargs)
 
 
 def build_horizon_db_private_endpoint_connections_delete_request(  # pylint: disable=name-too-long
-    resource_group_name: str, private_endpoint_connection_name: str, subscription_id: str, **kwargs: Any
+    resource_group_name: str,
+    cluster_name: str,
+    private_endpoint_connection_name: str,
+    subscription_id: str,
+    **kwargs: Any
 ) -> HttpRequest:
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-01-20-preview"))
     # Construct URL
-    _url = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HorizonDb/privateEndpointConnections/{privateEndpointConnectionName}"
+    _url = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HorizonDb/clusters/{clusterName}/privateEndpointConnections/{privateEndpointConnectionName}"
     path_format_arguments = {
         "subscriptionId": _SERIALIZER.url("subscription_id", subscription_id, "str"),
         "resourceGroupName": _SERIALIZER.url("resource_group_name", resource_group_name, "str"),
+        "clusterName": _SERIALIZER.url("cluster_name", cluster_name, "str"),
         "privateEndpointConnectionName": _SERIALIZER.url(
             "private_endpoint_connection_name", private_endpoint_connection_name, "str"
         ),
@@ -3781,6 +3791,7 @@ class HorizonDbPrivateEndpointConnectionsOperations:  # pylint: disable=name-too
     def _update_initial(
         self,
         resource_group_name: str,
+        cluster_name: str,
         private_endpoint_connection_name: str,
         properties: Union[_models.PrivateEndpointConnectionUpdate, JSON, IO[bytes]],
         **kwargs: Any
@@ -3808,6 +3819,7 @@ class HorizonDbPrivateEndpointConnectionsOperations:  # pylint: disable=name-too
 
         _request = build_horizon_db_private_endpoint_connections_update_request(
             resource_group_name=resource_group_name,
+            cluster_name=cluster_name,
             private_endpoint_connection_name=private_endpoint_connection_name,
             subscription_id=self._config.subscription_id,
             content_type=content_type,
@@ -3857,6 +3869,7 @@ class HorizonDbPrivateEndpointConnectionsOperations:  # pylint: disable=name-too
     def begin_update(
         self,
         resource_group_name: str,
+        cluster_name: str,
         private_endpoint_connection_name: str,
         properties: _models.PrivateEndpointConnectionUpdate,
         *,
@@ -3868,6 +3881,8 @@ class HorizonDbPrivateEndpointConnectionsOperations:  # pylint: disable=name-too
         :param resource_group_name: The name of the resource group. The name is case insensitive.
          Required.
         :type resource_group_name: str
+        :param cluster_name: The name of the HorizonDb cluster. Required.
+        :type cluster_name: str
         :param private_endpoint_connection_name: The name of the private endpoint connection associated
          with the Azure resource. Required.
         :type private_endpoint_connection_name: str
@@ -3886,6 +3901,7 @@ class HorizonDbPrivateEndpointConnectionsOperations:  # pylint: disable=name-too
     def begin_update(
         self,
         resource_group_name: str,
+        cluster_name: str,
         private_endpoint_connection_name: str,
         properties: JSON,
         *,
@@ -3897,6 +3913,8 @@ class HorizonDbPrivateEndpointConnectionsOperations:  # pylint: disable=name-too
         :param resource_group_name: The name of the resource group. The name is case insensitive.
          Required.
         :type resource_group_name: str
+        :param cluster_name: The name of the HorizonDb cluster. Required.
+        :type cluster_name: str
         :param private_endpoint_connection_name: The name of the private endpoint connection associated
          with the Azure resource. Required.
         :type private_endpoint_connection_name: str
@@ -3915,6 +3933,7 @@ class HorizonDbPrivateEndpointConnectionsOperations:  # pylint: disable=name-too
     def begin_update(
         self,
         resource_group_name: str,
+        cluster_name: str,
         private_endpoint_connection_name: str,
         properties: IO[bytes],
         *,
@@ -3926,6 +3945,8 @@ class HorizonDbPrivateEndpointConnectionsOperations:  # pylint: disable=name-too
         :param resource_group_name: The name of the resource group. The name is case insensitive.
          Required.
         :type resource_group_name: str
+        :param cluster_name: The name of the HorizonDb cluster. Required.
+        :type cluster_name: str
         :param private_endpoint_connection_name: The name of the private endpoint connection associated
          with the Azure resource. Required.
         :type private_endpoint_connection_name: str
@@ -3944,6 +3965,7 @@ class HorizonDbPrivateEndpointConnectionsOperations:  # pylint: disable=name-too
     def begin_update(
         self,
         resource_group_name: str,
+        cluster_name: str,
         private_endpoint_connection_name: str,
         properties: Union[_models.PrivateEndpointConnectionUpdate, JSON, IO[bytes]],
         **kwargs: Any
@@ -3953,6 +3975,8 @@ class HorizonDbPrivateEndpointConnectionsOperations:  # pylint: disable=name-too
         :param resource_group_name: The name of the resource group. The name is case insensitive.
          Required.
         :type resource_group_name: str
+        :param cluster_name: The name of the HorizonDb cluster. Required.
+        :type cluster_name: str
         :param private_endpoint_connection_name: The name of the private endpoint connection associated
          with the Azure resource. Required.
         :type private_endpoint_connection_name: str
@@ -3976,6 +4000,7 @@ class HorizonDbPrivateEndpointConnectionsOperations:  # pylint: disable=name-too
         if cont_token is None:
             raw_result = self._update_initial(
                 resource_group_name=resource_group_name,
+                cluster_name=cluster_name,
                 private_endpoint_connection_name=private_endpoint_connection_name,
                 properties=properties,
                 content_type=content_type,
@@ -4018,7 +4043,7 @@ class HorizonDbPrivateEndpointConnectionsOperations:  # pylint: disable=name-too
         )
 
     def _delete_initial(
-        self, resource_group_name: str, private_endpoint_connection_name: str, **kwargs: Any
+        self, resource_group_name: str, cluster_name: str, private_endpoint_connection_name: str, **kwargs: Any
     ) -> Iterator[bytes]:
         error_map: MutableMapping = {
             401: ClientAuthenticationError,
@@ -4035,6 +4060,7 @@ class HorizonDbPrivateEndpointConnectionsOperations:  # pylint: disable=name-too
 
         _request = build_horizon_db_private_endpoint_connections_delete_request(
             resource_group_name=resource_group_name,
+            cluster_name=cluster_name,
             private_endpoint_connection_name=private_endpoint_connection_name,
             subscription_id=self._config.subscription_id,
             api_version=self._config.api_version,
@@ -4083,13 +4109,15 @@ class HorizonDbPrivateEndpointConnectionsOperations:  # pylint: disable=name-too
 
     @distributed_trace
     def begin_delete(
-        self, resource_group_name: str, private_endpoint_connection_name: str, **kwargs: Any
+        self, resource_group_name: str, cluster_name: str, private_endpoint_connection_name: str, **kwargs: Any
     ) -> LROPoller[None]:
         """Deletes a private endpoint connection.
 
         :param resource_group_name: The name of the resource group. The name is case insensitive.
          Required.
         :type resource_group_name: str
+        :param cluster_name: The name of the HorizonDb cluster. Required.
+        :type cluster_name: str
         :param private_endpoint_connection_name: The name of the private endpoint connection associated
          with the Azure resource. Required.
         :type private_endpoint_connection_name: str
@@ -4107,6 +4135,7 @@ class HorizonDbPrivateEndpointConnectionsOperations:  # pylint: disable=name-too
         if cont_token is None:
             raw_result = self._delete_initial(
                 resource_group_name=resource_group_name,
+                cluster_name=cluster_name,
                 private_endpoint_connection_name=private_endpoint_connection_name,
                 cls=lambda x, y, z: x,
                 headers=_headers,

--- a/src/horizondb/linter_exclusions.yml
+++ b/src/horizondb/linter_exclusions.yml
@@ -1,1 +1,3 @@
-{}
+horizondb:
+    rule_exclusions:
+    - require_wait_command_if_no_wait

--- a/src/horizondb/setup.py
+++ b/src/horizondb/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     from distutils import log as logger
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
 
-VERSION = '1.0.0b5'
+VERSION = '1.0.0b6'
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',


### PR DESCRIPTION
### Related command

`az horizondb private-endpoint-connection`
`az horizondb private-link-resource`

### Summary

- Add HorizonDB-specific private endpoint connection commands: `list`, `show`, `approve`, `reject`, and `delete`.
- Add HorizonDB-specific private link resource commands: `list` and `show`.
- Update the vendored HorizonDB SDK private endpoint connection update/delete route shape to match the cluster-scoped backend contract.
- Add help, README, history/version updates, and targeted command/validator tests.
- Add a replayable scenario test and recording for the HorizonDB private endpoint command surface.

### Validation

- `python -m unittest discover -s src\horizondb\azext_horizondb\tests\latest -p test_horizondb_private_endpoint_commands.py`
- `azdev test test_horizondb_private_endpoint_command_scenario --discover`
- `python -m compileall -q src\horizondb\azext_horizondb`
- `azdev style horizondb`
- `azdev linter horizondb --min-severity medium`
- `git diff --check`
- `python scripts\ci\test_index.py -q`

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`azdev` required; see `.azure-pipelines/templates/azdev_setup.yml` for the install command until `azdev==0.2.11b1` is on PyPI)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).

<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ⚠️ Review suggested

| Breaking Changes | Tests | Linting |
| :--: | :--: | :--: |
| ⚠️ None | ⏳ Pending | ⏳ Pending |

<details><summary>See details</summary>

**Breaking Changes**

<!-- Azure CLI Extensions Breaking Change Test --><details>
<summary>⚠️Azure CLI Extensions Breaking Change Test</summary>

><details>
> <summary>⚠️horizondb</summary>
>
>|rule|cmd_name|rule_message|suggest_message|
>|---|---|---|---|
>|⚠️ [1011 - SubgroupAdd](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1011.md)|horizondb private-endpoint-connection|sub group `horizondb private-endpoint-connection` added||
>|⚠️ [1011 - SubgroupAdd](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1011.md)|horizondb private-link-resource|sub group `horizondb private-link-resource` added||
>
></details>
</details>


</details>

<!-- act-bot:section title="Azure CLI Extensions Breaking Change Test" category="breaking_change" label="Breaking Changes" status="Warning" summary="None" -->
<!-- Azure CLI Extensions Breaking Change Test --><details>
<summary>⚠️Azure CLI Extensions Breaking Change Test</summary>

><details>
> <summary>⚠️horizondb</summary>
>
>|rule|cmd_name|rule_message|suggest_message|
>|---|---|---|---|
>|⚠️ [1011 - SubgroupAdd](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1011.md)|horizondb private-endpoint-connection|sub group `horizondb private-endpoint-connection` added||
>|⚠️ [1011 - SubgroupAdd](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1011.md)|horizondb private-link-resource|sub group `horizondb private-link-resource` added||
>
></details>
</details>

<!-- act-bot:section-end -->
<!-- act-bot:pr-validation:end -->