### PR TITLE
[AKS] aks-preview: bump minCliCoreVersion to 2.85.0 for ACNS performance compatibility

### DIFF
--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -12,6 +12,10 @@ To release a new version, please select a new version number (usually plus 1 to 
 Pending
 +++++++
 
+21.0.0b9
+++++++++
+* Update the minimum required cli core version to `2.85.0` (actually required since `20.0.0b5`).
+
 21.0.0b8
 ++++++++
 * `az aks create`: Add `--enable-on-demand-monitor` to enable on-demand monitor for the cluster.
@@ -73,7 +77,7 @@ Pending
 ++++++
 * `az aks nodepool update --crg-id`: Allow updating `--crg-id` to associate an existing Capacity Reservation Group with a nodepool not currently associated with one.
 * Vendor new SDK and bump API version to 2026-03-02-preview.
-* Update the minimum required cli core version to `2.76.0` (actually since `20.0.0b3`).
+* Update the minimum required cli core version to `2.76.0` (actually required since `20.0.0b3`).
 * `az aks upgrade`: Add `--k8s-support-plan` and `--tier` flag support to allow cluster support plan and tier configuration during cluster upgrade.
 
 20.0.0b6
@@ -237,7 +241,7 @@ Pending
 
 19.0.0b6
 +++++++
-* Update the minimum required cli core version to `2.73.0` (actually since `18.0.0b35`).
+* Update the minimum required cli core version to `2.73.0` (actually required since `18.0.0b35`).
 
 19.0.0b5
 +++++++
@@ -802,7 +806,7 @@ Pending
 2.0.0b8
 +++++++
 * Add `az aks check-network outbound` command to check outbound network from nodes.
-* Update the minimum required cli core version to `2.56.0` (actually since `2.0.0b7`).
+* Update the minimum required cli core version to `2.56.0` (actually required since `2.0.0b7`).
 
 2.0.0b7
 +++++++
@@ -1311,7 +1315,7 @@ Pending
 ++++++
 
 * Add `--enable-node-restriction`/`--disable-node-restriction` to enable/disable node restriction feature
-* Update the minimum required cli core version to `2.38.0` (actually since `0.5.92`).
+* Update the minimum required cli core version to `2.38.0` (actually required since `0.5.92`).
 * Add new value `Mariner` for option `--os-sku` in `az aks create` and `az aks nodepool add`.
 
 0.5.94

--- a/src/aks-preview/README.rst
+++ b/src/aks-preview/README.rst
@@ -53,8 +53,10 @@ Dependency between aks-preview and azure-cli/acs (azure-cli-core)
       - >= `\2.61.0 <https://github.com/Azure/azure-cli/releases/tag/azure-cli-2.61.0>`_, 2024/05/21
     * - 18.0.0b35 ~ 20.0.0b2
       - >= `\2.73.0 <https://github.com/Azure/azure-cli/releases/tag/azure-cli-2.73.0>`_, 2025/05/19
-    * - 20.0.0b3 ~ latest
+    * - 20.0.0b3 ~ 20.0.0b4
       - >= `\2.76.0 <https://github.com/Azure/azure-cli/releases/tag/azure-cli-2.76.0>`_, 2025/08/15
+    * - 20.0.0b5 ~ latest
+      - >= `\2.85.0 <https://github.com/Azure/azure-cli/releases/tag/azure-cli-2.85.0>`_, 2026/04/07
 
 Released version and adopted API version
 ========================================

--- a/src/aks-preview/azext_aks_preview/azext_metadata.json
+++ b/src/aks-preview/azext_aks_preview/azext_metadata.json
@@ -1,5 +1,5 @@
 {
-    "azext.minCliCoreVersion": "2.76.0",
+    "azext.minCliCoreVersion": "2.85.0",
     "azext.isPreview": true,
     "name": "aks-preview"
 }

--- a/src/aks-preview/setup.py
+++ b/src/aks-preview/setup.py
@@ -9,7 +9,7 @@ from codecs import open as open1
 
 from setuptools import find_packages, setup
 
-VERSION = "21.0.0b8"
+VERSION = "21.0.0b9"
 
 CLASSIFIERS = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
### Related command

`az aks create`, `az aks update` (network profile / ACNS setup path)

### Description

Raise `azext.minCliCoreVersion` for `aks-preview` from `2.76.0` to `2.85.0` and bump the extension to `21.0.0b9`.

Since `aks-preview` **20.0.0b5** (PR #9779), `AKSPreviewManagedClusterContext.get_acns_enablement()` returns **four** values (adding the ACNS performance / datapath-acceleration flag). The extension's `set_up_network_profile()` calls `super().set_up_network_profile()`, and the base `acs` module only started consuming that fourth value (via `get_acns_enablement_with_perf()`) in azure-cli core **2.85.0**.

On any core older than `2.85.0`, the base `set_up_network_profile()` still unpacks three values:

```python
(acns_enabled, acns_observability, acns_security) = self.context.get_acns_enablement()
```

so every `az aks create` / `az aks update` fails with:

```
ValueError: too many values to unpack (expected 3)
```

Because the manifest advertised `minCliCoreVersion = 2.76.0`, the extension could be installed on incompatible cores and crashed at runtime (e.g. `aks-preview 21.0.0b6` on `azure-cli 2.82.0`). Raising the floor makes `az` refuse to load the extension on an incompatible core (prompting an upgrade) instead of crashing mid-command.

- Regression introduced in: `20.0.0b5`
- Minimum required core: `>= 2.85.0`

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style aks-preview` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install azdev` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

### About Extension Publish

Only `setup.py` (version) and `HISTORY.rst` are updated for the release; `src/index.json` is intentionally left untouched.
