### PR TITLE
[AKS] Fix az aks create crash

### DIFF
--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -11,6 +11,7 @@ To release a new version, please select a new version number (usually plus 1 to 
 
 Pending
 +++++++
+* `az aks create`: Fix `TypeError: 'NoneType' object is not iterable` crash when creating AKS Automatic clusters with `--enable-hosted-system` (HoBO). The `agent_pool_profiles` field may be None for hosted system pool clusters.
 
 21.0.0b7
 ++++++++

--- a/src/aks-preview/azext_aks_preview/prepared_image_specification.py
+++ b/src/aks-preview/azext_aks_preview/prepared_image_specification.py
@@ -37,7 +37,7 @@ def pis_identity_resource_id(cmd, agentpool):
 
 
 def ensure_pis_managed_identity_permission_for_cluster(cmd, cluster):
-    for agentpool in cluster.agent_pool_profiles:
+    for agentpool in (cluster.agent_pool_profiles or []):
         pis_identity_id = pis_identity_resource_id(cmd, agentpool)
         if not pis_identity_id:
             continue


### PR DESCRIPTION
## Description

Fix `TypeError: 'NoneType' object is not iterable` when running `az aks create --sku automatic --enable-hosted-system`.

AKS Automatic clusters with hosted system pools have `agent_pool_profiles = None` at creation time because the system pool is managed infrastructure. The `ensure_pis_managed_identity_permission_for_cluster` function introduced in #9887 iterates `cluster.agent_pool_profiles` without a None guard, causing a crash.

The aks-preview extension already handles this case elsewhere — in `managed_cluster_decorator.py` the update path checks `if not mc.agent_pool_profiles` and returns early for clusters with the comment: *"an AKS ManagedCluster of automatic cluster with hosted system components may not have agent pools"*. The create path in `prepared_image_specification.py` was missing the same guard.

**Repro:**
```bash
$ az aks create -g my-rg -n my-cluster -l eastus2 --sku automatic --enable-hosted-system --no-ssh-key -o table

ERROR: The command failed with an unexpected error. Here is the traceback:
ERROR: 'NoneType' object is not iterable
Traceback (most recent call last):
  ...
  File ".../custom.py", line 1483, in aks_create
    ensure_pis_managed_identity_permission_for_cluster(cmd, mc)
  File ".../prepared_image_specification.py", line 40, in ensure_pis_managed_identity_permission_for_cluster
    for agentpool in cluster.agent_pool_profiles:
TypeError: 'NoneType' object is not iterable
```

**Fix:** Add a None guard to the iteration.

### Related command

`az aks create`

### General Guidelines

- [x] Have you run `azdev style aks-preview` locally?
- [x] Have you run `python scripts/ci/test_index.py -q` locally?
- [x] My extension version conforms to the Extension version schema

### About Extension Publish

No version bump needed — this is a bug fix under Pending.

cc @jim-minter @FumingZhang