### PR TITLE
{Container Apps} `az containerapp function list/show`: Raise clear error when ingress is disabled

### DIFF
--- a/src/containerapp/HISTORY.rst
+++ b/src/containerapp/HISTORY.rst
@@ -4,6 +4,7 @@ Release History
 ===============
 upcoming
 ++++++
+* 'az containerapp function list/show': Raise a clear error when ingress is disabled instead of a generic server error
 
 1.3.0b4
 ++++++

--- a/src/containerapp/azext_containerapp/_validators.py
+++ b/src/containerapp/azext_containerapp/_validators.py
@@ -348,7 +348,7 @@ def validate_functionapp_kind(cmd, resource_group_name, container_app_name):
 
     if kind and kind.lower() == "functionapp":
         logger.debug("Container app '%s' validated as Azure Function App", container_app_name)
-        return
+        return containerapp_def
 
     logger.debug("Container app '%s' is not a function app - validation failed", container_app_name)
     raise ValidationError(
@@ -356,16 +356,19 @@ def validate_functionapp_kind(cmd, resource_group_name, container_app_name):
     )
 
 
-def validate_functionapp_ingress_enabled(cmd, resource_group_name, container_app_name):
+def validate_functionapp_ingress_enabled(cmd, resource_group_name, container_app_name, containerapp_def=None):
     # Listing/showing functions reads function metadata that the platform only populates
     # while ingress is enabled, so the underlying API fails with a generic server error
     # when ingress is disabled. Detect that case up front and surface an actionable message
     # instead of the opaque error the service returns.
-    containerapp_def = validate_container_app_exists(
-        cmd=cmd,
-        resource_group_name=resource_group_name,
-        container_app_name=container_app_name
-    )
+    # Callers that have already retrieved the Container App can pass it via `containerapp_def`
+    # to avoid an extra ARM GET.
+    if containerapp_def is None:
+        containerapp_def = validate_container_app_exists(
+            cmd=cmd,
+            resource_group_name=resource_group_name,
+            container_app_name=container_app_name
+        )
 
     ingress = safe_get(containerapp_def, "properties", "configuration", "ingress")
 

--- a/src/containerapp/azext_containerapp/_validators.py
+++ b/src/containerapp/azext_containerapp/_validators.py
@@ -356,6 +356,29 @@ def validate_functionapp_kind(cmd, resource_group_name, container_app_name):
     )
 
 
+def validate_functionapp_ingress_enabled(cmd, resource_group_name, container_app_name):
+    # Listing/showing functions reads function metadata that the platform only populates
+    # while ingress is enabled, so the underlying API fails with a generic server error
+    # when ingress is disabled. Detect that case up front and surface an actionable message
+    # instead of the opaque error the service returns.
+    containerapp_def = validate_container_app_exists(
+        cmd=cmd,
+        resource_group_name=resource_group_name,
+        container_app_name=container_app_name
+    )
+
+    ingress = safe_get(containerapp_def, "properties", "configuration", "ingress")
+
+    if not ingress:
+        logger.debug("Container app '%s' has ingress disabled - functions cannot be listed", container_app_name)
+        raise ValidationError(
+            f"Ingress must be enabled to view functions for the containerapp '{container_app_name}'. "
+            f"Enable ingress on the container app and try again."
+        )
+
+    logger.debug("Container app '%s' has ingress enabled", container_app_name)
+
+
 def validate_basic_arguments(resource_group_name, container_app_name, **kwargs):
     if not resource_group_name:
         logger.debug("Resource group name validation failed - empty or None")

--- a/src/containerapp/azext_containerapp/containerapp_functions_decorator.py
+++ b/src/containerapp/azext_containerapp/containerapp_functions_decorator.py
@@ -105,7 +105,7 @@ class ContainerAppFunctionsListDecorator(ContainerAppFunctionsDecorator):
             resource_group_name, name, revision_name = self.validate_common_arguments()
 
             # Validate that the Container App has kind 'functionapp'
