### PR TITLE
[image-gallery] Migrate commands calling Compute module to aaz-based implementation and removed `--marker` and `--show-next-marker` from `sig image-definition list-community` and `sig image-version list-community`

### DIFF
--- a/src/image-gallery/HISTORY.rst
+++ b/src/image-gallery/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+1.1.0
++++++++++++++++
+* Migrate code from Azure SDK to AAZ based commands for compute operations.
+* Remove `--marker` and `--show-next-marker` from `sig image-definition list-community` and `sig image-version list-community`. AAZ has its own handling for pagination.
+
 1.0.0b2
 +++++++++++++++
 * Remove `__import__('pkg_resources').declare_namespace(__name__)` to fix the namespace package issue.

--- a/src/image-gallery/setup.py
+++ b/src/image-gallery/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
-VERSION = '1.0.0b2'
+VERSION = '1.1.0'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Migration from mgmt.compute to aaz-based
Remove `--marker` and `--show-next-marker` from `sig image-definition list-community` and `sig image-version list-community`. AAZ have its own handling for pagination.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install azdev` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
