### PR TITLE
Safely unwrapping of enum object

### DIFF
--- a/src/quantum/HISTORY.rst
+++ b/src/quantum/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+1.0.0b17
++++++++++++++++
+* Fixed bug where Quantum workspace creation flow uses plain (JSON-serializable) primitive values instead of SDK enum objects in ARM-template deployment parameters, preventing serialization issues and test failures.
+
 1.0.0b16
 +++++++++++++++
 * Removed deprecated ``--location``/``-l`` parameter from ``quantum execute``, ``quantum run``, ``quantum job submit``, ``quantum job cancel``, ``quantum job list``, ``quantum job output``, ``quantum job show``, ``quantum job wait``, ``quantum target list``, ``quantum workspace set``, and ``quantum workspace quotas`` commands.

--- a/src/quantum/azext_quantum/operations/workspace.py
+++ b/src/quantum/azext_quantum/operations/workspace.py
@@ -196,7 +196,8 @@ def _validate_storage_account(tier_or_kind_msg_text, tier_or_kind, supported_tie
 
 def _enum_to_value(value):
     # ARM deployment parameters must use plain string values, not enum objects.
-    return value.value if hasattr(value, 'value') else value
+    import enum
+    return value.value if isinstance(value, enum.Enum) else value
 
 
 def create(cmd, resource_group_name, workspace_name, location, storage_account, skip_role_assignment=False,

--- a/src/quantum/azext_quantum/operations/workspace.py
+++ b/src/quantum/azext_quantum/operations/workspace.py
@@ -194,6 +194,11 @@ def _validate_storage_account(tier_or_kind_msg_text, tier_or_kind, supported_tie
                                         f"Storage account {tier_or_kind_msg_text}{plural} currently supported: {tier_or_kind_list}")
 
 
+def _enum_to_value(value):
+    # ARM deployment parameters must use plain string values, not enum objects.
+    return value.value if hasattr(value, 'value') else value
+
+
 def create(cmd, resource_group_name, workspace_name, location, storage_account, skip_role_assignment=False,
            provider_sku_list=None, auto_accept=False, skip_autoadd=False):
     """
@@ -244,9 +249,9 @@ def create(cmd, resource_group_name, workspace_name, location, storage_account, 
     if storage_account_list:
         for storage_account_info in storage_account_list:
             if storage_account_info.name == storage_account:
-                storage_account_sku = storage_account_info.sku.name
-                storage_account_sku_tier = storage_account_info.sku.tier
-                storage_account_kind = storage_account_info.kind
+                storage_account_sku = _enum_to_value(storage_account_info.sku.name)
+                storage_account_sku_tier = _enum_to_value(storage_account_info.sku.tier)
+                storage_account_kind = _enum_to_value(storage_account_info.kind)
                 storage_account_location = storage_account_info.location
                 # Preserve the existing account's setting to avoid breaking customers
                 # who rely on shared-key auth/connection strings for that account.

--- a/src/quantum/setup.py
+++ b/src/quantum/setup.py
@@ -17,7 +17,7 @@ except ImportError:
 # This version should match the latest entry in HISTORY.rst
 # Also, when updating this, please review the version used by the extension to
 # submit requests, which can be found at './azext_quantum/__init__.py'
-VERSION = '1.0.0b16'
+VERSION = '1.0.0b17'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Safely unwrapping of enum object into its plain string value, or passes the value through unchanged if it's already a plain type.
ARM deployment templates require plain string values, not enum objects. Passing an enum directly would cause serialization errors.

Currently, tests get SkuName.Standard_LRS value instead of Standard_LRS that causes test failures.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`azdev` required; see `.azure-pipelines/templates/azdev_setup.yml` for the install command until `azdev==0.2.11b1` is on PyPI)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