-            validate_functionapp_kind(
+            containerapp_def = validate_functionapp_kind(
                 cmd=self.cmd,
                 resource_group_name=resource_group_name,
                 container_app_name=name
@@ -114,10 +114,12 @@ class ContainerAppFunctionsListDecorator(ContainerAppFunctionsDecorator):
             # Functions can only be listed while ingress is enabled (the platform
             # populates the function metadata behind ingress). Fail fast with an
             # actionable message instead of the generic server error otherwise.
+            # Reuse the Container App fetched above to avoid an extra ARM GET.
             validate_functionapp_ingress_enabled(
                 cmd=self.cmd,
                 resource_group_name=resource_group_name,
-                container_app_name=name
+                container_app_name=name,
+                containerapp_def=containerapp_def
             )
 
             if revision_name and revision_name is not None:
@@ -153,7 +155,7 @@ class ContainerAppFunctionsShowDecorator(ContainerAppFunctionsDecorator):
             resource_group_name, name, revision_name, function_name = self.validate_show_arguments()
 
             # Validate that the Container App has kind 'functionapp'
-            validate_functionapp_kind(
+            containerapp_def = validate_functionapp_kind(
                 cmd=self.cmd,
                 resource_group_name=resource_group_name,
                 container_app_name=name
@@ -162,10 +164,12 @@ class ContainerAppFunctionsShowDecorator(ContainerAppFunctionsDecorator):
             # Functions can only be retrieved while ingress is enabled (the platform
             # populates the function metadata behind ingress). Fail fast with an
             # actionable message instead of the generic server error otherwise.
+            # Reuse the Container App fetched above to avoid an extra ARM GET.
             validate_functionapp_ingress_enabled(
                 cmd=self.cmd,
                 resource_group_name=resource_group_name,
-                container_app_name=name
+                container_app_name=name,
+                containerapp_def=containerapp_def
             )
 
             if revision_name and revision_name is not None:

--- a/src/containerapp/azext_containerapp/containerapp_functions_decorator.py
+++ b/src/containerapp/azext_containerapp/containerapp_functions_decorator.py
@@ -13,7 +13,12 @@ from azure.cli.core.util import send_raw_request
 from azure.cli.command_modules.containerapp.base_resource import BaseResource
 
 from ._client_factory import handle_raw_exception
-from ._validators import validate_basic_arguments, validate_revision_and_get_name, validate_functionapp_kind
+from ._validators import (
+    validate_basic_arguments,
+    validate_revision_and_get_name,
+    validate_functionapp_kind,
+    validate_functionapp_ingress_enabled,
+)
 from ._transformers import process_app_insights_response
 from ._clients import ContainerAppPreviewClient
 
@@ -106,6 +111,15 @@ class ContainerAppFunctionsListDecorator(ContainerAppFunctionsDecorator):
                 container_app_name=name
             )
 
+            # Functions can only be listed while ingress is enabled (the platform
+            # populates the function metadata behind ingress). Fail fast with an
+            # actionable message instead of the generic server error otherwise.
+            validate_functionapp_ingress_enabled(
+                cmd=self.cmd,
+                resource_group_name=resource_group_name,
+                container_app_name=name
+            )
+
             if revision_name and revision_name is not None:
                 # List functions for a specific revision
                 return self.client.list_functions_by_revision(
@@ -140,6 +154,15 @@ class ContainerAppFunctionsShowDecorator(ContainerAppFunctionsDecorator):
 
             # Validate that the Container App has kind 'functionapp'
             validate_functionapp_kind(
+                cmd=self.cmd,
+                resource_group_name=resource_group_name,
+                container_app_name=name
+            )
+
+            # Functions can only be retrieved while ingress is enabled (the platform
+            # populates the function metadata behind ingress). Fail fast with an
+            # actionable message instead of the generic server error otherwise.
+            validate_functionapp_ingress_enabled(
                 cmd=self.cmd,
                 resource_group_name=resource_group_name,
                 container_app_name=name

--- a/src/containerapp/azext_containerapp/tests/latest/recordings/test_containerapp_function_list_show_ingress_disabled.yaml
+++ b/src/containerapp/azext_containerapp/tests/latest/recordings/test_containerapp_function_list_show_ingress_disabled.yaml
@@ -1,0 +1,5852 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App?api-version=2024-11-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App","namespace":"Microsoft.App","authorizations":[{"applicationId":"59f0a04a-b322-4310-adc9-39ac41e9631e","roleDefinitionId":"be29d5e9-f2ee-4c50-bf95-71cec72c205f"},{"applicationId":"7e3bc4fd-85a3-4192-b177-5b8bfc87f42c","roleDefinitionId":"39a74f72-b40f-4bdc-b639-562fe2260bf0"},{"applicationId":"3734c1a4-2bed-4998-a37a-ff1a9e7bf019","roleDefinitionId":"5c779a4f-5cb2-4547-8c41-478d9be8ba90"},{"applicationId":"55ebbb62-3b9c-49fd-9b87-9595226dd4ac","roleDefinitionId":"e49ca620-7992-4561-a7df-4ed67dad77b5","managedByRoleDefinitionId":"9e3af657-a8ff-583c-a75c-2fe7c4bcb635"},{"applicationId":"1459b1f6-7a5b-4300-93a2-44b4a651759f","roleDefinitionId":"3c5f1b29-9e3d-4a22-b5d6-9ff4e5a37974"},{"applicationId":"2c7dd73f-7a21-485b-b97d-a2508fa152c3","roleDefinitionId":"8a9982ae-66df-4135-b8da-2655633c4a4c"},{"applicationId":"6104ad52-755e-428b-9fb5-5fdf4d2c4d53","roleDefinitionId":"472cfb56-379d-4465-84ff-17404641b16c"},{"applicationId":"409eb69a-5e20-4e1e-a8bf-c23300057950","roleDefinitionId":"e211c432-0a34-4b73-9303-2a489c814a1d"}],"resourceTypes":[{"resourceType":"managedEnvironments","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"managedEnvironments/certificates","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/managedCertificates","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"containerApps","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"containerApps/privateEndpointConnectionProxies","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"containerApps/resiliencyPolicies","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"managedEnvironments/privateEndpointConnectionProxies","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"sessionPools","locations":["North
+        Central US (Stage)","West US 2","North Europe","East US","East Asia","North
+        Central US","Germany West Central","Poland Central","Italy North","Switzerland
+        North","Sweden Central","Norway East","Japan East","Australia East","West
+        Central US","East US 2","West US","Brazil South","Canada East","France Central","Korea
+        Central","South Africa North","South Central US","South India","UAE North","UK
+        South","West Europe","West US 3","Canada Central","Central US","Japan West","Southeast
+        Asia","Spain Central","UK West","Australia Southeast","Central India","Jio
+        India West","France South","Malaysia West","Indonesia Central"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"jobs","locations":["North Central US (Stage)","West
+        US 2","Southeast Asia","Sweden Central","Canada Central","West Europe","North
+        Europe","East US","East US 2","East Asia","Australia East","Germany West Central","Japan
+        East","UK South","West US","Central US","North Central US","South Central
+        US","Korea Central","Brazil South","West US 3","France Central","South Africa
+        North","Norway East","Switzerland North","UAE North","Canada East","West Central
+        US","UK West","Central India","Japan West","Australia Southeast","France South","Jio
+        India West","Spain Central","Italy North","Poland Central","Malaysia West","Indonesia
+        Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/containerappOperationResults","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/containerappOperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/containerappsjobOperationResults","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/containerappsjobOperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/sourceControlOperationResults","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/sourceControlOperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/usages","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"operations","locations":["East
+        Asia","North Central US","West Europe"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2023-02-01","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"connectedEnvironments","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectedEnvironments/certificates","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/connectedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/managedCertificateOperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/billingMeters","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/availableManagedEnvironmentsWorkloadProfileTypes","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"getCustomDomainVerificationId","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Italy North","Poland Central","South
+        India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"builders","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"builders/builds","locations":["North Central
+        US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada Central","West
+        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
+        West Central","Japan East","UK South","West US","Central US","North Central
+        US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"builders/patches","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/OperationResults","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/OperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"managedEnvironments/dotNetComponents","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"managedEnvironments/javaComponents","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"managedEnvironments/daprComponents","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"managedEnvironments/daprComponents/resiliencyPolicies","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"functions","locations":["North
+        Central US (Stage)","West Central US","West US 2","Southeast Asia","Sweden
+        Central","Canada Central","West Europe","North Europe","East US","East US
+        2","East Asia","Australia East","Germany West Central","Japan East","UK South","West
+        US","Central US","North Central US","South Central US","Korea Central","Brazil
+        South","West US 3","France Central","South Africa North","Norway East","Switzerland
+        North","UAE North","Canada East","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"SupportsExtension"},{"resourceType":"logicApps","locations":["North
+        Central US (Stage)","West Europe","East US","East Asia","North Central US","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"SupportsExtension"},{"resourceType":"locations/connectedOperationResults","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview"],"capabilities":"None"},{"resourceType":"locations/connectedOperationStatuses","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview"],"capabilities":"None"},{"resourceType":"agents","locations":["Sweden
+        Central","UK South","East US 2","Australia East","France Central","Canada
+        Central","Korea Central"],"apiVersions":["2026-01-01","2025-05-01-preview"],"defaultApiVersion":"2025-05-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"agentSpaces","locations":["Sweden Central","UK
+        South","East US 2","Australia East","France Central","Canada Central","Korea
+        Central"],"apiVersions":["2026-01-01","2025-05-01-preview"],"defaultApiVersion":"2025-05-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"locations/sreAgentOperationResults","locations":["Sweden
+        Central","UK South","East US 2","Australia East","France Central","Canada
+        Central","Korea Central"],"apiVersions":["2026-01-01","2025-10-02-preview","2025-05-01-preview"],"defaultApiVersion":"2025-05-01-preview","capabilities":"None"},{"resourceType":"locations/sreAgentOperationStatuses","locations":["Sweden
+        Central","UK South","East US 2","Australia East","France Central","Canada
+        Central","Korea Central"],"apiVersions":["2026-01-01","2025-10-02-preview","2025-05-01-preview"],"defaultApiVersion":"2025-05-01-preview","capabilities":"None"},{"resourceType":"locations/supportedAgentModels","locations":["Sweden
+        Central","UK South","East US 2","Australia East","France Central","Canada
+        Central","Korea Central"],"apiVersions":["2026-01-01","2025-05-01-preview"],"defaultApiVersion":"2025-05-01-preview","capabilities":"None"},{"resourceType":"sandboxGroups","locations":["North
+        Central US (Stage)","Sweden Central","East Asia","Australia East","North Europe","UK
+        South","Canada Central","Canada East","Mexico Central","North Central US","West
+        Central US","Central US","West US 2","Brazil South","France Central","Germany
+        West Central","Japan East","Japan West","Korea Central","Norway East","Poland
+        Central","South Africa North","Southeast Asia","South India","Spain Central","Switzerland
+        North","West US 3","West US","East US 2"],"apiVersions":["2026-02-01-preview"],"defaultApiVersion":"2026-02-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"sandboxGroups/vnetConnections","locations":["North
+        Central US (Stage)","Sweden Central","East Asia","Australia East","North Europe","UK
+        South","Canada Central","Canada East","Mexico Central","North Central US","West
+        Central US","Central US","West US 2","Brazil South","France Central","Germany
+        West Central","Japan East","Japan West","Korea Central","Norway East","Poland
+        Central","South Africa North","Southeast Asia","South India","Spain Central","Switzerland
+        North","West US 3","West US","East US 2"],"apiVersions":["2026-02-01-preview"],"defaultApiVersion":"2026-02-01-preview","capabilities":"None"},{"resourceType":"sandboxes","locations":["North
+        Central US (Stage)","Canada Central","Central US EUAP"],"apiVersions":["2026-02-01-preview"],"defaultApiVersion":"2026-02-01-preview","capabilities":"SystemAssignedResourceIdentity"},{"resourceType":"artifacts","locations":["North
+        Central US (Stage)","Central US EUAP","East US 2 EUAP","Sweden Central","East
+        Asia","Australia East","North Europe","UK South","Canada Central","Canada
+        East","Mexico Central","North Central US","West Central US","Central US","West
+        US 2","Brazil South","France Central","Germany West Central","Japan East","Japan
+        West","Korea Central","Norway East","Poland Central","South Africa North","Southeast
+        Asia","South India","Spain Central","Switzerland North","West US 3","West
+        US","East US 2"],"apiVersions":["2026-02-01-preview"],"defaultApiVersion":"2026-02-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"artifactApps","locations":["North Central
+        US (Stage)","Central US EUAP","East US 2 EUAP","Sweden Central","East Asia","Australia
+        East","North Europe","UK South","Canada Central","Canada East","Mexico Central","North
+        Central US","West Central US","Central US","West US 2","Brazil South","France
+        Central","Germany West Central","Japan East","Japan West","Korea Central","Norway
+        East","Poland Central","South Africa North","Southeast Asia","South India","Spain
+        Central","Switzerland North","West US 3","West US","East US 2"],"apiVersions":["2026-02-01-preview"],"defaultApiVersion":"2026-02-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '44592'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:38:55 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: B04B3FAE97484885BA3F95632EE6D6D4 Ref B: PNQ231110908040 Ref C: 2026-07-03T09:38:55Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/client.env_rg_eastus2/providers/Microsoft.App/managedEnvironments/env-eastus2?api-version=2025-10-02-preview
+  response:
+    body:
+      string: '{"error":{"code":"ResourceGroupNotFound","message":"Resource group
+        ''client.env_rg_eastus2'' could not be found."}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '113'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:38:56 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-failure-cause:
+      - gateway
+      x-msedge-ref:
+      - 'Ref A: 89B32DFC58554B7C923B087BC9D1DFA9 Ref B: PNQ231110909040 Ref C: 2026-07-03T09:38:56Z'
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: '{"location": "eastus2"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - group create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '23'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -n -l
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/client.env_rg_eastus2?api-version=2024-11-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/client.env_rg_eastus2","name":"client.env_rg_eastus2","type":"Microsoft.Resources/resourceGroups","location":"eastus2","properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '240'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:38:58 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-writes:
+      - '11999'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '799'
+      x-msedge-ref:
+      - 'Ref A: BE81D94F145D48C2A421A5F8AC460DDB Ref B: PNQ231110909034 Ref C: 2026-07-03T09:38:57Z'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --logs-destination
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App?api-version=2024-11-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App","namespace":"Microsoft.App","authorizations":[{"applicationId":"59f0a04a-b322-4310-adc9-39ac41e9631e","roleDefinitionId":"be29d5e9-f2ee-4c50-bf95-71cec72c205f"},{"applicationId":"7e3bc4fd-85a3-4192-b177-5b8bfc87f42c","roleDefinitionId":"39a74f72-b40f-4bdc-b639-562fe2260bf0"},{"applicationId":"3734c1a4-2bed-4998-a37a-ff1a9e7bf019","roleDefinitionId":"5c779a4f-5cb2-4547-8c41-478d9be8ba90"},{"applicationId":"55ebbb62-3b9c-49fd-9b87-9595226dd4ac","roleDefinitionId":"e49ca620-7992-4561-a7df-4ed67dad77b5","managedByRoleDefinitionId":"9e3af657-a8ff-583c-a75c-2fe7c4bcb635"},{"applicationId":"1459b1f6-7a5b-4300-93a2-44b4a651759f","roleDefinitionId":"3c5f1b29-9e3d-4a22-b5d6-9ff4e5a37974"},{"applicationId":"2c7dd73f-7a21-485b-b97d-a2508fa152c3","roleDefinitionId":"8a9982ae-66df-4135-b8da-2655633c4a4c"},{"applicationId":"6104ad52-755e-428b-9fb5-5fdf4d2c4d53","roleDefinitionId":"472cfb56-379d-4465-84ff-17404641b16c"},{"applicationId":"409eb69a-5e20-4e1e-a8bf-c23300057950","roleDefinitionId":"e211c432-0a34-4b73-9303-2a489c814a1d"}],"resourceTypes":[{"resourceType":"managedEnvironments","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"managedEnvironments/certificates","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/managedCertificates","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"containerApps","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"containerApps/privateEndpointConnectionProxies","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"containerApps/resiliencyPolicies","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"managedEnvironments/privateEndpointConnectionProxies","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"sessionPools","locations":["North
+        Central US (Stage)","West US 2","North Europe","East US","East Asia","North
+        Central US","Germany West Central","Poland Central","Italy North","Switzerland
+        North","Sweden Central","Norway East","Japan East","Australia East","West
+        Central US","East US 2","West US","Brazil South","Canada East","France Central","Korea
+        Central","South Africa North","South Central US","South India","UAE North","UK
+        South","West Europe","West US 3","Canada Central","Central US","Japan West","Southeast
+        Asia","Spain Central","UK West","Australia Southeast","Central India","Jio
+        India West","France South","Malaysia West","Indonesia Central"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"jobs","locations":["North Central US (Stage)","West
+        US 2","Southeast Asia","Sweden Central","Canada Central","West Europe","North
+        Europe","East US","East US 2","East Asia","Australia East","Germany West Central","Japan
+        East","UK South","West US","Central US","North Central US","South Central
+        US","Korea Central","Brazil South","West US 3","France Central","South Africa
+        North","Norway East","Switzerland North","UAE North","Canada East","West Central
+        US","UK West","Central India","Japan West","Australia Southeast","France South","Jio
+        India West","Spain Central","Italy North","Poland Central","Malaysia West","Indonesia
+        Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/containerappOperationResults","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/containerappOperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/containerappsjobOperationResults","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/containerappsjobOperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/sourceControlOperationResults","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/sourceControlOperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/usages","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"operations","locations":["East
+        Asia","North Central US","West Europe"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2023-02-01","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"connectedEnvironments","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectedEnvironments/certificates","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/connectedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/managedCertificateOperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/billingMeters","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/availableManagedEnvironmentsWorkloadProfileTypes","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"getCustomDomainVerificationId","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Italy North","Poland Central","South
+        India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"builders","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"builders/builds","locations":["North Central
+        US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada Central","West
+        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
+        West Central","Japan East","UK South","West US","Central US","North Central
+        US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"builders/patches","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/OperationResults","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/OperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"managedEnvironments/dotNetComponents","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"managedEnvironments/javaComponents","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"managedEnvironments/daprComponents","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"managedEnvironments/daprComponents/resiliencyPolicies","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"functions","locations":["North
+        Central US (Stage)","West Central US","West US 2","Southeast Asia","Sweden
+        Central","Canada Central","West Europe","North Europe","East US","East US
+        2","East Asia","Australia East","Germany West Central","Japan East","UK South","West
+        US","Central US","North Central US","South Central US","Korea Central","Brazil
+        South","West US 3","France Central","South Africa North","Norway East","Switzerland
+        North","UAE North","Canada East","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"SupportsExtension"},{"resourceType":"logicApps","locations":["North
+        Central US (Stage)","West Europe","East US","East Asia","North Central US","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"SupportsExtension"},{"resourceType":"locations/connectedOperationResults","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview"],"capabilities":"None"},{"resourceType":"locations/connectedOperationStatuses","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview"],"capabilities":"None"},{"resourceType":"agents","locations":["Sweden
+        Central","UK South","East US 2","Australia East","France Central","Canada
+        Central","Korea Central"],"apiVersions":["2026-01-01","2025-05-01-preview"],"defaultApiVersion":"2025-05-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"agentSpaces","locations":["Sweden Central","UK
+        South","East US 2","Australia East","France Central","Canada Central","Korea
+        Central"],"apiVersions":["2026-01-01","2025-05-01-preview"],"defaultApiVersion":"2025-05-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"locations/sreAgentOperationResults","locations":["Sweden
+        Central","UK South","East US 2","Australia East","France Central","Canada
+        Central","Korea Central"],"apiVersions":["2026-01-01","2025-10-02-preview","2025-05-01-preview"],"defaultApiVersion":"2025-05-01-preview","capabilities":"None"},{"resourceType":"locations/sreAgentOperationStatuses","locations":["Sweden
+        Central","UK South","East US 2","Australia East","France Central","Canada
+        Central","Korea Central"],"apiVersions":["2026-01-01","2025-10-02-preview","2025-05-01-preview"],"defaultApiVersion":"2025-05-01-preview","capabilities":"None"},{"resourceType":"locations/supportedAgentModels","locations":["Sweden
+        Central","UK South","East US 2","Australia East","France Central","Canada
+        Central","Korea Central"],"apiVersions":["2026-01-01","2025-05-01-preview"],"defaultApiVersion":"2025-05-01-preview","capabilities":"None"},{"resourceType":"sandboxGroups","locations":["North
+        Central US (Stage)","Sweden Central","East Asia","Australia East","North Europe","UK
+        South","Canada Central","Canada East","Mexico Central","North Central US","West
+        Central US","Central US","West US 2","Brazil South","France Central","Germany
+        West Central","Japan East","Japan West","Korea Central","Norway East","Poland
+        Central","South Africa North","Southeast Asia","South India","Spain Central","Switzerland
+        North","West US 3","West US","East US 2"],"apiVersions":["2026-02-01-preview"],"defaultApiVersion":"2026-02-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"sandboxGroups/vnetConnections","locations":["North
+        Central US (Stage)","Sweden Central","East Asia","Australia East","North Europe","UK
+        South","Canada Central","Canada East","Mexico Central","North Central US","West
+        Central US","Central US","West US 2","Brazil South","France Central","Germany
+        West Central","Japan East","Japan West","Korea Central","Norway East","Poland
+        Central","South Africa North","Southeast Asia","South India","Spain Central","Switzerland
+        North","West US 3","West US","East US 2"],"apiVersions":["2026-02-01-preview"],"defaultApiVersion":"2026-02-01-preview","capabilities":"None"},{"resourceType":"sandboxes","locations":["North
+        Central US (Stage)","Canada Central","Central US EUAP"],"apiVersions":["2026-02-01-preview"],"defaultApiVersion":"2026-02-01-preview","capabilities":"SystemAssignedResourceIdentity"},{"resourceType":"artifacts","locations":["North
+        Central US (Stage)","Central US EUAP","East US 2 EUAP","Sweden Central","East
+        Asia","Australia East","North Europe","UK South","Canada Central","Canada
+        East","Mexico Central","North Central US","West Central US","Central US","West
+        US 2","Brazil South","France Central","Germany West Central","Japan East","Japan
+        West","Korea Central","Norway East","Poland Central","South Africa North","Southeast
+        Asia","South India","Spain Central","Switzerland North","West US 3","West
+        US","East US 2"],"apiVersions":["2026-02-01-preview"],"defaultApiVersion":"2026-02-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"artifactApps","locations":["North Central
+        US (Stage)","Central US EUAP","East US 2 EUAP","Sweden Central","East Asia","Australia
+        East","North Europe","UK South","Canada Central","Canada East","Mexico Central","North
+        Central US","West Central US","Central US","West US 2","Brazil South","France
+        Central","Germany West Central","Japan East","Japan West","Korea Central","Norway
+        East","Poland Central","South Africa North","Southeast Asia","South India","Spain
+        Central","Switzerland North","West US 3","West US","East US 2"],"apiVersions":["2026-02-01-preview"],"defaultApiVersion":"2026-02-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '44592'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:38:58 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: E61107408C1A418ABE61D6A94AFF1967 Ref B: PNQ231110908052 Ref C: 2026-07-03T09:38:59Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --logs-destination
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App?api-version=2024-11-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App","namespace":"Microsoft.App","authorizations":[{"applicationId":"59f0a04a-b322-4310-adc9-39ac41e9631e","roleDefinitionId":"be29d5e9-f2ee-4c50-bf95-71cec72c205f"},{"applicationId":"7e3bc4fd-85a3-4192-b177-5b8bfc87f42c","roleDefinitionId":"39a74f72-b40f-4bdc-b639-562fe2260bf0"},{"applicationId":"3734c1a4-2bed-4998-a37a-ff1a9e7bf019","roleDefinitionId":"5c779a4f-5cb2-4547-8c41-478d9be8ba90"},{"applicationId":"55ebbb62-3b9c-49fd-9b87-9595226dd4ac","roleDefinitionId":"e49ca620-7992-4561-a7df-4ed67dad77b5","managedByRoleDefinitionId":"9e3af657-a8ff-583c-a75c-2fe7c4bcb635"},{"applicationId":"1459b1f6-7a5b-4300-93a2-44b4a651759f","roleDefinitionId":"3c5f1b29-9e3d-4a22-b5d6-9ff4e5a37974"},{"applicationId":"2c7dd73f-7a21-485b-b97d-a2508fa152c3","roleDefinitionId":"8a9982ae-66df-4135-b8da-2655633c4a4c"},{"applicationId":"6104ad52-755e-428b-9fb5-5fdf4d2c4d53","roleDefinitionId":"472cfb56-379d-4465-84ff-17404641b16c"},{"applicationId":"409eb69a-5e20-4e1e-a8bf-c23300057950","roleDefinitionId":"e211c432-0a34-4b73-9303-2a489c814a1d"}],"resourceTypes":[{"resourceType":"managedEnvironments","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"managedEnvironments/certificates","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/managedCertificates","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"containerApps","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"containerApps/privateEndpointConnectionProxies","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"containerApps/resiliencyPolicies","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"managedEnvironments/privateEndpointConnectionProxies","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"sessionPools","locations":["North
+        Central US (Stage)","West US 2","North Europe","East US","East Asia","North
+        Central US","Germany West Central","Poland Central","Italy North","Switzerland
+        North","Sweden Central","Norway East","Japan East","Australia East","West
+        Central US","East US 2","West US","Brazil South","Canada East","France Central","Korea
+        Central","South Africa North","South Central US","South India","UAE North","UK
+        South","West Europe","West US 3","Canada Central","Central US","Japan West","Southeast
+        Asia","Spain Central","UK West","Australia Southeast","Central India","Jio
+        India West","France South","Malaysia West","Indonesia Central"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"jobs","locations":["North Central US (Stage)","West
+        US 2","Southeast Asia","Sweden Central","Canada Central","West Europe","North
+        Europe","East US","East US 2","East Asia","Australia East","Germany West Central","Japan
+        East","UK South","West US","Central US","North Central US","South Central
+        US","Korea Central","Brazil South","West US 3","France Central","South Africa
+        North","Norway East","Switzerland North","UAE North","Canada East","West Central
+        US","UK West","Central India","Japan West","Australia Southeast","France South","Jio
+        India West","Spain Central","Italy North","Poland Central","Malaysia West","Indonesia
+        Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/containerappOperationResults","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/containerappOperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/containerappsjobOperationResults","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/containerappsjobOperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/sourceControlOperationResults","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/sourceControlOperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/usages","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"operations","locations":["East
+        Asia","North Central US","West Europe"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2023-02-01","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"connectedEnvironments","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectedEnvironments/certificates","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/connectedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/managedCertificateOperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/billingMeters","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/availableManagedEnvironmentsWorkloadProfileTypes","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"getCustomDomainVerificationId","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Italy North","Poland Central","South
+        India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"builders","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"builders/builds","locations":["North Central
+        US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada Central","West
+        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
+        West Central","Japan East","UK South","West US","Central US","North Central
+        US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"builders/patches","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/OperationResults","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/OperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"managedEnvironments/dotNetComponents","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"managedEnvironments/javaComponents","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"managedEnvironments/daprComponents","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"managedEnvironments/daprComponents/resiliencyPolicies","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"functions","locations":["North
+        Central US (Stage)","West Central US","West US 2","Southeast Asia","Sweden
+        Central","Canada Central","West Europe","North Europe","East US","East US
+        2","East Asia","Australia East","Germany West Central","Japan East","UK South","West
+        US","Central US","North Central US","South Central US","Korea Central","Brazil
+        South","West US 3","France Central","South Africa North","Norway East","Switzerland
+        North","UAE North","Canada East","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"SupportsExtension"},{"resourceType":"logicApps","locations":["North
+        Central US (Stage)","West Europe","East US","East Asia","North Central US","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"SupportsExtension"},{"resourceType":"locations/connectedOperationResults","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview"],"capabilities":"None"},{"resourceType":"locations/connectedOperationStatuses","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview"],"capabilities":"None"},{"resourceType":"agents","locations":["Sweden
+        Central","UK South","East US 2","Australia East","France Central","Canada
+        Central","Korea Central"],"apiVersions":["2026-01-01","2025-05-01-preview"],"defaultApiVersion":"2025-05-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"agentSpaces","locations":["Sweden Central","UK
+        South","East US 2","Australia East","France Central","Canada Central","Korea
+        Central"],"apiVersions":["2026-01-01","2025-05-01-preview"],"defaultApiVersion":"2025-05-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"locations/sreAgentOperationResults","locations":["Sweden
+        Central","UK South","East US 2","Australia East","France Central","Canada
+        Central","Korea Central"],"apiVersions":["2026-01-01","2025-10-02-preview","2025-05-01-preview"],"defaultApiVersion":"2025-05-01-preview","capabilities":"None"},{"resourceType":"locations/sreAgentOperationStatuses","locations":["Sweden
+        Central","UK South","East US 2","Australia East","France Central","Canada
+        Central","Korea Central"],"apiVersions":["2026-01-01","2025-10-02-preview","2025-05-01-preview"],"defaultApiVersion":"2025-05-01-preview","capabilities":"None"},{"resourceType":"locations/supportedAgentModels","locations":["Sweden
+        Central","UK South","East US 2","Australia East","France Central","Canada
+        Central","Korea Central"],"apiVersions":["2026-01-01","2025-05-01-preview"],"defaultApiVersion":"2025-05-01-preview","capabilities":"None"},{"resourceType":"sandboxGroups","locations":["North
+        Central US (Stage)","Sweden Central","East Asia","Australia East","North Europe","UK
+        South","Canada Central","Canada East","Mexico Central","North Central US","West
+        Central US","Central US","West US 2","Brazil South","France Central","Germany
+        West Central","Japan East","Japan West","Korea Central","Norway East","Poland
+        Central","South Africa North","Southeast Asia","South India","Spain Central","Switzerland
+        North","West US 3","West US","East US 2"],"apiVersions":["2026-02-01-preview"],"defaultApiVersion":"2026-02-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"sandboxGroups/vnetConnections","locations":["North
+        Central US (Stage)","Sweden Central","East Asia","Australia East","North Europe","UK
+        South","Canada Central","Canada East","Mexico Central","North Central US","West
+        Central US","Central US","West US 2","Brazil South","France Central","Germany
+        West Central","Japan East","Japan West","Korea Central","Norway East","Poland
+        Central","South Africa North","Southeast Asia","South India","Spain Central","Switzerland
+        North","West US 3","West US","East US 2"],"apiVersions":["2026-02-01-preview"],"defaultApiVersion":"2026-02-01-preview","capabilities":"None"},{"resourceType":"sandboxes","locations":["North
+        Central US (Stage)","Canada Central","Central US EUAP"],"apiVersions":["2026-02-01-preview"],"defaultApiVersion":"2026-02-01-preview","capabilities":"SystemAssignedResourceIdentity"},{"resourceType":"artifacts","locations":["North
+        Central US (Stage)","Central US EUAP","East US 2 EUAP","Sweden Central","East
+        Asia","Australia East","North Europe","UK South","Canada Central","Canada
+        East","Mexico Central","North Central US","West Central US","Central US","West
+        US 2","Brazil South","France Central","Germany West Central","Japan East","Japan
+        West","Korea Central","Norway East","Poland Central","South Africa North","Southeast
+        Asia","South India","Spain Central","Switzerland North","West US 3","West
+        US","East US 2"],"apiVersions":["2026-02-01-preview"],"defaultApiVersion":"2026-02-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"artifactApps","locations":["North Central
+        US (Stage)","Central US EUAP","East US 2 EUAP","Sweden Central","East Asia","Australia
+        East","North Europe","UK South","Canada Central","Canada East","Mexico Central","North
+        Central US","West Central US","Central US","West US 2","Brazil South","France
+        Central","Germany West Central","Japan East","Japan West","Korea Central","Norway
+        East","Poland Central","South Africa North","Southeast Asia","South India","Spain
+        Central","Switzerland North","West US 3","West US","East US 2"],"apiVersions":["2026-02-01-preview"],"defaultApiVersion":"2026-02-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '44592'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:38:59 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 6024661A578E4FDBA5DC39B19C23B174 Ref B: PNQ231110908025 Ref C: 2026-07-03T09:38:59Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --logs-destination
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App?api-version=2024-11-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App","namespace":"Microsoft.App","authorizations":[{"applicationId":"59f0a04a-b322-4310-adc9-39ac41e9631e","roleDefinitionId":"be29d5e9-f2ee-4c50-bf95-71cec72c205f"},{"applicationId":"7e3bc4fd-85a3-4192-b177-5b8bfc87f42c","roleDefinitionId":"39a74f72-b40f-4bdc-b639-562fe2260bf0"},{"applicationId":"3734c1a4-2bed-4998-a37a-ff1a9e7bf019","roleDefinitionId":"5c779a4f-5cb2-4547-8c41-478d9be8ba90"},{"applicationId":"55ebbb62-3b9c-49fd-9b87-9595226dd4ac","roleDefinitionId":"e49ca620-7992-4561-a7df-4ed67dad77b5","managedByRoleDefinitionId":"9e3af657-a8ff-583c-a75c-2fe7c4bcb635"},{"applicationId":"1459b1f6-7a5b-4300-93a2-44b4a651759f","roleDefinitionId":"3c5f1b29-9e3d-4a22-b5d6-9ff4e5a37974"},{"applicationId":"2c7dd73f-7a21-485b-b97d-a2508fa152c3","roleDefinitionId":"8a9982ae-66df-4135-b8da-2655633c4a4c"},{"applicationId":"6104ad52-755e-428b-9fb5-5fdf4d2c4d53","roleDefinitionId":"472cfb56-379d-4465-84ff-17404641b16c"},{"applicationId":"409eb69a-5e20-4e1e-a8bf-c23300057950","roleDefinitionId":"e211c432-0a34-4b73-9303-2a489c814a1d"}],"resourceTypes":[{"resourceType":"managedEnvironments","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"managedEnvironments/certificates","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/managedCertificates","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"containerApps","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"containerApps/privateEndpointConnectionProxies","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"containerApps/resiliencyPolicies","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"managedEnvironments/privateEndpointConnectionProxies","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"sessionPools","locations":["North
+        Central US (Stage)","West US 2","North Europe","East US","East Asia","North
+        Central US","Germany West Central","Poland Central","Italy North","Switzerland
+        North","Sweden Central","Norway East","Japan East","Australia East","West
+        Central US","East US 2","West US","Brazil South","Canada East","France Central","Korea
+        Central","South Africa North","South Central US","South India","UAE North","UK
+        South","West Europe","West US 3","Canada Central","Central US","Japan West","Southeast
+        Asia","Spain Central","UK West","Australia Southeast","Central India","Jio
+        India West","France South","Malaysia West","Indonesia Central"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"jobs","locations":["North Central US (Stage)","West
+        US 2","Southeast Asia","Sweden Central","Canada Central","West Europe","North
+        Europe","East US","East US 2","East Asia","Australia East","Germany West Central","Japan
+        East","UK South","West US","Central US","North Central US","South Central
+        US","Korea Central","Brazil South","West US 3","France Central","South Africa
+        North","Norway East","Switzerland North","UAE North","Canada East","West Central
+        US","UK West","Central India","Japan West","Australia Southeast","France South","Jio
+        India West","Spain Central","Italy North","Poland Central","Malaysia West","Indonesia
+        Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/containerappOperationResults","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/containerappOperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/containerappsjobOperationResults","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/containerappsjobOperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/sourceControlOperationResults","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/sourceControlOperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/usages","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"operations","locations":["East
+        Asia","North Central US","West Europe"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2023-02-01","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"connectedEnvironments","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectedEnvironments/certificates","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/connectedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/managedCertificateOperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/billingMeters","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/availableManagedEnvironmentsWorkloadProfileTypes","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"getCustomDomainVerificationId","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Italy North","Poland Central","South
+        India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"builders","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"builders/builds","locations":["North Central
+        US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada Central","West
+        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
+        West Central","Japan East","UK South","West US","Central US","North Central
+        US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"builders/patches","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/OperationResults","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/OperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"managedEnvironments/dotNetComponents","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"managedEnvironments/javaComponents","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"managedEnvironments/daprComponents","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"managedEnvironments/daprComponents/resiliencyPolicies","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"functions","locations":["North
+        Central US (Stage)","West Central US","West US 2","Southeast Asia","Sweden
+        Central","Canada Central","West Europe","North Europe","East US","East US
+        2","East Asia","Australia East","Germany West Central","Japan East","UK South","West
+        US","Central US","North Central US","South Central US","Korea Central","Brazil
+        South","West US 3","France Central","South Africa North","Norway East","Switzerland
+        North","UAE North","Canada East","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"SupportsExtension"},{"resourceType":"logicApps","locations":["North
+        Central US (Stage)","West Europe","East US","East Asia","North Central US","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"SupportsExtension"},{"resourceType":"locations/connectedOperationResults","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview"],"capabilities":"None"},{"resourceType":"locations/connectedOperationStatuses","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview"],"capabilities":"None"},{"resourceType":"agents","locations":["Sweden
+        Central","UK South","East US 2","Australia East","France Central","Canada
+        Central","Korea Central"],"apiVersions":["2026-01-01","2025-05-01-preview"],"defaultApiVersion":"2025-05-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"agentSpaces","locations":["Sweden Central","UK
+        South","East US 2","Australia East","France Central","Canada Central","Korea
+        Central"],"apiVersions":["2026-01-01","2025-05-01-preview"],"defaultApiVersion":"2025-05-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"locations/sreAgentOperationResults","locations":["Sweden
+        Central","UK South","East US 2","Australia East","France Central","Canada
+        Central","Korea Central"],"apiVersions":["2026-01-01","2025-10-02-preview","2025-05-01-preview"],"defaultApiVersion":"2025-05-01-preview","capabilities":"None"},{"resourceType":"locations/sreAgentOperationStatuses","locations":["Sweden
+        Central","UK South","East US 2","Australia East","France Central","Canada
+        Central","Korea Central"],"apiVersions":["2026-01-01","2025-10-02-preview","2025-05-01-preview"],"defaultApiVersion":"2025-05-01-preview","capabilities":"None"},{"resourceType":"locations/supportedAgentModels","locations":["Sweden
+        Central","UK South","East US 2","Australia East","France Central","Canada
+        Central","Korea Central"],"apiVersions":["2026-01-01","2025-05-01-preview"],"defaultApiVersion":"2025-05-01-preview","capabilities":"None"},{"resourceType":"sandboxGroups","locations":["North
+        Central US (Stage)","Sweden Central","East Asia","Australia East","North Europe","UK
+        South","Canada Central","Canada East","Mexico Central","North Central US","West
+        Central US","Central US","West US 2","Brazil South","France Central","Germany
+        West Central","Japan East","Japan West","Korea Central","Norway East","Poland
+        Central","South Africa North","Southeast Asia","South India","Spain Central","Switzerland
+        North","West US 3","West US","East US 2"],"apiVersions":["2026-02-01-preview"],"defaultApiVersion":"2026-02-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"sandboxGroups/vnetConnections","locations":["North
+        Central US (Stage)","Sweden Central","East Asia","Australia East","North Europe","UK
+        South","Canada Central","Canada East","Mexico Central","North Central US","West
+        Central US","Central US","West US 2","Brazil South","France Central","Germany
+        West Central","Japan East","Japan West","Korea Central","Norway East","Poland
+        Central","South Africa North","Southeast Asia","South India","Spain Central","Switzerland
+        North","West US 3","West US","East US 2"],"apiVersions":["2026-02-01-preview"],"defaultApiVersion":"2026-02-01-preview","capabilities":"None"},{"resourceType":"sandboxes","locations":["North
+        Central US (Stage)","Canada Central","Central US EUAP"],"apiVersions":["2026-02-01-preview"],"defaultApiVersion":"2026-02-01-preview","capabilities":"SystemAssignedResourceIdentity"},{"resourceType":"artifacts","locations":["North
+        Central US (Stage)","Central US EUAP","East US 2 EUAP","Sweden Central","East
+        Asia","Australia East","North Europe","UK South","Canada Central","Canada
+        East","Mexico Central","North Central US","West Central US","Central US","West
+        US 2","Brazil South","France Central","Germany West Central","Japan East","Japan
+        West","Korea Central","Norway East","Poland Central","South Africa North","Southeast
+        Asia","South India","Spain Central","Switzerland North","West US 3","West
+        US","East US 2"],"apiVersions":["2026-02-01-preview"],"defaultApiVersion":"2026-02-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"artifactApps","locations":["North Central
+        US (Stage)","Central US EUAP","East US 2 EUAP","Sweden Central","East Asia","Australia
+        East","North Europe","UK South","Canada Central","Canada East","Mexico Central","North
+        Central US","West Central US","Central US","West US 2","Brazil South","France
+        Central","Germany West Central","Japan East","Japan West","Korea Central","Norway
+        East","Poland Central","South Africa North","Southeast Asia","South India","Spain
+        Central","Switzerland North","West US 3","West US","East US 2"],"apiVersions":["2026-02-01-preview"],"defaultApiVersion":"2026-02-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '44592'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:39:01 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 2F92128B600A43E5910EE33815E3E38F Ref B: PNQ231110906031 Ref C: 2026-07-03T09:39:00Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --logs-destination
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App?api-version=2024-11-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App","namespace":"Microsoft.App","authorizations":[{"applicationId":"59f0a04a-b322-4310-adc9-39ac41e9631e","roleDefinitionId":"be29d5e9-f2ee-4c50-bf95-71cec72c205f"},{"applicationId":"7e3bc4fd-85a3-4192-b177-5b8bfc87f42c","roleDefinitionId":"39a74f72-b40f-4bdc-b639-562fe2260bf0"},{"applicationId":"3734c1a4-2bed-4998-a37a-ff1a9e7bf019","roleDefinitionId":"5c779a4f-5cb2-4547-8c41-478d9be8ba90"},{"applicationId":"55ebbb62-3b9c-49fd-9b87-9595226dd4ac","roleDefinitionId":"e49ca620-7992-4561-a7df-4ed67dad77b5","managedByRoleDefinitionId":"9e3af657-a8ff-583c-a75c-2fe7c4bcb635"},{"applicationId":"1459b1f6-7a5b-4300-93a2-44b4a651759f","roleDefinitionId":"3c5f1b29-9e3d-4a22-b5d6-9ff4e5a37974"},{"applicationId":"2c7dd73f-7a21-485b-b97d-a2508fa152c3","roleDefinitionId":"8a9982ae-66df-4135-b8da-2655633c4a4c"},{"applicationId":"6104ad52-755e-428b-9fb5-5fdf4d2c4d53","roleDefinitionId":"472cfb56-379d-4465-84ff-17404641b16c"},{"applicationId":"409eb69a-5e20-4e1e-a8bf-c23300057950","roleDefinitionId":"e211c432-0a34-4b73-9303-2a489c814a1d"}],"resourceTypes":[{"resourceType":"managedEnvironments","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"managedEnvironments/certificates","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/managedCertificates","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"containerApps","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"containerApps/privateEndpointConnectionProxies","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"containerApps/resiliencyPolicies","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"managedEnvironments/privateEndpointConnectionProxies","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"sessionPools","locations":["North
+        Central US (Stage)","West US 2","North Europe","East US","East Asia","North
+        Central US","Germany West Central","Poland Central","Italy North","Switzerland
+        North","Sweden Central","Norway East","Japan East","Australia East","West
+        Central US","East US 2","West US","Brazil South","Canada East","France Central","Korea
+        Central","South Africa North","South Central US","South India","UAE North","UK
+        South","West Europe","West US 3","Canada Central","Central US","Japan West","Southeast
+        Asia","Spain Central","UK West","Australia Southeast","Central India","Jio
+        India West","France South","Malaysia West","Indonesia Central"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"jobs","locations":["North Central US (Stage)","West
+        US 2","Southeast Asia","Sweden Central","Canada Central","West Europe","North
+        Europe","East US","East US 2","East Asia","Australia East","Germany West Central","Japan
+        East","UK South","West US","Central US","North Central US","South Central
+        US","Korea Central","Brazil South","West US 3","France Central","South Africa
+        North","Norway East","Switzerland North","UAE North","Canada East","West Central
+        US","UK West","Central India","Japan West","Australia Southeast","France South","Jio
+        India West","Spain Central","Italy North","Poland Central","Malaysia West","Indonesia
+        Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/containerappOperationResults","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/containerappOperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/containerappsjobOperationResults","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/containerappsjobOperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/sourceControlOperationResults","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/sourceControlOperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/usages","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"operations","locations":["East
+        Asia","North Central US","West Europe"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2023-02-01","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"connectedEnvironments","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectedEnvironments/certificates","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/connectedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/managedCertificateOperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/billingMeters","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/availableManagedEnvironmentsWorkloadProfileTypes","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"getCustomDomainVerificationId","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Italy North","Poland Central","South
+        India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"builders","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"builders/builds","locations":["North Central
+        US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada Central","West
+        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
+        West Central","Japan East","UK South","West US","Central US","North Central
+        US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"builders/patches","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/OperationResults","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/OperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"managedEnvironments/dotNetComponents","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"managedEnvironments/javaComponents","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"managedEnvironments/daprComponents","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"managedEnvironments/daprComponents/resiliencyPolicies","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"functions","locations":["North
+        Central US (Stage)","West Central US","West US 2","Southeast Asia","Sweden
+        Central","Canada Central","West Europe","North Europe","East US","East US
+        2","East Asia","Australia East","Germany West Central","Japan East","UK South","West
+        US","Central US","North Central US","South Central US","Korea Central","Brazil
+        South","West US 3","France Central","South Africa North","Norway East","Switzerland
+        North","UAE North","Canada East","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"SupportsExtension"},{"resourceType":"logicApps","locations":["North
+        Central US (Stage)","West Europe","East US","East Asia","North Central US","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"SupportsExtension"},{"resourceType":"locations/connectedOperationResults","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview"],"capabilities":"None"},{"resourceType":"locations/connectedOperationStatuses","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview"],"capabilities":"None"},{"resourceType":"agents","locations":["Sweden
+        Central","UK South","East US 2","Australia East","France Central","Canada
+        Central","Korea Central"],"apiVersions":["2026-01-01","2025-05-01-preview"],"defaultApiVersion":"2025-05-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"agentSpaces","locations":["Sweden Central","UK
+        South","East US 2","Australia East","France Central","Canada Central","Korea
+        Central"],"apiVersions":["2026-01-01","2025-05-01-preview"],"defaultApiVersion":"2025-05-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"locations/sreAgentOperationResults","locations":["Sweden
+        Central","UK South","East US 2","Australia East","France Central","Canada
+        Central","Korea Central"],"apiVersions":["2026-01-01","2025-10-02-preview","2025-05-01-preview"],"defaultApiVersion":"2025-05-01-preview","capabilities":"None"},{"resourceType":"locations/sreAgentOperationStatuses","locations":["Sweden
+        Central","UK South","East US 2","Australia East","France Central","Canada
+        Central","Korea Central"],"apiVersions":["2026-01-01","2025-10-02-preview","2025-05-01-preview"],"defaultApiVersion":"2025-05-01-preview","capabilities":"None"},{"resourceType":"locations/supportedAgentModels","locations":["Sweden
+        Central","UK South","East US 2","Australia East","France Central","Canada
+        Central","Korea Central"],"apiVersions":["2026-01-01","2025-05-01-preview"],"defaultApiVersion":"2025-05-01-preview","capabilities":"None"},{"resourceType":"sandboxGroups","locations":["North
+        Central US (Stage)","Sweden Central","East Asia","Australia East","North Europe","UK
+        South","Canada Central","Canada East","Mexico Central","North Central US","West
+        Central US","Central US","West US 2","Brazil South","France Central","Germany
+        West Central","Japan East","Japan West","Korea Central","Norway East","Poland
+        Central","South Africa North","Southeast Asia","South India","Spain Central","Switzerland
+        North","West US 3","West US","East US 2"],"apiVersions":["2026-02-01-preview"],"defaultApiVersion":"2026-02-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"sandboxGroups/vnetConnections","locations":["North
+        Central US (Stage)","Sweden Central","East Asia","Australia East","North Europe","UK
+        South","Canada Central","Canada East","Mexico Central","North Central US","West
+        Central US","Central US","West US 2","Brazil South","France Central","Germany
+        West Central","Japan East","Japan West","Korea Central","Norway East","Poland
+        Central","South Africa North","Southeast Asia","South India","Spain Central","Switzerland
+        North","West US 3","West US","East US 2"],"apiVersions":["2026-02-01-preview"],"defaultApiVersion":"2026-02-01-preview","capabilities":"None"},{"resourceType":"sandboxes","locations":["North
+        Central US (Stage)","Canada Central","Central US EUAP"],"apiVersions":["2026-02-01-preview"],"defaultApiVersion":"2026-02-01-preview","capabilities":"SystemAssignedResourceIdentity"},{"resourceType":"artifacts","locations":["North
+        Central US (Stage)","Central US EUAP","East US 2 EUAP","Sweden Central","East
+        Asia","Australia East","North Europe","UK South","Canada Central","Canada
+        East","Mexico Central","North Central US","West Central US","Central US","West
+        US 2","Brazil South","France Central","Germany West Central","Japan East","Japan
+        West","Korea Central","Norway East","Poland Central","South Africa North","Southeast
+        Asia","South India","Spain Central","Switzerland North","West US 3","West
+        US","East US 2"],"apiVersions":["2026-02-01-preview"],"defaultApiVersion":"2026-02-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"artifactApps","locations":["North Central
+        US (Stage)","Central US EUAP","East US 2 EUAP","Sweden Central","East Asia","Australia
+        East","North Europe","UK South","Canada Central","Canada East","Mexico Central","North
+        Central US","West Central US","Central US","West US 2","Brazil South","France
+        Central","Germany West Central","Japan East","Japan West","Korea Central","Norway
+        East","Poland Central","South Africa North","Southeast Asia","South India","Spain
+        Central","Switzerland North","West US 3","West US","East US 2"],"apiVersions":["2026-02-01-preview"],"defaultApiVersion":"2026-02-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '44592'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:39:01 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: E7B879F6863A48399AB378ACE6232FEA Ref B: PNQ231110907025 Ref C: 2026-07-03T09:39:01Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --logs-destination
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/client.env_rg_eastus2/providers/Microsoft.App/managedEnvironments/env-eastus2?api-version=2025-10-02-preview
+  response:
+    body:
+      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.App/managedEnvironments/env-eastus2''
+        under resource group ''client.env_rg_eastus2'' was not found. For more details
+        please go to https://aka.ms/ARMResourceNotFoundFix"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '238'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:39:02 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-failure-cause:
+      - gateway
+      x-msedge-ref:
+      - 'Ref A: AB9A6FC8E88042F68F2D128F70F8B850 Ref B: PNQ231110909034 Ref C: 2026-07-03T09:39:02Z'
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: '{"location": "eastus2", "tags": null, "properties": {"daprAIInstrumentationKey":
+      null, "vnetConfiguration": null, "appLogsConfiguration": {"destination": null,
+      "logAnalyticsConfiguration": null}, "customDomainConfiguration": null, "workloadProfiles":
+      [{"workloadProfileType": "Consumption", "Name": "Consumption"}], "zoneRedundant":
+      false}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '340'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -n --logs-destination
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/client.env_rg_eastus2/providers/Microsoft.App/managedEnvironments/env-eastus2?api-version=2025-10-02-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/client.env_rg_eastus2/providers/Microsoft.App/managedEnvironments/env-eastus2","name":"env-eastus2","type":"Microsoft.App/managedEnvironments","location":"East
+        US 2","systemData":{"createdBy":"test@example.com","createdByType":"User","createdAt":"2026-07-03T09:39:06.5523215","lastModifiedBy":"test@example.com","lastModifiedByType":"User","lastModifiedAt":"2026-07-03T09:39:06.5523215"},"properties":{"environmentMode":"WorkloadProfiles","provisioningState":"Waiting","daprAIInstrumentationKey":null,"daprAIConnectionString":null,"vnetConfiguration":null,"defaultDomain":"agreeableglacier-f19611d0.eastus2.azurecontainerapps.io","staticIp":"20.22.167.102","appLogsConfiguration":{"destination":null,"logAnalyticsConfiguration":null},"openTelemetryConfiguration":null,"zoneRedundant":false,"availabilityZones":null,"kedaConfiguration":{"version":"2.18.1"},"daprConfiguration":{"version":"1.16.4-msft.9"},"ingressConfiguration":null,"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/client.env_rg_eastus2/managedEnvironments/env-eastus2/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6C8AEA45371636CA70C78CCAB1A4B36CB1FEC824B6F1F0ECDB89BE23575F6907","dnsSuffix":null,"certificateKeyVaultProperties":null,"certificateValue":null,"certificatePassword":null,"thumbprint":null,"subjectName":null,"expirationDate":null},"workloadProfiles":[{"workloadProfileType":"Consumption","name":"Consumption","enableFips":false}],"appInsightsConfiguration":null,"infrastructureResourceGroup":null,"peerAuthentication":{"mtls":{"enabled":false}},"peerTrafficConfiguration":{"encryption":{"enabled":false}},"publicNetworkAccess":"Enabled","diskEncryptionConfiguration":null}}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7?api-version=2025-10-02-preview&azureAsyncOperation=true&t=639186683495057394&c=MIIHlDCCBnygAwIBAgIQcyzofG45BJ3kcmojGUTNPTANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwOTAzNTYxNVoXDTI2MTAwNDA5NTYxNVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCylTdveId_fRZKb4c5-b6XRtq1MlgavUk9VSsvq-MKaNFseSyQ8yqTwT9OK0C_fsbruj5pXgS5NS8dKnBuhTD8eTuk8hAW2llcTIxVYp3wwJ5yFuq_HxoIz2l6AVXYGgsfGlZK94DOlk6A9562HvK17TWNc2ayOIo-mC9MmkCxZ_rXYVrMKIRg_isDORfT3kCxrzuBy6lE2eZ0X658RGu0gmFy_lQ6JVYwUw-cHa5DpkWyehsimxoADtZSa2P1J8nOuiW0EdXZHQ1tI2F7s-Lv2YmiEiafCFqoj36c1MDcox2dg6RjjYeO0yaFZ253xVVWE0NfxG0O8-tilXOIliudAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSJoobI6tkACyvCkJOPNhRxifdDjzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzEwL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8xMC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCsdBlY42g0q2nn0d8lpeH6ahq9WkMaeCf3qNTS_xUQ0gvNnEcqOXmZcwM26wmfAcEMpcilenOA_A6eqjBdjBqp2vpyFFS0nnkq9bDB4lvA9N6DIDwjW-tMamhtahcdVukmPJxLxNR2WRMoncYWVJ4Ibd626NUs9bKYjY_xjimNlidbPhEdfHhfe9sOzqNBDXdE0RhSANcHzI21dTSl8knc8FmpSKBy5i5O40W0mH0D99zxFen2WaqrKuTsH649bfsGfS1eoLfl-AmSxXXw9dXn_R6fwSAPp5zgdjbthr0iwfVH7vkBBpXnJxuB17_gPoP-s52UjySEzroAMbZl815H&s=kRm1ZWM5GnFwn3SRLsaMsMeLK2f86w-HWvCcVSi-hfvUvboFvYp-j7hoWr8BRZVxHiFlTCU1goGWClJKMzg-_hK8ctcNpYlf-zuBLggZPdhmWPs631LKG4zivLkVUNvBEbHFlGAPWssdFVUwrQDH-6_8AoHa4XMbEJX84ayuHrwuKPp-KTR0RMdl5wCZdbW89ODInLIm21cpWZ90inDiEZPQwgubSGRc7lAnPWhzS-F51j9E9t3XlG6TBMg9EIB__5NRogJ0ghm7oqY1k_ETk-S8tUy2iphWtIMu4e9nVUEk4w1GbrEx9NuekXnz83tlhKEG7ob-r9rmY10G8hV0gg&h=9ZhvKOTtVQDncaaXcOkjDNDgcHRcYrNHW9sxBNvSUQI
+      cache-control:
+      - no-cache
+      content-length:
+      - '1833'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:39:08 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-async-operation-timeout:
+      - PT15M
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=dbb7c858-7fe6-47e8-9b0e-aeae5587ef6a/southindia/6b4524b8-b2a3-4eec-8c68-6ffaa62cf16b
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '99'
+      x-msedge-ref:
+      - 'Ref A: 9F014CF8FEB04B63B6870290ED56E856 Ref B: PNQ231110907062 Ref C: 2026-07-03T09:39:03Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --logs-destination
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7?api-version=2025-10-02-preview&azureAsyncOperation=true&t=639186683495057394&c=MIIHlDCCBnygAwIBAgIQcyzofG45BJ3kcmojGUTNPTANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwOTAzNTYxNVoXDTI2MTAwNDA5NTYxNVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCylTdveId_fRZKb4c5-b6XRtq1MlgavUk9VSsvq-MKaNFseSyQ8yqTwT9OK0C_fsbruj5pXgS5NS8dKnBuhTD8eTuk8hAW2llcTIxVYp3wwJ5yFuq_HxoIz2l6AVXYGgsfGlZK94DOlk6A9562HvK17TWNc2ayOIo-mC9MmkCxZ_rXYVrMKIRg_isDORfT3kCxrzuBy6lE2eZ0X658RGu0gmFy_lQ6JVYwUw-cHa5DpkWyehsimxoADtZSa2P1J8nOuiW0EdXZHQ1tI2F7s-Lv2YmiEiafCFqoj36c1MDcox2dg6RjjYeO0yaFZ253xVVWE0NfxG0O8-tilXOIliudAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSJoobI6tkACyvCkJOPNhRxifdDjzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzEwL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8xMC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCsdBlY42g0q2nn0d8lpeH6ahq9WkMaeCf3qNTS_xUQ0gvNnEcqOXmZcwM26wmfAcEMpcilenOA_A6eqjBdjBqp2vpyFFS0nnkq9bDB4lvA9N6DIDwjW-tMamhtahcdVukmPJxLxNR2WRMoncYWVJ4Ibd626NUs9bKYjY_xjimNlidbPhEdfHhfe9sOzqNBDXdE0RhSANcHzI21dTSl8knc8FmpSKBy5i5O40W0mH0D99zxFen2WaqrKuTsH649bfsGfS1eoLfl-AmSxXXw9dXn_R6fwSAPp5zgdjbthr0iwfVH7vkBBpXnJxuB17_gPoP-s52UjySEzroAMbZl815H&s=kRm1ZWM5GnFwn3SRLsaMsMeLK2f86w-HWvCcVSi-hfvUvboFvYp-j7hoWr8BRZVxHiFlTCU1goGWClJKMzg-_hK8ctcNpYlf-zuBLggZPdhmWPs631LKG4zivLkVUNvBEbHFlGAPWssdFVUwrQDH-6_8AoHa4XMbEJX84ayuHrwuKPp-KTR0RMdl5wCZdbW89ODInLIm21cpWZ90inDiEZPQwgubSGRc7lAnPWhzS-F51j9E9t3XlG6TBMg9EIB__5NRogJ0ghm7oqY1k_ETk-S8tUy2iphWtIMu4e9nVUEk4w1GbrEx9NuekXnz83tlhKEG7ob-r9rmY10G8hV0gg&h=9ZhvKOTtVQDncaaXcOkjDNDgcHRcYrNHW9sxBNvSUQI
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","name":"448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","status":"InProgress","startTime":"2026-07-03T09:39:08.0488826"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '285'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:39:10 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=dbb7c858-7fe6-47e8-9b0e-aeae5587ef6a/southindia/d3e484a6-58d3-4fb0-9752-3c3bbd36ee5d
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 80ABDE77455544A1B631AC326B73CF5A Ref B: PNQ231110909031 Ref C: 2026-07-03T09:39:10Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --logs-destination
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7?api-version=2025-10-02-preview&azureAsyncOperation=true&t=639186683495057394&c=MIIHlDCCBnygAwIBAgIQcyzofG45BJ3kcmojGUTNPTANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwOTAzNTYxNVoXDTI2MTAwNDA5NTYxNVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCylTdveId_fRZKb4c5-b6XRtq1MlgavUk9VSsvq-MKaNFseSyQ8yqTwT9OK0C_fsbruj5pXgS5NS8dKnBuhTD8eTuk8hAW2llcTIxVYp3wwJ5yFuq_HxoIz2l6AVXYGgsfGlZK94DOlk6A9562HvK17TWNc2ayOIo-mC9MmkCxZ_rXYVrMKIRg_isDORfT3kCxrzuBy6lE2eZ0X658RGu0gmFy_lQ6JVYwUw-cHa5DpkWyehsimxoADtZSa2P1J8nOuiW0EdXZHQ1tI2F7s-Lv2YmiEiafCFqoj36c1MDcox2dg6RjjYeO0yaFZ253xVVWE0NfxG0O8-tilXOIliudAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSJoobI6tkACyvCkJOPNhRxifdDjzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzEwL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8xMC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCsdBlY42g0q2nn0d8lpeH6ahq9WkMaeCf3qNTS_xUQ0gvNnEcqOXmZcwM26wmfAcEMpcilenOA_A6eqjBdjBqp2vpyFFS0nnkq9bDB4lvA9N6DIDwjW-tMamhtahcdVukmPJxLxNR2WRMoncYWVJ4Ibd626NUs9bKYjY_xjimNlidbPhEdfHhfe9sOzqNBDXdE0RhSANcHzI21dTSl8knc8FmpSKBy5i5O40W0mH0D99zxFen2WaqrKuTsH649bfsGfS1eoLfl-AmSxXXw9dXn_R6fwSAPp5zgdjbthr0iwfVH7vkBBpXnJxuB17_gPoP-s52UjySEzroAMbZl815H&s=kRm1ZWM5GnFwn3SRLsaMsMeLK2f86w-HWvCcVSi-hfvUvboFvYp-j7hoWr8BRZVxHiFlTCU1goGWClJKMzg-_hK8ctcNpYlf-zuBLggZPdhmWPs631LKG4zivLkVUNvBEbHFlGAPWssdFVUwrQDH-6_8AoHa4XMbEJX84ayuHrwuKPp-KTR0RMdl5wCZdbW89ODInLIm21cpWZ90inDiEZPQwgubSGRc7lAnPWhzS-F51j9E9t3XlG6TBMg9EIB__5NRogJ0ghm7oqY1k_ETk-S8tUy2iphWtIMu4e9nVUEk4w1GbrEx9NuekXnz83tlhKEG7ob-r9rmY10G8hV0gg&h=9ZhvKOTtVQDncaaXcOkjDNDgcHRcYrNHW9sxBNvSUQI
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","name":"448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","status":"InProgress","startTime":"2026-07-03T09:39:08.0488826"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '285'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:39:13 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=dbb7c858-7fe6-47e8-9b0e-aeae5587ef6a/centralindia/2f8af46a-a6aa-4855-a377-88c5f878d902
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16498'
+      x-msedge-ref:
+      - 'Ref A: AE51043F62CA4819AF05BF376CBF3878 Ref B: PNQ231110908025 Ref C: 2026-07-03T09:39:13Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --logs-destination
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7?api-version=2025-10-02-preview&azureAsyncOperation=true&t=639186683495057394&c=MIIHlDCCBnygAwIBAgIQcyzofG45BJ3kcmojGUTNPTANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwOTAzNTYxNVoXDTI2MTAwNDA5NTYxNVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCylTdveId_fRZKb4c5-b6XRtq1MlgavUk9VSsvq-MKaNFseSyQ8yqTwT9OK0C_fsbruj5pXgS5NS8dKnBuhTD8eTuk8hAW2llcTIxVYp3wwJ5yFuq_HxoIz2l6AVXYGgsfGlZK94DOlk6A9562HvK17TWNc2ayOIo-mC9MmkCxZ_rXYVrMKIRg_isDORfT3kCxrzuBy6lE2eZ0X658RGu0gmFy_lQ6JVYwUw-cHa5DpkWyehsimxoADtZSa2P1J8nOuiW0EdXZHQ1tI2F7s-Lv2YmiEiafCFqoj36c1MDcox2dg6RjjYeO0yaFZ253xVVWE0NfxG0O8-tilXOIliudAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSJoobI6tkACyvCkJOPNhRxifdDjzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzEwL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8xMC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCsdBlY42g0q2nn0d8lpeH6ahq9WkMaeCf3qNTS_xUQ0gvNnEcqOXmZcwM26wmfAcEMpcilenOA_A6eqjBdjBqp2vpyFFS0nnkq9bDB4lvA9N6DIDwjW-tMamhtahcdVukmPJxLxNR2WRMoncYWVJ4Ibd626NUs9bKYjY_xjimNlidbPhEdfHhfe9sOzqNBDXdE0RhSANcHzI21dTSl8knc8FmpSKBy5i5O40W0mH0D99zxFen2WaqrKuTsH649bfsGfS1eoLfl-AmSxXXw9dXn_R6fwSAPp5zgdjbthr0iwfVH7vkBBpXnJxuB17_gPoP-s52UjySEzroAMbZl815H&s=kRm1ZWM5GnFwn3SRLsaMsMeLK2f86w-HWvCcVSi-hfvUvboFvYp-j7hoWr8BRZVxHiFlTCU1goGWClJKMzg-_hK8ctcNpYlf-zuBLggZPdhmWPs631LKG4zivLkVUNvBEbHFlGAPWssdFVUwrQDH-6_8AoHa4XMbEJX84ayuHrwuKPp-KTR0RMdl5wCZdbW89ODInLIm21cpWZ90inDiEZPQwgubSGRc7lAnPWhzS-F51j9E9t3XlG6TBMg9EIB__5NRogJ0ghm7oqY1k_ETk-S8tUy2iphWtIMu4e9nVUEk4w1GbrEx9NuekXnz83tlhKEG7ob-r9rmY10G8hV0gg&h=9ZhvKOTtVQDncaaXcOkjDNDgcHRcYrNHW9sxBNvSUQI
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","name":"448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","status":"InProgress","startTime":"2026-07-03T09:39:08.0488826"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '285'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:39:17 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=dbb7c858-7fe6-47e8-9b0e-aeae5587ef6a/centralindia/35f5d014-bb25-4ac7-8ca8-6d2853218bc8
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: BDFED974015D47C8AA1A8C71BCC04D08 Ref B: PNQ231110908025 Ref C: 2026-07-03T09:39:16Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --logs-destination
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7?api-version=2025-10-02-preview&azureAsyncOperation=true&t=639186683495057394&c=MIIHlDCCBnygAwIBAgIQcyzofG45BJ3kcmojGUTNPTANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwOTAzNTYxNVoXDTI2MTAwNDA5NTYxNVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCylTdveId_fRZKb4c5-b6XRtq1MlgavUk9VSsvq-MKaNFseSyQ8yqTwT9OK0C_fsbruj5pXgS5NS8dKnBuhTD8eTuk8hAW2llcTIxVYp3wwJ5yFuq_HxoIz2l6AVXYGgsfGlZK94DOlk6A9562HvK17TWNc2ayOIo-mC9MmkCxZ_rXYVrMKIRg_isDORfT3kCxrzuBy6lE2eZ0X658RGu0gmFy_lQ6JVYwUw-cHa5DpkWyehsimxoADtZSa2P1J8nOuiW0EdXZHQ1tI2F7s-Lv2YmiEiafCFqoj36c1MDcox2dg6RjjYeO0yaFZ253xVVWE0NfxG0O8-tilXOIliudAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSJoobI6tkACyvCkJOPNhRxifdDjzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzEwL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8xMC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCsdBlY42g0q2nn0d8lpeH6ahq9WkMaeCf3qNTS_xUQ0gvNnEcqOXmZcwM26wmfAcEMpcilenOA_A6eqjBdjBqp2vpyFFS0nnkq9bDB4lvA9N6DIDwjW-tMamhtahcdVukmPJxLxNR2WRMoncYWVJ4Ibd626NUs9bKYjY_xjimNlidbPhEdfHhfe9sOzqNBDXdE0RhSANcHzI21dTSl8knc8FmpSKBy5i5O40W0mH0D99zxFen2WaqrKuTsH649bfsGfS1eoLfl-AmSxXXw9dXn_R6fwSAPp5zgdjbthr0iwfVH7vkBBpXnJxuB17_gPoP-s52UjySEzroAMbZl815H&s=kRm1ZWM5GnFwn3SRLsaMsMeLK2f86w-HWvCcVSi-hfvUvboFvYp-j7hoWr8BRZVxHiFlTCU1goGWClJKMzg-_hK8ctcNpYlf-zuBLggZPdhmWPs631LKG4zivLkVUNvBEbHFlGAPWssdFVUwrQDH-6_8AoHa4XMbEJX84ayuHrwuKPp-KTR0RMdl5wCZdbW89ODInLIm21cpWZ90inDiEZPQwgubSGRc7lAnPWhzS-F51j9E9t3XlG6TBMg9EIB__5NRogJ0ghm7oqY1k_ETk-S8tUy2iphWtIMu4e9nVUEk4w1GbrEx9NuekXnz83tlhKEG7ob-r9rmY10G8hV0gg&h=9ZhvKOTtVQDncaaXcOkjDNDgcHRcYrNHW9sxBNvSUQI
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","name":"448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","status":"InProgress","startTime":"2026-07-03T09:39:08.0488826"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '285'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:39:21 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=dbb7c858-7fe6-47e8-9b0e-aeae5587ef6a/southindia/67a92739-fada-4e75-8d5c-655a07812694
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 2D6269E995274759BD2AA0742696A3B8 Ref B: PNQ231110908029 Ref C: 2026-07-03T09:39:21Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --logs-destination
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7?api-version=2025-10-02-preview&azureAsyncOperation=true&t=639186683495057394&c=MIIHlDCCBnygAwIBAgIQcyzofG45BJ3kcmojGUTNPTANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwOTAzNTYxNVoXDTI2MTAwNDA5NTYxNVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCylTdveId_fRZKb4c5-b6XRtq1MlgavUk9VSsvq-MKaNFseSyQ8yqTwT9OK0C_fsbruj5pXgS5NS8dKnBuhTD8eTuk8hAW2llcTIxVYp3wwJ5yFuq_HxoIz2l6AVXYGgsfGlZK94DOlk6A9562HvK17TWNc2ayOIo-mC9MmkCxZ_rXYVrMKIRg_isDORfT3kCxrzuBy6lE2eZ0X658RGu0gmFy_lQ6JVYwUw-cHa5DpkWyehsimxoADtZSa2P1J8nOuiW0EdXZHQ1tI2F7s-Lv2YmiEiafCFqoj36c1MDcox2dg6RjjYeO0yaFZ253xVVWE0NfxG0O8-tilXOIliudAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSJoobI6tkACyvCkJOPNhRxifdDjzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzEwL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8xMC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCsdBlY42g0q2nn0d8lpeH6ahq9WkMaeCf3qNTS_xUQ0gvNnEcqOXmZcwM26wmfAcEMpcilenOA_A6eqjBdjBqp2vpyFFS0nnkq9bDB4lvA9N6DIDwjW-tMamhtahcdVukmPJxLxNR2WRMoncYWVJ4Ibd626NUs9bKYjY_xjimNlidbPhEdfHhfe9sOzqNBDXdE0RhSANcHzI21dTSl8knc8FmpSKBy5i5O40W0mH0D99zxFen2WaqrKuTsH649bfsGfS1eoLfl-AmSxXXw9dXn_R6fwSAPp5zgdjbthr0iwfVH7vkBBpXnJxuB17_gPoP-s52UjySEzroAMbZl815H&s=kRm1ZWM5GnFwn3SRLsaMsMeLK2f86w-HWvCcVSi-hfvUvboFvYp-j7hoWr8BRZVxHiFlTCU1goGWClJKMzg-_hK8ctcNpYlf-zuBLggZPdhmWPs631LKG4zivLkVUNvBEbHFlGAPWssdFVUwrQDH-6_8AoHa4XMbEJX84ayuHrwuKPp-KTR0RMdl5wCZdbW89ODInLIm21cpWZ90inDiEZPQwgubSGRc7lAnPWhzS-F51j9E9t3XlG6TBMg9EIB__5NRogJ0ghm7oqY1k_ETk-S8tUy2iphWtIMu4e9nVUEk4w1GbrEx9NuekXnz83tlhKEG7ob-r9rmY10G8hV0gg&h=9ZhvKOTtVQDncaaXcOkjDNDgcHRcYrNHW9sxBNvSUQI
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","name":"448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","status":"InProgress","startTime":"2026-07-03T09:39:08.0488826"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '285'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:39:24 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=dbb7c858-7fe6-47e8-9b0e-aeae5587ef6a/westindia/aa2fdd10-4470-42cb-9195-1a0889b5932f
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 64F9F65896A2479DA71395EF2E8572F5 Ref B: PNQ231110909031 Ref C: 2026-07-03T09:39:24Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --logs-destination
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7?api-version=2025-10-02-preview&azureAsyncOperation=true&t=639186683495057394&c=MIIHlDCCBnygAwIBAgIQcyzofG45BJ3kcmojGUTNPTANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwOTAzNTYxNVoXDTI2MTAwNDA5NTYxNVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCylTdveId_fRZKb4c5-b6XRtq1MlgavUk9VSsvq-MKaNFseSyQ8yqTwT9OK0C_fsbruj5pXgS5NS8dKnBuhTD8eTuk8hAW2llcTIxVYp3wwJ5yFuq_HxoIz2l6AVXYGgsfGlZK94DOlk6A9562HvK17TWNc2ayOIo-mC9MmkCxZ_rXYVrMKIRg_isDORfT3kCxrzuBy6lE2eZ0X658RGu0gmFy_lQ6JVYwUw-cHa5DpkWyehsimxoADtZSa2P1J8nOuiW0EdXZHQ1tI2F7s-Lv2YmiEiafCFqoj36c1MDcox2dg6RjjYeO0yaFZ253xVVWE0NfxG0O8-tilXOIliudAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSJoobI6tkACyvCkJOPNhRxifdDjzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzEwL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8xMC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCsdBlY42g0q2nn0d8lpeH6ahq9WkMaeCf3qNTS_xUQ0gvNnEcqOXmZcwM26wmfAcEMpcilenOA_A6eqjBdjBqp2vpyFFS0nnkq9bDB4lvA9N6DIDwjW-tMamhtahcdVukmPJxLxNR2WRMoncYWVJ4Ibd626NUs9bKYjY_xjimNlidbPhEdfHhfe9sOzqNBDXdE0RhSANcHzI21dTSl8knc8FmpSKBy5i5O40W0mH0D99zxFen2WaqrKuTsH649bfsGfS1eoLfl-AmSxXXw9dXn_R6fwSAPp5zgdjbthr0iwfVH7vkBBpXnJxuB17_gPoP-s52UjySEzroAMbZl815H&s=kRm1ZWM5GnFwn3SRLsaMsMeLK2f86w-HWvCcVSi-hfvUvboFvYp-j7hoWr8BRZVxHiFlTCU1goGWClJKMzg-_hK8ctcNpYlf-zuBLggZPdhmWPs631LKG4zivLkVUNvBEbHFlGAPWssdFVUwrQDH-6_8AoHa4XMbEJX84ayuHrwuKPp-KTR0RMdl5wCZdbW89ODInLIm21cpWZ90inDiEZPQwgubSGRc7lAnPWhzS-F51j9E9t3XlG6TBMg9EIB__5NRogJ0ghm7oqY1k_ETk-S8tUy2iphWtIMu4e9nVUEk4w1GbrEx9NuekXnz83tlhKEG7ob-r9rmY10G8hV0gg&h=9ZhvKOTtVQDncaaXcOkjDNDgcHRcYrNHW9sxBNvSUQI
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","name":"448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","status":"InProgress","startTime":"2026-07-03T09:39:08.0488826"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '285'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:39:28 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=dbb7c858-7fe6-47e8-9b0e-aeae5587ef6a/westindia/f8b2f44b-1e7f-491f-96eb-6249ddd45a8a
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 34244FA5A5B641A79E1D6569E75578FF Ref B: PNQ231110909034 Ref C: 2026-07-03T09:39:28Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --logs-destination
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7?api-version=2025-10-02-preview&azureAsyncOperation=true&t=639186683495057394&c=MIIHlDCCBnygAwIBAgIQcyzofG45BJ3kcmojGUTNPTANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwOTAzNTYxNVoXDTI2MTAwNDA5NTYxNVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCylTdveId_fRZKb4c5-b6XRtq1MlgavUk9VSsvq-MKaNFseSyQ8yqTwT9OK0C_fsbruj5pXgS5NS8dKnBuhTD8eTuk8hAW2llcTIxVYp3wwJ5yFuq_HxoIz2l6AVXYGgsfGlZK94DOlk6A9562HvK17TWNc2ayOIo-mC9MmkCxZ_rXYVrMKIRg_isDORfT3kCxrzuBy6lE2eZ0X658RGu0gmFy_lQ6JVYwUw-cHa5DpkWyehsimxoADtZSa2P1J8nOuiW0EdXZHQ1tI2F7s-Lv2YmiEiafCFqoj36c1MDcox2dg6RjjYeO0yaFZ253xVVWE0NfxG0O8-tilXOIliudAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSJoobI6tkACyvCkJOPNhRxifdDjzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzEwL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8xMC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCsdBlY42g0q2nn0d8lpeH6ahq9WkMaeCf3qNTS_xUQ0gvNnEcqOXmZcwM26wmfAcEMpcilenOA_A6eqjBdjBqp2vpyFFS0nnkq9bDB4lvA9N6DIDwjW-tMamhtahcdVukmPJxLxNR2WRMoncYWVJ4Ibd626NUs9bKYjY_xjimNlidbPhEdfHhfe9sOzqNBDXdE0RhSANcHzI21dTSl8knc8FmpSKBy5i5O40W0mH0D99zxFen2WaqrKuTsH649bfsGfS1eoLfl-AmSxXXw9dXn_R6fwSAPp5zgdjbthr0iwfVH7vkBBpXnJxuB17_gPoP-s52UjySEzroAMbZl815H&s=kRm1ZWM5GnFwn3SRLsaMsMeLK2f86w-HWvCcVSi-hfvUvboFvYp-j7hoWr8BRZVxHiFlTCU1goGWClJKMzg-_hK8ctcNpYlf-zuBLggZPdhmWPs631LKG4zivLkVUNvBEbHFlGAPWssdFVUwrQDH-6_8AoHa4XMbEJX84ayuHrwuKPp-KTR0RMdl5wCZdbW89ODInLIm21cpWZ90inDiEZPQwgubSGRc7lAnPWhzS-F51j9E9t3XlG6TBMg9EIB__5NRogJ0ghm7oqY1k_ETk-S8tUy2iphWtIMu4e9nVUEk4w1GbrEx9NuekXnz83tlhKEG7ob-r9rmY10G8hV0gg&h=9ZhvKOTtVQDncaaXcOkjDNDgcHRcYrNHW9sxBNvSUQI
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","name":"448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","status":"InProgress","startTime":"2026-07-03T09:39:08.0488826"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '285'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:39:31 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=dbb7c858-7fe6-47e8-9b0e-aeae5587ef6a/westindia/ed73efff-29f7-4534-8ab0-e6e217a5c0aa
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 69869153631F4B2A8B1F270E6D3C76C6 Ref B: PNQ231110906036 Ref C: 2026-07-03T09:39:31Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --logs-destination
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7?api-version=2025-10-02-preview&azureAsyncOperation=true&t=639186683495057394&c=MIIHlDCCBnygAwIBAgIQcyzofG45BJ3kcmojGUTNPTANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwOTAzNTYxNVoXDTI2MTAwNDA5NTYxNVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCylTdveId_fRZKb4c5-b6XRtq1MlgavUk9VSsvq-MKaNFseSyQ8yqTwT9OK0C_fsbruj5pXgS5NS8dKnBuhTD8eTuk8hAW2llcTIxVYp3wwJ5yFuq_HxoIz2l6AVXYGgsfGlZK94DOlk6A9562HvK17TWNc2ayOIo-mC9MmkCxZ_rXYVrMKIRg_isDORfT3kCxrzuBy6lE2eZ0X658RGu0gmFy_lQ6JVYwUw-cHa5DpkWyehsimxoADtZSa2P1J8nOuiW0EdXZHQ1tI2F7s-Lv2YmiEiafCFqoj36c1MDcox2dg6RjjYeO0yaFZ253xVVWE0NfxG0O8-tilXOIliudAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSJoobI6tkACyvCkJOPNhRxifdDjzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzEwL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8xMC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCsdBlY42g0q2nn0d8lpeH6ahq9WkMaeCf3qNTS_xUQ0gvNnEcqOXmZcwM26wmfAcEMpcilenOA_A6eqjBdjBqp2vpyFFS0nnkq9bDB4lvA9N6DIDwjW-tMamhtahcdVukmPJxLxNR2WRMoncYWVJ4Ibd626NUs9bKYjY_xjimNlidbPhEdfHhfe9sOzqNBDXdE0RhSANcHzI21dTSl8knc8FmpSKBy5i5O40W0mH0D99zxFen2WaqrKuTsH649bfsGfS1eoLfl-AmSxXXw9dXn_R6fwSAPp5zgdjbthr0iwfVH7vkBBpXnJxuB17_gPoP-s52UjySEzroAMbZl815H&s=kRm1ZWM5GnFwn3SRLsaMsMeLK2f86w-HWvCcVSi-hfvUvboFvYp-j7hoWr8BRZVxHiFlTCU1goGWClJKMzg-_hK8ctcNpYlf-zuBLggZPdhmWPs631LKG4zivLkVUNvBEbHFlGAPWssdFVUwrQDH-6_8AoHa4XMbEJX84ayuHrwuKPp-KTR0RMdl5wCZdbW89ODInLIm21cpWZ90inDiEZPQwgubSGRc7lAnPWhzS-F51j9E9t3XlG6TBMg9EIB__5NRogJ0ghm7oqY1k_ETk-S8tUy2iphWtIMu4e9nVUEk4w1GbrEx9NuekXnz83tlhKEG7ob-r9rmY10G8hV0gg&h=9ZhvKOTtVQDncaaXcOkjDNDgcHRcYrNHW9sxBNvSUQI
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","name":"448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","status":"InProgress","startTime":"2026-07-03T09:39:08.0488826"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '285'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:39:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=dbb7c858-7fe6-47e8-9b0e-aeae5587ef6a/westindia/5fcedf23-34f7-4c97-b2f1-19d4e7c47685
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: B83639FC3B7344FBBDDED1AFBDD48B61 Ref B: PNQ231110909034 Ref C: 2026-07-03T09:39:34Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --logs-destination
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7?api-version=2025-10-02-preview&azureAsyncOperation=true&t=639186683495057394&c=MIIHlDCCBnygAwIBAgIQcyzofG45BJ3kcmojGUTNPTANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwOTAzNTYxNVoXDTI2MTAwNDA5NTYxNVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCylTdveId_fRZKb4c5-b6XRtq1MlgavUk9VSsvq-MKaNFseSyQ8yqTwT9OK0C_fsbruj5pXgS5NS8dKnBuhTD8eTuk8hAW2llcTIxVYp3wwJ5yFuq_HxoIz2l6AVXYGgsfGlZK94DOlk6A9562HvK17TWNc2ayOIo-mC9MmkCxZ_rXYVrMKIRg_isDORfT3kCxrzuBy6lE2eZ0X658RGu0gmFy_lQ6JVYwUw-cHa5DpkWyehsimxoADtZSa2P1J8nOuiW0EdXZHQ1tI2F7s-Lv2YmiEiafCFqoj36c1MDcox2dg6RjjYeO0yaFZ253xVVWE0NfxG0O8-tilXOIliudAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSJoobI6tkACyvCkJOPNhRxifdDjzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzEwL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8xMC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCsdBlY42g0q2nn0d8lpeH6ahq9WkMaeCf3qNTS_xUQ0gvNnEcqOXmZcwM26wmfAcEMpcilenOA_A6eqjBdjBqp2vpyFFS0nnkq9bDB4lvA9N6DIDwjW-tMamhtahcdVukmPJxLxNR2WRMoncYWVJ4Ibd626NUs9bKYjY_xjimNlidbPhEdfHhfe9sOzqNBDXdE0RhSANcHzI21dTSl8knc8FmpSKBy5i5O40W0mH0D99zxFen2WaqrKuTsH649bfsGfS1eoLfl-AmSxXXw9dXn_R6fwSAPp5zgdjbthr0iwfVH7vkBBpXnJxuB17_gPoP-s52UjySEzroAMbZl815H&s=kRm1ZWM5GnFwn3SRLsaMsMeLK2f86w-HWvCcVSi-hfvUvboFvYp-j7hoWr8BRZVxHiFlTCU1goGWClJKMzg-_hK8ctcNpYlf-zuBLggZPdhmWPs631LKG4zivLkVUNvBEbHFlGAPWssdFVUwrQDH-6_8AoHa4XMbEJX84ayuHrwuKPp-KTR0RMdl5wCZdbW89ODInLIm21cpWZ90inDiEZPQwgubSGRc7lAnPWhzS-F51j9E9t3XlG6TBMg9EIB__5NRogJ0ghm7oqY1k_ETk-S8tUy2iphWtIMu4e9nVUEk4w1GbrEx9NuekXnz83tlhKEG7ob-r9rmY10G8hV0gg&h=9ZhvKOTtVQDncaaXcOkjDNDgcHRcYrNHW9sxBNvSUQI
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","name":"448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","status":"InProgress","startTime":"2026-07-03T09:39:08.0488826"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '285'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:39:38 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=dbb7c858-7fe6-47e8-9b0e-aeae5587ef6a/westindia/e7f88e00-9c01-4866-be34-e77bb3d759a0
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 4D0D14577F7D40838546396E0F0D95B6 Ref B: PNQ231110909023 Ref C: 2026-07-03T09:39:38Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --logs-destination
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7?api-version=2025-10-02-preview&azureAsyncOperation=true&t=639186683495057394&c=MIIHlDCCBnygAwIBAgIQcyzofG45BJ3kcmojGUTNPTANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwOTAzNTYxNVoXDTI2MTAwNDA5NTYxNVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCylTdveId_fRZKb4c5-b6XRtq1MlgavUk9VSsvq-MKaNFseSyQ8yqTwT9OK0C_fsbruj5pXgS5NS8dKnBuhTD8eTuk8hAW2llcTIxVYp3wwJ5yFuq_HxoIz2l6AVXYGgsfGlZK94DOlk6A9562HvK17TWNc2ayOIo-mC9MmkCxZ_rXYVrMKIRg_isDORfT3kCxrzuBy6lE2eZ0X658RGu0gmFy_lQ6JVYwUw-cHa5DpkWyehsimxoADtZSa2P1J8nOuiW0EdXZHQ1tI2F7s-Lv2YmiEiafCFqoj36c1MDcox2dg6RjjYeO0yaFZ253xVVWE0NfxG0O8-tilXOIliudAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSJoobI6tkACyvCkJOPNhRxifdDjzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzEwL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8xMC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCsdBlY42g0q2nn0d8lpeH6ahq9WkMaeCf3qNTS_xUQ0gvNnEcqOXmZcwM26wmfAcEMpcilenOA_A6eqjBdjBqp2vpyFFS0nnkq9bDB4lvA9N6DIDwjW-tMamhtahcdVukmPJxLxNR2WRMoncYWVJ4Ibd626NUs9bKYjY_xjimNlidbPhEdfHhfe9sOzqNBDXdE0RhSANcHzI21dTSl8knc8FmpSKBy5i5O40W0mH0D99zxFen2WaqrKuTsH649bfsGfS1eoLfl-AmSxXXw9dXn_R6fwSAPp5zgdjbthr0iwfVH7vkBBpXnJxuB17_gPoP-s52UjySEzroAMbZl815H&s=kRm1ZWM5GnFwn3SRLsaMsMeLK2f86w-HWvCcVSi-hfvUvboFvYp-j7hoWr8BRZVxHiFlTCU1goGWClJKMzg-_hK8ctcNpYlf-zuBLggZPdhmWPs631LKG4zivLkVUNvBEbHFlGAPWssdFVUwrQDH-6_8AoHa4XMbEJX84ayuHrwuKPp-KTR0RMdl5wCZdbW89ODInLIm21cpWZ90inDiEZPQwgubSGRc7lAnPWhzS-F51j9E9t3XlG6TBMg9EIB__5NRogJ0ghm7oqY1k_ETk-S8tUy2iphWtIMu4e9nVUEk4w1GbrEx9NuekXnz83tlhKEG7ob-r9rmY10G8hV0gg&h=9ZhvKOTtVQDncaaXcOkjDNDgcHRcYrNHW9sxBNvSUQI
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","name":"448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","status":"InProgress","startTime":"2026-07-03T09:39:08.0488826"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '285'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:39:42 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=dbb7c858-7fe6-47e8-9b0e-aeae5587ef6a/westindia/d2059e04-95b4-4218-9fe2-77ddfb0026e0
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: DCC81620CDB340B480A15A6EDAB234E7 Ref B: PNQ231110908034 Ref C: 2026-07-03T09:39:41Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --logs-destination
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7?api-version=2025-10-02-preview&azureAsyncOperation=true&t=639186683495057394&c=MIIHlDCCBnygAwIBAgIQcyzofG45BJ3kcmojGUTNPTANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwOTAzNTYxNVoXDTI2MTAwNDA5NTYxNVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCylTdveId_fRZKb4c5-b6XRtq1MlgavUk9VSsvq-MKaNFseSyQ8yqTwT9OK0C_fsbruj5pXgS5NS8dKnBuhTD8eTuk8hAW2llcTIxVYp3wwJ5yFuq_HxoIz2l6AVXYGgsfGlZK94DOlk6A9562HvK17TWNc2ayOIo-mC9MmkCxZ_rXYVrMKIRg_isDORfT3kCxrzuBy6lE2eZ0X658RGu0gmFy_lQ6JVYwUw-cHa5DpkWyehsimxoADtZSa2P1J8nOuiW0EdXZHQ1tI2F7s-Lv2YmiEiafCFqoj36c1MDcox2dg6RjjYeO0yaFZ253xVVWE0NfxG0O8-tilXOIliudAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSJoobI6tkACyvCkJOPNhRxifdDjzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzEwL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8xMC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCsdBlY42g0q2nn0d8lpeH6ahq9WkMaeCf3qNTS_xUQ0gvNnEcqOXmZcwM26wmfAcEMpcilenOA_A6eqjBdjBqp2vpyFFS0nnkq9bDB4lvA9N6DIDwjW-tMamhtahcdVukmPJxLxNR2WRMoncYWVJ4Ibd626NUs9bKYjY_xjimNlidbPhEdfHhfe9sOzqNBDXdE0RhSANcHzI21dTSl8knc8FmpSKBy5i5O40W0mH0D99zxFen2WaqrKuTsH649bfsGfS1eoLfl-AmSxXXw9dXn_R6fwSAPp5zgdjbthr0iwfVH7vkBBpXnJxuB17_gPoP-s52UjySEzroAMbZl815H&s=kRm1ZWM5GnFwn3SRLsaMsMeLK2f86w-HWvCcVSi-hfvUvboFvYp-j7hoWr8BRZVxHiFlTCU1goGWClJKMzg-_hK8ctcNpYlf-zuBLggZPdhmWPs631LKG4zivLkVUNvBEbHFlGAPWssdFVUwrQDH-6_8AoHa4XMbEJX84ayuHrwuKPp-KTR0RMdl5wCZdbW89ODInLIm21cpWZ90inDiEZPQwgubSGRc7lAnPWhzS-F51j9E9t3XlG6TBMg9EIB__5NRogJ0ghm7oqY1k_ETk-S8tUy2iphWtIMu4e9nVUEk4w1GbrEx9NuekXnz83tlhKEG7ob-r9rmY10G8hV0gg&h=9ZhvKOTtVQDncaaXcOkjDNDgcHRcYrNHW9sxBNvSUQI
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","name":"448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","status":"InProgress","startTime":"2026-07-03T09:39:08.0488826"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '285'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:39:45 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=dbb7c858-7fe6-47e8-9b0e-aeae5587ef6a/centralindia/1a93fba9-6b94-48b8-8fda-521127b51307
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 28B228FBE6ED49D1A9ED6B555C213B9F Ref B: PNQ231110907040 Ref C: 2026-07-03T09:39:44Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --logs-destination
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7?api-version=2025-10-02-preview&azureAsyncOperation=true&t=639186683495057394&c=MIIHlDCCBnygAwIBAgIQcyzofG45BJ3kcmojGUTNPTANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwOTAzNTYxNVoXDTI2MTAwNDA5NTYxNVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCylTdveId_fRZKb4c5-b6XRtq1MlgavUk9VSsvq-MKaNFseSyQ8yqTwT9OK0C_fsbruj5pXgS5NS8dKnBuhTD8eTuk8hAW2llcTIxVYp3wwJ5yFuq_HxoIz2l6AVXYGgsfGlZK94DOlk6A9562HvK17TWNc2ayOIo-mC9MmkCxZ_rXYVrMKIRg_isDORfT3kCxrzuBy6lE2eZ0X658RGu0gmFy_lQ6JVYwUw-cHa5DpkWyehsimxoADtZSa2P1J8nOuiW0EdXZHQ1tI2F7s-Lv2YmiEiafCFqoj36c1MDcox2dg6RjjYeO0yaFZ253xVVWE0NfxG0O8-tilXOIliudAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSJoobI6tkACyvCkJOPNhRxifdDjzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzEwL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8xMC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCsdBlY42g0q2nn0d8lpeH6ahq9WkMaeCf3qNTS_xUQ0gvNnEcqOXmZcwM26wmfAcEMpcilenOA_A6eqjBdjBqp2vpyFFS0nnkq9bDB4lvA9N6DIDwjW-tMamhtahcdVukmPJxLxNR2WRMoncYWVJ4Ibd626NUs9bKYjY_xjimNlidbPhEdfHhfe9sOzqNBDXdE0RhSANcHzI21dTSl8knc8FmpSKBy5i5O40W0mH0D99zxFen2WaqrKuTsH649bfsGfS1eoLfl-AmSxXXw9dXn_R6fwSAPp5zgdjbthr0iwfVH7vkBBpXnJxuB17_gPoP-s52UjySEzroAMbZl815H&s=kRm1ZWM5GnFwn3SRLsaMsMeLK2f86w-HWvCcVSi-hfvUvboFvYp-j7hoWr8BRZVxHiFlTCU1goGWClJKMzg-_hK8ctcNpYlf-zuBLggZPdhmWPs631LKG4zivLkVUNvBEbHFlGAPWssdFVUwrQDH-6_8AoHa4XMbEJX84ayuHrwuKPp-KTR0RMdl5wCZdbW89ODInLIm21cpWZ90inDiEZPQwgubSGRc7lAnPWhzS-F51j9E9t3XlG6TBMg9EIB__5NRogJ0ghm7oqY1k_ETk-S8tUy2iphWtIMu4e9nVUEk4w1GbrEx9NuekXnz83tlhKEG7ob-r9rmY10G8hV0gg&h=9ZhvKOTtVQDncaaXcOkjDNDgcHRcYrNHW9sxBNvSUQI
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","name":"448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","status":"InProgress","startTime":"2026-07-03T09:39:08.0488826"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '285'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:39:49 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=dbb7c858-7fe6-47e8-9b0e-aeae5587ef6a/jioindiawest/858d5119-8e31-4f07-a16c-b768036efed2
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 56DA529E5E404261A7149EC5E4E182E2 Ref B: PNQ231110909036 Ref C: 2026-07-03T09:39:48Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --logs-destination
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7?api-version=2025-10-02-preview&azureAsyncOperation=true&t=639186683495057394&c=MIIHlDCCBnygAwIBAgIQcyzofG45BJ3kcmojGUTNPTANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwOTAzNTYxNVoXDTI2MTAwNDA5NTYxNVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCylTdveId_fRZKb4c5-b6XRtq1MlgavUk9VSsvq-MKaNFseSyQ8yqTwT9OK0C_fsbruj5pXgS5NS8dKnBuhTD8eTuk8hAW2llcTIxVYp3wwJ5yFuq_HxoIz2l6AVXYGgsfGlZK94DOlk6A9562HvK17TWNc2ayOIo-mC9MmkCxZ_rXYVrMKIRg_isDORfT3kCxrzuBy6lE2eZ0X658RGu0gmFy_lQ6JVYwUw-cHa5DpkWyehsimxoADtZSa2P1J8nOuiW0EdXZHQ1tI2F7s-Lv2YmiEiafCFqoj36c1MDcox2dg6RjjYeO0yaFZ253xVVWE0NfxG0O8-tilXOIliudAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSJoobI6tkACyvCkJOPNhRxifdDjzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzEwL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8xMC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCsdBlY42g0q2nn0d8lpeH6ahq9WkMaeCf3qNTS_xUQ0gvNnEcqOXmZcwM26wmfAcEMpcilenOA_A6eqjBdjBqp2vpyFFS0nnkq9bDB4lvA9N6DIDwjW-tMamhtahcdVukmPJxLxNR2WRMoncYWVJ4Ibd626NUs9bKYjY_xjimNlidbPhEdfHhfe9sOzqNBDXdE0RhSANcHzI21dTSl8knc8FmpSKBy5i5O40W0mH0D99zxFen2WaqrKuTsH649bfsGfS1eoLfl-AmSxXXw9dXn_R6fwSAPp5zgdjbthr0iwfVH7vkBBpXnJxuB17_gPoP-s52UjySEzroAMbZl815H&s=kRm1ZWM5GnFwn3SRLsaMsMeLK2f86w-HWvCcVSi-hfvUvboFvYp-j7hoWr8BRZVxHiFlTCU1goGWClJKMzg-_hK8ctcNpYlf-zuBLggZPdhmWPs631LKG4zivLkVUNvBEbHFlGAPWssdFVUwrQDH-6_8AoHa4XMbEJX84ayuHrwuKPp-KTR0RMdl5wCZdbW89ODInLIm21cpWZ90inDiEZPQwgubSGRc7lAnPWhzS-F51j9E9t3XlG6TBMg9EIB__5NRogJ0ghm7oqY1k_ETk-S8tUy2iphWtIMu4e9nVUEk4w1GbrEx9NuekXnz83tlhKEG7ob-r9rmY10G8hV0gg&h=9ZhvKOTtVQDncaaXcOkjDNDgcHRcYrNHW9sxBNvSUQI
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","name":"448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","status":"InProgress","startTime":"2026-07-03T09:39:08.0488826"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '285'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:39:52 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=dbb7c858-7fe6-47e8-9b0e-aeae5587ef6a/centralindia/c3bd2096-00d1-4ced-8e4b-388159fba6c4
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: C6A8630F80FD4E5E993CFF95FC00A1E7 Ref B: PNQ231110906029 Ref C: 2026-07-03T09:39:52Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --logs-destination
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7?api-version=2025-10-02-preview&azureAsyncOperation=true&t=639186683495057394&c=MIIHlDCCBnygAwIBAgIQcyzofG45BJ3kcmojGUTNPTANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwOTAzNTYxNVoXDTI2MTAwNDA5NTYxNVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCylTdveId_fRZKb4c5-b6XRtq1MlgavUk9VSsvq-MKaNFseSyQ8yqTwT9OK0C_fsbruj5pXgS5NS8dKnBuhTD8eTuk8hAW2llcTIxVYp3wwJ5yFuq_HxoIz2l6AVXYGgsfGlZK94DOlk6A9562HvK17TWNc2ayOIo-mC9MmkCxZ_rXYVrMKIRg_isDORfT3kCxrzuBy6lE2eZ0X658RGu0gmFy_lQ6JVYwUw-cHa5DpkWyehsimxoADtZSa2P1J8nOuiW0EdXZHQ1tI2F7s-Lv2YmiEiafCFqoj36c1MDcox2dg6RjjYeO0yaFZ253xVVWE0NfxG0O8-tilXOIliudAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSJoobI6tkACyvCkJOPNhRxifdDjzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzEwL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8xMC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCsdBlY42g0q2nn0d8lpeH6ahq9WkMaeCf3qNTS_xUQ0gvNnEcqOXmZcwM26wmfAcEMpcilenOA_A6eqjBdjBqp2vpyFFS0nnkq9bDB4lvA9N6DIDwjW-tMamhtahcdVukmPJxLxNR2WRMoncYWVJ4Ibd626NUs9bKYjY_xjimNlidbPhEdfHhfe9sOzqNBDXdE0RhSANcHzI21dTSl8knc8FmpSKBy5i5O40W0mH0D99zxFen2WaqrKuTsH649bfsGfS1eoLfl-AmSxXXw9dXn_R6fwSAPp5zgdjbthr0iwfVH7vkBBpXnJxuB17_gPoP-s52UjySEzroAMbZl815H&s=kRm1ZWM5GnFwn3SRLsaMsMeLK2f86w-HWvCcVSi-hfvUvboFvYp-j7hoWr8BRZVxHiFlTCU1goGWClJKMzg-_hK8ctcNpYlf-zuBLggZPdhmWPs631LKG4zivLkVUNvBEbHFlGAPWssdFVUwrQDH-6_8AoHa4XMbEJX84ayuHrwuKPp-KTR0RMdl5wCZdbW89ODInLIm21cpWZ90inDiEZPQwgubSGRc7lAnPWhzS-F51j9E9t3XlG6TBMg9EIB__5NRogJ0ghm7oqY1k_ETk-S8tUy2iphWtIMu4e9nVUEk4w1GbrEx9NuekXnz83tlhKEG7ob-r9rmY10G8hV0gg&h=9ZhvKOTtVQDncaaXcOkjDNDgcHRcYrNHW9sxBNvSUQI
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","name":"448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","status":"InProgress","startTime":"2026-07-03T09:39:08.0488826"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '285'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:39:56 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=dbb7c858-7fe6-47e8-9b0e-aeae5587ef6a/jioindiacentral/bd0c1320-b80e-49dc-be1e-297fade804e7
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: B8FCA135A87848C3B263C982B7E00206 Ref B: PNQ231110907025 Ref C: 2026-07-03T09:39:56Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --logs-destination
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7?api-version=2025-10-02-preview&azureAsyncOperation=true&t=639186683495057394&c=MIIHlDCCBnygAwIBAgIQcyzofG45BJ3kcmojGUTNPTANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwOTAzNTYxNVoXDTI2MTAwNDA5NTYxNVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCylTdveId_fRZKb4c5-b6XRtq1MlgavUk9VSsvq-MKaNFseSyQ8yqTwT9OK0C_fsbruj5pXgS5NS8dKnBuhTD8eTuk8hAW2llcTIxVYp3wwJ5yFuq_HxoIz2l6AVXYGgsfGlZK94DOlk6A9562HvK17TWNc2ayOIo-mC9MmkCxZ_rXYVrMKIRg_isDORfT3kCxrzuBy6lE2eZ0X658RGu0gmFy_lQ6JVYwUw-cHa5DpkWyehsimxoADtZSa2P1J8nOuiW0EdXZHQ1tI2F7s-Lv2YmiEiafCFqoj36c1MDcox2dg6RjjYeO0yaFZ253xVVWE0NfxG0O8-tilXOIliudAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSJoobI6tkACyvCkJOPNhRxifdDjzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzEwL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8xMC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCsdBlY42g0q2nn0d8lpeH6ahq9WkMaeCf3qNTS_xUQ0gvNnEcqOXmZcwM26wmfAcEMpcilenOA_A6eqjBdjBqp2vpyFFS0nnkq9bDB4lvA9N6DIDwjW-tMamhtahcdVukmPJxLxNR2WRMoncYWVJ4Ibd626NUs9bKYjY_xjimNlidbPhEdfHhfe9sOzqNBDXdE0RhSANcHzI21dTSl8knc8FmpSKBy5i5O40W0mH0D99zxFen2WaqrKuTsH649bfsGfS1eoLfl-AmSxXXw9dXn_R6fwSAPp5zgdjbthr0iwfVH7vkBBpXnJxuB17_gPoP-s52UjySEzroAMbZl815H&s=kRm1ZWM5GnFwn3SRLsaMsMeLK2f86w-HWvCcVSi-hfvUvboFvYp-j7hoWr8BRZVxHiFlTCU1goGWClJKMzg-_hK8ctcNpYlf-zuBLggZPdhmWPs631LKG4zivLkVUNvBEbHFlGAPWssdFVUwrQDH-6_8AoHa4XMbEJX84ayuHrwuKPp-KTR0RMdl5wCZdbW89ODInLIm21cpWZ90inDiEZPQwgubSGRc7lAnPWhzS-F51j9E9t3XlG6TBMg9EIB__5NRogJ0ghm7oqY1k_ETk-S8tUy2iphWtIMu4e9nVUEk4w1GbrEx9NuekXnz83tlhKEG7ob-r9rmY10G8hV0gg&h=9ZhvKOTtVQDncaaXcOkjDNDgcHRcYrNHW9sxBNvSUQI
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","name":"448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","status":"InProgress","startTime":"2026-07-03T09:39:08.0488826"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '285'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:40:00 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=dbb7c858-7fe6-47e8-9b0e-aeae5587ef6a/westindia/550f7ae2-6620-48d4-a693-abe38cec3d63
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 136AAE8E14F84533B55AFD32198F3945 Ref B: PNQ231110909034 Ref C: 2026-07-03T09:39:59Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --logs-destination
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7?api-version=2025-10-02-preview&azureAsyncOperation=true&t=639186683495057394&c=MIIHlDCCBnygAwIBAgIQcyzofG45BJ3kcmojGUTNPTANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwOTAzNTYxNVoXDTI2MTAwNDA5NTYxNVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCylTdveId_fRZKb4c5-b6XRtq1MlgavUk9VSsvq-MKaNFseSyQ8yqTwT9OK0C_fsbruj5pXgS5NS8dKnBuhTD8eTuk8hAW2llcTIxVYp3wwJ5yFuq_HxoIz2l6AVXYGgsfGlZK94DOlk6A9562HvK17TWNc2ayOIo-mC9MmkCxZ_rXYVrMKIRg_isDORfT3kCxrzuBy6lE2eZ0X658RGu0gmFy_lQ6JVYwUw-cHa5DpkWyehsimxoADtZSa2P1J8nOuiW0EdXZHQ1tI2F7s-Lv2YmiEiafCFqoj36c1MDcox2dg6RjjYeO0yaFZ253xVVWE0NfxG0O8-tilXOIliudAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSJoobI6tkACyvCkJOPNhRxifdDjzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzEwL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8xMC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCsdBlY42g0q2nn0d8lpeH6ahq9WkMaeCf3qNTS_xUQ0gvNnEcqOXmZcwM26wmfAcEMpcilenOA_A6eqjBdjBqp2vpyFFS0nnkq9bDB4lvA9N6DIDwjW-tMamhtahcdVukmPJxLxNR2WRMoncYWVJ4Ibd626NUs9bKYjY_xjimNlidbPhEdfHhfe9sOzqNBDXdE0RhSANcHzI21dTSl8knc8FmpSKBy5i5O40W0mH0D99zxFen2WaqrKuTsH649bfsGfS1eoLfl-AmSxXXw9dXn_R6fwSAPp5zgdjbthr0iwfVH7vkBBpXnJxuB17_gPoP-s52UjySEzroAMbZl815H&s=kRm1ZWM5GnFwn3SRLsaMsMeLK2f86w-HWvCcVSi-hfvUvboFvYp-j7hoWr8BRZVxHiFlTCU1goGWClJKMzg-_hK8ctcNpYlf-zuBLggZPdhmWPs631LKG4zivLkVUNvBEbHFlGAPWssdFVUwrQDH-6_8AoHa4XMbEJX84ayuHrwuKPp-KTR0RMdl5wCZdbW89ODInLIm21cpWZ90inDiEZPQwgubSGRc7lAnPWhzS-F51j9E9t3XlG6TBMg9EIB__5NRogJ0ghm7oqY1k_ETk-S8tUy2iphWtIMu4e9nVUEk4w1GbrEx9NuekXnz83tlhKEG7ob-r9rmY10G8hV0gg&h=9ZhvKOTtVQDncaaXcOkjDNDgcHRcYrNHW9sxBNvSUQI
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","name":"448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","status":"InProgress","startTime":"2026-07-03T09:39:08.0488826"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '285'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:40:04 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=dbb7c858-7fe6-47e8-9b0e-aeae5587ef6a/centralindia/2e85db54-87d8-4462-b7fe-9fb9cf281c85
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: BDAB2DEC569644FDB3045DFFCDB02094 Ref B: PNQ231110906062 Ref C: 2026-07-03T09:40:03Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --logs-destination
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7?api-version=2025-10-02-preview&azureAsyncOperation=true&t=639186683495057394&c=MIIHlDCCBnygAwIBAgIQcyzofG45BJ3kcmojGUTNPTANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwOTAzNTYxNVoXDTI2MTAwNDA5NTYxNVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCylTdveId_fRZKb4c5-b6XRtq1MlgavUk9VSsvq-MKaNFseSyQ8yqTwT9OK0C_fsbruj5pXgS5NS8dKnBuhTD8eTuk8hAW2llcTIxVYp3wwJ5yFuq_HxoIz2l6AVXYGgsfGlZK94DOlk6A9562HvK17TWNc2ayOIo-mC9MmkCxZ_rXYVrMKIRg_isDORfT3kCxrzuBy6lE2eZ0X658RGu0gmFy_lQ6JVYwUw-cHa5DpkWyehsimxoADtZSa2P1J8nOuiW0EdXZHQ1tI2F7s-Lv2YmiEiafCFqoj36c1MDcox2dg6RjjYeO0yaFZ253xVVWE0NfxG0O8-tilXOIliudAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSJoobI6tkACyvCkJOPNhRxifdDjzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzEwL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8xMC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCsdBlY42g0q2nn0d8lpeH6ahq9WkMaeCf3qNTS_xUQ0gvNnEcqOXmZcwM26wmfAcEMpcilenOA_A6eqjBdjBqp2vpyFFS0nnkq9bDB4lvA9N6DIDwjW-tMamhtahcdVukmPJxLxNR2WRMoncYWVJ4Ibd626NUs9bKYjY_xjimNlidbPhEdfHhfe9sOzqNBDXdE0RhSANcHzI21dTSl8knc8FmpSKBy5i5O40W0mH0D99zxFen2WaqrKuTsH649bfsGfS1eoLfl-AmSxXXw9dXn_R6fwSAPp5zgdjbthr0iwfVH7vkBBpXnJxuB17_gPoP-s52UjySEzroAMbZl815H&s=kRm1ZWM5GnFwn3SRLsaMsMeLK2f86w-HWvCcVSi-hfvUvboFvYp-j7hoWr8BRZVxHiFlTCU1goGWClJKMzg-_hK8ctcNpYlf-zuBLggZPdhmWPs631LKG4zivLkVUNvBEbHFlGAPWssdFVUwrQDH-6_8AoHa4XMbEJX84ayuHrwuKPp-KTR0RMdl5wCZdbW89ODInLIm21cpWZ90inDiEZPQwgubSGRc7lAnPWhzS-F51j9E9t3XlG6TBMg9EIB__5NRogJ0ghm7oqY1k_ETk-S8tUy2iphWtIMu4e9nVUEk4w1GbrEx9NuekXnz83tlhKEG7ob-r9rmY10G8hV0gg&h=9ZhvKOTtVQDncaaXcOkjDNDgcHRcYrNHW9sxBNvSUQI
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","name":"448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","status":"InProgress","startTime":"2026-07-03T09:39:08.0488826"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '285'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:40:07 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=dbb7c858-7fe6-47e8-9b0e-aeae5587ef6a/southindia/d5668a76-bcdd-4233-96e7-9e5d36f6b56e
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 69BE86E2FBE84204A39932A2A44AE40C Ref B: PNQ231110909029 Ref C: 2026-07-03T09:40:07Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --logs-destination
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7?api-version=2025-10-02-preview&azureAsyncOperation=true&t=639186683495057394&c=MIIHlDCCBnygAwIBAgIQcyzofG45BJ3kcmojGUTNPTANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwOTAzNTYxNVoXDTI2MTAwNDA5NTYxNVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCylTdveId_fRZKb4c5-b6XRtq1MlgavUk9VSsvq-MKaNFseSyQ8yqTwT9OK0C_fsbruj5pXgS5NS8dKnBuhTD8eTuk8hAW2llcTIxVYp3wwJ5yFuq_HxoIz2l6AVXYGgsfGlZK94DOlk6A9562HvK17TWNc2ayOIo-mC9MmkCxZ_rXYVrMKIRg_isDORfT3kCxrzuBy6lE2eZ0X658RGu0gmFy_lQ6JVYwUw-cHa5DpkWyehsimxoADtZSa2P1J8nOuiW0EdXZHQ1tI2F7s-Lv2YmiEiafCFqoj36c1MDcox2dg6RjjYeO0yaFZ253xVVWE0NfxG0O8-tilXOIliudAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSJoobI6tkACyvCkJOPNhRxifdDjzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzEwL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8xMC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCsdBlY42g0q2nn0d8lpeH6ahq9WkMaeCf3qNTS_xUQ0gvNnEcqOXmZcwM26wmfAcEMpcilenOA_A6eqjBdjBqp2vpyFFS0nnkq9bDB4lvA9N6DIDwjW-tMamhtahcdVukmPJxLxNR2WRMoncYWVJ4Ibd626NUs9bKYjY_xjimNlidbPhEdfHhfe9sOzqNBDXdE0RhSANcHzI21dTSl8knc8FmpSKBy5i5O40W0mH0D99zxFen2WaqrKuTsH649bfsGfS1eoLfl-AmSxXXw9dXn_R6fwSAPp5zgdjbthr0iwfVH7vkBBpXnJxuB17_gPoP-s52UjySEzroAMbZl815H&s=kRm1ZWM5GnFwn3SRLsaMsMeLK2f86w-HWvCcVSi-hfvUvboFvYp-j7hoWr8BRZVxHiFlTCU1goGWClJKMzg-_hK8ctcNpYlf-zuBLggZPdhmWPs631LKG4zivLkVUNvBEbHFlGAPWssdFVUwrQDH-6_8AoHa4XMbEJX84ayuHrwuKPp-KTR0RMdl5wCZdbW89ODInLIm21cpWZ90inDiEZPQwgubSGRc7lAnPWhzS-F51j9E9t3XlG6TBMg9EIB__5NRogJ0ghm7oqY1k_ETk-S8tUy2iphWtIMu4e9nVUEk4w1GbrEx9NuekXnz83tlhKEG7ob-r9rmY10G8hV0gg&h=9ZhvKOTtVQDncaaXcOkjDNDgcHRcYrNHW9sxBNvSUQI
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","name":"448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","status":"InProgress","startTime":"2026-07-03T09:39:08.0488826"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '285'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:40:10 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=dbb7c858-7fe6-47e8-9b0e-aeae5587ef6a/westindia/ffc46634-f65e-4a67-83ef-cd4f08aa0dbc
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: ED177EAB6042443A842EEE63C9AB0B95 Ref B: PNQ231110909054 Ref C: 2026-07-03T09:40:10Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --logs-destination
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7?api-version=2025-10-02-preview&azureAsyncOperation=true&t=639186683495057394&c=MIIHlDCCBnygAwIBAgIQcyzofG45BJ3kcmojGUTNPTANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwOTAzNTYxNVoXDTI2MTAwNDA5NTYxNVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCylTdveId_fRZKb4c5-b6XRtq1MlgavUk9VSsvq-MKaNFseSyQ8yqTwT9OK0C_fsbruj5pXgS5NS8dKnBuhTD8eTuk8hAW2llcTIxVYp3wwJ5yFuq_HxoIz2l6AVXYGgsfGlZK94DOlk6A9562HvK17TWNc2ayOIo-mC9MmkCxZ_rXYVrMKIRg_isDORfT3kCxrzuBy6lE2eZ0X658RGu0gmFy_lQ6JVYwUw-cHa5DpkWyehsimxoADtZSa2P1J8nOuiW0EdXZHQ1tI2F7s-Lv2YmiEiafCFqoj36c1MDcox2dg6RjjYeO0yaFZ253xVVWE0NfxG0O8-tilXOIliudAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSJoobI6tkACyvCkJOPNhRxifdDjzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzEwL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8xMC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCsdBlY42g0q2nn0d8lpeH6ahq9WkMaeCf3qNTS_xUQ0gvNnEcqOXmZcwM26wmfAcEMpcilenOA_A6eqjBdjBqp2vpyFFS0nnkq9bDB4lvA9N6DIDwjW-tMamhtahcdVukmPJxLxNR2WRMoncYWVJ4Ibd626NUs9bKYjY_xjimNlidbPhEdfHhfe9sOzqNBDXdE0RhSANcHzI21dTSl8knc8FmpSKBy5i5O40W0mH0D99zxFen2WaqrKuTsH649bfsGfS1eoLfl-AmSxXXw9dXn_R6fwSAPp5zgdjbthr0iwfVH7vkBBpXnJxuB17_gPoP-s52UjySEzroAMbZl815H&s=kRm1ZWM5GnFwn3SRLsaMsMeLK2f86w-HWvCcVSi-hfvUvboFvYp-j7hoWr8BRZVxHiFlTCU1goGWClJKMzg-_hK8ctcNpYlf-zuBLggZPdhmWPs631LKG4zivLkVUNvBEbHFlGAPWssdFVUwrQDH-6_8AoHa4XMbEJX84ayuHrwuKPp-KTR0RMdl5wCZdbW89ODInLIm21cpWZ90inDiEZPQwgubSGRc7lAnPWhzS-F51j9E9t3XlG6TBMg9EIB__5NRogJ0ghm7oqY1k_ETk-S8tUy2iphWtIMu4e9nVUEk4w1GbrEx9NuekXnz83tlhKEG7ob-r9rmY10G8hV0gg&h=9ZhvKOTtVQDncaaXcOkjDNDgcHRcYrNHW9sxBNvSUQI
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","name":"448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","status":"InProgress","startTime":"2026-07-03T09:39:08.0488826"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '285'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:40:14 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=dbb7c858-7fe6-47e8-9b0e-aeae5587ef6a/centralindia/da10c6b9-1030-4a31-9f20-d1b1d5cf69be
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 5A288E1C9B9843B6A66E92F61D516C9C Ref B: PNQ231110906036 Ref C: 2026-07-03T09:40:13Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --logs-destination
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7?api-version=2025-10-02-preview&azureAsyncOperation=true&t=639186683495057394&c=MIIHlDCCBnygAwIBAgIQcyzofG45BJ3kcmojGUTNPTANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwOTAzNTYxNVoXDTI2MTAwNDA5NTYxNVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCylTdveId_fRZKb4c5-b6XRtq1MlgavUk9VSsvq-MKaNFseSyQ8yqTwT9OK0C_fsbruj5pXgS5NS8dKnBuhTD8eTuk8hAW2llcTIxVYp3wwJ5yFuq_HxoIz2l6AVXYGgsfGlZK94DOlk6A9562HvK17TWNc2ayOIo-mC9MmkCxZ_rXYVrMKIRg_isDORfT3kCxrzuBy6lE2eZ0X658RGu0gmFy_lQ6JVYwUw-cHa5DpkWyehsimxoADtZSa2P1J8nOuiW0EdXZHQ1tI2F7s-Lv2YmiEiafCFqoj36c1MDcox2dg6RjjYeO0yaFZ253xVVWE0NfxG0O8-tilXOIliudAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSJoobI6tkACyvCkJOPNhRxifdDjzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzEwL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8xMC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCsdBlY42g0q2nn0d8lpeH6ahq9WkMaeCf3qNTS_xUQ0gvNnEcqOXmZcwM26wmfAcEMpcilenOA_A6eqjBdjBqp2vpyFFS0nnkq9bDB4lvA9N6DIDwjW-tMamhtahcdVukmPJxLxNR2WRMoncYWVJ4Ibd626NUs9bKYjY_xjimNlidbPhEdfHhfe9sOzqNBDXdE0RhSANcHzI21dTSl8knc8FmpSKBy5i5O40W0mH0D99zxFen2WaqrKuTsH649bfsGfS1eoLfl-AmSxXXw9dXn_R6fwSAPp5zgdjbthr0iwfVH7vkBBpXnJxuB17_gPoP-s52UjySEzroAMbZl815H&s=kRm1ZWM5GnFwn3SRLsaMsMeLK2f86w-HWvCcVSi-hfvUvboFvYp-j7hoWr8BRZVxHiFlTCU1goGWClJKMzg-_hK8ctcNpYlf-zuBLggZPdhmWPs631LKG4zivLkVUNvBEbHFlGAPWssdFVUwrQDH-6_8AoHa4XMbEJX84ayuHrwuKPp-KTR0RMdl5wCZdbW89ODInLIm21cpWZ90inDiEZPQwgubSGRc7lAnPWhzS-F51j9E9t3XlG6TBMg9EIB__5NRogJ0ghm7oqY1k_ETk-S8tUy2iphWtIMu4e9nVUEk4w1GbrEx9NuekXnz83tlhKEG7ob-r9rmY10G8hV0gg&h=9ZhvKOTtVQDncaaXcOkjDNDgcHRcYrNHW9sxBNvSUQI
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","name":"448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","status":"InProgress","startTime":"2026-07-03T09:39:08.0488826"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '285'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:40:17 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=dbb7c858-7fe6-47e8-9b0e-aeae5587ef6a/southindia/7db8817a-d86a-4430-b5aa-f20d86e73524
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 59D6CBEA780949AFBD4011F681A2A517 Ref B: PNQ231110909054 Ref C: 2026-07-03T09:40:17Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --logs-destination
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7?api-version=2025-10-02-preview&azureAsyncOperation=true&t=639186683495057394&c=MIIHlDCCBnygAwIBAgIQcyzofG45BJ3kcmojGUTNPTANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwOTAzNTYxNVoXDTI2MTAwNDA5NTYxNVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCylTdveId_fRZKb4c5-b6XRtq1MlgavUk9VSsvq-MKaNFseSyQ8yqTwT9OK0C_fsbruj5pXgS5NS8dKnBuhTD8eTuk8hAW2llcTIxVYp3wwJ5yFuq_HxoIz2l6AVXYGgsfGlZK94DOlk6A9562HvK17TWNc2ayOIo-mC9MmkCxZ_rXYVrMKIRg_isDORfT3kCxrzuBy6lE2eZ0X658RGu0gmFy_lQ6JVYwUw-cHa5DpkWyehsimxoADtZSa2P1J8nOuiW0EdXZHQ1tI2F7s-Lv2YmiEiafCFqoj36c1MDcox2dg6RjjYeO0yaFZ253xVVWE0NfxG0O8-tilXOIliudAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSJoobI6tkACyvCkJOPNhRxifdDjzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzEwL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8xMC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCsdBlY42g0q2nn0d8lpeH6ahq9WkMaeCf3qNTS_xUQ0gvNnEcqOXmZcwM26wmfAcEMpcilenOA_A6eqjBdjBqp2vpyFFS0nnkq9bDB4lvA9N6DIDwjW-tMamhtahcdVukmPJxLxNR2WRMoncYWVJ4Ibd626NUs9bKYjY_xjimNlidbPhEdfHhfe9sOzqNBDXdE0RhSANcHzI21dTSl8knc8FmpSKBy5i5O40W0mH0D99zxFen2WaqrKuTsH649bfsGfS1eoLfl-AmSxXXw9dXn_R6fwSAPp5zgdjbthr0iwfVH7vkBBpXnJxuB17_gPoP-s52UjySEzroAMbZl815H&s=kRm1ZWM5GnFwn3SRLsaMsMeLK2f86w-HWvCcVSi-hfvUvboFvYp-j7hoWr8BRZVxHiFlTCU1goGWClJKMzg-_hK8ctcNpYlf-zuBLggZPdhmWPs631LKG4zivLkVUNvBEbHFlGAPWssdFVUwrQDH-6_8AoHa4XMbEJX84ayuHrwuKPp-KTR0RMdl5wCZdbW89ODInLIm21cpWZ90inDiEZPQwgubSGRc7lAnPWhzS-F51j9E9t3XlG6TBMg9EIB__5NRogJ0ghm7oqY1k_ETk-S8tUy2iphWtIMu4e9nVUEk4w1GbrEx9NuekXnz83tlhKEG7ob-r9rmY10G8hV0gg&h=9ZhvKOTtVQDncaaXcOkjDNDgcHRcYrNHW9sxBNvSUQI
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","name":"448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","status":"InProgress","startTime":"2026-07-03T09:39:08.0488826"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '285'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:40:21 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=dbb7c858-7fe6-47e8-9b0e-aeae5587ef6a/jioindiacentral/3b0aab58-b1e3-42d1-b2c8-932af96ce97a
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 0394E0E8C1704BFAAB1261EEEC1E0DE1 Ref B: PNQ231110907052 Ref C: 2026-07-03T09:40:21Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --logs-destination
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7?api-version=2025-10-02-preview&azureAsyncOperation=true&t=639186683495057394&c=MIIHlDCCBnygAwIBAgIQcyzofG45BJ3kcmojGUTNPTANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwOTAzNTYxNVoXDTI2MTAwNDA5NTYxNVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCylTdveId_fRZKb4c5-b6XRtq1MlgavUk9VSsvq-MKaNFseSyQ8yqTwT9OK0C_fsbruj5pXgS5NS8dKnBuhTD8eTuk8hAW2llcTIxVYp3wwJ5yFuq_HxoIz2l6AVXYGgsfGlZK94DOlk6A9562HvK17TWNc2ayOIo-mC9MmkCxZ_rXYVrMKIRg_isDORfT3kCxrzuBy6lE2eZ0X658RGu0gmFy_lQ6JVYwUw-cHa5DpkWyehsimxoADtZSa2P1J8nOuiW0EdXZHQ1tI2F7s-Lv2YmiEiafCFqoj36c1MDcox2dg6RjjYeO0yaFZ253xVVWE0NfxG0O8-tilXOIliudAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSJoobI6tkACyvCkJOPNhRxifdDjzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzEwL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8xMC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCsdBlY42g0q2nn0d8lpeH6ahq9WkMaeCf3qNTS_xUQ0gvNnEcqOXmZcwM26wmfAcEMpcilenOA_A6eqjBdjBqp2vpyFFS0nnkq9bDB4lvA9N6DIDwjW-tMamhtahcdVukmPJxLxNR2WRMoncYWVJ4Ibd626NUs9bKYjY_xjimNlidbPhEdfHhfe9sOzqNBDXdE0RhSANcHzI21dTSl8knc8FmpSKBy5i5O40W0mH0D99zxFen2WaqrKuTsH649bfsGfS1eoLfl-AmSxXXw9dXn_R6fwSAPp5zgdjbthr0iwfVH7vkBBpXnJxuB17_gPoP-s52UjySEzroAMbZl815H&s=kRm1ZWM5GnFwn3SRLsaMsMeLK2f86w-HWvCcVSi-hfvUvboFvYp-j7hoWr8BRZVxHiFlTCU1goGWClJKMzg-_hK8ctcNpYlf-zuBLggZPdhmWPs631LKG4zivLkVUNvBEbHFlGAPWssdFVUwrQDH-6_8AoHa4XMbEJX84ayuHrwuKPp-KTR0RMdl5wCZdbW89ODInLIm21cpWZ90inDiEZPQwgubSGRc7lAnPWhzS-F51j9E9t3XlG6TBMg9EIB__5NRogJ0ghm7oqY1k_ETk-S8tUy2iphWtIMu4e9nVUEk4w1GbrEx9NuekXnz83tlhKEG7ob-r9rmY10G8hV0gg&h=9ZhvKOTtVQDncaaXcOkjDNDgcHRcYrNHW9sxBNvSUQI
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","name":"448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","status":"InProgress","startTime":"2026-07-03T09:39:08.0488826"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '285'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:40:25 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=dbb7c858-7fe6-47e8-9b0e-aeae5587ef6a/westindia/5c4362b0-6645-4140-a2b6-26ef34a3a920
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 30D9087383144F9DB2884A4C869A5651 Ref B: PNQ231110906034 Ref C: 2026-07-03T09:40:24Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --logs-destination
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7?api-version=2025-10-02-preview&azureAsyncOperation=true&t=639186683495057394&c=MIIHlDCCBnygAwIBAgIQcyzofG45BJ3kcmojGUTNPTANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwOTAzNTYxNVoXDTI2MTAwNDA5NTYxNVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCylTdveId_fRZKb4c5-b6XRtq1MlgavUk9VSsvq-MKaNFseSyQ8yqTwT9OK0C_fsbruj5pXgS5NS8dKnBuhTD8eTuk8hAW2llcTIxVYp3wwJ5yFuq_HxoIz2l6AVXYGgsfGlZK94DOlk6A9562HvK17TWNc2ayOIo-mC9MmkCxZ_rXYVrMKIRg_isDORfT3kCxrzuBy6lE2eZ0X658RGu0gmFy_lQ6JVYwUw-cHa5DpkWyehsimxoADtZSa2P1J8nOuiW0EdXZHQ1tI2F7s-Lv2YmiEiafCFqoj36c1MDcox2dg6RjjYeO0yaFZ253xVVWE0NfxG0O8-tilXOIliudAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSJoobI6tkACyvCkJOPNhRxifdDjzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzEwL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8xMC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCsdBlY42g0q2nn0d8lpeH6ahq9WkMaeCf3qNTS_xUQ0gvNnEcqOXmZcwM26wmfAcEMpcilenOA_A6eqjBdjBqp2vpyFFS0nnkq9bDB4lvA9N6DIDwjW-tMamhtahcdVukmPJxLxNR2WRMoncYWVJ4Ibd626NUs9bKYjY_xjimNlidbPhEdfHhfe9sOzqNBDXdE0RhSANcHzI21dTSl8knc8FmpSKBy5i5O40W0mH0D99zxFen2WaqrKuTsH649bfsGfS1eoLfl-AmSxXXw9dXn_R6fwSAPp5zgdjbthr0iwfVH7vkBBpXnJxuB17_gPoP-s52UjySEzroAMbZl815H&s=kRm1ZWM5GnFwn3SRLsaMsMeLK2f86w-HWvCcVSi-hfvUvboFvYp-j7hoWr8BRZVxHiFlTCU1goGWClJKMzg-_hK8ctcNpYlf-zuBLggZPdhmWPs631LKG4zivLkVUNvBEbHFlGAPWssdFVUwrQDH-6_8AoHa4XMbEJX84ayuHrwuKPp-KTR0RMdl5wCZdbW89ODInLIm21cpWZ90inDiEZPQwgubSGRc7lAnPWhzS-F51j9E9t3XlG6TBMg9EIB__5NRogJ0ghm7oqY1k_ETk-S8tUy2iphWtIMu4e9nVUEk4w1GbrEx9NuekXnz83tlhKEG7ob-r9rmY10G8hV0gg&h=9ZhvKOTtVQDncaaXcOkjDNDgcHRcYrNHW9sxBNvSUQI
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","name":"448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","status":"InProgress","startTime":"2026-07-03T09:39:08.0488826"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '285'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:40:28 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=dbb7c858-7fe6-47e8-9b0e-aeae5587ef6a/westindia/45ed8f17-cc70-4279-b59b-8b38e161895d
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 5A3710A0AC8A48898E3DDEA7473D64E4 Ref B: PNQ231110909054 Ref C: 2026-07-03T09:40:28Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --logs-destination
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7?api-version=2025-10-02-preview&azureAsyncOperation=true&t=639186683495057394&c=MIIHlDCCBnygAwIBAgIQcyzofG45BJ3kcmojGUTNPTANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwOTAzNTYxNVoXDTI2MTAwNDA5NTYxNVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCylTdveId_fRZKb4c5-b6XRtq1MlgavUk9VSsvq-MKaNFseSyQ8yqTwT9OK0C_fsbruj5pXgS5NS8dKnBuhTD8eTuk8hAW2llcTIxVYp3wwJ5yFuq_HxoIz2l6AVXYGgsfGlZK94DOlk6A9562HvK17TWNc2ayOIo-mC9MmkCxZ_rXYVrMKIRg_isDORfT3kCxrzuBy6lE2eZ0X658RGu0gmFy_lQ6JVYwUw-cHa5DpkWyehsimxoADtZSa2P1J8nOuiW0EdXZHQ1tI2F7s-Lv2YmiEiafCFqoj36c1MDcox2dg6RjjYeO0yaFZ253xVVWE0NfxG0O8-tilXOIliudAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSJoobI6tkACyvCkJOPNhRxifdDjzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzEwL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8xMC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCsdBlY42g0q2nn0d8lpeH6ahq9WkMaeCf3qNTS_xUQ0gvNnEcqOXmZcwM26wmfAcEMpcilenOA_A6eqjBdjBqp2vpyFFS0nnkq9bDB4lvA9N6DIDwjW-tMamhtahcdVukmPJxLxNR2WRMoncYWVJ4Ibd626NUs9bKYjY_xjimNlidbPhEdfHhfe9sOzqNBDXdE0RhSANcHzI21dTSl8knc8FmpSKBy5i5O40W0mH0D99zxFen2WaqrKuTsH649bfsGfS1eoLfl-AmSxXXw9dXn_R6fwSAPp5zgdjbthr0iwfVH7vkBBpXnJxuB17_gPoP-s52UjySEzroAMbZl815H&s=kRm1ZWM5GnFwn3SRLsaMsMeLK2f86w-HWvCcVSi-hfvUvboFvYp-j7hoWr8BRZVxHiFlTCU1goGWClJKMzg-_hK8ctcNpYlf-zuBLggZPdhmWPs631LKG4zivLkVUNvBEbHFlGAPWssdFVUwrQDH-6_8AoHa4XMbEJX84ayuHrwuKPp-KTR0RMdl5wCZdbW89ODInLIm21cpWZ90inDiEZPQwgubSGRc7lAnPWhzS-F51j9E9t3XlG6TBMg9EIB__5NRogJ0ghm7oqY1k_ETk-S8tUy2iphWtIMu4e9nVUEk4w1GbrEx9NuekXnz83tlhKEG7ob-r9rmY10G8hV0gg&h=9ZhvKOTtVQDncaaXcOkjDNDgcHRcYrNHW9sxBNvSUQI
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","name":"448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","status":"InProgress","startTime":"2026-07-03T09:39:08.0488826"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '285'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:40:32 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=dbb7c858-7fe6-47e8-9b0e-aeae5587ef6a/centralindia/3364db9a-e9e5-4326-b680-a23d69c6e04d
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 16E217F34AF945F9BC487C11EF86A184 Ref B: PNQ231110908036 Ref C: 2026-07-03T09:40:31Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --logs-destination
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7?api-version=2025-10-02-preview&azureAsyncOperation=true&t=639186683495057394&c=MIIHlDCCBnygAwIBAgIQcyzofG45BJ3kcmojGUTNPTANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwOTAzNTYxNVoXDTI2MTAwNDA5NTYxNVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCylTdveId_fRZKb4c5-b6XRtq1MlgavUk9VSsvq-MKaNFseSyQ8yqTwT9OK0C_fsbruj5pXgS5NS8dKnBuhTD8eTuk8hAW2llcTIxVYp3wwJ5yFuq_HxoIz2l6AVXYGgsfGlZK94DOlk6A9562HvK17TWNc2ayOIo-mC9MmkCxZ_rXYVrMKIRg_isDORfT3kCxrzuBy6lE2eZ0X658RGu0gmFy_lQ6JVYwUw-cHa5DpkWyehsimxoADtZSa2P1J8nOuiW0EdXZHQ1tI2F7s-Lv2YmiEiafCFqoj36c1MDcox2dg6RjjYeO0yaFZ253xVVWE0NfxG0O8-tilXOIliudAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSJoobI6tkACyvCkJOPNhRxifdDjzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzEwL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8xMC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCsdBlY42g0q2nn0d8lpeH6ahq9WkMaeCf3qNTS_xUQ0gvNnEcqOXmZcwM26wmfAcEMpcilenOA_A6eqjBdjBqp2vpyFFS0nnkq9bDB4lvA9N6DIDwjW-tMamhtahcdVukmPJxLxNR2WRMoncYWVJ4Ibd626NUs9bKYjY_xjimNlidbPhEdfHhfe9sOzqNBDXdE0RhSANcHzI21dTSl8knc8FmpSKBy5i5O40W0mH0D99zxFen2WaqrKuTsH649bfsGfS1eoLfl-AmSxXXw9dXn_R6fwSAPp5zgdjbthr0iwfVH7vkBBpXnJxuB17_gPoP-s52UjySEzroAMbZl815H&s=kRm1ZWM5GnFwn3SRLsaMsMeLK2f86w-HWvCcVSi-hfvUvboFvYp-j7hoWr8BRZVxHiFlTCU1goGWClJKMzg-_hK8ctcNpYlf-zuBLggZPdhmWPs631LKG4zivLkVUNvBEbHFlGAPWssdFVUwrQDH-6_8AoHa4XMbEJX84ayuHrwuKPp-KTR0RMdl5wCZdbW89ODInLIm21cpWZ90inDiEZPQwgubSGRc7lAnPWhzS-F51j9E9t3XlG6TBMg9EIB__5NRogJ0ghm7oqY1k_ETk-S8tUy2iphWtIMu4e9nVUEk4w1GbrEx9NuekXnz83tlhKEG7ob-r9rmY10G8hV0gg&h=9ZhvKOTtVQDncaaXcOkjDNDgcHRcYrNHW9sxBNvSUQI
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","name":"448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","status":"InProgress","startTime":"2026-07-03T09:39:08.0488826"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '285'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:40:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=dbb7c858-7fe6-47e8-9b0e-aeae5587ef6a/centralindia/1766ef0d-d1c3-478f-b7d2-8ba86b9b27d4
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 65C73D1B95A8476099C619EDC4DA1A29 Ref B: PNQ231110909040 Ref C: 2026-07-03T09:40:35Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --logs-destination
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7?api-version=2025-10-02-preview&azureAsyncOperation=true&t=639186683495057394&c=MIIHlDCCBnygAwIBAgIQcyzofG45BJ3kcmojGUTNPTANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwOTAzNTYxNVoXDTI2MTAwNDA5NTYxNVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCylTdveId_fRZKb4c5-b6XRtq1MlgavUk9VSsvq-MKaNFseSyQ8yqTwT9OK0C_fsbruj5pXgS5NS8dKnBuhTD8eTuk8hAW2llcTIxVYp3wwJ5yFuq_HxoIz2l6AVXYGgsfGlZK94DOlk6A9562HvK17TWNc2ayOIo-mC9MmkCxZ_rXYVrMKIRg_isDORfT3kCxrzuBy6lE2eZ0X658RGu0gmFy_lQ6JVYwUw-cHa5DpkWyehsimxoADtZSa2P1J8nOuiW0EdXZHQ1tI2F7s-Lv2YmiEiafCFqoj36c1MDcox2dg6RjjYeO0yaFZ253xVVWE0NfxG0O8-tilXOIliudAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSJoobI6tkACyvCkJOPNhRxifdDjzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzEwL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8xMC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCsdBlY42g0q2nn0d8lpeH6ahq9WkMaeCf3qNTS_xUQ0gvNnEcqOXmZcwM26wmfAcEMpcilenOA_A6eqjBdjBqp2vpyFFS0nnkq9bDB4lvA9N6DIDwjW-tMamhtahcdVukmPJxLxNR2WRMoncYWVJ4Ibd626NUs9bKYjY_xjimNlidbPhEdfHhfe9sOzqNBDXdE0RhSANcHzI21dTSl8knc8FmpSKBy5i5O40W0mH0D99zxFen2WaqrKuTsH649bfsGfS1eoLfl-AmSxXXw9dXn_R6fwSAPp5zgdjbthr0iwfVH7vkBBpXnJxuB17_gPoP-s52UjySEzroAMbZl815H&s=kRm1ZWM5GnFwn3SRLsaMsMeLK2f86w-HWvCcVSi-hfvUvboFvYp-j7hoWr8BRZVxHiFlTCU1goGWClJKMzg-_hK8ctcNpYlf-zuBLggZPdhmWPs631LKG4zivLkVUNvBEbHFlGAPWssdFVUwrQDH-6_8AoHa4XMbEJX84ayuHrwuKPp-KTR0RMdl5wCZdbW89ODInLIm21cpWZ90inDiEZPQwgubSGRc7lAnPWhzS-F51j9E9t3XlG6TBMg9EIB__5NRogJ0ghm7oqY1k_ETk-S8tUy2iphWtIMu4e9nVUEk4w1GbrEx9NuekXnz83tlhKEG7ob-r9rmY10G8hV0gg&h=9ZhvKOTtVQDncaaXcOkjDNDgcHRcYrNHW9sxBNvSUQI
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","name":"448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","status":"InProgress","startTime":"2026-07-03T09:39:08.0488826"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '285'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:40:38 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=dbb7c858-7fe6-47e8-9b0e-aeae5587ef6a/centralindia/83639dc5-a7d5-4bc7-a251-2ea4fe5b92b7
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: CA7CDFE1FCDE4D019FC687605279E3E8 Ref B: PNQ231110907062 Ref C: 2026-07-03T09:40:38Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --logs-destination
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7?api-version=2025-10-02-preview&azureAsyncOperation=true&t=639186683495057394&c=MIIHlDCCBnygAwIBAgIQcyzofG45BJ3kcmojGUTNPTANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwOTAzNTYxNVoXDTI2MTAwNDA5NTYxNVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCylTdveId_fRZKb4c5-b6XRtq1MlgavUk9VSsvq-MKaNFseSyQ8yqTwT9OK0C_fsbruj5pXgS5NS8dKnBuhTD8eTuk8hAW2llcTIxVYp3wwJ5yFuq_HxoIz2l6AVXYGgsfGlZK94DOlk6A9562HvK17TWNc2ayOIo-mC9MmkCxZ_rXYVrMKIRg_isDORfT3kCxrzuBy6lE2eZ0X658RGu0gmFy_lQ6JVYwUw-cHa5DpkWyehsimxoADtZSa2P1J8nOuiW0EdXZHQ1tI2F7s-Lv2YmiEiafCFqoj36c1MDcox2dg6RjjYeO0yaFZ253xVVWE0NfxG0O8-tilXOIliudAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSJoobI6tkACyvCkJOPNhRxifdDjzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzEwL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8xMC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCsdBlY42g0q2nn0d8lpeH6ahq9WkMaeCf3qNTS_xUQ0gvNnEcqOXmZcwM26wmfAcEMpcilenOA_A6eqjBdjBqp2vpyFFS0nnkq9bDB4lvA9N6DIDwjW-tMamhtahcdVukmPJxLxNR2WRMoncYWVJ4Ibd626NUs9bKYjY_xjimNlidbPhEdfHhfe9sOzqNBDXdE0RhSANcHzI21dTSl8knc8FmpSKBy5i5O40W0mH0D99zxFen2WaqrKuTsH649bfsGfS1eoLfl-AmSxXXw9dXn_R6fwSAPp5zgdjbthr0iwfVH7vkBBpXnJxuB17_gPoP-s52UjySEzroAMbZl815H&s=kRm1ZWM5GnFwn3SRLsaMsMeLK2f86w-HWvCcVSi-hfvUvboFvYp-j7hoWr8BRZVxHiFlTCU1goGWClJKMzg-_hK8ctcNpYlf-zuBLggZPdhmWPs631LKG4zivLkVUNvBEbHFlGAPWssdFVUwrQDH-6_8AoHa4XMbEJX84ayuHrwuKPp-KTR0RMdl5wCZdbW89ODInLIm21cpWZ90inDiEZPQwgubSGRc7lAnPWhzS-F51j9E9t3XlG6TBMg9EIB__5NRogJ0ghm7oqY1k_ETk-S8tUy2iphWtIMu4e9nVUEk4w1GbrEx9NuekXnz83tlhKEG7ob-r9rmY10G8hV0gg&h=9ZhvKOTtVQDncaaXcOkjDNDgcHRcYrNHW9sxBNvSUQI
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","name":"448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","status":"InProgress","startTime":"2026-07-03T09:39:08.0488826"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '285'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:40:42 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=dbb7c858-7fe6-47e8-9b0e-aeae5587ef6a/southindia/06ae2511-9807-4c44-b2c3-9eaea4603ed5
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 74D39E1451AF49F2A6B9EB44E06B07CC Ref B: PNQ231110908029 Ref C: 2026-07-03T09:40:41Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --logs-destination
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7?api-version=2025-10-02-preview&azureAsyncOperation=true&t=639186683495057394&c=MIIHlDCCBnygAwIBAgIQcyzofG45BJ3kcmojGUTNPTANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwOTAzNTYxNVoXDTI2MTAwNDA5NTYxNVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCylTdveId_fRZKb4c5-b6XRtq1MlgavUk9VSsvq-MKaNFseSyQ8yqTwT9OK0C_fsbruj5pXgS5NS8dKnBuhTD8eTuk8hAW2llcTIxVYp3wwJ5yFuq_HxoIz2l6AVXYGgsfGlZK94DOlk6A9562HvK17TWNc2ayOIo-mC9MmkCxZ_rXYVrMKIRg_isDORfT3kCxrzuBy6lE2eZ0X658RGu0gmFy_lQ6JVYwUw-cHa5DpkWyehsimxoADtZSa2P1J8nOuiW0EdXZHQ1tI2F7s-Lv2YmiEiafCFqoj36c1MDcox2dg6RjjYeO0yaFZ253xVVWE0NfxG0O8-tilXOIliudAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSJoobI6tkACyvCkJOPNhRxifdDjzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzEwL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8xMC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCsdBlY42g0q2nn0d8lpeH6ahq9WkMaeCf3qNTS_xUQ0gvNnEcqOXmZcwM26wmfAcEMpcilenOA_A6eqjBdjBqp2vpyFFS0nnkq9bDB4lvA9N6DIDwjW-tMamhtahcdVukmPJxLxNR2WRMoncYWVJ4Ibd626NUs9bKYjY_xjimNlidbPhEdfHhfe9sOzqNBDXdE0RhSANcHzI21dTSl8knc8FmpSKBy5i5O40W0mH0D99zxFen2WaqrKuTsH649bfsGfS1eoLfl-AmSxXXw9dXn_R6fwSAPp5zgdjbthr0iwfVH7vkBBpXnJxuB17_gPoP-s52UjySEzroAMbZl815H&s=kRm1ZWM5GnFwn3SRLsaMsMeLK2f86w-HWvCcVSi-hfvUvboFvYp-j7hoWr8BRZVxHiFlTCU1goGWClJKMzg-_hK8ctcNpYlf-zuBLggZPdhmWPs631LKG4zivLkVUNvBEbHFlGAPWssdFVUwrQDH-6_8AoHa4XMbEJX84ayuHrwuKPp-KTR0RMdl5wCZdbW89ODInLIm21cpWZ90inDiEZPQwgubSGRc7lAnPWhzS-F51j9E9t3XlG6TBMg9EIB__5NRogJ0ghm7oqY1k_ETk-S8tUy2iphWtIMu4e9nVUEk4w1GbrEx9NuekXnz83tlhKEG7ob-r9rmY10G8hV0gg&h=9ZhvKOTtVQDncaaXcOkjDNDgcHRcYrNHW9sxBNvSUQI
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","name":"448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","status":"InProgress","startTime":"2026-07-03T09:39:08.0488826"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '285'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:40:46 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=dbb7c858-7fe6-47e8-9b0e-aeae5587ef6a/centralindia/5a0fe126-4075-41ce-acd0-6d4da6869c8d
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: FB44A90EFBC54EFDA936BBDB0910EC67 Ref B: PNQ231110906040 Ref C: 2026-07-03T09:40:45Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --logs-destination
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7?api-version=2025-10-02-preview&azureAsyncOperation=true&t=639186683495057394&c=MIIHlDCCBnygAwIBAgIQcyzofG45BJ3kcmojGUTNPTANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwOTAzNTYxNVoXDTI2MTAwNDA5NTYxNVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCylTdveId_fRZKb4c5-b6XRtq1MlgavUk9VSsvq-MKaNFseSyQ8yqTwT9OK0C_fsbruj5pXgS5NS8dKnBuhTD8eTuk8hAW2llcTIxVYp3wwJ5yFuq_HxoIz2l6AVXYGgsfGlZK94DOlk6A9562HvK17TWNc2ayOIo-mC9MmkCxZ_rXYVrMKIRg_isDORfT3kCxrzuBy6lE2eZ0X658RGu0gmFy_lQ6JVYwUw-cHa5DpkWyehsimxoADtZSa2P1J8nOuiW0EdXZHQ1tI2F7s-Lv2YmiEiafCFqoj36c1MDcox2dg6RjjYeO0yaFZ253xVVWE0NfxG0O8-tilXOIliudAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSJoobI6tkACyvCkJOPNhRxifdDjzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzEwL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8xMC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCsdBlY42g0q2nn0d8lpeH6ahq9WkMaeCf3qNTS_xUQ0gvNnEcqOXmZcwM26wmfAcEMpcilenOA_A6eqjBdjBqp2vpyFFS0nnkq9bDB4lvA9N6DIDwjW-tMamhtahcdVukmPJxLxNR2WRMoncYWVJ4Ibd626NUs9bKYjY_xjimNlidbPhEdfHhfe9sOzqNBDXdE0RhSANcHzI21dTSl8knc8FmpSKBy5i5O40W0mH0D99zxFen2WaqrKuTsH649bfsGfS1eoLfl-AmSxXXw9dXn_R6fwSAPp5zgdjbthr0iwfVH7vkBBpXnJxuB17_gPoP-s52UjySEzroAMbZl815H&s=kRm1ZWM5GnFwn3SRLsaMsMeLK2f86w-HWvCcVSi-hfvUvboFvYp-j7hoWr8BRZVxHiFlTCU1goGWClJKMzg-_hK8ctcNpYlf-zuBLggZPdhmWPs631LKG4zivLkVUNvBEbHFlGAPWssdFVUwrQDH-6_8AoHa4XMbEJX84ayuHrwuKPp-KTR0RMdl5wCZdbW89ODInLIm21cpWZ90inDiEZPQwgubSGRc7lAnPWhzS-F51j9E9t3XlG6TBMg9EIB__5NRogJ0ghm7oqY1k_ETk-S8tUy2iphWtIMu4e9nVUEk4w1GbrEx9NuekXnz83tlhKEG7ob-r9rmY10G8hV0gg&h=9ZhvKOTtVQDncaaXcOkjDNDgcHRcYrNHW9sxBNvSUQI
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","name":"448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","status":"InProgress","startTime":"2026-07-03T09:39:08.0488826"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '285'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:40:49 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=dbb7c858-7fe6-47e8-9b0e-aeae5587ef6a/centralindia/51e224e8-d7ff-46f6-9e10-75717eb38c77
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: CBC07FBF930043F3898089D47F162091 Ref B: PNQ231110909040 Ref C: 2026-07-03T09:40:49Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --logs-destination
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7?api-version=2025-10-02-preview&azureAsyncOperation=true&t=639186683495057394&c=MIIHlDCCBnygAwIBAgIQcyzofG45BJ3kcmojGUTNPTANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwOTAzNTYxNVoXDTI2MTAwNDA5NTYxNVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCylTdveId_fRZKb4c5-b6XRtq1MlgavUk9VSsvq-MKaNFseSyQ8yqTwT9OK0C_fsbruj5pXgS5NS8dKnBuhTD8eTuk8hAW2llcTIxVYp3wwJ5yFuq_HxoIz2l6AVXYGgsfGlZK94DOlk6A9562HvK17TWNc2ayOIo-mC9MmkCxZ_rXYVrMKIRg_isDORfT3kCxrzuBy6lE2eZ0X658RGu0gmFy_lQ6JVYwUw-cHa5DpkWyehsimxoADtZSa2P1J8nOuiW0EdXZHQ1tI2F7s-Lv2YmiEiafCFqoj36c1MDcox2dg6RjjYeO0yaFZ253xVVWE0NfxG0O8-tilXOIliudAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSJoobI6tkACyvCkJOPNhRxifdDjzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzEwL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8xMC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCsdBlY42g0q2nn0d8lpeH6ahq9WkMaeCf3qNTS_xUQ0gvNnEcqOXmZcwM26wmfAcEMpcilenOA_A6eqjBdjBqp2vpyFFS0nnkq9bDB4lvA9N6DIDwjW-tMamhtahcdVukmPJxLxNR2WRMoncYWVJ4Ibd626NUs9bKYjY_xjimNlidbPhEdfHhfe9sOzqNBDXdE0RhSANcHzI21dTSl8knc8FmpSKBy5i5O40W0mH0D99zxFen2WaqrKuTsH649bfsGfS1eoLfl-AmSxXXw9dXn_R6fwSAPp5zgdjbthr0iwfVH7vkBBpXnJxuB17_gPoP-s52UjySEzroAMbZl815H&s=kRm1ZWM5GnFwn3SRLsaMsMeLK2f86w-HWvCcVSi-hfvUvboFvYp-j7hoWr8BRZVxHiFlTCU1goGWClJKMzg-_hK8ctcNpYlf-zuBLggZPdhmWPs631LKG4zivLkVUNvBEbHFlGAPWssdFVUwrQDH-6_8AoHa4XMbEJX84ayuHrwuKPp-KTR0RMdl5wCZdbW89ODInLIm21cpWZ90inDiEZPQwgubSGRc7lAnPWhzS-F51j9E9t3XlG6TBMg9EIB__5NRogJ0ghm7oqY1k_ETk-S8tUy2iphWtIMu4e9nVUEk4w1GbrEx9NuekXnz83tlhKEG7ob-r9rmY10G8hV0gg&h=9ZhvKOTtVQDncaaXcOkjDNDgcHRcYrNHW9sxBNvSUQI
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","name":"448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","status":"InProgress","startTime":"2026-07-03T09:39:08.0488826"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '285'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:40:53 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=dbb7c858-7fe6-47e8-9b0e-aeae5587ef6a/jioindiawest/1cb94a00-fff4-46e5-9f0d-26deada2ab45
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 39835021A7FE4E7499F415F5372822C5 Ref B: PNQ231110908031 Ref C: 2026-07-03T09:40:52Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --logs-destination
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7?api-version=2025-10-02-preview&azureAsyncOperation=true&t=639186683495057394&c=MIIHlDCCBnygAwIBAgIQcyzofG45BJ3kcmojGUTNPTANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXVVMyIENBIDAxMB4XDTI2MDQwOTAzNTYxNVoXDTI2MTAwNDA5NTYxNVowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCylTdveId_fRZKb4c5-b6XRtq1MlgavUk9VSsvq-MKaNFseSyQ8yqTwT9OK0C_fsbruj5pXgS5NS8dKnBuhTD8eTuk8hAW2llcTIxVYp3wwJ5yFuq_HxoIz2l6AVXYGgsfGlZK94DOlk6A9562HvK17TWNc2ayOIo-mC9MmkCxZ_rXYVrMKIRg_isDORfT3kCxrzuBy6lE2eZ0X658RGu0gmFy_lQ6JVYwUw-cHa5DpkWyehsimxoADtZSa2P1J8nOuiW0EdXZHQ1tI2F7s-Lv2YmiEiafCFqoj36c1MDcox2dg6RjjYeO0yaFZ253xVVWE0NfxG0O8-tilXOIliudAgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBSJoobI6tkACyvCkJOPNhRxifdDjzAfBgNVHSMEGDAWgBSs43L6A7Jznj2VyO-HW67dG6HtaDCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3R1czIvY3Jscy9jY21ld2VzdHVzMnBraS9jY21ld2VzdHVzMmljYTAxLzEwL2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdHVzMi9jcmxzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvMTAvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21ld2VzdHVzMnBraS53ZXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZXdlc3R1czJpY2EwMS8xMC9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdHVzMi9jYWNlcnRzL2NjbWV3ZXN0dXMycGtpL2NjbWV3ZXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS93ZXN0dXMyL2NhY2VydHMvY2NtZXdlc3R1czJwa2kvY2NtZXdlc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWV3ZXN0dXMycGtpLndlc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21ld2VzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCsdBlY42g0q2nn0d8lpeH6ahq9WkMaeCf3qNTS_xUQ0gvNnEcqOXmZcwM26wmfAcEMpcilenOA_A6eqjBdjBqp2vpyFFS0nnkq9bDB4lvA9N6DIDwjW-tMamhtahcdVukmPJxLxNR2WRMoncYWVJ4Ibd626NUs9bKYjY_xjimNlidbPhEdfHhfe9sOzqNBDXdE0RhSANcHzI21dTSl8knc8FmpSKBy5i5O40W0mH0D99zxFen2WaqrKuTsH649bfsGfS1eoLfl-AmSxXXw9dXn_R6fwSAPp5zgdjbthr0iwfVH7vkBBpXnJxuB17_gPoP-s52UjySEzroAMbZl815H&s=kRm1ZWM5GnFwn3SRLsaMsMeLK2f86w-HWvCcVSi-hfvUvboFvYp-j7hoWr8BRZVxHiFlTCU1goGWClJKMzg-_hK8ctcNpYlf-zuBLggZPdhmWPs631LKG4zivLkVUNvBEbHFlGAPWssdFVUwrQDH-6_8AoHa4XMbEJX84ayuHrwuKPp-KTR0RMdl5wCZdbW89ODInLIm21cpWZ90inDiEZPQwgubSGRc7lAnPWhzS-F51j9E9t3XlG6TBMg9EIB__5NRogJ0ghm7oqY1k_ETk-S8tUy2iphWtIMu4e9nVUEk4w1GbrEx9NuekXnz83tlhKEG7ob-r9rmY10G8hV0gg&h=9ZhvKOTtVQDncaaXcOkjDNDgcHRcYrNHW9sxBNvSUQI
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/managedEnvironmentOperationStatuses/448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","name":"448de6e5-d7c0-46f1-993d-7b3abc8d0fc7","status":"Succeeded","startTime":"2026-07-03T09:39:08.0488826"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '284'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:40:57 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=dbb7c858-7fe6-47e8-9b0e-aeae5587ef6a/centralindia/10f5b51e-57b3-47bc-a7aa-714c4b0ab955
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 5ECE3EF68DFB4C1391CEA2F94CBA4E68 Ref B: PNQ231110907025 Ref C: 2026-07-03T09:40:56Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --logs-destination
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/client.env_rg_eastus2/providers/Microsoft.App/managedEnvironments/env-eastus2?api-version=2025-10-02-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/client.env_rg_eastus2/providers/Microsoft.App/managedEnvironments/env-eastus2","name":"env-eastus2","type":"Microsoft.App/managedEnvironments","location":"East
+        US 2","systemData":{"createdBy":"test@example.com","createdByType":"User","createdAt":"2026-07-03T09:39:06.5523215","lastModifiedBy":"test@example.com","lastModifiedByType":"User","lastModifiedAt":"2026-07-03T09:39:06.5523215"},"properties":{"environmentMode":"WorkloadProfiles","provisioningState":"Succeeded","daprAIInstrumentationKey":null,"daprAIConnectionString":null,"vnetConfiguration":null,"defaultDomain":"agreeableglacier-f19611d0.eastus2.azurecontainerapps.io","staticIp":"20.22.167.102","appLogsConfiguration":{"destination":null,"logAnalyticsConfiguration":null},"openTelemetryConfiguration":null,"zoneRedundant":false,"availabilityZones":null,"kedaConfiguration":{"version":"2.18.1"},"daprConfiguration":{"version":"1.16.4-msft.9"},"ingressConfiguration":null,"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/client.env_rg_eastus2/managedEnvironments/env-eastus2/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6C8AEA45371636CA70C78CCAB1A4B36CB1FEC824B6F1F0ECDB89BE23575F6907","dnsSuffix":null,"certificateKeyVaultProperties":null,"certificateValue":null,"certificatePassword":null,"thumbprint":null,"subjectName":null,"expirationDate":null},"workloadProfiles":[{"workloadProfileType":"Consumption","name":"Consumption","enableFips":false}],"appInsightsConfiguration":null,"infrastructureResourceGroup":null,"peerAuthentication":{"mtls":{"enabled":false}},"peerTrafficConfiguration":{"encryption":{"enabled":false}},"publicNetworkAccess":"Enabled","diskEncryptionConfiguration":null}}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '1835'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:40:58 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: ECED575C0CDB4CC298618669FFFB8E74 Ref B: PNQ231110908042 Ref C: 2026-07-03T09:40:58Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App?api-version=2024-11-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App","namespace":"Microsoft.App","authorizations":[{"applicationId":"59f0a04a-b322-4310-adc9-39ac41e9631e","roleDefinitionId":"be29d5e9-f2ee-4c50-bf95-71cec72c205f"},{"applicationId":"7e3bc4fd-85a3-4192-b177-5b8bfc87f42c","roleDefinitionId":"39a74f72-b40f-4bdc-b639-562fe2260bf0"},{"applicationId":"3734c1a4-2bed-4998-a37a-ff1a9e7bf019","roleDefinitionId":"5c779a4f-5cb2-4547-8c41-478d9be8ba90"},{"applicationId":"55ebbb62-3b9c-49fd-9b87-9595226dd4ac","roleDefinitionId":"e49ca620-7992-4561-a7df-4ed67dad77b5","managedByRoleDefinitionId":"9e3af657-a8ff-583c-a75c-2fe7c4bcb635"},{"applicationId":"1459b1f6-7a5b-4300-93a2-44b4a651759f","roleDefinitionId":"3c5f1b29-9e3d-4a22-b5d6-9ff4e5a37974"},{"applicationId":"2c7dd73f-7a21-485b-b97d-a2508fa152c3","roleDefinitionId":"8a9982ae-66df-4135-b8da-2655633c4a4c"},{"applicationId":"6104ad52-755e-428b-9fb5-5fdf4d2c4d53","roleDefinitionId":"472cfb56-379d-4465-84ff-17404641b16c"},{"applicationId":"409eb69a-5e20-4e1e-a8bf-c23300057950","roleDefinitionId":"e211c432-0a34-4b73-9303-2a489c814a1d"}],"resourceTypes":[{"resourceType":"managedEnvironments","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"managedEnvironments/certificates","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/managedCertificates","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"containerApps","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"containerApps/privateEndpointConnectionProxies","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"containerApps/resiliencyPolicies","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"managedEnvironments/privateEndpointConnectionProxies","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"sessionPools","locations":["North
+        Central US (Stage)","West US 2","North Europe","East US","East Asia","North
+        Central US","Germany West Central","Poland Central","Italy North","Switzerland
+        North","Sweden Central","Norway East","Japan East","Australia East","West
+        Central US","East US 2","West US","Brazil South","Canada East","France Central","Korea
+        Central","South Africa North","South Central US","South India","UAE North","UK
+        South","West Europe","West US 3","Canada Central","Central US","Japan West","Southeast
+        Asia","Spain Central","UK West","Australia Southeast","Central India","Jio
+        India West","France South","Malaysia West","Indonesia Central"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"jobs","locations":["North Central US (Stage)","West
+        US 2","Southeast Asia","Sweden Central","Canada Central","West Europe","North
+        Europe","East US","East US 2","East Asia","Australia East","Germany West Central","Japan
+        East","UK South","West US","Central US","North Central US","South Central
+        US","Korea Central","Brazil South","West US 3","France Central","South Africa
+        North","Norway East","Switzerland North","UAE North","Canada East","West Central
+        US","UK West","Central India","Japan West","Australia Southeast","France South","Jio
+        India West","Spain Central","Italy North","Poland Central","Malaysia West","Indonesia
+        Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/containerappOperationResults","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/containerappOperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/containerappsjobOperationResults","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/containerappsjobOperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/sourceControlOperationResults","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/sourceControlOperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/usages","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"operations","locations":["East
+        Asia","North Central US","West Europe"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2023-02-01","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"connectedEnvironments","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectedEnvironments/certificates","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/connectedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/managedCertificateOperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/billingMeters","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/availableManagedEnvironmentsWorkloadProfileTypes","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"getCustomDomainVerificationId","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Italy North","Poland Central","South
+        India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"builders","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"builders/builds","locations":["North Central
+        US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada Central","West
+        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
+        West Central","Japan East","UK South","West US","Central US","North Central
+        US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"builders/patches","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/OperationResults","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/OperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"managedEnvironments/dotNetComponents","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"managedEnvironments/javaComponents","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"managedEnvironments/daprComponents","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"managedEnvironments/daprComponents/resiliencyPolicies","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"functions","locations":["North
+        Central US (Stage)","West Central US","West US 2","Southeast Asia","Sweden
+        Central","Canada Central","West Europe","North Europe","East US","East US
+        2","East Asia","Australia East","Germany West Central","Japan East","UK South","West
+        US","Central US","North Central US","South Central US","Korea Central","Brazil
+        South","West US 3","France Central","South Africa North","Norway East","Switzerland
+        North","UAE North","Canada East","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"SupportsExtension"},{"resourceType":"logicApps","locations":["North
+        Central US (Stage)","West Europe","East US","East Asia","North Central US","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"SupportsExtension"},{"resourceType":"locations/connectedOperationResults","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview"],"capabilities":"None"},{"resourceType":"locations/connectedOperationStatuses","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview"],"capabilities":"None"},{"resourceType":"agents","locations":["Sweden
+        Central","UK South","East US 2","Australia East","France Central","Canada
+        Central","Korea Central"],"apiVersions":["2026-01-01","2025-05-01-preview"],"defaultApiVersion":"2025-05-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"agentSpaces","locations":["Sweden Central","UK
+        South","East US 2","Australia East","France Central","Canada Central","Korea
+        Central"],"apiVersions":["2026-01-01","2025-05-01-preview"],"defaultApiVersion":"2025-05-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"locations/sreAgentOperationResults","locations":["Sweden
+        Central","UK South","East US 2","Australia East","France Central","Canada
+        Central","Korea Central"],"apiVersions":["2026-01-01","2025-10-02-preview","2025-05-01-preview"],"defaultApiVersion":"2025-05-01-preview","capabilities":"None"},{"resourceType":"locations/sreAgentOperationStatuses","locations":["Sweden
+        Central","UK South","East US 2","Australia East","France Central","Canada
+        Central","Korea Central"],"apiVersions":["2026-01-01","2025-10-02-preview","2025-05-01-preview"],"defaultApiVersion":"2025-05-01-preview","capabilities":"None"},{"resourceType":"locations/supportedAgentModels","locations":["Sweden
+        Central","UK South","East US 2","Australia East","France Central","Canada
+        Central","Korea Central"],"apiVersions":["2026-01-01","2025-05-01-preview"],"defaultApiVersion":"2025-05-01-preview","capabilities":"None"},{"resourceType":"sandboxGroups","locations":["North
+        Central US (Stage)","Sweden Central","East Asia","Australia East","North Europe","UK
+        South","Canada Central","Canada East","Mexico Central","North Central US","West
+        Central US","Central US","West US 2","Brazil South","France Central","Germany
+        West Central","Japan East","Japan West","Korea Central","Norway East","Poland
+        Central","South Africa North","Southeast Asia","South India","Spain Central","Switzerland
+        North","West US 3","West US","East US 2"],"apiVersions":["2026-02-01-preview"],"defaultApiVersion":"2026-02-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"sandboxGroups/vnetConnections","locations":["North
+        Central US (Stage)","Sweden Central","East Asia","Australia East","North Europe","UK
+        South","Canada Central","Canada East","Mexico Central","North Central US","West
+        Central US","Central US","West US 2","Brazil South","France Central","Germany
+        West Central","Japan East","Japan West","Korea Central","Norway East","Poland
+        Central","South Africa North","Southeast Asia","South India","Spain Central","Switzerland
+        North","West US 3","West US","East US 2"],"apiVersions":["2026-02-01-preview"],"defaultApiVersion":"2026-02-01-preview","capabilities":"None"},{"resourceType":"sandboxes","locations":["North
+        Central US (Stage)","Canada Central","Central US EUAP"],"apiVersions":["2026-02-01-preview"],"defaultApiVersion":"2026-02-01-preview","capabilities":"SystemAssignedResourceIdentity"},{"resourceType":"artifacts","locations":["North
+        Central US (Stage)","Central US EUAP","East US 2 EUAP","Sweden Central","East
+        Asia","Australia East","North Europe","UK South","Canada Central","Canada
+        East","Mexico Central","North Central US","West Central US","Central US","West
+        US 2","Brazil South","France Central","Germany West Central","Japan East","Japan
+        West","Korea Central","Norway East","Poland Central","South Africa North","Southeast
+        Asia","South India","Spain Central","Switzerland North","West US 3","West
+        US","East US 2"],"apiVersions":["2026-02-01-preview"],"defaultApiVersion":"2026-02-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"artifactApps","locations":["North Central
+        US (Stage)","Central US EUAP","East US 2 EUAP","Sweden Central","East Asia","Australia
+        East","North Europe","UK South","Canada Central","Canada East","Mexico Central","North
+        Central US","West Central US","Central US","West US 2","Brazil South","France
+        Central","Germany West Central","Japan East","Japan West","Korea Central","Norway
+        East","Poland Central","South Africa North","Southeast Asia","South India","Spain
+        Central","Switzerland North","West US 3","West US","East US 2"],"apiVersions":["2026-02-01-preview"],"defaultApiVersion":"2026-02-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '44592'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:40:59 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 3D8927DDD2DB4C2BAE7D7CC24171A72C Ref B: PNQ231110906036 Ref C: 2026-07-03T09:40:59Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/client.env_rg_eastus2/providers/Microsoft.App/managedEnvironments/env-eastus2?api-version=2025-10-02-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/client.env_rg_eastus2/providers/Microsoft.App/managedEnvironments/env-eastus2","name":"env-eastus2","type":"Microsoft.App/managedEnvironments","location":"East
+        US 2","systemData":{"createdBy":"test@example.com","createdByType":"User","createdAt":"2026-07-03T09:39:06.5523215","lastModifiedBy":"test@example.com","lastModifiedByType":"User","lastModifiedAt":"2026-07-03T09:39:06.5523215"},"properties":{"environmentMode":"WorkloadProfiles","provisioningState":"Succeeded","daprAIInstrumentationKey":null,"daprAIConnectionString":null,"vnetConfiguration":null,"defaultDomain":"agreeableglacier-f19611d0.eastus2.azurecontainerapps.io","staticIp":"20.22.167.102","appLogsConfiguration":{"destination":null,"logAnalyticsConfiguration":null},"openTelemetryConfiguration":null,"zoneRedundant":false,"availabilityZones":null,"kedaConfiguration":{"version":"2.18.1"},"daprConfiguration":{"version":"1.16.4-msft.9"},"ingressConfiguration":null,"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/client.env_rg_eastus2/managedEnvironments/env-eastus2/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6C8AEA45371636CA70C78CCAB1A4B36CB1FEC824B6F1F0ECDB89BE23575F6907","dnsSuffix":null,"certificateKeyVaultProperties":null,"certificateValue":null,"certificatePassword":null,"thumbprint":null,"subjectName":null,"expirationDate":null},"workloadProfiles":[{"workloadProfileType":"Consumption","name":"Consumption","enableFips":false}],"appInsightsConfiguration":null,"infrastructureResourceGroup":null,"peerAuthentication":{"mtls":{"enabled":false}},"peerTrafficConfiguration":{"encryption":{"enabled":false}},"publicNetworkAccess":"Enabled","diskEncryptionConfiguration":null}}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '1835'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:41:00 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 170DA2E5F7A8482E86435D738F12C3F8 Ref B: PNQ231110909052 Ref C: 2026-07-03T09:41:00Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --environment --kind
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App?api-version=2024-11-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App","namespace":"Microsoft.App","authorizations":[{"applicationId":"59f0a04a-b322-4310-adc9-39ac41e9631e","roleDefinitionId":"be29d5e9-f2ee-4c50-bf95-71cec72c205f"},{"applicationId":"7e3bc4fd-85a3-4192-b177-5b8bfc87f42c","roleDefinitionId":"39a74f72-b40f-4bdc-b639-562fe2260bf0"},{"applicationId":"3734c1a4-2bed-4998-a37a-ff1a9e7bf019","roleDefinitionId":"5c779a4f-5cb2-4547-8c41-478d9be8ba90"},{"applicationId":"55ebbb62-3b9c-49fd-9b87-9595226dd4ac","roleDefinitionId":"e49ca620-7992-4561-a7df-4ed67dad77b5","managedByRoleDefinitionId":"9e3af657-a8ff-583c-a75c-2fe7c4bcb635"},{"applicationId":"1459b1f6-7a5b-4300-93a2-44b4a651759f","roleDefinitionId":"3c5f1b29-9e3d-4a22-b5d6-9ff4e5a37974"},{"applicationId":"2c7dd73f-7a21-485b-b97d-a2508fa152c3","roleDefinitionId":"8a9982ae-66df-4135-b8da-2655633c4a4c"},{"applicationId":"6104ad52-755e-428b-9fb5-5fdf4d2c4d53","roleDefinitionId":"472cfb56-379d-4465-84ff-17404641b16c"},{"applicationId":"409eb69a-5e20-4e1e-a8bf-c23300057950","roleDefinitionId":"e211c432-0a34-4b73-9303-2a489c814a1d"}],"resourceTypes":[{"resourceType":"managedEnvironments","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"managedEnvironments/certificates","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/managedCertificates","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"containerApps","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"containerApps/privateEndpointConnectionProxies","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"containerApps/resiliencyPolicies","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"managedEnvironments/privateEndpointConnectionProxies","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"sessionPools","locations":["North
+        Central US (Stage)","West US 2","North Europe","East US","East Asia","North
+        Central US","Germany West Central","Poland Central","Italy North","Switzerland
+        North","Sweden Central","Norway East","Japan East","Australia East","West
+        Central US","East US 2","West US","Brazil South","Canada East","France Central","Korea
+        Central","South Africa North","South Central US","South India","UAE North","UK
+        South","West Europe","West US 3","Canada Central","Central US","Japan West","Southeast
+        Asia","Spain Central","UK West","Australia Southeast","Central India","Jio
+        India West","France South","Malaysia West","Indonesia Central"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"jobs","locations":["North Central US (Stage)","West
+        US 2","Southeast Asia","Sweden Central","Canada Central","West Europe","North
+        Europe","East US","East US 2","East Asia","Australia East","Germany West Central","Japan
+        East","UK South","West US","Central US","North Central US","South Central
+        US","Korea Central","Brazil South","West US 3","France Central","South Africa
+        North","Norway East","Switzerland North","UAE North","Canada East","West Central
+        US","UK West","Central India","Japan West","Australia Southeast","France South","Jio
+        India West","Spain Central","Italy North","Poland Central","Malaysia West","Indonesia
+        Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/containerappOperationResults","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/containerappOperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/containerappsjobOperationResults","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/containerappsjobOperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/sourceControlOperationResults","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/sourceControlOperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/usages","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"operations","locations":["East
+        Asia","North Central US","West Europe"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2023-02-01","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"connectedEnvironments","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectedEnvironments/certificates","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/connectedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/managedCertificateOperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/billingMeters","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/availableManagedEnvironmentsWorkloadProfileTypes","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"getCustomDomainVerificationId","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Italy North","Poland Central","South
+        India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"builders","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"builders/builds","locations":["North Central
+        US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada Central","West
+        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
+        West Central","Japan East","UK South","West US","Central US","North Central
+        US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"builders/patches","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/OperationResults","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/OperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"managedEnvironments/dotNetComponents","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"managedEnvironments/javaComponents","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"managedEnvironments/daprComponents","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"managedEnvironments/daprComponents/resiliencyPolicies","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"functions","locations":["North
+        Central US (Stage)","West Central US","West US 2","Southeast Asia","Sweden
+        Central","Canada Central","West Europe","North Europe","East US","East US
+        2","East Asia","Australia East","Germany West Central","Japan East","UK South","West
+        US","Central US","North Central US","South Central US","Korea Central","Brazil
+        South","West US 3","France Central","South Africa North","Norway East","Switzerland
+        North","UAE North","Canada East","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"SupportsExtension"},{"resourceType":"logicApps","locations":["North
+        Central US (Stage)","West Europe","East US","East Asia","North Central US","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"SupportsExtension"},{"resourceType":"locations/connectedOperationResults","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview"],"capabilities":"None"},{"resourceType":"locations/connectedOperationStatuses","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview"],"capabilities":"None"},{"resourceType":"agents","locations":["Sweden
+        Central","UK South","East US 2","Australia East","France Central","Canada
+        Central","Korea Central"],"apiVersions":["2026-01-01","2025-05-01-preview"],"defaultApiVersion":"2025-05-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"agentSpaces","locations":["Sweden Central","UK
+        South","East US 2","Australia East","France Central","Canada Central","Korea
+        Central"],"apiVersions":["2026-01-01","2025-05-01-preview"],"defaultApiVersion":"2025-05-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"locations/sreAgentOperationResults","locations":["Sweden
+        Central","UK South","East US 2","Australia East","France Central","Canada
+        Central","Korea Central"],"apiVersions":["2026-01-01","2025-10-02-preview","2025-05-01-preview"],"defaultApiVersion":"2025-05-01-preview","capabilities":"None"},{"resourceType":"locations/sreAgentOperationStatuses","locations":["Sweden
+        Central","UK South","East US 2","Australia East","France Central","Canada
+        Central","Korea Central"],"apiVersions":["2026-01-01","2025-10-02-preview","2025-05-01-preview"],"defaultApiVersion":"2025-05-01-preview","capabilities":"None"},{"resourceType":"locations/supportedAgentModels","locations":["Sweden
+        Central","UK South","East US 2","Australia East","France Central","Canada
+        Central","Korea Central"],"apiVersions":["2026-01-01","2025-05-01-preview"],"defaultApiVersion":"2025-05-01-preview","capabilities":"None"},{"resourceType":"sandboxGroups","locations":["North
+        Central US (Stage)","Sweden Central","East Asia","Australia East","North Europe","UK
+        South","Canada Central","Canada East","Mexico Central","North Central US","West
+        Central US","Central US","West US 2","Brazil South","France Central","Germany
+        West Central","Japan East","Japan West","Korea Central","Norway East","Poland
+        Central","South Africa North","Southeast Asia","South India","Spain Central","Switzerland
+        North","West US 3","West US","East US 2"],"apiVersions":["2026-02-01-preview"],"defaultApiVersion":"2026-02-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"sandboxGroups/vnetConnections","locations":["North
+        Central US (Stage)","Sweden Central","East Asia","Australia East","North Europe","UK
+        South","Canada Central","Canada East","Mexico Central","North Central US","West
+        Central US","Central US","West US 2","Brazil South","France Central","Germany
+        West Central","Japan East","Japan West","Korea Central","Norway East","Poland
+        Central","South Africa North","Southeast Asia","South India","Spain Central","Switzerland
+        North","West US 3","West US","East US 2"],"apiVersions":["2026-02-01-preview"],"defaultApiVersion":"2026-02-01-preview","capabilities":"None"},{"resourceType":"sandboxes","locations":["North
+        Central US (Stage)","Canada Central","Central US EUAP"],"apiVersions":["2026-02-01-preview"],"defaultApiVersion":"2026-02-01-preview","capabilities":"SystemAssignedResourceIdentity"},{"resourceType":"artifacts","locations":["North
+        Central US (Stage)","Central US EUAP","East US 2 EUAP","Sweden Central","East
+        Asia","Australia East","North Europe","UK South","Canada Central","Canada
+        East","Mexico Central","North Central US","West Central US","Central US","West
+        US 2","Brazil South","France Central","Germany West Central","Japan East","Japan
+        West","Korea Central","Norway East","Poland Central","South Africa North","Southeast
+        Asia","South India","Spain Central","Switzerland North","West US 3","West
+        US","East US 2"],"apiVersions":["2026-02-01-preview"],"defaultApiVersion":"2026-02-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"artifactApps","locations":["North Central
+        US (Stage)","Central US EUAP","East US 2 EUAP","Sweden Central","East Asia","Australia
+        East","North Europe","UK South","Canada Central","Canada East","Mexico Central","North
+        Central US","West Central US","Central US","West US 2","Brazil South","France
+        Central","Germany West Central","Japan East","Japan West","Korea Central","Norway
+        East","Poland Central","South Africa North","Southeast Asia","South India","Spain
+        Central","Switzerland North","West US 3","West US","East US 2"],"apiVersions":["2026-02-01-preview"],"defaultApiVersion":"2026-02-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '44592'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:41:00 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 87B34FDB1A5744F6B441DF52DFDDB182 Ref B: PNQ231110908031 Ref C: 2026-07-03T09:41:01Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --environment --kind
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/client.env_rg_eastus2/providers/Microsoft.App/managedEnvironments/env-eastus2?api-version=2025-10-02-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/client.env_rg_eastus2/providers/Microsoft.App/managedEnvironments/env-eastus2","name":"env-eastus2","type":"Microsoft.App/managedEnvironments","location":"East
+        US 2","systemData":{"createdBy":"test@example.com","createdByType":"User","createdAt":"2026-07-03T09:39:06.5523215","lastModifiedBy":"test@example.com","lastModifiedByType":"User","lastModifiedAt":"2026-07-03T09:39:06.5523215"},"properties":{"environmentMode":"WorkloadProfiles","provisioningState":"Succeeded","daprAIInstrumentationKey":null,"daprAIConnectionString":null,"vnetConfiguration":null,"defaultDomain":"agreeableglacier-f19611d0.eastus2.azurecontainerapps.io","staticIp":"20.22.167.102","appLogsConfiguration":{"destination":null,"logAnalyticsConfiguration":null},"openTelemetryConfiguration":null,"zoneRedundant":false,"availabilityZones":null,"kedaConfiguration":{"version":"2.18.1"},"daprConfiguration":{"version":"1.16.4-msft.9"},"ingressConfiguration":null,"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/client.env_rg_eastus2/managedEnvironments/env-eastus2/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6C8AEA45371636CA70C78CCAB1A4B36CB1FEC824B6F1F0ECDB89BE23575F6907","dnsSuffix":null,"certificateKeyVaultProperties":null,"certificateValue":null,"certificatePassword":null,"thumbprint":null,"subjectName":null,"expirationDate":null},"workloadProfiles":[{"workloadProfileType":"Consumption","name":"Consumption","enableFips":false}],"appInsightsConfiguration":null,"infrastructureResourceGroup":null,"peerAuthentication":{"mtls":{"enabled":false}},"peerTrafficConfiguration":{"encryption":{"enabled":false}},"publicNetworkAccess":"Enabled","diskEncryptionConfiguration":null}}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '1835'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:41:01 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: FDAB7B45432A428ABDB637B5162F1B39 Ref B: PNQ231110909023 Ref C: 2026-07-03T09:41:01Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --environment --kind
+      User-Agent:
+      - AZURECLI/2.87.0 azsdk-python-core/1.39.0 Python/3.12.10 (Windows-11-10.0.26200-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App?api-version=2024-11-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App","namespace":"Microsoft.App","authorizations":[{"applicationId":"59f0a04a-b322-4310-adc9-39ac41e9631e","roleDefinitionId":"be29d5e9-f2ee-4c50-bf95-71cec72c205f"},{"applicationId":"7e3bc4fd-85a3-4192-b177-5b8bfc87f42c","roleDefinitionId":"39a74f72-b40f-4bdc-b639-562fe2260bf0"},{"applicationId":"3734c1a4-2bed-4998-a37a-ff1a9e7bf019","roleDefinitionId":"5c779a4f-5cb2-4547-8c41-478d9be8ba90"},{"applicationId":"55ebbb62-3b9c-49fd-9b87-9595226dd4ac","roleDefinitionId":"e49ca620-7992-4561-a7df-4ed67dad77b5","managedByRoleDefinitionId":"9e3af657-a8ff-583c-a75c-2fe7c4bcb635"},{"applicationId":"1459b1f6-7a5b-4300-93a2-44b4a651759f","roleDefinitionId":"3c5f1b29-9e3d-4a22-b5d6-9ff4e5a37974"},{"applicationId":"2c7dd73f-7a21-485b-b97d-a2508fa152c3","roleDefinitionId":"8a9982ae-66df-4135-b8da-2655633c4a4c"},{"applicationId":"6104ad52-755e-428b-9fb5-5fdf4d2c4d53","roleDefinitionId":"472cfb56-379d-4465-84ff-17404641b16c"},{"applicationId":"409eb69a-5e20-4e1e-a8bf-c23300057950","roleDefinitionId":"e211c432-0a34-4b73-9303-2a489c814a1d"}],"resourceTypes":[{"resourceType":"managedEnvironments","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"managedEnvironments/certificates","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/managedCertificates","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"containerApps","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"containerApps/privateEndpointConnectionProxies","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"containerApps/resiliencyPolicies","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"managedEnvironments/privateEndpointConnectionProxies","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"sessionPools","locations":["North
+        Central US (Stage)","West US 2","North Europe","East US","East Asia","North
+        Central US","Germany West Central","Poland Central","Italy North","Switzerland
+        North","Sweden Central","Norway East","Japan East","Australia East","West
+        Central US","East US 2","West US","Brazil South","Canada East","France Central","Korea
+        Central","South Africa North","South Central US","South India","UAE North","UK
+        South","West Europe","West US 3","Canada Central","Central US","Japan West","Southeast
+        Asia","Spain Central","UK West","Australia Southeast","Central India","Jio
+        India West","France South","Malaysia West","Indonesia Central"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"jobs","locations":["North Central US (Stage)","West
+        US 2","Southeast Asia","Sweden Central","Canada Central","West Europe","North
+        Europe","East US","East US 2","East Asia","Australia East","Germany West Central","Japan
+        East","UK South","West US","Central US","North Central US","South Central
+        US","Korea Central","Brazil South","West US 3","France Central","South Africa
+        North","Norway East","Switzerland North","UAE North","Canada East","West Central
+        US","UK West","Central India","Japan West","Australia Southeast","France South","Jio
+        India West","Spain Central","Italy North","Poland Central","Malaysia West","Indonesia
+        Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/containerappOperationResults","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/containerappOperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/containerappsjobOperationResults","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/containerappsjobOperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/sourceControlOperationResults","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/sourceControlOperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/usages","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"operations","locations":["East
+        Asia","North Central US","West Europe"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2023-02-01","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"connectedEnvironments","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectedEnvironments/certificates","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/connectedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/managedCertificateOperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/billingMeters","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/availableManagedEnvironmentsWorkloadProfileTypes","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"getCustomDomainVerificationId","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Italy North","Poland Central","South
+        India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"builders","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"builders/builds","locations":["North Central
+        US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada Central","West
+        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
+        West Central","Japan East","UK South","West US","Central US","North Central
+        US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"builders/patches","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/OperationResults","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"locations/OperationStatuses","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"managedEnvironments/dotNetComponents","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"managedEnvironments/javaComponents","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"managedEnvironments/daprComponents","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2025-01-01","2024-10-02-preview","2024-08-02-preview","2024-03-01","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview","2023-05-02-preview","2023-05-01","2023-04-01-preview","2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"managedEnvironments/daprComponents/resiliencyPolicies","locations":["North
+        Central US (Stage)","West US 2","Southeast Asia","Sweden Central","Canada
+        Central","West Europe","North Europe","East US","East US 2","East Asia","Australia
+        East","Germany West Central","Japan East","UK South","West US","Central US","North
+        Central US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North","Canada
+        East","West Central US","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2025-10-02-preview","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview","2023-11-02-preview","2023-08-01-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"None"},{"resourceType":"functions","locations":["North
+        Central US (Stage)","West Central US","West US 2","Southeast Asia","Sweden
+        Central","Canada Central","West Europe","North Europe","East US","East US
+        2","East Asia","Australia East","Germany West Central","Japan East","UK South","West
+        US","Central US","North Central US","South Central US","Korea Central","Brazil
+        South","West US 3","France Central","South Africa North","Norway East","Switzerland
+        North","UAE North","Canada East","UK West","Central India","Japan West","Australia
+        Southeast","France South","Jio India West","Spain Central","Italy North","Poland
+        Central","Malaysia West","Indonesia Central","South India"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"SupportsExtension"},{"resourceType":"logicApps","locations":["North
+        Central US (Stage)","West Europe","East US","East Asia","North Central US","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview","2024-08-02-preview","2024-02-02-preview"],"defaultApiVersion":"2025-10-02-preview","capabilities":"SupportsExtension"},{"resourceType":"locations/connectedOperationResults","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview"],"capabilities":"None"},{"resourceType":"locations/connectedOperationStatuses","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Southeast
+        Asia","Sweden Central","UK South","West US","Australia East"],"apiVersions":["2026-03-02-preview","2026-01-01","2025-10-02-preview","2025-07-01","2025-02-02-preview","2024-10-02-preview"],"capabilities":"None"},{"resourceType":"agents","locations":["Sweden
+        Central","UK South","East US 2","Australia East","France Central","Canada
+        Central","Korea Central"],"apiVersions":["2026-01-01","2025-05-01-preview"],"defaultApiVersion":"2025-05-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"agentSpaces","locations":["Sweden Central","UK
+        South","East US 2","Australia East","France Central","Canada Central","Korea
+        Central"],"apiVersions":["2026-01-01","2025-05-01-preview"],"defaultApiVersion":"2025-05-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"locations/sreAgentOperationResults","locations":["Sweden
+        Central","UK South","East US 2","Australia East","France Central","Canada
+        Central","Korea Central"],"apiVersions":["2026-01-01","2025-10-02-preview","2025-05-01-preview"],"defaultApiVersion":"2025-05-01-preview","capabilities":"None"},{"resourceType":"locations/sreAgentOperationStatuses","locations":["Sweden
+        Central","UK South","East US 2","Australia East","France Central","Canada
+        Central","Korea Central"],"apiVersions":["2026-01-01","2025-10-02-preview","2025-05-01-preview"],"defaultApiVersion":"2025-05-01-preview","capabilities":"None"},{"resourceType":"locations/supportedAgentModels","locations":["Sweden
+        Central","UK South","East US 2","Australia East","France Central","Canada
+        Central","Korea Central"],"apiVersions":["2026-01-01","2025-05-01-preview"],"defaultApiVersion":"2025-05-01-preview","capabilities":"None"},{"resourceType":"sandboxGroups","locations":["North
+        Central US (Stage)","Sweden Central","East Asia","Australia East","North Europe","UK
+        South","Canada Central","Canada East","Mexico Central","North Central US","West
+        Central US","Central US","West US 2","Brazil South","France Central","Germany
+        West Central","Japan East","Japan West","Korea Central","Norway East","Poland
+        Central","South Africa North","Southeast Asia","South India","Spain Central","Switzerland
+        North","West US 3","West US","East US 2"],"apiVersions":["2026-02-01-preview"],"defaultApiVersion":"2026-02-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"sandboxGroups/vnetConnections","locations":["North
+        Central US (Stage)","Sweden Central","East Asia","Australia East","North Europe","UK
+        South","Canada Central","Canada East","Mexico Central","North Central US","West
+        Central US","Central US","West US 2","Brazil South","France Central","Germany
+        West Central","Japan East","Japan West","Korea Central","Norway East","Poland
+        Central","South Africa North","Southeast Asia","South India","Spain Central","Switzerland
+        North","West US 3","West US","East US 2"],"apiVersions":["2026-02-01-preview"],"defaultApiVersion":"2026-02-01-preview","capabilities":"None"},{"resourceType":"sandboxes","locations":["North
+        Central US (Stage)","Canada Central","Central US EUAP"],"apiVersions":["2026-02-01-preview"],"defaultApiVersion":"2026-02-01-preview","capabilities":"SystemAssignedResourceIdentity"},{"resourceType":"artifacts","locations":["North
+        Central US (Stage)","Central US EUAP","East US 2 EUAP","Sweden Central","East
+        Asia","Australia East","North Europe","UK South","Canada Central","Canada
+        East","Mexico Central","North Central US","West Central US","Central US","West
+        US 2","Brazil South","France Central","Germany West Central","Japan East","Japan
+        West","Korea Central","Norway East","Poland Central","South Africa North","Southeast
+        Asia","South India","Spain Central","Switzerland North","West US 3","West
+        US","East US 2"],"apiVersions":["2026-02-01-preview"],"defaultApiVersion":"2026-02-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"artifactApps","locations":["North Central
+        US (Stage)","Central US EUAP","East US 2 EUAP","Sweden Central","East Asia","Australia
+        East","North Europe","UK South","Canada Central","Canada East","Mexico Central","North
+        Central US","West Central US","Central US","West US 2","Brazil South","France
+        Central","Germany West Central","Japan East","Japan West","Korea Central","Norway
+        East","Poland Central","South Africa North","Southeast Asia","South India","Spain
+        Central","Switzerland North","West US 3","West US","East US 2"],"apiVersions":["2026-02-01-preview"],"defaultApiVersion":"2026-02-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '44592'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:41:02 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16498'
+      x-msedge-ref:
+      - 'Ref A: 9375158BFA094060B4E696EBBEEC5EAF Ref B: PNQ231110909052 Ref C: 2026-07-03T09:41:02Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "East US 2", "identity": null, "properties": {"environmentId":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/client.env_rg_eastus2/providers/Microsoft.App/managedEnvironments/env-eastus2",
+      "configuration": {"secrets": null, "activeRevisionsMode": "single", "ingress":
+      null, "dapr": null, "registries": null, "targetLabel": null, "service": null},
+      "template": {"revisionSuffix": null, "containers": [{"image": "mcr.microsoft.com/azure-functions/dotnet8-quickstart-demo:1.0",
+      "name": "functionapp000002", "command": null, "args": null, "env": null, "resources":
+      null, "volumeMounts": null}], "initContainers": null, "scale": null, "volumes":
+      null, "serviceBinds": null}, "workloadProfileName": null}, "tags": null, "kind":
+      "functionapp"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '770'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -n --image --environment --kind
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerApps/functionapp000002?api-version=2025-10-02-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerapps/functionapp000002","name":"functionapp000002","type":"Microsoft.App/containerApps","location":"East
+        US 2","systemData":{"createdBy":"test@example.com","createdByType":"User","createdAt":"2026-07-03T09:41:06.1398185Z","lastModifiedBy":"test@example.com","lastModifiedByType":"User","lastModifiedAt":"2026-07-03T09:41:06.1398185Z"},"properties":{"provisioningState":"InProgress","managedEnvironmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/client.env_rg_eastus2/providers/Microsoft.App/managedEnvironments/env-eastus2","environmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/client.env_rg_eastus2/providers/Microsoft.App/managedEnvironments/env-eastus2","workloadProfileName":"Consumption","patchingMode":"Automatic","outboundIpAddresses":["20.1.250.250","20.1.251.135","20.1.251.104","20.1.251.2","13.68.118.203","13.68.119.127","52.184.147.35","52.184.147.9","20.94.111.32","20.94.110.46","20.7.131.26","20.7.130.240","20.7.131.54","20.7.131.60","20.7.131.34","20.7.131.59","20.7.131.44","20.7.131.5","20.7.131.39","20.7.131.50","172.200.51.234","172.200.52.27","172.200.51.44","172.200.51.235","172.200.51.243","172.200.51.45","172.200.51.191","172.200.51.242","172.200.52.26","172.200.51.190","4.153.75.54","172.193.97.218","68.220.18.20","172.193.72.214","20.161.102.207","130.213.148.50","68.220.243.198","20.22.147.169","20.122.241.246","20.72.121.157","20.75.24.112","20.36.255.10","20.10.96.162","20.10.77.30","20.22.59.25","20.94.21.158","20.96.95.82","20.80.208.249","20.186.165.206","4.150.106.135","4.153.178.159","20.10.117.247","48.211.244.39","135.18.202.95","20.96.232.164","20.10.115.21","132.196.179.37","132.196.139.222","130.213.159.120","20.22.179.116","20.10.72.153","20.22.71.237","68.220.129.123","20.15.50.90","20.15.50.66","57.162.104.207","48.211.128.73","4.152.32.38","48.211.203.35","57.162.104.208","135.222.147.33","20.72.106.233","4.150.115.104","135.237.230.50","48.204.162.90","172.176.48.208","52.179.229.197","135.18.146.211","52.177.29.129","4.152.45.85","132.196.199.105","52.184.249.176","172.175.160.88","20.85.79.72","57.165.49.155","172.193.112.244","57.162.45.229","48.211.199.212","135.237.231.126","48.204.167.79","20.15.38.216","20.161.158.212","20.10.122.104","172.175.211.41","20.15.53.40","4.153.36.1","135.224.219.190","48.214.0.25","172.193.115.158","132.196.212.198","4.153.231.37","52.251.8.192","130.213.197.208","135.18.143.203","135.18.192.95","130.213.254.40","20.7.235.22","135.237.204.151","52.247.33.54","20.15.17.157","172.175.119.184","132.196.213.1","132.196.188.132","57.166.139.239","57.166.251.219","132.196.144.197","20.161.107.186","20.15.48.196","132.196.212.240","172.193.115.74","130.213.254.44","132.196.199.152","57.162.111.250","52.184.249.177","132.196.174.126","135.18.162.196","68.220.2.101","57.165.91.55","20.161.99.155","57.166.252.6","52.232.209.131","135.224.231.203","135.18.163.226","172.193.66.194","132.196.199.76","48.211.194.4","135.224.163.166","20.15.53.46","135.18.163.191","20.161.99.146","57.162.111.230","135.222.165.45","172.175.210.116","172.175.212.113","48.204.154.11","48.204.153.246","57.165.49.165","135.224.163.235","57.166.252.2","57.165.49.166","4.153.131.161","57.165.49.157","130.213.254.31","52.184.255.121","172.175.119.140","4.152.190.135","20.96.151.63","130.213.197.166","68.220.2.130","135.222.184.142","20.97.130.219","20.69.200.68","20.97.132.38","20.97.133.137","20.94.122.99","20.94.122.65","20.94.122.133","20.94.122.111","20.94.122.70","20.94.122.101","52.167.135.54","52.184.149.238","52.179.250.88","52.184.149.147","52.184.198.180","52.184.138.179","52.179.253.112","52.184.190.79","52.184.141.185","52.184.151.206","4.153.163.131","20.36.242.179","20.36.243.222","20.36.243.227","20.36.243.208","128.85.230.186","4.153.163.156","20.36.242.169","4.153.163.201","20.36.244.19","20.36.244.21","20.36.243.201","128.85.220.176","128.85.212.114","135.18.214.171","20.85.91.213","128.85.239.223","4.153.23.192","4.153.23.210","4.153.23.204","4.153.23.173","68.220.200.37","20.22.76.62","20.22.133.225","20.97.149.136","20.85.54.118","20.22.84.80","20.15.28.155","135.224.218.66","132.196.159.79","172.193.41.130","52.167.25.168","132.196.164.34","20.94.2.95","20.75.97.208","135.224.208.235","20.75.109.7","20.22.64.248","20.62.39.9","20.85.16.209","9.169.239.156","172.193.72.242","172.193.27.147","4.152.228.209","20.36.246.185","135.237.222.217","135.232.58.187","20.15.32.122","4.153.191.17","128.85.223.237","172.193.40.170","20.75.41.180","135.224.210.246","135.224.216.114","135.224.213.140","135.224.185.170","132.196.183.213","172.175.33.61","20.12.101.103","135.18.146.254","20.22.16.179","20.75.127.1","20.75.67.92","20.1.251.122","4.153.151.187","135.224.209.109","20.75.1.111","20.1.226.146","20.7.80.26","20.75.99.67","20.10.90.46","20.75.104.174","40.70.153.121","20.186.184.95","68.220.235.57","52.177.38.207","135.237.215.145","135.224.185.188","128.85.229.133","135.224.250.193","72.153.36.134","20.12.102.108","135.224.185.174","4.153.62.175","48.211.150.180","135.18.168.30","172.193.34.238","4.153.71.55","48.211.203.231","135.222.164.197","135.18.146.169","4.152.79.15","4.150.70.211","9.169.143.186","68.220.24.87","48.214.33.89","172.175.114.132","130.213.179.249","132.196.177.100","135.222.147.221","48.214.33.85","172.193.38.136","9.169.142.73","4.152.41.125","20.75.109.89","172.193.58.160","172.193.28.169","4.153.52.96","48.204.160.140","172.193.38.141","20.15.61.123","128.85.238.121","135.222.147.158","48.214.23.254","128.85.211.88","20.96.143.163","128.85.239.65","128.85.229.189","4.152.3.179","130.213.167.42","48.211.145.157","4.153.48.14","130.213.180.16","130.213.178.236","52.177.235.178","48.211.182.187","172.193.43.183","135.18.168.33","52.167.31.168","135.237.249.114","4.153.156.117","57.162.40.176","4.153.104.192","132.196.155.249","20.36.238.22","20.186.162.108","4.153.31.203","20.22.93.71","20.12.95.82","48.211.145.156","4.152.243.12","48.214.1.31","20.22.182.117","20.22.113.146","20.7.216.130","20.161.150.197","20.10.235.4","20.12.124.68","130.213.252.62","20.1.227.209","135.18.218.130","20.94.103.85","20.85.58.60","20.1.221.138","20.161.177.102","52.138.106.25","130.213.251.223","20.62.36.221","52.138.115.89","20.22.118.145","20.88.119.225","57.166.252.203","52.138.112.244","20.75.60.154","20.161.148.158","57.165.89.165","172.193.52.229","4.153.8.84","20.161.178.164","20.22.113.147","52.242.96.196","4.152.32.229","48.214.3.41","20.22.170.19","20.10.234.83","20.22.43.74","52.138.106.40","20.85.90.84","20.94.14.9","20.161.178.225","20.122.242.74","172.175.161.22","172.193.52.189","20.10.76.255","48.214.69.158","20.96.54.171","20.10.66.176","20.122.232.93","20.65.21.157","48.214.85.92","20.85.118.158","128.85.241.225","48.214.69.70","128.85.246.132","20.97.134.183","20.161.229.142","20.15.77.105","52.167.12.197","20.96.99.137","20.122.227.225","130.213.251.216","48.214.20.105","20.96.97.219","172.193.121.244","20.96.159.130","20.161.147.200","172.175.162.39","20.80.198.70","20.15.84.33","52.177.106.109","20.7.235.60","48.214.2.73","48.204.167.91","57.165.89.94","20.161.176.191","132.196.158.139","128.85.228.227","51.8.134.196","57.165.49.189","20.22.173.68","4.153.39.135"],"customDomainVerificationId":"6C8AEA45371636CA70C78CCAB1A4B36CB1FEC824B6F1F0ECDB89BE23575F6907","configuration":{"secrets":null,"activeRevisionsMode":"Single","targetLabel":null,"revisionTransitionThreshold":null,"ingress":null,"registries":null,"identitySettings":[],"dapr":null,"runtime":null,"maxInactiveRevisions":100,"service":null},"template":{"revisionSuffix":null,"terminationGracePeriodSeconds":null,"customMetricsSettings":null,"containers":[{"image":"mcr.microsoft.com/azure-functions/dotnet8-quickstart-demo:1.0","imageType":"CloudBuild","name":"functionapp000002"}],"initContainers":null,"scale":null,"volumes":null,"serviceBinds":null},"delegatedIdentities":[]},"identity":{"type":"None"},"kind":"functionapp"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/containerappOperationStatuses/2d60629f-c3a6-4c5e-9cd4-edbfd696e4d2?api-version=2025-10-02-preview&azureAsyncOperation=true&t=639186684674991910&c=MIIHxDCCBqygAwIBAgIRAK7oIN2QhDExzoBjh_cyko8wDQYJKoZIhvcNAQELBQAwNTEzMDEGA1UEAxMqQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgQ1VTIENBIDAxMB4XDTI2MDQwNzIxNTkyN1oXDTI2MTAwMzAzNTkyN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC7siBV6m8z4XG_zskDmB6TVKaYPpR6743n8NHS71Mc2x6qqhKzu60k7a0DMf_o6cxyc8REihZWl9vwk6vEqSfLbK6BTlqlTCQC6UmZ015sRFQSbB9XuekU4d6FpBdTz87KnirxCo2dotPMASgL-EpuXGBRfv7OUq0DbWgjHjmV-sS5ybmAfhJK7M2hxWB7GtNnHUqObpjRD8DOR0jPZrl_g6bxsiv1oiI9agKp3vEbChERW5NVSCHJGCQfO0_5qRNFEo2Q9UcZX8sasvrpPXcuBcrE6SV2oCn3bla4IerVV5tHcI2UXkDBsxKQUEHu_b0YWUCKhRgE-80pO4iRW4pRAgMBAAGjggTCMIIEvjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRO6PNSS4YHYiqrY0WWvPxKfM0J_jAfBgNVHSMEGDAWgBT85FoKL4UO50S5B3N44NREB6IZETCCAcoGA1UdHwSCAcEwggG9MG-gbaBrhmlodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvY2VudHJhbHVzL2NybHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvMTgvY3VycmVudC5jcmwwcaBvoG2Ga2h0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2NlbnRyYWx1cy9jcmxzL2NjbWVjZW50cmFsdXNwa2kvY2NtZWNlbnRyYWx1c2ljYTAxLzE4L2N1cnJlbnQuY3JsMGCgXqBchlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vY2VudHJhbHVzL2NybHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvMTgvY3VycmVudC5jcmwwdaBzoHGGb2h0dHA6Ly9jY21lY2VudHJhbHVzcGtpLmNlbnRyYWx1cy5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVjZW50cmFsdXNpY2EwMS8xOC9jdXJyZW50LmNybDCCAc8GCCsGAQUFBwEBBIIBwTCCAb0wcgYIKwYBBQUHMAKGZmh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZW50cmFsdXMvY2FjZXJ0cy9jY21lY2VudHJhbHVzcGtpL2NjbWVjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjB0BggrBgEFBQcwAoZoaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvY2VudHJhbHVzL2NhY2VydHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvY2VydC5jZXIwYwYIKwYBBQUHMAKGV2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9jZW50cmFsdXMvY2FjZXJ0cy9jY21lY2VudHJhbHVzcGtpL2NjbWVjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjBsBggrBgEFBQcwAoZgaHR0cDovL2NjbWVjZW50cmFsdXNwa2kuY2VudHJhbHVzLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWNlbnRyYWx1c2ljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCAS9DnIMBrIJIkxU64o3lDpIB3oGxHuWyLNS1kreH8HX5RwmB5sOaXLi5CgbyM1fi_GEx2n7CUMNjAETzHLUuc8Wh65SZFll7K2hNCnzafuB2JlGEAxxJkAOJtyPm87XpuhHut2iAf0ZsV394Wvb0_11c0oJArJ3WXXCquMlc3B7-odmdkLYsob-Xzjy5ZboKrOr_oN6UC5Hw2roCmfTFLNXekxJCt7LkdPfYzG6scWhN8dhKa_JAfvv16K8DCxzIyh2z171gnnlTEmIdKG_pC-g7vJDzRQcpPQ9KHEaVLl2WAQgs9YJmAiu2qwhfzW96fMtCmdMXUxsfug_qM3Qlo&s=IbV8zV3hc1POQjBKuiInlfPy_sfE_1iLGGTklHW-pxEXEgBZEOAW_AH3L5nUz25oGMOIKZqqhfQHkeM4hC6bZTOypE_WJICcy3H7swO1GOjaSuYpJzYQg0dZ7ZY0fmjBvxMznY3e_gzhWLiAM_wNb9854_x2hw6lpI3bZjOJgvGUMj14PA4xm52ZW2h2wEUm_Ue49ShpcTQksLtNlSVW-EBNpLNObtizdf8MQbAPxTplLi7ptQVN5y4ETSt8p7Ff70nvXB58riK5eVEmM-D41HzJr_CipGTqurF4sJ_ZzzGjvI0v5eZFo14bbAU7ih7Z95nya8jC1YE7Xgpk1OnQvA&h=VchfEFarMwB6k2ckSzv4T-2O-NaCElgUrXothwwRlss
+      cache-control:
+      - no-cache
+      content-length:
+      - '8073'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:41:07 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-async-operation-timeout:
+      - PT15M
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=dbb7c858-7fe6-47e8-9b0e-aeae5587ef6a/centralindia/f0f5dea3-16e4-4d3e-af7a-ff2db5fc92b1
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '199'
+      x-msedge-ref:
+      - 'Ref A: 7C8F3EB8D37B48C2873352B2B239096E Ref B: PNQ231110906062 Ref C: 2026-07-03T09:41:03Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --environment --kind
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/containerappOperationStatuses/2d60629f-c3a6-4c5e-9cd4-edbfd696e4d2?api-version=2025-10-02-preview&azureAsyncOperation=true&t=639186684674991910&c=MIIHxDCCBqygAwIBAgIRAK7oIN2QhDExzoBjh_cyko8wDQYJKoZIhvcNAQELBQAwNTEzMDEGA1UEAxMqQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgQ1VTIENBIDAxMB4XDTI2MDQwNzIxNTkyN1oXDTI2MTAwMzAzNTkyN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC7siBV6m8z4XG_zskDmB6TVKaYPpR6743n8NHS71Mc2x6qqhKzu60k7a0DMf_o6cxyc8REihZWl9vwk6vEqSfLbK6BTlqlTCQC6UmZ015sRFQSbB9XuekU4d6FpBdTz87KnirxCo2dotPMASgL-EpuXGBRfv7OUq0DbWgjHjmV-sS5ybmAfhJK7M2hxWB7GtNnHUqObpjRD8DOR0jPZrl_g6bxsiv1oiI9agKp3vEbChERW5NVSCHJGCQfO0_5qRNFEo2Q9UcZX8sasvrpPXcuBcrE6SV2oCn3bla4IerVV5tHcI2UXkDBsxKQUEHu_b0YWUCKhRgE-80pO4iRW4pRAgMBAAGjggTCMIIEvjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRO6PNSS4YHYiqrY0WWvPxKfM0J_jAfBgNVHSMEGDAWgBT85FoKL4UO50S5B3N44NREB6IZETCCAcoGA1UdHwSCAcEwggG9MG-gbaBrhmlodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvY2VudHJhbHVzL2NybHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvMTgvY3VycmVudC5jcmwwcaBvoG2Ga2h0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2NlbnRyYWx1cy9jcmxzL2NjbWVjZW50cmFsdXNwa2kvY2NtZWNlbnRyYWx1c2ljYTAxLzE4L2N1cnJlbnQuY3JsMGCgXqBchlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vY2VudHJhbHVzL2NybHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvMTgvY3VycmVudC5jcmwwdaBzoHGGb2h0dHA6Ly9jY21lY2VudHJhbHVzcGtpLmNlbnRyYWx1cy5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVjZW50cmFsdXNpY2EwMS8xOC9jdXJyZW50LmNybDCCAc8GCCsGAQUFBwEBBIIBwTCCAb0wcgYIKwYBBQUHMAKGZmh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZW50cmFsdXMvY2FjZXJ0cy9jY21lY2VudHJhbHVzcGtpL2NjbWVjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjB0BggrBgEFBQcwAoZoaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvY2VudHJhbHVzL2NhY2VydHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvY2VydC5jZXIwYwYIKwYBBQUHMAKGV2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9jZW50cmFsdXMvY2FjZXJ0cy9jY21lY2VudHJhbHVzcGtpL2NjbWVjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjBsBggrBgEFBQcwAoZgaHR0cDovL2NjbWVjZW50cmFsdXNwa2kuY2VudHJhbHVzLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWNlbnRyYWx1c2ljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCAS9DnIMBrIJIkxU64o3lDpIB3oGxHuWyLNS1kreH8HX5RwmB5sOaXLi5CgbyM1fi_GEx2n7CUMNjAETzHLUuc8Wh65SZFll7K2hNCnzafuB2JlGEAxxJkAOJtyPm87XpuhHut2iAf0ZsV394Wvb0_11c0oJArJ3WXXCquMlc3B7-odmdkLYsob-Xzjy5ZboKrOr_oN6UC5Hw2roCmfTFLNXekxJCt7LkdPfYzG6scWhN8dhKa_JAfvv16K8DCxzIyh2z171gnnlTEmIdKG_pC-g7vJDzRQcpPQ9KHEaVLl2WAQgs9YJmAiu2qwhfzW96fMtCmdMXUxsfug_qM3Qlo&s=IbV8zV3hc1POQjBKuiInlfPy_sfE_1iLGGTklHW-pxEXEgBZEOAW_AH3L5nUz25oGMOIKZqqhfQHkeM4hC6bZTOypE_WJICcy3H7swO1GOjaSuYpJzYQg0dZ7ZY0fmjBvxMznY3e_gzhWLiAM_wNb9854_x2hw6lpI3bZjOJgvGUMj14PA4xm52ZW2h2wEUm_Ue49ShpcTQksLtNlSVW-EBNpLNObtizdf8MQbAPxTplLi7ptQVN5y4ETSt8p7Ff70nvXB58riK5eVEmM-D41HzJr_CipGTqurF4sJ_ZzzGjvI0v5eZFo14bbAU7ih7Z95nya8jC1YE7Xgpk1OnQvA&h=VchfEFarMwB6k2ckSzv4T-2O-NaCElgUrXothwwRlss
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/containerappOperationStatuses/2d60629f-c3a6-4c5e-9cd4-edbfd696e4d2","name":"2d60629f-c3a6-4c5e-9cd4-edbfd696e4d2","status":"InProgress","startTime":"2026-07-03T09:41:06.290373"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '278'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:41:08 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=dbb7c858-7fe6-47e8-9b0e-aeae5587ef6a/centralindia/2642d965-beb1-4bfa-b943-c05dcf01f512
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 0B3F73ED7F9541329F72B8A804BEC963 Ref B: PNQ231110907025 Ref C: 2026-07-03T09:41:08Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --environment --kind
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/containerappOperationStatuses/2d60629f-c3a6-4c5e-9cd4-edbfd696e4d2?api-version=2025-10-02-preview&azureAsyncOperation=true&t=639186684674991910&c=MIIHxDCCBqygAwIBAgIRAK7oIN2QhDExzoBjh_cyko8wDQYJKoZIhvcNAQELBQAwNTEzMDEGA1UEAxMqQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgQ1VTIENBIDAxMB4XDTI2MDQwNzIxNTkyN1oXDTI2MTAwMzAzNTkyN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC7siBV6m8z4XG_zskDmB6TVKaYPpR6743n8NHS71Mc2x6qqhKzu60k7a0DMf_o6cxyc8REihZWl9vwk6vEqSfLbK6BTlqlTCQC6UmZ015sRFQSbB9XuekU4d6FpBdTz87KnirxCo2dotPMASgL-EpuXGBRfv7OUq0DbWgjHjmV-sS5ybmAfhJK7M2hxWB7GtNnHUqObpjRD8DOR0jPZrl_g6bxsiv1oiI9agKp3vEbChERW5NVSCHJGCQfO0_5qRNFEo2Q9UcZX8sasvrpPXcuBcrE6SV2oCn3bla4IerVV5tHcI2UXkDBsxKQUEHu_b0YWUCKhRgE-80pO4iRW4pRAgMBAAGjggTCMIIEvjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRO6PNSS4YHYiqrY0WWvPxKfM0J_jAfBgNVHSMEGDAWgBT85FoKL4UO50S5B3N44NREB6IZETCCAcoGA1UdHwSCAcEwggG9MG-gbaBrhmlodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvY2VudHJhbHVzL2NybHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvMTgvY3VycmVudC5jcmwwcaBvoG2Ga2h0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2NlbnRyYWx1cy9jcmxzL2NjbWVjZW50cmFsdXNwa2kvY2NtZWNlbnRyYWx1c2ljYTAxLzE4L2N1cnJlbnQuY3JsMGCgXqBchlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vY2VudHJhbHVzL2NybHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvMTgvY3VycmVudC5jcmwwdaBzoHGGb2h0dHA6Ly9jY21lY2VudHJhbHVzcGtpLmNlbnRyYWx1cy5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVjZW50cmFsdXNpY2EwMS8xOC9jdXJyZW50LmNybDCCAc8GCCsGAQUFBwEBBIIBwTCCAb0wcgYIKwYBBQUHMAKGZmh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZW50cmFsdXMvY2FjZXJ0cy9jY21lY2VudHJhbHVzcGtpL2NjbWVjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjB0BggrBgEFBQcwAoZoaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvY2VudHJhbHVzL2NhY2VydHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvY2VydC5jZXIwYwYIKwYBBQUHMAKGV2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9jZW50cmFsdXMvY2FjZXJ0cy9jY21lY2VudHJhbHVzcGtpL2NjbWVjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjBsBggrBgEFBQcwAoZgaHR0cDovL2NjbWVjZW50cmFsdXNwa2kuY2VudHJhbHVzLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWNlbnRyYWx1c2ljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCAS9DnIMBrIJIkxU64o3lDpIB3oGxHuWyLNS1kreH8HX5RwmB5sOaXLi5CgbyM1fi_GEx2n7CUMNjAETzHLUuc8Wh65SZFll7K2hNCnzafuB2JlGEAxxJkAOJtyPm87XpuhHut2iAf0ZsV394Wvb0_11c0oJArJ3WXXCquMlc3B7-odmdkLYsob-Xzjy5ZboKrOr_oN6UC5Hw2roCmfTFLNXekxJCt7LkdPfYzG6scWhN8dhKa_JAfvv16K8DCxzIyh2z171gnnlTEmIdKG_pC-g7vJDzRQcpPQ9KHEaVLl2WAQgs9YJmAiu2qwhfzW96fMtCmdMXUxsfug_qM3Qlo&s=IbV8zV3hc1POQjBKuiInlfPy_sfE_1iLGGTklHW-pxEXEgBZEOAW_AH3L5nUz25oGMOIKZqqhfQHkeM4hC6bZTOypE_WJICcy3H7swO1GOjaSuYpJzYQg0dZ7ZY0fmjBvxMznY3e_gzhWLiAM_wNb9854_x2hw6lpI3bZjOJgvGUMj14PA4xm52ZW2h2wEUm_Ue49ShpcTQksLtNlSVW-EBNpLNObtizdf8MQbAPxTplLi7ptQVN5y4ETSt8p7Ff70nvXB58riK5eVEmM-D41HzJr_CipGTqurF4sJ_ZzzGjvI0v5eZFo14bbAU7ih7Z95nya8jC1YE7Xgpk1OnQvA&h=VchfEFarMwB6k2ckSzv4T-2O-NaCElgUrXothwwRlss
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/containerappOperationStatuses/2d60629f-c3a6-4c5e-9cd4-edbfd696e4d2","name":"2d60629f-c3a6-4c5e-9cd4-edbfd696e4d2","status":"InProgress","startTime":"2026-07-03T09:41:06.290373"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '278'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:41:11 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=dbb7c858-7fe6-47e8-9b0e-aeae5587ef6a/centralindia/c1f82577-291a-4cfe-b6c4-122be5ffd6bf
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: B8993CFB434C4D98904658E343523C22 Ref B: PNQ231110907042 Ref C: 2026-07-03T09:41:11Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --environment --kind
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/containerappOperationStatuses/2d60629f-c3a6-4c5e-9cd4-edbfd696e4d2?api-version=2025-10-02-preview&azureAsyncOperation=true&t=639186684674991910&c=MIIHxDCCBqygAwIBAgIRAK7oIN2QhDExzoBjh_cyko8wDQYJKoZIhvcNAQELBQAwNTEzMDEGA1UEAxMqQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgQ1VTIENBIDAxMB4XDTI2MDQwNzIxNTkyN1oXDTI2MTAwMzAzNTkyN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC7siBV6m8z4XG_zskDmB6TVKaYPpR6743n8NHS71Mc2x6qqhKzu60k7a0DMf_o6cxyc8REihZWl9vwk6vEqSfLbK6BTlqlTCQC6UmZ015sRFQSbB9XuekU4d6FpBdTz87KnirxCo2dotPMASgL-EpuXGBRfv7OUq0DbWgjHjmV-sS5ybmAfhJK7M2hxWB7GtNnHUqObpjRD8DOR0jPZrl_g6bxsiv1oiI9agKp3vEbChERW5NVSCHJGCQfO0_5qRNFEo2Q9UcZX8sasvrpPXcuBcrE6SV2oCn3bla4IerVV5tHcI2UXkDBsxKQUEHu_b0YWUCKhRgE-80pO4iRW4pRAgMBAAGjggTCMIIEvjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRO6PNSS4YHYiqrY0WWvPxKfM0J_jAfBgNVHSMEGDAWgBT85FoKL4UO50S5B3N44NREB6IZETCCAcoGA1UdHwSCAcEwggG9MG-gbaBrhmlodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvY2VudHJhbHVzL2NybHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvMTgvY3VycmVudC5jcmwwcaBvoG2Ga2h0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2NlbnRyYWx1cy9jcmxzL2NjbWVjZW50cmFsdXNwa2kvY2NtZWNlbnRyYWx1c2ljYTAxLzE4L2N1cnJlbnQuY3JsMGCgXqBchlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vY2VudHJhbHVzL2NybHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvMTgvY3VycmVudC5jcmwwdaBzoHGGb2h0dHA6Ly9jY21lY2VudHJhbHVzcGtpLmNlbnRyYWx1cy5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVjZW50cmFsdXNpY2EwMS8xOC9jdXJyZW50LmNybDCCAc8GCCsGAQUFBwEBBIIBwTCCAb0wcgYIKwYBBQUHMAKGZmh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZW50cmFsdXMvY2FjZXJ0cy9jY21lY2VudHJhbHVzcGtpL2NjbWVjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjB0BggrBgEFBQcwAoZoaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvY2VudHJhbHVzL2NhY2VydHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvY2VydC5jZXIwYwYIKwYBBQUHMAKGV2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9jZW50cmFsdXMvY2FjZXJ0cy9jY21lY2VudHJhbHVzcGtpL2NjbWVjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjBsBggrBgEFBQcwAoZgaHR0cDovL2NjbWVjZW50cmFsdXNwa2kuY2VudHJhbHVzLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWNlbnRyYWx1c2ljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCAS9DnIMBrIJIkxU64o3lDpIB3oGxHuWyLNS1kreH8HX5RwmB5sOaXLi5CgbyM1fi_GEx2n7CUMNjAETzHLUuc8Wh65SZFll7K2hNCnzafuB2JlGEAxxJkAOJtyPm87XpuhHut2iAf0ZsV394Wvb0_11c0oJArJ3WXXCquMlc3B7-odmdkLYsob-Xzjy5ZboKrOr_oN6UC5Hw2roCmfTFLNXekxJCt7LkdPfYzG6scWhN8dhKa_JAfvv16K8DCxzIyh2z171gnnlTEmIdKG_pC-g7vJDzRQcpPQ9KHEaVLl2WAQgs9YJmAiu2qwhfzW96fMtCmdMXUxsfug_qM3Qlo&s=IbV8zV3hc1POQjBKuiInlfPy_sfE_1iLGGTklHW-pxEXEgBZEOAW_AH3L5nUz25oGMOIKZqqhfQHkeM4hC6bZTOypE_WJICcy3H7swO1GOjaSuYpJzYQg0dZ7ZY0fmjBvxMznY3e_gzhWLiAM_wNb9854_x2hw6lpI3bZjOJgvGUMj14PA4xm52ZW2h2wEUm_Ue49ShpcTQksLtNlSVW-EBNpLNObtizdf8MQbAPxTplLi7ptQVN5y4ETSt8p7Ff70nvXB58riK5eVEmM-D41HzJr_CipGTqurF4sJ_ZzzGjvI0v5eZFo14bbAU7ih7Z95nya8jC1YE7Xgpk1OnQvA&h=VchfEFarMwB6k2ckSzv4T-2O-NaCElgUrXothwwRlss
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/containerappOperationStatuses/2d60629f-c3a6-4c5e-9cd4-edbfd696e4d2","name":"2d60629f-c3a6-4c5e-9cd4-edbfd696e4d2","status":"InProgress","startTime":"2026-07-03T09:41:06.290373"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '278'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:41:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=dbb7c858-7fe6-47e8-9b0e-aeae5587ef6a/southindia/c86a618e-c42a-4cb0-9731-cffe301e000a
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: B346C7ADBEB84062A313742B1A1A02FC Ref B: PNQ231110908034 Ref C: 2026-07-03T09:41:14Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --environment --kind
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/containerappOperationStatuses/2d60629f-c3a6-4c5e-9cd4-edbfd696e4d2?api-version=2025-10-02-preview&azureAsyncOperation=true&t=639186684674991910&c=MIIHxDCCBqygAwIBAgIRAK7oIN2QhDExzoBjh_cyko8wDQYJKoZIhvcNAQELBQAwNTEzMDEGA1UEAxMqQ0NNRSBHMSBUTFMgUlNBIDIwNDggU0hBMjU2IDIwNDkgQ1VTIENBIDAxMB4XDTI2MDQwNzIxNTkyN1oXDTI2MTAwMzAzNTkyN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC7siBV6m8z4XG_zskDmB6TVKaYPpR6743n8NHS71Mc2x6qqhKzu60k7a0DMf_o6cxyc8REihZWl9vwk6vEqSfLbK6BTlqlTCQC6UmZ015sRFQSbB9XuekU4d6FpBdTz87KnirxCo2dotPMASgL-EpuXGBRfv7OUq0DbWgjHjmV-sS5ybmAfhJK7M2hxWB7GtNnHUqObpjRD8DOR0jPZrl_g6bxsiv1oiI9agKp3vEbChERW5NVSCHJGCQfO0_5qRNFEo2Q9UcZX8sasvrpPXcuBcrE6SV2oCn3bla4IerVV5tHcI2UXkDBsxKQUEHu_b0YWUCKhRgE-80pO4iRW4pRAgMBAAGjggTCMIIEvjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRO6PNSS4YHYiqrY0WWvPxKfM0J_jAfBgNVHSMEGDAWgBT85FoKL4UO50S5B3N44NREB6IZETCCAcoGA1UdHwSCAcEwggG9MG-gbaBrhmlodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvY2VudHJhbHVzL2NybHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvMTgvY3VycmVudC5jcmwwcaBvoG2Ga2h0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2NlbnRyYWx1cy9jcmxzL2NjbWVjZW50cmFsdXNwa2kvY2NtZWNlbnRyYWx1c2ljYTAxLzE4L2N1cnJlbnQuY3JsMGCgXqBchlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vY2VudHJhbHVzL2NybHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvMTgvY3VycmVudC5jcmwwdaBzoHGGb2h0dHA6Ly9jY21lY2VudHJhbHVzcGtpLmNlbnRyYWx1cy5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWVjZW50cmFsdXNpY2EwMS8xOC9jdXJyZW50LmNybDCCAc8GCCsGAQUFBwEBBIIBwTCCAb0wcgYIKwYBBQUHMAKGZmh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZW50cmFsdXMvY2FjZXJ0cy9jY21lY2VudHJhbHVzcGtpL2NjbWVjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjB0BggrBgEFBQcwAoZoaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvY2VudHJhbHVzL2NhY2VydHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvY2VydC5jZXIwYwYIKwYBBQUHMAKGV2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9jZW50cmFsdXMvY2FjZXJ0cy9jY21lY2VudHJhbHVzcGtpL2NjbWVjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjBsBggrBgEFBQcwAoZgaHR0cDovL2NjbWVjZW50cmFsdXNwa2kuY2VudHJhbHVzLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWNlbnRyYWx1c2ljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQCAS9DnIMBrIJIkxU64o3lDpIB3oGxHuWyLNS1kreH8HX5RwmB5sOaXLi5CgbyM1fi_GEx2n7CUMNjAETzHLUuc8Wh65SZFll7K2hNCnzafuB2JlGEAxxJkAOJtyPm87XpuhHut2iAf0ZsV394Wvb0_11c0oJArJ3WXXCquMlc3B7-odmdkLYsob-Xzjy5ZboKrOr_oN6UC5Hw2roCmfTFLNXekxJCt7LkdPfYzG6scWhN8dhKa_JAfvv16K8DCxzIyh2z171gnnlTEmIdKG_pC-g7vJDzRQcpPQ9KHEaVLl2WAQgs9YJmAiu2qwhfzW96fMtCmdMXUxsfug_qM3Qlo&s=IbV8zV3hc1POQjBKuiInlfPy_sfE_1iLGGTklHW-pxEXEgBZEOAW_AH3L5nUz25oGMOIKZqqhfQHkeM4hC6bZTOypE_WJICcy3H7swO1GOjaSuYpJzYQg0dZ7ZY0fmjBvxMznY3e_gzhWLiAM_wNb9854_x2hw6lpI3bZjOJgvGUMj14PA4xm52ZW2h2wEUm_Ue49ShpcTQksLtNlSVW-EBNpLNObtizdf8MQbAPxTplLi7ptQVN5y4ETSt8p7Ff70nvXB58riK5eVEmM-D41HzJr_CipGTqurF4sJ_ZzzGjvI0v5eZFo14bbAU7ih7Z95nya8jC1YE7Xgpk1OnQvA&h=VchfEFarMwB6k2ckSzv4T-2O-NaCElgUrXothwwRlss
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus2/containerappOperationStatuses/2d60629f-c3a6-4c5e-9cd4-edbfd696e4d2","name":"2d60629f-c3a6-4c5e-9cd4-edbfd696e4d2","status":"Succeeded","startTime":"2026-07-03T09:41:06.290373"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '277'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:41:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-operation-identifier:
+      - tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=dbb7c858-7fe6-47e8-9b0e-aeae5587ef6a/westindia/a58a56cd-1ccc-4b6a-a0f8-21ff6af6d91b
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 7C1DC06D763F45E29239C779F331F0B5 Ref B: PNQ231110906040 Ref C: 2026-07-03T09:41:18Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --environment --kind
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerApps/functionapp000002?api-version=2025-10-02-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerapps/functionapp000002","name":"functionapp000002","type":"Microsoft.App/containerApps","location":"East
+        US 2","systemData":{"createdBy":"test@example.com","createdByType":"User","createdAt":"2026-07-03T09:41:06.1398185","lastModifiedBy":"test@example.com","lastModifiedByType":"User","lastModifiedAt":"2026-07-03T09:41:06.1398185"},"properties":{"provisioningState":"Succeeded","runningStatus":"Running","managedEnvironmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/client.env_rg_eastus2/providers/Microsoft.App/managedEnvironments/env-eastus2","environmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/client.env_rg_eastus2/providers/Microsoft.App/managedEnvironments/env-eastus2","workloadProfileName":"Consumption","patchingMode":"Automatic","outboundIpAddresses":["20.1.250.250","20.1.251.135","20.1.251.104","20.1.251.2","13.68.118.203","13.68.119.127","52.184.147.35","52.184.147.9","20.94.111.32","20.94.110.46","20.7.131.26","20.7.130.240","20.7.131.54","20.7.131.60","20.7.131.34","20.7.131.59","20.7.131.44","20.7.131.5","20.7.131.39","20.7.131.50","172.200.51.234","172.200.52.27","172.200.51.44","172.200.51.235","172.200.51.243","172.200.51.45","172.200.51.191","172.200.51.242","172.200.52.26","172.200.51.190","4.153.75.54","172.193.97.218","68.220.18.20","172.193.72.214","20.161.102.207","130.213.148.50","68.220.243.198","20.22.147.169","20.122.241.246","20.72.121.157","20.75.24.112","20.36.255.10","20.10.96.162","20.10.77.30","20.22.59.25","20.94.21.158","20.96.95.82","20.80.208.249","20.186.165.206","4.150.106.135","4.153.178.159","20.10.117.247","48.211.244.39","135.18.202.95","20.96.232.164","20.10.115.21","132.196.179.37","132.196.139.222","130.213.159.120","20.22.179.116","20.10.72.153","20.22.71.237","68.220.129.123","20.15.50.90","20.15.50.66","57.162.104.207","48.211.128.73","4.152.32.38","48.211.203.35","57.162.104.208","135.222.147.33","20.72.106.233","4.150.115.104","135.237.230.50","48.204.162.90","172.176.48.208","52.179.229.197","135.18.146.211","52.177.29.129","4.152.45.85","132.196.199.105","52.184.249.176","172.175.160.88","20.85.79.72","57.165.49.155","172.193.112.244","57.162.45.229","48.211.199.212","135.237.231.126","48.204.167.79","20.15.38.216","20.161.158.212","20.10.122.104","172.175.211.41","20.15.53.40","4.153.36.1","135.224.219.190","48.214.0.25","172.193.115.158","132.196.212.198","4.153.231.37","52.251.8.192","130.213.197.208","135.18.143.203","135.18.192.95","130.213.254.40","20.7.235.22","135.237.204.151","52.247.33.54","20.15.17.157","172.175.119.184","132.196.213.1","132.196.188.132","57.166.139.239","57.166.251.219","132.196.144.197","20.161.107.186","20.15.48.196","132.196.212.240","172.193.115.74","130.213.254.44","132.196.199.152","57.162.111.250","52.184.249.177","132.196.174.126","135.18.162.196","68.220.2.101","57.165.91.55","20.161.99.155","57.166.252.6","52.232.209.131","135.224.231.203","135.18.163.226","172.193.66.194","132.196.199.76","48.211.194.4","135.224.163.166","20.15.53.46","135.18.163.191","20.161.99.146","57.162.111.230","135.222.165.45","172.175.210.116","172.175.212.113","48.204.154.11","48.204.153.246","57.165.49.165","135.224.163.235","57.166.252.2","57.165.49.166","4.153.131.161","57.165.49.157","130.213.254.31","52.184.255.121","172.175.119.140","4.152.190.135","20.96.151.63","130.213.197.166","68.220.2.130","135.222.184.142","20.97.130.219","20.69.200.68","20.97.132.38","20.97.133.137","20.94.122.99","20.94.122.65","20.94.122.133","20.94.122.111","20.94.122.70","20.94.122.101","52.167.135.54","52.184.149.238","52.179.250.88","52.184.149.147","52.184.198.180","52.184.138.179","52.179.253.112","52.184.190.79","52.184.141.185","52.184.151.206","4.153.163.131","20.36.242.179","20.36.243.222","20.36.243.227","20.36.243.208","128.85.230.186","4.153.163.156","20.36.242.169","4.153.163.201","20.36.244.19","20.36.244.21","20.36.243.201","128.85.220.176","128.85.212.114","135.18.214.171","20.85.91.213","128.85.239.223","4.153.23.192","4.153.23.210","4.153.23.204","4.153.23.173","68.220.200.37","20.22.76.62","20.22.133.225","20.97.149.136","20.85.54.118","20.22.84.80","20.15.28.155","135.224.218.66","132.196.159.79","172.193.41.130","52.167.25.168","132.196.164.34","20.94.2.95","20.75.97.208","135.224.208.235","20.75.109.7","20.22.64.248","20.62.39.9","20.85.16.209","9.169.239.156","172.193.72.242","172.193.27.147","4.152.228.209","20.36.246.185","135.237.222.217","135.232.58.187","20.15.32.122","4.153.191.17","128.85.223.237","172.193.40.170","20.75.41.180","135.224.210.246","135.224.216.114","135.224.213.140","135.224.185.170","132.196.183.213","172.175.33.61","20.12.101.103","135.18.146.254","20.22.16.179","20.75.127.1","20.75.67.92","20.1.251.122","4.153.151.187","135.224.209.109","20.75.1.111","20.1.226.146","20.7.80.26","20.75.99.67","20.10.90.46","20.75.104.174","40.70.153.121","20.186.184.95","68.220.235.57","52.177.38.207","135.237.215.145","135.224.185.188","128.85.229.133","135.224.250.193","72.153.36.134","20.12.102.108","135.224.185.174","4.153.62.175","48.211.150.180","135.18.168.30","172.193.34.238","4.153.71.55","48.211.203.231","135.222.164.197","135.18.146.169","4.152.79.15","4.150.70.211","9.169.143.186","68.220.24.87","48.214.33.89","172.175.114.132","130.213.179.249","132.196.177.100","135.222.147.221","48.214.33.85","172.193.38.136","9.169.142.73","4.152.41.125","20.75.109.89","172.193.58.160","172.193.28.169","4.153.52.96","48.204.160.140","172.193.38.141","20.15.61.123","128.85.238.121","135.222.147.158","48.214.23.254","128.85.211.88","20.96.143.163","128.85.239.65","128.85.229.189","4.152.3.179","130.213.167.42","48.211.145.157","4.153.48.14","130.213.180.16","130.213.178.236","52.177.235.178","48.211.182.187","172.193.43.183","135.18.168.33","52.167.31.168","135.237.249.114","4.153.156.117","57.162.40.176","4.153.104.192","132.196.155.249","20.36.238.22","20.186.162.108","4.153.31.203","20.22.93.71","20.12.95.82","48.211.145.156","4.152.243.12","48.214.1.31","20.22.182.117","20.22.113.146","20.7.216.130","20.161.150.197","20.10.235.4","20.12.124.68","130.213.252.62","20.1.227.209","135.18.218.130","20.94.103.85","20.85.58.60","20.1.221.138","20.161.177.102","52.138.106.25","130.213.251.223","20.62.36.221","52.138.115.89","20.22.118.145","20.88.119.225","57.166.252.203","52.138.112.244","20.75.60.154","20.161.148.158","57.165.89.165","172.193.52.229","4.153.8.84","20.161.178.164","20.22.113.147","52.242.96.196","4.152.32.229","48.214.3.41","20.22.170.19","20.10.234.83","20.22.43.74","52.138.106.40","20.85.90.84","20.94.14.9","20.161.178.225","20.122.242.74","172.175.161.22","172.193.52.189","20.10.76.255","48.214.69.158","20.96.54.171","20.10.66.176","20.122.232.93","20.65.21.157","48.214.85.92","20.85.118.158","128.85.241.225","48.214.69.70","128.85.246.132","20.97.134.183","20.161.229.142","20.15.77.105","52.167.12.197","20.96.99.137","20.122.227.225","130.213.251.216","48.214.20.105","20.96.97.219","172.193.121.244","20.96.159.130","20.161.147.200","172.175.162.39","20.80.198.70","20.15.84.33","52.177.106.109","20.7.235.60","48.214.2.73","48.204.167.91","57.165.89.94","20.161.176.191","132.196.158.139","128.85.228.227","51.8.134.196","57.165.49.189","20.22.173.68","4.153.39.135"],"latestRevisionName":"functionapp000002--hmfk94s","latestReadyRevisionName":"functionapp000002--hmfk94s","latestRevisionFqdn":"","customDomainVerificationId":"6C8AEA45371636CA70C78CCAB1A4B36CB1FEC824B6F1F0ECDB89BE23575F6907","configuration":{"secrets":null,"activeRevisionsMode":"Single","targetLabel":"","revisionTransitionThreshold":null,"ingress":null,"registries":null,"identitySettings":[],"dapr":null,"runtime":null,"maxInactiveRevisions":100,"service":null},"template":{"revisionSuffix":"","terminationGracePeriodSeconds":null,"customMetricsSettings":null,"containers":[{"image":"mcr.microsoft.com/azure-functions/dotnet8-quickstart-demo:1.0","imageType":"ContainerImage","name":"functionapp000002","resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":null,"maxReplicas":10,"cooldownPeriod":300,"pollingInterval":30,"rules":null},"volumes":null,"serviceBinds":null},"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/containerApps/functionapp000002/eventstream","delegatedIdentities":[]},"identity":{"type":"None"},"kind":"functionapp"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '8567'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:41:19 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: CCB17991E97F4A4EBA4219EC3BEF33D2 Ref B: PNQ231110908025 Ref C: 2026-07-03T09:41:19Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp function list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerApps/functionapp000002?api-version=2025-10-02-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerapps/functionapp000002","name":"functionapp000002","type":"Microsoft.App/containerApps","location":"East
+        US 2","systemData":{"createdBy":"test@example.com","createdByType":"User","createdAt":"2026-07-03T09:41:06.1398185","lastModifiedBy":"test@example.com","lastModifiedByType":"User","lastModifiedAt":"2026-07-03T09:41:06.1398185"},"properties":{"provisioningState":"Succeeded","runningStatus":"Running","managedEnvironmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/client.env_rg_eastus2/providers/Microsoft.App/managedEnvironments/env-eastus2","environmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/client.env_rg_eastus2/providers/Microsoft.App/managedEnvironments/env-eastus2","workloadProfileName":"Consumption","patchingMode":"Automatic","outboundIpAddresses":["20.1.250.250","20.1.251.135","20.1.251.104","20.1.251.2","13.68.118.203","13.68.119.127","52.184.147.35","52.184.147.9","20.94.111.32","20.94.110.46","20.7.131.26","20.7.130.240","20.7.131.54","20.7.131.60","20.7.131.34","20.7.131.59","20.7.131.44","20.7.131.5","20.7.131.39","20.7.131.50","172.200.51.234","172.200.52.27","172.200.51.44","172.200.51.235","172.200.51.243","172.200.51.45","172.200.51.191","172.200.51.242","172.200.52.26","172.200.51.190","4.153.75.54","172.193.97.218","68.220.18.20","172.193.72.214","20.161.102.207","130.213.148.50","68.220.243.198","20.22.147.169","20.122.241.246","20.72.121.157","20.75.24.112","20.36.255.10","20.10.96.162","20.10.77.30","20.22.59.25","20.94.21.158","20.96.95.82","20.80.208.249","20.186.165.206","4.150.106.135","4.153.178.159","20.10.117.247","48.211.244.39","135.18.202.95","20.96.232.164","20.10.115.21","132.196.179.37","132.196.139.222","130.213.159.120","20.22.179.116","20.10.72.153","20.22.71.237","68.220.129.123","20.15.50.90","20.15.50.66","57.162.104.207","48.211.128.73","4.152.32.38","48.211.203.35","57.162.104.208","135.222.147.33","20.72.106.233","4.150.115.104","135.237.230.50","48.204.162.90","172.176.48.208","52.179.229.197","135.18.146.211","52.177.29.129","4.152.45.85","132.196.199.105","52.184.249.176","172.175.160.88","20.85.79.72","57.165.49.155","172.193.112.244","57.162.45.229","48.211.199.212","135.237.231.126","48.204.167.79","20.15.38.216","20.161.158.212","20.10.122.104","172.175.211.41","20.15.53.40","4.153.36.1","135.224.219.190","48.214.0.25","172.193.115.158","132.196.212.198","4.153.231.37","52.251.8.192","130.213.197.208","135.18.143.203","135.18.192.95","130.213.254.40","20.7.235.22","135.237.204.151","52.247.33.54","20.15.17.157","172.175.119.184","132.196.213.1","132.196.188.132","57.166.139.239","57.166.251.219","132.196.144.197","20.161.107.186","20.15.48.196","132.196.212.240","172.193.115.74","130.213.254.44","132.196.199.152","57.162.111.250","52.184.249.177","132.196.174.126","135.18.162.196","68.220.2.101","57.165.91.55","20.161.99.155","57.166.252.6","52.232.209.131","135.224.231.203","135.18.163.226","172.193.66.194","132.196.199.76","48.211.194.4","135.224.163.166","20.15.53.46","135.18.163.191","20.161.99.146","57.162.111.230","135.222.165.45","172.175.210.116","172.175.212.113","48.204.154.11","48.204.153.246","57.165.49.165","135.224.163.235","57.166.252.2","57.165.49.166","4.153.131.161","57.165.49.157","130.213.254.31","52.184.255.121","172.175.119.140","4.152.190.135","20.96.151.63","130.213.197.166","68.220.2.130","135.222.184.142","20.97.130.219","20.69.200.68","20.97.132.38","20.97.133.137","20.94.122.99","20.94.122.65","20.94.122.133","20.94.122.111","20.94.122.70","20.94.122.101","52.167.135.54","52.184.149.238","52.179.250.88","52.184.149.147","52.184.198.180","52.184.138.179","52.179.253.112","52.184.190.79","52.184.141.185","52.184.151.206","4.153.163.131","20.36.242.179","20.36.243.222","20.36.243.227","20.36.243.208","128.85.230.186","4.153.163.156","20.36.242.169","4.153.163.201","20.36.244.19","20.36.244.21","20.36.243.201","128.85.220.176","128.85.212.114","135.18.214.171","20.85.91.213","128.85.239.223","4.153.23.192","4.153.23.210","4.153.23.204","4.153.23.173","68.220.200.37","20.22.76.62","20.22.133.225","20.97.149.136","20.85.54.118","20.22.84.80","20.15.28.155","135.224.218.66","132.196.159.79","172.193.41.130","52.167.25.168","132.196.164.34","20.94.2.95","20.75.97.208","135.224.208.235","20.75.109.7","20.22.64.248","20.62.39.9","20.85.16.209","9.169.239.156","172.193.72.242","172.193.27.147","4.152.228.209","20.36.246.185","135.237.222.217","135.232.58.187","20.15.32.122","4.153.191.17","128.85.223.237","172.193.40.170","20.75.41.180","135.224.210.246","135.224.216.114","135.224.213.140","135.224.185.170","132.196.183.213","172.175.33.61","20.12.101.103","135.18.146.254","20.22.16.179","20.75.127.1","20.75.67.92","20.1.251.122","4.153.151.187","135.224.209.109","20.75.1.111","20.1.226.146","20.7.80.26","20.75.99.67","20.10.90.46","20.75.104.174","40.70.153.121","20.186.184.95","68.220.235.57","52.177.38.207","135.237.215.145","135.224.185.188","128.85.229.133","135.224.250.193","72.153.36.134","20.12.102.108","135.224.185.174","4.153.62.175","48.211.150.180","135.18.168.30","172.193.34.238","4.153.71.55","48.211.203.231","135.222.164.197","135.18.146.169","4.152.79.15","4.150.70.211","9.169.143.186","68.220.24.87","48.214.33.89","172.175.114.132","130.213.179.249","132.196.177.100","135.222.147.221","48.214.33.85","172.193.38.136","9.169.142.73","4.152.41.125","20.75.109.89","172.193.58.160","172.193.28.169","4.153.52.96","48.204.160.140","172.193.38.141","20.15.61.123","128.85.238.121","135.222.147.158","48.214.23.254","128.85.211.88","20.96.143.163","128.85.239.65","128.85.229.189","4.152.3.179","130.213.167.42","48.211.145.157","4.153.48.14","130.213.180.16","130.213.178.236","52.177.235.178","48.211.182.187","172.193.43.183","135.18.168.33","52.167.31.168","135.237.249.114","4.153.156.117","57.162.40.176","4.153.104.192","132.196.155.249","20.36.238.22","20.186.162.108","4.153.31.203","20.22.93.71","20.12.95.82","48.211.145.156","4.152.243.12","48.214.1.31","20.22.182.117","20.22.113.146","20.7.216.130","20.161.150.197","20.10.235.4","20.12.124.68","130.213.252.62","20.1.227.209","135.18.218.130","20.94.103.85","20.85.58.60","20.1.221.138","20.161.177.102","52.138.106.25","130.213.251.223","20.62.36.221","52.138.115.89","20.22.118.145","20.88.119.225","57.166.252.203","52.138.112.244","20.75.60.154","20.161.148.158","57.165.89.165","172.193.52.229","4.153.8.84","20.161.178.164","20.22.113.147","52.242.96.196","4.152.32.229","48.214.3.41","20.22.170.19","20.10.234.83","20.22.43.74","52.138.106.40","20.85.90.84","20.94.14.9","20.161.178.225","20.122.242.74","172.175.161.22","172.193.52.189","20.10.76.255","48.214.69.158","20.96.54.171","20.10.66.176","20.122.232.93","20.65.21.157","48.214.85.92","20.85.118.158","128.85.241.225","48.214.69.70","128.85.246.132","20.97.134.183","20.161.229.142","20.15.77.105","52.167.12.197","20.96.99.137","20.122.227.225","130.213.251.216","48.214.20.105","20.96.97.219","172.193.121.244","20.96.159.130","20.161.147.200","172.175.162.39","20.80.198.70","20.15.84.33","52.177.106.109","20.7.235.60","48.214.2.73","48.204.167.91","57.165.89.94","20.161.176.191","132.196.158.139","128.85.228.227","51.8.134.196","57.165.49.189","20.22.173.68","4.153.39.135"],"latestRevisionName":"functionapp000002--hmfk94s","latestReadyRevisionName":"functionapp000002--hmfk94s","latestRevisionFqdn":"","customDomainVerificationId":"6C8AEA45371636CA70C78CCAB1A4B36CB1FEC824B6F1F0ECDB89BE23575F6907","configuration":{"secrets":null,"activeRevisionsMode":"Single","targetLabel":"","revisionTransitionThreshold":null,"ingress":null,"registries":null,"identitySettings":[],"dapr":null,"runtime":null,"maxInactiveRevisions":100,"service":null},"template":{"revisionSuffix":"","terminationGracePeriodSeconds":null,"customMetricsSettings":null,"containers":[{"image":"mcr.microsoft.com/azure-functions/dotnet8-quickstart-demo:1.0","imageType":"ContainerImage","name":"functionapp000002","resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":null,"maxReplicas":10,"cooldownPeriod":300,"pollingInterval":30,"rules":null},"volumes":null,"serviceBinds":null},"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/containerApps/functionapp000002/eventstream","delegatedIdentities":[]},"identity":{"type":"None"},"kind":"functionapp"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '8567'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:41:50 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: B7734D82A87D4F6F94866D83AD8AF0D5 Ref B: PNQ231110909025 Ref C: 2026-07-03T09:41:50Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp function list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerApps/functionapp000002?api-version=2025-10-02-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerapps/functionapp000002","name":"functionapp000002","type":"Microsoft.App/containerApps","location":"East
+        US 2","systemData":{"createdBy":"test@example.com","createdByType":"User","createdAt":"2026-07-03T09:41:06.1398185","lastModifiedBy":"test@example.com","lastModifiedByType":"User","lastModifiedAt":"2026-07-03T09:41:06.1398185"},"properties":{"provisioningState":"Succeeded","runningStatus":"Running","managedEnvironmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/client.env_rg_eastus2/providers/Microsoft.App/managedEnvironments/env-eastus2","environmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/client.env_rg_eastus2/providers/Microsoft.App/managedEnvironments/env-eastus2","workloadProfileName":"Consumption","patchingMode":"Automatic","outboundIpAddresses":["20.1.250.250","20.1.251.135","20.1.251.104","20.1.251.2","13.68.118.203","13.68.119.127","52.184.147.35","52.184.147.9","20.94.111.32","20.94.110.46","20.7.131.26","20.7.130.240","20.7.131.54","20.7.131.60","20.7.131.34","20.7.131.59","20.7.131.44","20.7.131.5","20.7.131.39","20.7.131.50","172.200.51.234","172.200.52.27","172.200.51.44","172.200.51.235","172.200.51.243","172.200.51.45","172.200.51.191","172.200.51.242","172.200.52.26","172.200.51.190","4.153.75.54","172.193.97.218","68.220.18.20","172.193.72.214","20.161.102.207","130.213.148.50","68.220.243.198","20.22.147.169","20.122.241.246","20.72.121.157","20.75.24.112","20.36.255.10","20.10.96.162","20.10.77.30","20.22.59.25","20.94.21.158","20.96.95.82","20.80.208.249","20.186.165.206","4.150.106.135","4.153.178.159","20.10.117.247","48.211.244.39","135.18.202.95","20.96.232.164","20.10.115.21","132.196.179.37","132.196.139.222","130.213.159.120","20.22.179.116","20.10.72.153","20.22.71.237","68.220.129.123","20.15.50.90","20.15.50.66","57.162.104.207","48.211.128.73","4.152.32.38","48.211.203.35","57.162.104.208","135.222.147.33","20.72.106.233","4.150.115.104","135.237.230.50","48.204.162.90","172.176.48.208","52.179.229.197","135.18.146.211","52.177.29.129","4.152.45.85","132.196.199.105","52.184.249.176","172.175.160.88","20.85.79.72","57.165.49.155","172.193.112.244","57.162.45.229","48.211.199.212","135.237.231.126","48.204.167.79","20.15.38.216","20.161.158.212","20.10.122.104","172.175.211.41","20.15.53.40","4.153.36.1","135.224.219.190","48.214.0.25","172.193.115.158","132.196.212.198","4.153.231.37","52.251.8.192","130.213.197.208","135.18.143.203","135.18.192.95","130.213.254.40","20.7.235.22","135.237.204.151","52.247.33.54","20.15.17.157","172.175.119.184","132.196.213.1","132.196.188.132","57.166.139.239","57.166.251.219","132.196.144.197","20.161.107.186","20.15.48.196","132.196.212.240","172.193.115.74","130.213.254.44","132.196.199.152","57.162.111.250","52.184.249.177","132.196.174.126","135.18.162.196","68.220.2.101","57.165.91.55","20.161.99.155","57.166.252.6","52.232.209.131","135.224.231.203","135.18.163.226","172.193.66.194","132.196.199.76","48.211.194.4","135.224.163.166","20.15.53.46","135.18.163.191","20.161.99.146","57.162.111.230","135.222.165.45","172.175.210.116","172.175.212.113","48.204.154.11","48.204.153.246","57.165.49.165","135.224.163.235","57.166.252.2","57.165.49.166","4.153.131.161","57.165.49.157","130.213.254.31","52.184.255.121","172.175.119.140","4.152.190.135","20.96.151.63","130.213.197.166","68.220.2.130","135.222.184.142","20.97.130.219","20.69.200.68","20.97.132.38","20.97.133.137","20.94.122.99","20.94.122.65","20.94.122.133","20.94.122.111","20.94.122.70","20.94.122.101","52.167.135.54","52.184.149.238","52.179.250.88","52.184.149.147","52.184.198.180","52.184.138.179","52.179.253.112","52.184.190.79","52.184.141.185","52.184.151.206","4.153.163.131","20.36.242.179","20.36.243.222","20.36.243.227","20.36.243.208","128.85.230.186","4.153.163.156","20.36.242.169","4.153.163.201","20.36.244.19","20.36.244.21","20.36.243.201","128.85.220.176","128.85.212.114","135.18.214.171","20.85.91.213","128.85.239.223","4.153.23.192","4.153.23.210","4.153.23.204","4.153.23.173","68.220.200.37","20.22.76.62","20.22.133.225","20.97.149.136","20.85.54.118","20.22.84.80","20.15.28.155","135.224.218.66","132.196.159.79","172.193.41.130","52.167.25.168","132.196.164.34","20.94.2.95","20.75.97.208","135.224.208.235","20.75.109.7","20.22.64.248","20.62.39.9","20.85.16.209","9.169.239.156","172.193.72.242","172.193.27.147","4.152.228.209","20.36.246.185","135.237.222.217","135.232.58.187","20.15.32.122","4.153.191.17","128.85.223.237","172.193.40.170","20.75.41.180","135.224.210.246","135.224.216.114","135.224.213.140","135.224.185.170","132.196.183.213","172.175.33.61","20.12.101.103","135.18.146.254","20.22.16.179","20.75.127.1","20.75.67.92","20.1.251.122","4.153.151.187","135.224.209.109","20.75.1.111","20.1.226.146","20.7.80.26","20.75.99.67","20.10.90.46","20.75.104.174","40.70.153.121","20.186.184.95","68.220.235.57","52.177.38.207","135.237.215.145","135.224.185.188","128.85.229.133","135.224.250.193","72.153.36.134","20.12.102.108","135.224.185.174","4.153.62.175","48.211.150.180","135.18.168.30","172.193.34.238","4.153.71.55","48.211.203.231","135.222.164.197","135.18.146.169","4.152.79.15","4.150.70.211","9.169.143.186","68.220.24.87","48.214.33.89","172.175.114.132","130.213.179.249","132.196.177.100","135.222.147.221","48.214.33.85","172.193.38.136","9.169.142.73","4.152.41.125","20.75.109.89","172.193.58.160","172.193.28.169","4.153.52.96","48.204.160.140","172.193.38.141","20.15.61.123","128.85.238.121","135.222.147.158","48.214.23.254","128.85.211.88","20.96.143.163","128.85.239.65","128.85.229.189","4.152.3.179","130.213.167.42","48.211.145.157","4.153.48.14","130.213.180.16","130.213.178.236","52.177.235.178","48.211.182.187","172.193.43.183","135.18.168.33","52.167.31.168","135.237.249.114","4.153.156.117","57.162.40.176","4.153.104.192","132.196.155.249","20.36.238.22","20.186.162.108","4.153.31.203","20.22.93.71","20.12.95.82","48.211.145.156","4.152.243.12","48.214.1.31","20.22.182.117","20.22.113.146","20.7.216.130","20.161.150.197","20.10.235.4","20.12.124.68","130.213.252.62","20.1.227.209","135.18.218.130","20.94.103.85","20.85.58.60","20.1.221.138","20.161.177.102","52.138.106.25","130.213.251.223","20.62.36.221","52.138.115.89","20.22.118.145","20.88.119.225","57.166.252.203","52.138.112.244","20.75.60.154","20.161.148.158","57.165.89.165","172.193.52.229","4.153.8.84","20.161.178.164","20.22.113.147","52.242.96.196","4.152.32.229","48.214.3.41","20.22.170.19","20.10.234.83","20.22.43.74","52.138.106.40","20.85.90.84","20.94.14.9","20.161.178.225","20.122.242.74","172.175.161.22","172.193.52.189","20.10.76.255","48.214.69.158","20.96.54.171","20.10.66.176","20.122.232.93","20.65.21.157","48.214.85.92","20.85.118.158","128.85.241.225","48.214.69.70","128.85.246.132","20.97.134.183","20.161.229.142","20.15.77.105","52.167.12.197","20.96.99.137","20.122.227.225","130.213.251.216","48.214.20.105","20.96.97.219","172.193.121.244","20.96.159.130","20.161.147.200","172.175.162.39","20.80.198.70","20.15.84.33","52.177.106.109","20.7.235.60","48.214.2.73","48.204.167.91","57.165.89.94","20.161.176.191","132.196.158.139","128.85.228.227","51.8.134.196","57.165.49.189","20.22.173.68","4.153.39.135"],"latestRevisionName":"functionapp000002--hmfk94s","latestReadyRevisionName":"functionapp000002--hmfk94s","latestRevisionFqdn":"","customDomainVerificationId":"6C8AEA45371636CA70C78CCAB1A4B36CB1FEC824B6F1F0ECDB89BE23575F6907","configuration":{"secrets":null,"activeRevisionsMode":"Single","targetLabel":"","revisionTransitionThreshold":null,"ingress":null,"registries":null,"identitySettings":[],"dapr":null,"runtime":null,"maxInactiveRevisions":100,"service":null},"template":{"revisionSuffix":"","terminationGracePeriodSeconds":null,"customMetricsSettings":null,"containers":[{"image":"mcr.microsoft.com/azure-functions/dotnet8-quickstart-demo:1.0","imageType":"ContainerImage","name":"functionapp000002","resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":null,"maxReplicas":10,"cooldownPeriod":300,"pollingInterval":30,"rules":null},"volumes":null,"serviceBinds":null},"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/containerApps/functionapp000002/eventstream","delegatedIdentities":[]},"identity":{"type":"None"},"kind":"functionapp"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '8567'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:41:51 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 50839BA3575F44958E055E00249D0418 Ref B: PNQ231110909054 Ref C: 2026-07-03T09:41:51Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp function list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerApps/functionapp000002?api-version=2025-10-02-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerapps/functionapp000002","name":"functionapp000002","type":"Microsoft.App/containerApps","location":"East
+        US 2","systemData":{"createdBy":"test@example.com","createdByType":"User","createdAt":"2026-07-03T09:41:06.1398185","lastModifiedBy":"test@example.com","lastModifiedByType":"User","lastModifiedAt":"2026-07-03T09:41:06.1398185"},"properties":{"provisioningState":"Succeeded","runningStatus":"Running","managedEnvironmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/client.env_rg_eastus2/providers/Microsoft.App/managedEnvironments/env-eastus2","environmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/client.env_rg_eastus2/providers/Microsoft.App/managedEnvironments/env-eastus2","workloadProfileName":"Consumption","patchingMode":"Automatic","outboundIpAddresses":["20.1.250.250","20.1.251.135","20.1.251.104","20.1.251.2","13.68.118.203","13.68.119.127","52.184.147.35","52.184.147.9","20.94.111.32","20.94.110.46","20.7.131.26","20.7.130.240","20.7.131.54","20.7.131.60","20.7.131.34","20.7.131.59","20.7.131.44","20.7.131.5","20.7.131.39","20.7.131.50","172.200.51.234","172.200.52.27","172.200.51.44","172.200.51.235","172.200.51.243","172.200.51.45","172.200.51.191","172.200.51.242","172.200.52.26","172.200.51.190","4.153.75.54","172.193.97.218","68.220.18.20","172.193.72.214","20.161.102.207","130.213.148.50","68.220.243.198","20.22.147.169","20.122.241.246","20.72.121.157","20.75.24.112","20.36.255.10","20.10.96.162","20.10.77.30","20.22.59.25","20.94.21.158","20.96.95.82","20.80.208.249","20.186.165.206","4.150.106.135","4.153.178.159","20.10.117.247","48.211.244.39","135.18.202.95","20.96.232.164","20.10.115.21","132.196.179.37","132.196.139.222","130.213.159.120","20.22.179.116","20.10.72.153","20.22.71.237","68.220.129.123","20.15.50.90","20.15.50.66","57.162.104.207","48.211.128.73","4.152.32.38","48.211.203.35","57.162.104.208","135.222.147.33","20.72.106.233","4.150.115.104","135.237.230.50","48.204.162.90","172.176.48.208","52.179.229.197","135.18.146.211","52.177.29.129","4.152.45.85","132.196.199.105","52.184.249.176","172.175.160.88","20.85.79.72","57.165.49.155","172.193.112.244","57.162.45.229","48.211.199.212","135.237.231.126","48.204.167.79","20.15.38.216","20.161.158.212","20.10.122.104","172.175.211.41","20.15.53.40","4.153.36.1","135.224.219.190","48.214.0.25","172.193.115.158","132.196.212.198","4.153.231.37","52.251.8.192","130.213.197.208","135.18.143.203","135.18.192.95","130.213.254.40","20.7.235.22","135.237.204.151","52.247.33.54","20.15.17.157","172.175.119.184","132.196.213.1","132.196.188.132","57.166.139.239","57.166.251.219","132.196.144.197","20.161.107.186","20.15.48.196","132.196.212.240","172.193.115.74","130.213.254.44","132.196.199.152","57.162.111.250","52.184.249.177","132.196.174.126","135.18.162.196","68.220.2.101","57.165.91.55","20.161.99.155","57.166.252.6","52.232.209.131","135.224.231.203","135.18.163.226","172.193.66.194","132.196.199.76","48.211.194.4","135.224.163.166","20.15.53.46","135.18.163.191","20.161.99.146","57.162.111.230","135.222.165.45","172.175.210.116","172.175.212.113","48.204.154.11","48.204.153.246","57.165.49.165","135.224.163.235","57.166.252.2","57.165.49.166","4.153.131.161","57.165.49.157","130.213.254.31","52.184.255.121","172.175.119.140","4.152.190.135","20.96.151.63","130.213.197.166","68.220.2.130","135.222.184.142","20.97.130.219","20.69.200.68","20.97.132.38","20.97.133.137","20.94.122.99","20.94.122.65","20.94.122.133","20.94.122.111","20.94.122.70","20.94.122.101","52.167.135.54","52.184.149.238","52.179.250.88","52.184.149.147","52.184.198.180","52.184.138.179","52.179.253.112","52.184.190.79","52.184.141.185","52.184.151.206","4.153.163.131","20.36.242.179","20.36.243.222","20.36.243.227","20.36.243.208","128.85.230.186","4.153.163.156","20.36.242.169","4.153.163.201","20.36.244.19","20.36.244.21","20.36.243.201","128.85.220.176","128.85.212.114","135.18.214.171","20.85.91.213","128.85.239.223","4.153.23.192","4.153.23.210","4.153.23.204","4.153.23.173","68.220.200.37","20.22.76.62","20.22.133.225","20.97.149.136","20.85.54.118","20.22.84.80","20.15.28.155","135.224.218.66","132.196.159.79","172.193.41.130","52.167.25.168","132.196.164.34","20.94.2.95","20.75.97.208","135.224.208.235","20.75.109.7","20.22.64.248","20.62.39.9","20.85.16.209","9.169.239.156","172.193.72.242","172.193.27.147","4.152.228.209","20.36.246.185","135.237.222.217","135.232.58.187","20.15.32.122","4.153.191.17","128.85.223.237","172.193.40.170","20.75.41.180","135.224.210.246","135.224.216.114","135.224.213.140","135.224.185.170","132.196.183.213","172.175.33.61","20.12.101.103","135.18.146.254","20.22.16.179","20.75.127.1","20.75.67.92","20.1.251.122","4.153.151.187","135.224.209.109","20.75.1.111","20.1.226.146","20.7.80.26","20.75.99.67","20.10.90.46","20.75.104.174","40.70.153.121","20.186.184.95","68.220.235.57","52.177.38.207","135.237.215.145","135.224.185.188","128.85.229.133","135.224.250.193","72.153.36.134","20.12.102.108","135.224.185.174","4.153.62.175","48.211.150.180","135.18.168.30","172.193.34.238","4.153.71.55","48.211.203.231","135.222.164.197","135.18.146.169","4.152.79.15","4.150.70.211","9.169.143.186","68.220.24.87","48.214.33.89","172.175.114.132","130.213.179.249","132.196.177.100","135.222.147.221","48.214.33.85","172.193.38.136","9.169.142.73","4.152.41.125","20.75.109.89","172.193.58.160","172.193.28.169","4.153.52.96","48.204.160.140","172.193.38.141","20.15.61.123","128.85.238.121","135.222.147.158","48.214.23.254","128.85.211.88","20.96.143.163","128.85.239.65","128.85.229.189","4.152.3.179","130.213.167.42","48.211.145.157","4.153.48.14","130.213.180.16","130.213.178.236","52.177.235.178","48.211.182.187","172.193.43.183","135.18.168.33","52.167.31.168","135.237.249.114","4.153.156.117","57.162.40.176","4.153.104.192","132.196.155.249","20.36.238.22","20.186.162.108","4.153.31.203","20.22.93.71","20.12.95.82","48.211.145.156","4.152.243.12","48.214.1.31","20.22.182.117","20.22.113.146","20.7.216.130","20.161.150.197","20.10.235.4","20.12.124.68","130.213.252.62","20.1.227.209","135.18.218.130","20.94.103.85","20.85.58.60","20.1.221.138","20.161.177.102","52.138.106.25","130.213.251.223","20.62.36.221","52.138.115.89","20.22.118.145","20.88.119.225","57.166.252.203","52.138.112.244","20.75.60.154","20.161.148.158","57.165.89.165","172.193.52.229","4.153.8.84","20.161.178.164","20.22.113.147","52.242.96.196","4.152.32.229","48.214.3.41","20.22.170.19","20.10.234.83","20.22.43.74","52.138.106.40","20.85.90.84","20.94.14.9","20.161.178.225","20.122.242.74","172.175.161.22","172.193.52.189","20.10.76.255","48.214.69.158","20.96.54.171","20.10.66.176","20.122.232.93","20.65.21.157","48.214.85.92","20.85.118.158","128.85.241.225","48.214.69.70","128.85.246.132","20.97.134.183","20.161.229.142","20.15.77.105","52.167.12.197","20.96.99.137","20.122.227.225","130.213.251.216","48.214.20.105","20.96.97.219","172.193.121.244","20.96.159.130","20.161.147.200","172.175.162.39","20.80.198.70","20.15.84.33","52.177.106.109","20.7.235.60","48.214.2.73","48.204.167.91","57.165.89.94","20.161.176.191","132.196.158.139","128.85.228.227","51.8.134.196","57.165.49.189","20.22.173.68","4.153.39.135"],"latestRevisionName":"functionapp000002--hmfk94s","latestReadyRevisionName":"functionapp000002--hmfk94s","latestRevisionFqdn":"","customDomainVerificationId":"6C8AEA45371636CA70C78CCAB1A4B36CB1FEC824B6F1F0ECDB89BE23575F6907","configuration":{"secrets":null,"activeRevisionsMode":"Single","targetLabel":"","revisionTransitionThreshold":null,"ingress":null,"registries":null,"identitySettings":[],"dapr":null,"runtime":null,"maxInactiveRevisions":100,"service":null},"template":{"revisionSuffix":"","terminationGracePeriodSeconds":null,"customMetricsSettings":null,"containers":[{"image":"mcr.microsoft.com/azure-functions/dotnet8-quickstart-demo:1.0","imageType":"ContainerImage","name":"functionapp000002","resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":null,"maxReplicas":10,"cooldownPeriod":300,"pollingInterval":30,"rules":null},"volumes":null,"serviceBinds":null},"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/containerApps/functionapp000002/eventstream","delegatedIdentities":[]},"identity":{"type":"None"},"kind":"functionapp"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '8567'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:41:52 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: E04FB4202E874328B1E1BC9E684717A6 Ref B: PNQ231110909034 Ref C: 2026-07-03T09:41:52Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp function show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --function-name
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerApps/functionapp000002?api-version=2025-10-02-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerapps/functionapp000002","name":"functionapp000002","type":"Microsoft.App/containerApps","location":"East
+        US 2","systemData":{"createdBy":"test@example.com","createdByType":"User","createdAt":"2026-07-03T09:41:06.1398185","lastModifiedBy":"test@example.com","lastModifiedByType":"User","lastModifiedAt":"2026-07-03T09:41:06.1398185"},"properties":{"provisioningState":"Succeeded","runningStatus":"Running","managedEnvironmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/client.env_rg_eastus2/providers/Microsoft.App/managedEnvironments/env-eastus2","environmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/client.env_rg_eastus2/providers/Microsoft.App/managedEnvironments/env-eastus2","workloadProfileName":"Consumption","patchingMode":"Automatic","outboundIpAddresses":["20.1.250.250","20.1.251.135","20.1.251.104","20.1.251.2","13.68.118.203","13.68.119.127","52.184.147.35","52.184.147.9","20.94.111.32","20.94.110.46","20.7.131.26","20.7.130.240","20.7.131.54","20.7.131.60","20.7.131.34","20.7.131.59","20.7.131.44","20.7.131.5","20.7.131.39","20.7.131.50","172.200.51.234","172.200.52.27","172.200.51.44","172.200.51.235","172.200.51.243","172.200.51.45","172.200.51.191","172.200.51.242","172.200.52.26","172.200.51.190","4.153.75.54","172.193.97.218","68.220.18.20","172.193.72.214","20.161.102.207","130.213.148.50","68.220.243.198","20.22.147.169","20.122.241.246","20.72.121.157","20.75.24.112","20.36.255.10","20.10.96.162","20.10.77.30","20.22.59.25","20.94.21.158","20.96.95.82","20.80.208.249","20.186.165.206","4.150.106.135","4.153.178.159","20.10.117.247","48.211.244.39","135.18.202.95","20.96.232.164","20.10.115.21","132.196.179.37","132.196.139.222","130.213.159.120","20.22.179.116","20.10.72.153","20.22.71.237","68.220.129.123","20.15.50.90","20.15.50.66","57.162.104.207","48.211.128.73","4.152.32.38","48.211.203.35","57.162.104.208","135.222.147.33","20.72.106.233","4.150.115.104","135.237.230.50","48.204.162.90","172.176.48.208","52.179.229.197","135.18.146.211","52.177.29.129","4.152.45.85","132.196.199.105","52.184.249.176","172.175.160.88","20.85.79.72","57.165.49.155","172.193.112.244","57.162.45.229","48.211.199.212","135.237.231.126","48.204.167.79","20.15.38.216","20.161.158.212","20.10.122.104","172.175.211.41","20.15.53.40","4.153.36.1","135.224.219.190","48.214.0.25","172.193.115.158","132.196.212.198","4.153.231.37","52.251.8.192","130.213.197.208","135.18.143.203","135.18.192.95","130.213.254.40","20.7.235.22","135.237.204.151","52.247.33.54","20.15.17.157","172.175.119.184","132.196.213.1","132.196.188.132","57.166.139.239","57.166.251.219","132.196.144.197","20.161.107.186","20.15.48.196","132.196.212.240","172.193.115.74","130.213.254.44","132.196.199.152","57.162.111.250","52.184.249.177","132.196.174.126","135.18.162.196","68.220.2.101","57.165.91.55","20.161.99.155","57.166.252.6","52.232.209.131","135.224.231.203","135.18.163.226","172.193.66.194","132.196.199.76","48.211.194.4","135.224.163.166","20.15.53.46","135.18.163.191","20.161.99.146","57.162.111.230","135.222.165.45","172.175.210.116","172.175.212.113","48.204.154.11","48.204.153.246","57.165.49.165","135.224.163.235","57.166.252.2","57.165.49.166","4.153.131.161","57.165.49.157","130.213.254.31","52.184.255.121","172.175.119.140","4.152.190.135","20.96.151.63","130.213.197.166","68.220.2.130","135.222.184.142","20.97.130.219","20.69.200.68","20.97.132.38","20.97.133.137","20.94.122.99","20.94.122.65","20.94.122.133","20.94.122.111","20.94.122.70","20.94.122.101","52.167.135.54","52.184.149.238","52.179.250.88","52.184.149.147","52.184.198.180","52.184.138.179","52.179.253.112","52.184.190.79","52.184.141.185","52.184.151.206","4.153.163.131","20.36.242.179","20.36.243.222","20.36.243.227","20.36.243.208","128.85.230.186","4.153.163.156","20.36.242.169","4.153.163.201","20.36.244.19","20.36.244.21","20.36.243.201","128.85.220.176","128.85.212.114","135.18.214.171","20.85.91.213","128.85.239.223","4.153.23.192","4.153.23.210","4.153.23.204","4.153.23.173","68.220.200.37","20.22.76.62","20.22.133.225","20.97.149.136","20.85.54.118","20.22.84.80","20.15.28.155","135.224.218.66","132.196.159.79","172.193.41.130","52.167.25.168","132.196.164.34","20.94.2.95","20.75.97.208","135.224.208.235","20.75.109.7","20.22.64.248","20.62.39.9","20.85.16.209","9.169.239.156","172.193.72.242","172.193.27.147","4.152.228.209","20.36.246.185","135.237.222.217","135.232.58.187","20.15.32.122","4.153.191.17","128.85.223.237","172.193.40.170","20.75.41.180","135.224.210.246","135.224.216.114","135.224.213.140","135.224.185.170","132.196.183.213","172.175.33.61","20.12.101.103","135.18.146.254","20.22.16.179","20.75.127.1","20.75.67.92","20.1.251.122","4.153.151.187","135.224.209.109","20.75.1.111","20.1.226.146","20.7.80.26","20.75.99.67","20.10.90.46","20.75.104.174","40.70.153.121","20.186.184.95","68.220.235.57","52.177.38.207","135.237.215.145","135.224.185.188","128.85.229.133","135.224.250.193","72.153.36.134","20.12.102.108","135.224.185.174","4.153.62.175","48.211.150.180","135.18.168.30","172.193.34.238","4.153.71.55","48.211.203.231","135.222.164.197","135.18.146.169","4.152.79.15","4.150.70.211","9.169.143.186","68.220.24.87","48.214.33.89","172.175.114.132","130.213.179.249","132.196.177.100","135.222.147.221","48.214.33.85","172.193.38.136","9.169.142.73","4.152.41.125","20.75.109.89","172.193.58.160","172.193.28.169","4.153.52.96","48.204.160.140","172.193.38.141","20.15.61.123","128.85.238.121","135.222.147.158","48.214.23.254","128.85.211.88","20.96.143.163","128.85.239.65","128.85.229.189","4.152.3.179","130.213.167.42","48.211.145.157","4.153.48.14","130.213.180.16","130.213.178.236","52.177.235.178","48.211.182.187","172.193.43.183","135.18.168.33","52.167.31.168","135.237.249.114","4.153.156.117","57.162.40.176","4.153.104.192","132.196.155.249","20.36.238.22","20.186.162.108","4.153.31.203","20.22.93.71","20.12.95.82","48.211.145.156","4.152.243.12","48.214.1.31","20.22.182.117","20.22.113.146","20.7.216.130","20.161.150.197","20.10.235.4","20.12.124.68","130.213.252.62","20.1.227.209","135.18.218.130","20.94.103.85","20.85.58.60","20.1.221.138","20.161.177.102","52.138.106.25","130.213.251.223","20.62.36.221","52.138.115.89","20.22.118.145","20.88.119.225","57.166.252.203","52.138.112.244","20.75.60.154","20.161.148.158","57.165.89.165","172.193.52.229","4.153.8.84","20.161.178.164","20.22.113.147","52.242.96.196","4.152.32.229","48.214.3.41","20.22.170.19","20.10.234.83","20.22.43.74","52.138.106.40","20.85.90.84","20.94.14.9","20.161.178.225","20.122.242.74","172.175.161.22","172.193.52.189","20.10.76.255","48.214.69.158","20.96.54.171","20.10.66.176","20.122.232.93","20.65.21.157","48.214.85.92","20.85.118.158","128.85.241.225","48.214.69.70","128.85.246.132","20.97.134.183","20.161.229.142","20.15.77.105","52.167.12.197","20.96.99.137","20.122.227.225","130.213.251.216","48.214.20.105","20.96.97.219","172.193.121.244","20.96.159.130","20.161.147.200","172.175.162.39","20.80.198.70","20.15.84.33","52.177.106.109","20.7.235.60","48.214.2.73","48.204.167.91","57.165.89.94","20.161.176.191","132.196.158.139","128.85.228.227","51.8.134.196","57.165.49.189","20.22.173.68","4.153.39.135"],"latestRevisionName":"functionapp000002--hmfk94s","latestReadyRevisionName":"functionapp000002--hmfk94s","latestRevisionFqdn":"","customDomainVerificationId":"6C8AEA45371636CA70C78CCAB1A4B36CB1FEC824B6F1F0ECDB89BE23575F6907","configuration":{"secrets":null,"activeRevisionsMode":"Single","targetLabel":"","revisionTransitionThreshold":null,"ingress":null,"registries":null,"identitySettings":[],"dapr":null,"runtime":null,"maxInactiveRevisions":100,"service":null},"template":{"revisionSuffix":"","terminationGracePeriodSeconds":null,"customMetricsSettings":null,"containers":[{"image":"mcr.microsoft.com/azure-functions/dotnet8-quickstart-demo:1.0","imageType":"ContainerImage","name":"functionapp000002","resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":null,"maxReplicas":10,"cooldownPeriod":300,"pollingInterval":30,"rules":null},"volumes":null,"serviceBinds":null},"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/containerApps/functionapp000002/eventstream","delegatedIdentities":[]},"identity":{"type":"None"},"kind":"functionapp"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '8567'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:41:53 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: 2E45BDAE492F488DA2F4BD768A832DDB Ref B: PNQ231110906029 Ref C: 2026-07-03T09:41:53Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp function show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --function-name
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerApps/functionapp000002?api-version=2025-10-02-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerapps/functionapp000002","name":"functionapp000002","type":"Microsoft.App/containerApps","location":"East
+        US 2","systemData":{"createdBy":"test@example.com","createdByType":"User","createdAt":"2026-07-03T09:41:06.1398185","lastModifiedBy":"test@example.com","lastModifiedByType":"User","lastModifiedAt":"2026-07-03T09:41:06.1398185"},"properties":{"provisioningState":"Succeeded","runningStatus":"Running","managedEnvironmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/client.env_rg_eastus2/providers/Microsoft.App/managedEnvironments/env-eastus2","environmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/client.env_rg_eastus2/providers/Microsoft.App/managedEnvironments/env-eastus2","workloadProfileName":"Consumption","patchingMode":"Automatic","outboundIpAddresses":["20.1.250.250","20.1.251.135","20.1.251.104","20.1.251.2","13.68.118.203","13.68.119.127","52.184.147.35","52.184.147.9","20.94.111.32","20.94.110.46","20.7.131.26","20.7.130.240","20.7.131.54","20.7.131.60","20.7.131.34","20.7.131.59","20.7.131.44","20.7.131.5","20.7.131.39","20.7.131.50","172.200.51.234","172.200.52.27","172.200.51.44","172.200.51.235","172.200.51.243","172.200.51.45","172.200.51.191","172.200.51.242","172.200.52.26","172.200.51.190","4.153.75.54","172.193.97.218","68.220.18.20","172.193.72.214","20.161.102.207","130.213.148.50","68.220.243.198","20.22.147.169","20.122.241.246","20.72.121.157","20.75.24.112","20.36.255.10","20.10.96.162","20.10.77.30","20.22.59.25","20.94.21.158","20.96.95.82","20.80.208.249","20.186.165.206","4.150.106.135","4.153.178.159","20.10.117.247","48.211.244.39","135.18.202.95","20.96.232.164","20.10.115.21","132.196.179.37","132.196.139.222","130.213.159.120","20.22.179.116","20.10.72.153","20.22.71.237","68.220.129.123","20.15.50.90","20.15.50.66","57.162.104.207","48.211.128.73","4.152.32.38","48.211.203.35","57.162.104.208","135.222.147.33","20.72.106.233","4.150.115.104","135.237.230.50","48.204.162.90","172.176.48.208","52.179.229.197","135.18.146.211","52.177.29.129","4.152.45.85","132.196.199.105","52.184.249.176","172.175.160.88","20.85.79.72","57.165.49.155","172.193.112.244","57.162.45.229","48.211.199.212","135.237.231.126","48.204.167.79","20.15.38.216","20.161.158.212","20.10.122.104","172.175.211.41","20.15.53.40","4.153.36.1","135.224.219.190","48.214.0.25","172.193.115.158","132.196.212.198","4.153.231.37","52.251.8.192","130.213.197.208","135.18.143.203","135.18.192.95","130.213.254.40","20.7.235.22","135.237.204.151","52.247.33.54","20.15.17.157","172.175.119.184","132.196.213.1","132.196.188.132","57.166.139.239","57.166.251.219","132.196.144.197","20.161.107.186","20.15.48.196","132.196.212.240","172.193.115.74","130.213.254.44","132.196.199.152","57.162.111.250","52.184.249.177","132.196.174.126","135.18.162.196","68.220.2.101","57.165.91.55","20.161.99.155","57.166.252.6","52.232.209.131","135.224.231.203","135.18.163.226","172.193.66.194","132.196.199.76","48.211.194.4","135.224.163.166","20.15.53.46","135.18.163.191","20.161.99.146","57.162.111.230","135.222.165.45","172.175.210.116","172.175.212.113","48.204.154.11","48.204.153.246","57.165.49.165","135.224.163.235","57.166.252.2","57.165.49.166","4.153.131.161","57.165.49.157","130.213.254.31","52.184.255.121","172.175.119.140","4.152.190.135","20.96.151.63","130.213.197.166","68.220.2.130","135.222.184.142","20.97.130.219","20.69.200.68","20.97.132.38","20.97.133.137","20.94.122.99","20.94.122.65","20.94.122.133","20.94.122.111","20.94.122.70","20.94.122.101","52.167.135.54","52.184.149.238","52.179.250.88","52.184.149.147","52.184.198.180","52.184.138.179","52.179.253.112","52.184.190.79","52.184.141.185","52.184.151.206","4.153.163.131","20.36.242.179","20.36.243.222","20.36.243.227","20.36.243.208","128.85.230.186","4.153.163.156","20.36.242.169","4.153.163.201","20.36.244.19","20.36.244.21","20.36.243.201","128.85.220.176","128.85.212.114","135.18.214.171","20.85.91.213","128.85.239.223","4.153.23.192","4.153.23.210","4.153.23.204","4.153.23.173","68.220.200.37","20.22.76.62","20.22.133.225","20.97.149.136","20.85.54.118","20.22.84.80","20.15.28.155","135.224.218.66","132.196.159.79","172.193.41.130","52.167.25.168","132.196.164.34","20.94.2.95","20.75.97.208","135.224.208.235","20.75.109.7","20.22.64.248","20.62.39.9","20.85.16.209","9.169.239.156","172.193.72.242","172.193.27.147","4.152.228.209","20.36.246.185","135.237.222.217","135.232.58.187","20.15.32.122","4.153.191.17","128.85.223.237","172.193.40.170","20.75.41.180","135.224.210.246","135.224.216.114","135.224.213.140","135.224.185.170","132.196.183.213","172.175.33.61","20.12.101.103","135.18.146.254","20.22.16.179","20.75.127.1","20.75.67.92","20.1.251.122","4.153.151.187","135.224.209.109","20.75.1.111","20.1.226.146","20.7.80.26","20.75.99.67","20.10.90.46","20.75.104.174","40.70.153.121","20.186.184.95","68.220.235.57","52.177.38.207","135.237.215.145","135.224.185.188","128.85.229.133","135.224.250.193","72.153.36.134","20.12.102.108","135.224.185.174","4.153.62.175","48.211.150.180","135.18.168.30","172.193.34.238","4.153.71.55","48.211.203.231","135.222.164.197","135.18.146.169","4.152.79.15","4.150.70.211","9.169.143.186","68.220.24.87","48.214.33.89","172.175.114.132","130.213.179.249","132.196.177.100","135.222.147.221","48.214.33.85","172.193.38.136","9.169.142.73","4.152.41.125","20.75.109.89","172.193.58.160","172.193.28.169","4.153.52.96","48.204.160.140","172.193.38.141","20.15.61.123","128.85.238.121","135.222.147.158","48.214.23.254","128.85.211.88","20.96.143.163","128.85.239.65","128.85.229.189","4.152.3.179","130.213.167.42","48.211.145.157","4.153.48.14","130.213.180.16","130.213.178.236","52.177.235.178","48.211.182.187","172.193.43.183","135.18.168.33","52.167.31.168","135.237.249.114","4.153.156.117","57.162.40.176","4.153.104.192","132.196.155.249","20.36.238.22","20.186.162.108","4.153.31.203","20.22.93.71","20.12.95.82","48.211.145.156","4.152.243.12","48.214.1.31","20.22.182.117","20.22.113.146","20.7.216.130","20.161.150.197","20.10.235.4","20.12.124.68","130.213.252.62","20.1.227.209","135.18.218.130","20.94.103.85","20.85.58.60","20.1.221.138","20.161.177.102","52.138.106.25","130.213.251.223","20.62.36.221","52.138.115.89","20.22.118.145","20.88.119.225","57.166.252.203","52.138.112.244","20.75.60.154","20.161.148.158","57.165.89.165","172.193.52.229","4.153.8.84","20.161.178.164","20.22.113.147","52.242.96.196","4.152.32.229","48.214.3.41","20.22.170.19","20.10.234.83","20.22.43.74","52.138.106.40","20.85.90.84","20.94.14.9","20.161.178.225","20.122.242.74","172.175.161.22","172.193.52.189","20.10.76.255","48.214.69.158","20.96.54.171","20.10.66.176","20.122.232.93","20.65.21.157","48.214.85.92","20.85.118.158","128.85.241.225","48.214.69.70","128.85.246.132","20.97.134.183","20.161.229.142","20.15.77.105","52.167.12.197","20.96.99.137","20.122.227.225","130.213.251.216","48.214.20.105","20.96.97.219","172.193.121.244","20.96.159.130","20.161.147.200","172.175.162.39","20.80.198.70","20.15.84.33","52.177.106.109","20.7.235.60","48.214.2.73","48.204.167.91","57.165.89.94","20.161.176.191","132.196.158.139","128.85.228.227","51.8.134.196","57.165.49.189","20.22.173.68","4.153.39.135"],"latestRevisionName":"functionapp000002--hmfk94s","latestReadyRevisionName":"functionapp000002--hmfk94s","latestRevisionFqdn":"","customDomainVerificationId":"6C8AEA45371636CA70C78CCAB1A4B36CB1FEC824B6F1F0ECDB89BE23575F6907","configuration":{"secrets":null,"activeRevisionsMode":"Single","targetLabel":"","revisionTransitionThreshold":null,"ingress":null,"registries":null,"identitySettings":[],"dapr":null,"runtime":null,"maxInactiveRevisions":100,"service":null},"template":{"revisionSuffix":"","terminationGracePeriodSeconds":null,"customMetricsSettings":null,"containers":[{"image":"mcr.microsoft.com/azure-functions/dotnet8-quickstart-demo:1.0","imageType":"ContainerImage","name":"functionapp000002","resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":null,"maxReplicas":10,"cooldownPeriod":300,"pollingInterval":30,"rules":null},"volumes":null,"serviceBinds":null},"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/containerApps/functionapp000002/eventstream","delegatedIdentities":[]},"identity":{"type":"None"},"kind":"functionapp"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '8567'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:41:54 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: DADE7C81E577468E829F19876C2FEB93 Ref B: PNQ231110907023 Ref C: 2026-07-03T09:41:54Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp function show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --function-name
+      User-Agent:
+      - python/3.12.10 (Windows-11-10.0.26200-SP0) AZURECLI/2.87.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerApps/functionapp000002?api-version=2025-10-02-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/containerapps/functionapp000002","name":"functionapp000002","type":"Microsoft.App/containerApps","location":"East
+        US 2","systemData":{"createdBy":"test@example.com","createdByType":"User","createdAt":"2026-07-03T09:41:06.1398185","lastModifiedBy":"test@example.com","lastModifiedByType":"User","lastModifiedAt":"2026-07-03T09:41:06.1398185"},"properties":{"provisioningState":"Succeeded","runningStatus":"Running","managedEnvironmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/client.env_rg_eastus2/providers/Microsoft.App/managedEnvironments/env-eastus2","environmentId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/client.env_rg_eastus2/providers/Microsoft.App/managedEnvironments/env-eastus2","workloadProfileName":"Consumption","patchingMode":"Automatic","outboundIpAddresses":["20.1.250.250","20.1.251.135","20.1.251.104","20.1.251.2","13.68.118.203","13.68.119.127","52.184.147.35","52.184.147.9","20.94.111.32","20.94.110.46","20.7.131.26","20.7.130.240","20.7.131.54","20.7.131.60","20.7.131.34","20.7.131.59","20.7.131.44","20.7.131.5","20.7.131.39","20.7.131.50","172.200.51.234","172.200.52.27","172.200.51.44","172.200.51.235","172.200.51.243","172.200.51.45","172.200.51.191","172.200.51.242","172.200.52.26","172.200.51.190","4.153.75.54","172.193.97.218","68.220.18.20","172.193.72.214","20.161.102.207","130.213.148.50","68.220.243.198","20.22.147.169","20.122.241.246","20.72.121.157","20.75.24.112","20.36.255.10","20.10.96.162","20.10.77.30","20.22.59.25","20.94.21.158","20.96.95.82","20.80.208.249","20.186.165.206","4.150.106.135","4.153.178.159","20.10.117.247","48.211.244.39","135.18.202.95","20.96.232.164","20.10.115.21","132.196.179.37","132.196.139.222","130.213.159.120","20.22.179.116","20.10.72.153","20.22.71.237","68.220.129.123","20.15.50.90","20.15.50.66","57.162.104.207","48.211.128.73","4.152.32.38","48.211.203.35","57.162.104.208","135.222.147.33","20.72.106.233","4.150.115.104","135.237.230.50","48.204.162.90","172.176.48.208","52.179.229.197","135.18.146.211","52.177.29.129","4.152.45.85","132.196.199.105","52.184.249.176","172.175.160.88","20.85.79.72","57.165.49.155","172.193.112.244","57.162.45.229","48.211.199.212","135.237.231.126","48.204.167.79","20.15.38.216","20.161.158.212","20.10.122.104","172.175.211.41","20.15.53.40","4.153.36.1","135.224.219.190","48.214.0.25","172.193.115.158","132.196.212.198","4.153.231.37","52.251.8.192","130.213.197.208","135.18.143.203","135.18.192.95","130.213.254.40","20.7.235.22","135.237.204.151","52.247.33.54","20.15.17.157","172.175.119.184","132.196.213.1","132.196.188.132","57.166.139.239","57.166.251.219","132.196.144.197","20.161.107.186","20.15.48.196","132.196.212.240","172.193.115.74","130.213.254.44","132.196.199.152","57.162.111.250","52.184.249.177","132.196.174.126","135.18.162.196","68.220.2.101","57.165.91.55","20.161.99.155","57.166.252.6","52.232.209.131","135.224.231.203","135.18.163.226","172.193.66.194","132.196.199.76","48.211.194.4","135.224.163.166","20.15.53.46","135.18.163.191","20.161.99.146","57.162.111.230","135.222.165.45","172.175.210.116","172.175.212.113","48.204.154.11","48.204.153.246","57.165.49.165","135.224.163.235","57.166.252.2","57.165.49.166","4.153.131.161","57.165.49.157","130.213.254.31","52.184.255.121","172.175.119.140","4.152.190.135","20.96.151.63","130.213.197.166","68.220.2.130","135.222.184.142","20.97.130.219","20.69.200.68","20.97.132.38","20.97.133.137","20.94.122.99","20.94.122.65","20.94.122.133","20.94.122.111","20.94.122.70","20.94.122.101","52.167.135.54","52.184.149.238","52.179.250.88","52.184.149.147","52.184.198.180","52.184.138.179","52.179.253.112","52.184.190.79","52.184.141.185","52.184.151.206","4.153.163.131","20.36.242.179","20.36.243.222","20.36.243.227","20.36.243.208","128.85.230.186","4.153.163.156","20.36.242.169","4.153.163.201","20.36.244.19","20.36.244.21","20.36.243.201","128.85.220.176","128.85.212.114","135.18.214.171","20.85.91.213","128.85.239.223","4.153.23.192","4.153.23.210","4.153.23.204","4.153.23.173","68.220.200.37","20.22.76.62","20.22.133.225","20.97.149.136","20.85.54.118","20.22.84.80","20.15.28.155","135.224.218.66","132.196.159.79","172.193.41.130","52.167.25.168","132.196.164.34","20.94.2.95","20.75.97.208","135.224.208.235","20.75.109.7","20.22.64.248","20.62.39.9","20.85.16.209","9.169.239.156","172.193.72.242","172.193.27.147","4.152.228.209","20.36.246.185","135.237.222.217","135.232.58.187","20.15.32.122","4.153.191.17","128.85.223.237","172.193.40.170","20.75.41.180","135.224.210.246","135.224.216.114","135.224.213.140","135.224.185.170","132.196.183.213","172.175.33.61","20.12.101.103","135.18.146.254","20.22.16.179","20.75.127.1","20.75.67.92","20.1.251.122","4.153.151.187","135.224.209.109","20.75.1.111","20.1.226.146","20.7.80.26","20.75.99.67","20.10.90.46","20.75.104.174","40.70.153.121","20.186.184.95","68.220.235.57","52.177.38.207","135.237.215.145","135.224.185.188","128.85.229.133","135.224.250.193","72.153.36.134","20.12.102.108","135.224.185.174","4.153.62.175","48.211.150.180","135.18.168.30","172.193.34.238","4.153.71.55","48.211.203.231","135.222.164.197","135.18.146.169","4.152.79.15","4.150.70.211","9.169.143.186","68.220.24.87","48.214.33.89","172.175.114.132","130.213.179.249","132.196.177.100","135.222.147.221","48.214.33.85","172.193.38.136","9.169.142.73","4.152.41.125","20.75.109.89","172.193.58.160","172.193.28.169","4.153.52.96","48.204.160.140","172.193.38.141","20.15.61.123","128.85.238.121","135.222.147.158","48.214.23.254","128.85.211.88","20.96.143.163","128.85.239.65","128.85.229.189","4.152.3.179","130.213.167.42","48.211.145.157","4.153.48.14","130.213.180.16","130.213.178.236","52.177.235.178","48.211.182.187","172.193.43.183","135.18.168.33","52.167.31.168","135.237.249.114","4.153.156.117","57.162.40.176","4.153.104.192","132.196.155.249","20.36.238.22","20.186.162.108","4.153.31.203","20.22.93.71","20.12.95.82","48.211.145.156","4.152.243.12","48.214.1.31","20.22.182.117","20.22.113.146","20.7.216.130","20.161.150.197","20.10.235.4","20.12.124.68","130.213.252.62","20.1.227.209","135.18.218.130","20.94.103.85","20.85.58.60","20.1.221.138","20.161.177.102","52.138.106.25","130.213.251.223","20.62.36.221","52.138.115.89","20.22.118.145","20.88.119.225","57.166.252.203","52.138.112.244","20.75.60.154","20.161.148.158","57.165.89.165","172.193.52.229","4.153.8.84","20.161.178.164","20.22.113.147","52.242.96.196","4.152.32.229","48.214.3.41","20.22.170.19","20.10.234.83","20.22.43.74","52.138.106.40","20.85.90.84","20.94.14.9","20.161.178.225","20.122.242.74","172.175.161.22","172.193.52.189","20.10.76.255","48.214.69.158","20.96.54.171","20.10.66.176","20.122.232.93","20.65.21.157","48.214.85.92","20.85.118.158","128.85.241.225","48.214.69.70","128.85.246.132","20.97.134.183","20.161.229.142","20.15.77.105","52.167.12.197","20.96.99.137","20.122.227.225","130.213.251.216","48.214.20.105","20.96.97.219","172.193.121.244","20.96.159.130","20.161.147.200","172.175.162.39","20.80.198.70","20.15.84.33","52.177.106.109","20.7.235.60","48.214.2.73","48.204.167.91","57.165.89.94","20.161.176.191","132.196.158.139","128.85.228.227","51.8.134.196","57.165.49.189","20.22.173.68","4.153.39.135"],"latestRevisionName":"functionapp000002--hmfk94s","latestReadyRevisionName":"functionapp000002--hmfk94s","latestRevisionFqdn":"","customDomainVerificationId":"6C8AEA45371636CA70C78CCAB1A4B36CB1FEC824B6F1F0ECDB89BE23575F6907","configuration":{"secrets":null,"activeRevisionsMode":"Single","targetLabel":"","revisionTransitionThreshold":null,"ingress":null,"registries":null,"identitySettings":[],"dapr":null,"runtime":null,"maxInactiveRevisions":100,"service":null},"template":{"revisionSuffix":"","terminationGracePeriodSeconds":null,"customMetricsSettings":null,"containers":[{"image":"mcr.microsoft.com/azure-functions/dotnet8-quickstart-demo:1.0","imageType":"ContainerImage","name":"functionapp000002","resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":null,"maxReplicas":10,"cooldownPeriod":300,"pollingInterval":30,"rules":null},"volumes":null,"serviceBinds":null},"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/containerApps/functionapp000002/eventstream","delegatedIdentities":[]},"identity":{"type":"None"},"kind":"functionapp"}'
+    headers:
+      api-supported-versions:
+      - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview,
+        2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview,
+        2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview,
+        2025-07-01, 2025-10-02-preview, 2026-01-01, 2026-03-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '8567'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 03 Jul 2026 09:41:55 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-global-reads:
+      - '16499'
+      x-msedge-ref:
+      - 'Ref A: D338753CA1724A8B99077A5C025D9D2E Ref B: PNQ231110906031 Ref C: 2026-07-03T09:41:55Z'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/containerapp/azext_containerapp/tests/latest/test_containerapp_function.py
+++ b/src/containerapp/azext_containerapp/tests/latest/test_containerapp_function.py
@@ -155,6 +155,38 @@ class ContainerappFunctionTests(ScenarioTest):
 
     @AllowLargeResponse(8192)
     @ResourceGroupPreparer(location="eastus2")
+    def test_containerapp_function_list_show_ingress_disabled(self, resource_group):
+        """Functions cannot be listed/shown while ingress is disabled; a clear, actionable error should be raised."""
+        location = TEST_LOCATION
+        if format_location(location) == format_location(STAGE_LOCATION):
+            location = "eastus2"
+        self.cmd('configure --defaults location={}'.format(location))
+
+        ca_func_name = self.create_random_name(prefix='functionapp', length=24)
+        function_image = "mcr.microsoft.com/azure-functions/dotnet8-quickstart-demo:1.0"
+        function_name = "HttpExample"
+
+        env = prepare_containerapp_env_for_app_e2e_tests(self, location=location)
+
+        # Create a function app WITHOUT ingress (no --ingress/--target-port), so ingress is disabled.
+        self.cmd(f'containerapp create -g {resource_group} -n {ca_func_name} --image {function_image} --environment {env} --kind functionapp', checks=[
+            JMESPathCheck("properties.provisioningState", "Succeeded"),
+            JMESPathCheck("kind", "functionapp"),
+            JMESPathCheck("properties.configuration.ingress", None)
+        ])
+        time.sleep(30)
+
+        # Listing functions must fail fast with the actionable ingress-disabled message.
+        with self.assertRaisesRegex(ValidationError, "Ingress must be enabled"):
+            self.cmd(f'containerapp function list -g {resource_group} -n {ca_func_name}')
+
+        # Showing a function must fail with the same message.
+        with self.assertRaisesRegex(ValidationError, "Ingress must be enabled"):
+            self.cmd(f'containerapp function show -g {resource_group} -n {ca_func_name} --function-name {function_name}')
+
+
+    @AllowLargeResponse(8192)
+    @ResourceGroupPreparer(location="eastus2")
     def test_containerapp_function_list_show_multirevision_scenarios(self, resource_group):
         """Test multiple revisions scenarios for function list command"""
         location = TEST_LOCATION

--- a/src/containerapp/setup.py
+++ b/src/containerapp/setup.py
@@ -28,7 +28,7 @@ except ImportError:
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
 
-VERSION = '1.3.0b4'
+VERSION = '1.3.0b5'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/src/containerapp/setup.py
+++ b/src/containerapp/setup.py
@@ -28,7 +28,7 @@ except ImportError:
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
 
-VERSION = '1.3.0b5'
+VERSION = '1.3.0b4'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
### Summary

`az containerapp function list` and `az containerapp function show` returned a generic `InternalServerError` when the target Container App (Function) had **ingress disabled**. The function metadata these commands read is only populated by the platform while ingress is enabled, so the underlying API fails opaquely when it is off, giving users no indication of the cause or the fix.

This change adds a pre-check that detects the disabled-ingress case (using the Container App already fetched during validation, so no extra ARM call) and raises an actionable `ValidationError` instead of the opaque server error.

### Behavior

- **Ingress disabled** → `Ingress must be enabled to view functions for the containerapp '<name>'. Enable ingress on the container app and try again.`
- **Ingress enabled** → unchanged (functions list/show as before).
- Applies to both `az containerapp function list` and `az containerapp function show`.

### Changes

- New validator `validate_functionapp_ingress_enabled` in `_validators.py`.
- Wired into the `list` and `show` function decorators.
- Added a scenario test (`test_containerapp_function_list_show_ingress_disabled`) with its recording.
- Bumped extension version to `1.3.0b5` and added a `HISTORY.rst` entry.

### Testing

- Recorded the new scenario test live (`AZURE_TEST_RUN_LIVE=true`) and verified it passes in **playback** mode (offline, cassette-only).
- Manually verified against a real ingress-disabled Container App (Function): both `list` and `show` now return the actionable error; an ingress-enabled app lists/show functions normally.

### History Notes

* `az containerapp function list/show`: Raise a clear error when ingress is disabled instead of a generic server error