### PR TITLE
[image-gallery] Migrate commands calling Compute module to aaz-based implementation and removed `--marker` and `--show-next-marker` from `sig image-definition list-community` and `sig image-version list-community`

### DIFF
--- a/src/image-gallery/HISTORY.rst
+++ b/src/image-gallery/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+1.1.0
++++++++++++++++
+* Migrate code from Azure SDK to AAZ based commands for compute operations.
+
 1.0.0b2
 +++++++++++++++
 * Remove `__import__('pkg_resources').declare_namespace(__name__)` to fix the namespace package issue.

--- a/src/image-gallery/azext_image_gallery/_client_factory.py
+++ b/src/image-gallery/azext_image_gallery/_client_factory.py
@@ -14,10 +14,6 @@ def cf_galleries(cli_ctx, _):
     return _compute_client_factory(cli_ctx).galleries
 
 
-def cf_community_gallery(cli_ctx, *_):
-    return _compute_client_factory(cli_ctx).community_galleries
-
-
 def cf_community_gallery_image(cli_ctx, *_):
     return _compute_client_factory(cli_ctx).community_gallery_images
 

--- a/src/image-gallery/azext_image_gallery/_client_factory.py
+++ b/src/image-gallery/azext_image_gallery/_client_factory.py
@@ -12,7 +12,3 @@ def _compute_client_factory(cli_ctx):
 
 def cf_galleries(cli_ctx, _):
     return _compute_client_factory(cli_ctx).galleries
-
-
-def cf_community_gallery_image_version(cli_ctx, *_):
-    return _compute_client_factory(cli_ctx).community_gallery_image_versions

--- a/src/image-gallery/azext_image_gallery/_client_factory.py
+++ b/src/image-gallery/azext_image_gallery/_client_factory.py
@@ -14,9 +14,5 @@ def cf_galleries(cli_ctx, _):
     return _compute_client_factory(cli_ctx).galleries
 
 
-def cf_community_gallery_image(cli_ctx, *_):
-    return _compute_client_factory(cli_ctx).community_gallery_images
-
-
 def cf_community_gallery_image_version(cli_ctx, *_):
     return _compute_client_factory(cli_ctx).community_gallery_image_versions

--- a/src/image-gallery/azext_image_gallery/_client_factory.py
+++ b/src/image-gallery/azext_image_gallery/_client_factory.py
@@ -20,7 +20,3 @@ def cf_community_gallery_image(cli_ctx, *_):
 
 def cf_community_gallery_image_version(cli_ctx, *_):
     return _compute_client_factory(cli_ctx).community_gallery_image_versions
-
-
-def cf_community_gallery_sharing_profile(cli_ctx, *_):
-    return _compute_client_factory(cli_ctx).gallery_sharing_profile

--- a/src/image-gallery/azext_image_gallery/_client_factory.py
+++ b/src/image-gallery/azext_image_gallery/_client_factory.py
@@ -14,10 +14,6 @@ def cf_galleries(cli_ctx, _):
     return _compute_client_factory(cli_ctx).galleries
 
 
-def cf_gallery_images(cli_ctx, _):
-    return _compute_client_factory(cli_ctx).gallery_images
-
-
 def cf_community_gallery(cli_ctx, *_):
     return _compute_client_factory(cli_ctx).community_galleries
 

--- a/src/image-gallery/azext_image_gallery/_params.py
+++ b/src/image-gallery/azext_image_gallery/_params.py
@@ -27,13 +27,6 @@ def load_arguments(self, _):
              'Format: `<MajorVersion>.<MinorVersion>.<Patch>`', id_part='child_name_3'
     )
 
-    marker_type = CLIArgumentType(
-        help='A string value that identifies the portion of the list of containers to be '
-             'returned with the next listing operation. The operation returns the NextMarker value within '
-             'the response body if the listing operation did not return all containers remaining to be listed '
-             'with the current page. If specified, this generator will begin returning results from the point '
-             'where the previous generator stopped.')
-
     with self.argument_context('sig show-community') as c:
         c.argument('location', arg_type=get_location_type(self.cli_ctx), id_part='name')
         c.argument('public_gallery_name', public_gallery_name_type)
@@ -57,8 +50,6 @@ def load_arguments(self, _):
         c.argument('location', arg_type=get_location_type(self.cli_ctx), id_part='name')
         c.argument('public_gallery_name', public_gallery_name_type)
         c.argument('gallery_image_name', gallery_image_name_type)
-        c.argument('marker', arg_type=marker_type)
-        c.argument('show_next_marker', action='store_true', help='Show nextMarker in result when specified.')
 
     with self.argument_context('sig') as c:
         c.argument('tags', tags_type)

--- a/src/image-gallery/azext_image_gallery/_params.py
+++ b/src/image-gallery/azext_image_gallery/_params.py
@@ -46,8 +46,6 @@ def load_arguments(self, _):
     with self.argument_context('sig image-definition list-community') as c:
         c.argument('location', arg_type=get_location_type(self.cli_ctx), id_part='name')
         c.argument('public_gallery_name', public_gallery_name_type)
-        c.argument('marker', arg_type=marker_type)
-        c.argument('show_next_marker', action='store_true', help='Show nextMarker in result when specified.')
 
     with self.argument_context('sig image-version show-community') as c:
         c.argument('location', arg_type=get_location_type(self.cli_ctx), id_part='name')

--- a/src/image-gallery/azext_image_gallery/commands.py
+++ b/src/image-gallery/azext_image_gallery/commands.py
@@ -37,7 +37,7 @@ def load_command_table(self, _):
 
     with self.command_group('sig image-version', community_gallery_image_version_sdk,
                             client_factory=cf_community_gallery_image_version) as g:
-        g.command('show-community', 'get', is_experimental=True)
+        g.custom_command('show-community', 'sig_community_image_version_show', is_experimental=True)
         g.custom_command('list-community', 'sig_community_image_version_list', is_experimental=True)
 
     with self.command_group('sig share', community_gallery_sharing_profile_sdk,

--- a/src/image-gallery/azext_image_gallery/commands.py
+++ b/src/image-gallery/azext_image_gallery/commands.py
@@ -8,8 +8,7 @@
 # pylint: disable=too-many-statements
 # pylint: disable=too-many-locals
 from azure.cli.core.commands import CliCommandType
-from ._client_factory import (cf_community_gallery_image, cf_community_gallery_image_version,
-                              cf_community_gallery_sharing_profile)
+from ._client_factory import cf_community_gallery_image, cf_community_gallery_image_version
 
 
 def load_command_table(self, _):
@@ -21,10 +20,6 @@ def load_command_table(self, _):
     community_gallery_image_version_sdk = CliCommandType(
         operations_tmpl='azext_image_gallery.vendored_sdks.azure_mgmt_compute.operations._community_gallery_image_versions_operations#CommunityGalleryImageVersionsOperations.{}',
         client_factory=cf_community_gallery_image_version)
-
-    community_gallery_sharing_profile_sdk = CliCommandType(
-        operations_tmpl='azext_image_gallery.vendored_sdks.azure_mgmt_compute.operations._gallery_sharing_profile_operations#GallerySharingProfileOperations.{}',
-        client_factory=cf_community_gallery_sharing_profile)
 
     with self.command_group('sig') as g:
         g.custom_command('create', 'create_image_gallery')
@@ -40,6 +35,5 @@ def load_command_table(self, _):
         g.custom_command('show-community', 'sig_community_image_version_show', is_experimental=True)
         g.custom_command('list-community', 'sig_community_image_version_list', is_experimental=True)
 
-    with self.command_group('sig share', community_gallery_sharing_profile_sdk,
-                            client_factory=cf_community_gallery_sharing_profile) as g:
-        g.custom_command('enable-community', 'sig_share_update', supports_no_wait=True)
+    with self.command_group('sig share') as g:
+        g.custom_command('enable-community', 'sig_share_enable_community', supports_no_wait=True)

--- a/src/image-gallery/azext_image_gallery/commands.py
+++ b/src/image-gallery/azext_image_gallery/commands.py
@@ -32,7 +32,7 @@ def load_command_table(self, _):
 
     with self.command_group('sig image-definition', community_gallery_image_sdk,
                             client_factory=cf_community_gallery_image) as g:
-        g.command('show-community', 'get', is_experimental=True)
+        g.custom_command('show-community', 'sig_community_gallery_image_show', is_experimental=True)
         g.custom_command('list-community', 'sig_community_image_definition_list', is_experimental=True)
 
     with self.command_group('sig image-version', community_gallery_image_version_sdk,

--- a/src/image-gallery/azext_image_gallery/commands.py
+++ b/src/image-gallery/azext_image_gallery/commands.py
@@ -3,20 +3,8 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-# pylint: disable=line-too-long
-# pylint: disable=too-many-lines
-# pylint: disable=too-many-statements
-# pylint: disable=too-many-locals
-from azure.cli.core.commands import CliCommandType
-from ._client_factory import cf_community_gallery_image_version
-
 
 def load_command_table(self, _):
-
-    community_gallery_image_version_sdk = CliCommandType(
-        operations_tmpl='azext_image_gallery.vendored_sdks.azure_mgmt_compute.operations._community_gallery_image_versions_operations#CommunityGalleryImageVersionsOperations.{}',
-        client_factory=cf_community_gallery_image_version)
-
     with self.command_group('sig') as g:
         g.custom_command('create', 'create_image_gallery')
         g.custom_command('show-community', 'sig_community_gallery_show', is_experimental=True)
@@ -25,8 +13,7 @@ def load_command_table(self, _):
         g.custom_command('show-community', 'sig_community_gallery_image_show', is_experimental=True)
         g.custom_command('list-community', 'sig_community_image_definition_list', is_experimental=True)
 
-    with self.command_group('sig image-version', community_gallery_image_version_sdk,
-                            client_factory=cf_community_gallery_image_version) as g:
+    with self.command_group('sig image-version') as g:
         g.custom_command('show-community', 'sig_community_image_version_show', is_experimental=True)
         g.custom_command('list-community', 'sig_community_image_version_list', is_experimental=True)
 

--- a/src/image-gallery/azext_image_gallery/commands.py
+++ b/src/image-gallery/azext_image_gallery/commands.py
@@ -8,7 +8,8 @@
 # pylint: disable=too-many-statements
 # pylint: disable=too-many-locals
 from azure.cli.core.commands import CliCommandType
-from ._client_factory import cf_community_gallery, cf_community_gallery_image, cf_community_gallery_image_version, cf_galleries, cf_community_gallery_sharing_profile
+from ._client_factory import (cf_community_gallery, cf_community_gallery_image, cf_community_gallery_image_version,
+                              cf_community_gallery_sharing_profile)
 
 
 def load_command_table(self, _):
@@ -29,12 +30,7 @@ def load_command_table(self, _):
         operations_tmpl='azext_image_gallery.vendored_sdks.azure_mgmt_compute.operations._gallery_sharing_profile_operations#GallerySharingProfileOperations.{}',
         client_factory=cf_community_gallery_sharing_profile)
 
-    compute_galleries_sdk = CliCommandType(
-        operations_tmpl='azext_image_gallery.vendored_sdks.azure_mgmt_compute.operations._galleries_operations#GalleriesOperations.{}',
-        client_factory=cf_galleries,
-    )
-
-    with self.command_group('sig', compute_galleries_sdk, client_factory=cf_galleries) as g:
+    with self.command_group('sig') as g:
         g.custom_command('create', 'create_image_gallery')
 
     with self.command_group('sig', community_gallery_sdk, client_factory=cf_community_gallery) as g:

--- a/src/image-gallery/azext_image_gallery/commands.py
+++ b/src/image-gallery/azext_image_gallery/commands.py
@@ -8,14 +8,10 @@
 # pylint: disable=too-many-statements
 # pylint: disable=too-many-locals
 from azure.cli.core.commands import CliCommandType
-from ._client_factory import cf_community_gallery_image, cf_community_gallery_image_version
+from ._client_factory import cf_community_gallery_image_version
 
 
 def load_command_table(self, _):
-
-    community_gallery_image_sdk = CliCommandType(
-        operations_tmpl='azext_image_gallery.vendored_sdks.azure_mgmt_compute.operations._community_gallery_images_operations#CommunityGalleryImagesOperations.{}',
-        client_factory=cf_community_gallery_image)
 
     community_gallery_image_version_sdk = CliCommandType(
         operations_tmpl='azext_image_gallery.vendored_sdks.azure_mgmt_compute.operations._community_gallery_image_versions_operations#CommunityGalleryImageVersionsOperations.{}',
@@ -25,8 +21,7 @@ def load_command_table(self, _):
         g.custom_command('create', 'create_image_gallery')
         g.custom_command('show-community', 'sig_community_gallery_show', is_experimental=True)
 
-    with self.command_group('sig image-definition', community_gallery_image_sdk,
-                            client_factory=cf_community_gallery_image) as g:
+    with self.command_group('sig image-definition') as g:
         g.custom_command('show-community', 'sig_community_gallery_image_show', is_experimental=True)
         g.custom_command('list-community', 'sig_community_image_definition_list', is_experimental=True)
 

--- a/src/image-gallery/azext_image_gallery/commands.py
+++ b/src/image-gallery/azext_image_gallery/commands.py
@@ -8,15 +8,11 @@
 # pylint: disable=too-many-statements
 # pylint: disable=too-many-locals
 from azure.cli.core.commands import CliCommandType
-from ._client_factory import (cf_community_gallery, cf_community_gallery_image, cf_community_gallery_image_version,
+from ._client_factory import (cf_community_gallery_image, cf_community_gallery_image_version,
                               cf_community_gallery_sharing_profile)
 
 
 def load_command_table(self, _):
-
-    community_gallery_sdk = CliCommandType(
-        operations_tmpl='azext_image_gallery.vendored_sdks.azure_mgmt_compute.operations._community_galleries_operations#CommunityGalleriesOperations.{}',
-        client_factory=cf_community_gallery)
 
     community_gallery_image_sdk = CliCommandType(
         operations_tmpl='azext_image_gallery.vendored_sdks.azure_mgmt_compute.operations._community_gallery_images_operations#CommunityGalleryImagesOperations.{}',
@@ -32,9 +28,7 @@ def load_command_table(self, _):
 
     with self.command_group('sig') as g:
         g.custom_command('create', 'create_image_gallery')
-
-    with self.command_group('sig', community_gallery_sdk, client_factory=cf_community_gallery) as g:
-        g.command('show-community', 'get', is_experimental=True)
+        g.custom_command('show-community', 'sig_community_gallery_show', is_experimental=True)
 
     with self.command_group('sig image-definition', community_gallery_image_sdk,
                             client_factory=cf_community_gallery_image) as g:

--- a/src/image-gallery/azext_image_gallery/custom.py
+++ b/src/image-gallery/azext_image_gallery/custom.py
@@ -108,6 +108,14 @@ def create_image_gallery(cmd, resource_group_name, gallery_name, description=Non
     return SigCreate(cli_ctx=cmd.cli_ctx)(command_args=command_args)
 
 
+def sig_community_gallery_show(cmd, location, public_gallery_name):
+    from azure.cli.command_modules.vm.aaz.latest.sig import ShowCommunity
+    return ShowCommunity(cli_ctx=cmd.cli_ctx)(command_args={
+        'location': location,
+        'public_gallery_name': public_gallery_name,
+    })
+
+
 def sig_share_update(cmd, client, resource_group_name, gallery_name, subscription_ids=None, tenant_ids=None,
                      op_type=None):
     from .vendored_sdks.azure_mgmt_compute.models._models_py3 import SharingProfileGroup, SharingUpdate, SharingProfileGroupTypes

--- a/src/image-gallery/azext_image_gallery/custom.py
+++ b/src/image-gallery/azext_image_gallery/custom.py
@@ -12,8 +12,6 @@ from knack.log import get_logger
 from azure.cli.core.profiles import ResourceType
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.azclierror import RequiredArgumentMissingError
-from azure.cli.core.util import sdk_no_wait
-from ._client_factory import _compute_client_factory
 logger = get_logger(__name__)
 
 
@@ -73,30 +71,41 @@ def _get_resource_group_location(cli_ctx, resource_group_name):
     return client.resource_groups.get(resource_group_name).location
 
 
-def create_image_gallery(cmd, resource_group_name, gallery_name, description=None,
-                         location=None, no_wait=False, tags=None, permissions=None, soft_delete=None,
-                         publisher_uri=None, publisher_contact=None, eula=None, public_name_prefix=None):
-    from .vendored_sdks.azure_mgmt_compute.models._models_py3 import Gallery
+def create_image_gallery(cmd, resource_group_name, gallery_name, description=None, location=None,
+                         no_wait=False, tags=None, permissions=None, soft_delete=None, publisher_uri=None,
+                         publisher_contact=None, eula=None, public_name_prefix=None):
+    from azure.cli.command_modules.vm.operations.sig import SigCreate
     location = location or _get_resource_group_location(cmd.cli_ctx, resource_group_name)
-    gallery = Gallery(description=description, location=location, tags=(tags or {}))
+    command_args = {
+        'resource_group': resource_group_name,
+        'gallery_name': gallery_name,
+        'location': location,
+        'tags': tags or {},
+        'no_wait': no_wait,
+    }
+
+    if description is not None:
+        command_args['description'] = description
+
     if soft_delete is not None:
-        gallery.soft_delete_policy = {'is_soft_delete_enabled': soft_delete}
-    client = _compute_client_factory(cmd.cli_ctx)
+        command_args['soft_delete'] = soft_delete
+
     if permissions:
-        from .vendored_sdks.azure_mgmt_compute.models._models_py3 import SharingProfile
-        gallery.sharing_profile = SharingProfile(permissions=permissions)
+        command_args['permissions'] = permissions
         if permissions == 'Community':
-            if publisher_uri is None or publisher_contact is None or eula is None or public_name_prefix is None:
+            if publisher_uri is None \
+                    or publisher_contact is None \
+                    or eula is None \
+                    or public_name_prefix is None:
                 raise RequiredArgumentMissingError('If you want to share to the community, '
                                                    'you need to fill in all the following parameters:'
                                                    ' --publisher-uri, --publisher-email, --eula, --public-name-prefix.')
 
-            from .vendored_sdks.azure_mgmt_compute.models._models_py3 import CommunityGalleryInfo
-            gallery.sharing_profile.community_gallery_info = CommunityGalleryInfo(publisher_uri=publisher_uri,
-                                                                                  publisher_contact=publisher_contact,
-                                                                                  eula=eula,
-                                                                                  public_name_prefix=public_name_prefix)
-    return sdk_no_wait(no_wait, client.galleries.begin_create_or_update, resource_group_name, gallery_name, gallery)
+            command_args['publisher_uri'] = publisher_uri
+            command_args['publisher_contact'] = publisher_contact
+            command_args['eula'] = eula
+            command_args['public_name_prefix'] = public_name_prefix
+    return SigCreate(cli_ctx=cmd.cli_ctx)(command_args=command_args)
 
 
 def sig_share_update(cmd, client, resource_group_name, gallery_name, subscription_ids=None, tenant_ids=None,

--- a/src/image-gallery/azext_image_gallery/custom.py
+++ b/src/image-gallery/azext_image_gallery/custom.py
@@ -136,18 +136,18 @@ def sig_community_image_version_show(cmd, location, public_gallery_name, gallery
     })
 
 
-def sig_share_update(cmd, client, resource_group_name, gallery_name, subscription_ids=None, tenant_ids=None,
-                     op_type=None):
-    from .vendored_sdks.azure_mgmt_compute.models._models_py3 import SharingProfileGroup, SharingUpdate, SharingProfileGroupTypes
-    if op_type != 'EnableCommunity':
-        if subscription_ids is None and tenant_ids is None:
-            raise RequiredArgumentMissingError('At least one of subscription ids or tenant ids must be provided')
-    groups = []
+def sig_share_enable_community(cmd, resource_group_name, gallery_name, subscription_ids=None, tenant_ids=None,
+                               no_wait=False, op_type=None):
+    from azure.cli.command_modules.vm.operations.sig_share import SigShareEnableCommunity
+    command_args = {
+        'resource_group': resource_group_name,
+        'gallery_name': gallery_name,
+        'no_wait': no_wait,
+    }
     if subscription_ids:
-        groups.append(SharingProfileGroup(type=SharingProfileGroupTypes.SUBSCRIPTIONS, ids=subscription_ids))
+        command_args['subscription_ids'] = subscription_ids
     if tenant_ids:
-        groups.append(SharingProfileGroup(type=SharingProfileGroupTypes.AAD_TENANTS, ids=tenant_ids))
-    sharing_update = SharingUpdate(operation_type=op_type, groups=groups)
-    return client.begin_update(resource_group_name=resource_group_name,
-                               gallery_name=gallery_name,
-                               sharing_update=sharing_update)
+        command_args['tenant_ids'] = tenant_ids
+    if op_type:
+        command_args['operation_type'] = op_type
+    return SigShareEnableCommunity(cli_ctx=cmd.cli_ctx)(command_args=command_args)

--- a/src/image-gallery/azext_image_gallery/custom.py
+++ b/src/image-gallery/azext_image_gallery/custom.py
@@ -15,9 +15,12 @@ from azure.cli.core.azclierror import RequiredArgumentMissingError
 logger = get_logger(__name__)
 
 
-def sig_community_image_definition_list(client, location, public_gallery_name, marker=None, show_next_marker=None):
-    generator = client.list(location=location, public_gallery_name=public_gallery_name)
-    return get_page_result(generator, marker, show_next_marker)
+def sig_community_image_definition_list(cmd, location, public_gallery_name):
+    from azure.cli.command_modules.vm.aaz.latest.sig.image_definition import ListCommunity
+    return ListCommunity(cli_ctx=cmd.cli_ctx)(command_args={
+        'location': location,
+        'public_gallery_name': public_gallery_name,
+    })
 
 
 def sig_community_image_version_list(client, location, public_gallery_name, gallery_image_name, marker=None,

--- a/src/image-gallery/azext_image_gallery/custom.py
+++ b/src/image-gallery/azext_image_gallery/custom.py
@@ -8,11 +8,9 @@
 # pylint: disable=too-many-locals
 # pylint: disable=unused-argument
 
-from knack.log import get_logger
 from azure.cli.core.profiles import ResourceType
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.azclierror import RequiredArgumentMissingError
-logger = get_logger(__name__)
 
 
 def sig_community_image_definition_list(cmd, location, public_gallery_name):
@@ -23,49 +21,13 @@ def sig_community_image_definition_list(cmd, location, public_gallery_name):
     })
 
 
-def sig_community_image_version_list(client, location, public_gallery_name, gallery_image_name, marker=None,
-                                     show_next_marker=None):
-    generator = client.list(location=location, public_gallery_name=public_gallery_name,
-                            gallery_image_name=gallery_image_name)
-    return get_page_result(generator, marker, show_next_marker)
-
-
-def get_page_result(generator, marker, show_next_marker=None):
-    pages = generator.by_page(continuation_token=marker)  # ContainerPropertiesPaged
-    result = list_generator(pages=pages)
-
-    if show_next_marker:
-        next_marker = {"nextMarker": pages.continuation_token}
-        result.append(next_marker)
-    else:
-        if pages.continuation_token:
-            logger.warning('Next Marker:')
-            logger.warning(pages.continuation_token)
-
-    return result
-
-
-# The REST service takes 50 items as a page by default
-def list_generator(pages, num_results=50):
-    result = []
-
-    # get first page items
-    page = list(next(pages))
-    result += page
-
-    while True:
-        if not pages.continuation_token:
-            break
-
-        # handle num results
-        if num_results is not None:
-            if num_results == len(result):
-                break
-
-        page = list(next(pages))
-        result += page
-
-    return result
+def sig_community_image_version_list(cmd, location, public_gallery_name, gallery_image_name):
+    from azure.cli.command_modules.vm.aaz.latest.sig.image_version import ListCommunity
+    return ListCommunity(cli_ctx=cmd.cli_ctx)(command_args={
+        'location': location,
+        'public_gallery_name': public_gallery_name,
+        'gallery_image_definition': gallery_image_name,
+    })
 
 
 def _get_resource_group_location(cli_ctx, resource_group_name):

--- a/src/image-gallery/azext_image_gallery/custom.py
+++ b/src/image-gallery/azext_image_gallery/custom.py
@@ -125,6 +125,17 @@ def sig_community_gallery_image_show(cmd, location, public_gallery_name, gallery
     })
 
 
+def sig_community_image_version_show(cmd, location, public_gallery_name, gallery_image_name,
+                                     gallery_image_version_name):
+    from azure.cli.command_modules.vm.aaz.latest.sig.image_version import ShowCommunity
+    return ShowCommunity(cli_ctx=cmd.cli_ctx)(command_args={
+        'location': location,
+        'public_gallery_name': public_gallery_name,
+        'gallery_image_definition': gallery_image_name,
+        'gallery_image_version_name': gallery_image_version_name,
+    })
+
+
 def sig_share_update(cmd, client, resource_group_name, gallery_name, subscription_ids=None, tenant_ids=None,
                      op_type=None):
     from .vendored_sdks.azure_mgmt_compute.models._models_py3 import SharingProfileGroup, SharingUpdate, SharingProfileGroupTypes

--- a/src/image-gallery/azext_image_gallery/custom.py
+++ b/src/image-gallery/azext_image_gallery/custom.py
@@ -116,6 +116,15 @@ def sig_community_gallery_show(cmd, location, public_gallery_name):
     })
 
 
+def sig_community_gallery_image_show(cmd, location, public_gallery_name, gallery_image_name):
+    from azure.cli.command_modules.vm.aaz.latest.sig.image_definition import ShowCommunity
+    return ShowCommunity(cli_ctx=cmd.cli_ctx)(command_args={
+        'location': location,
+        'public_gallery_name': public_gallery_name,
+        'gallery_image_definition': gallery_image_name,
+    })
+
+
 def sig_share_update(cmd, client, resource_group_name, gallery_name, subscription_ids=None, tenant_ids=None,
                      op_type=None):
     from .vendored_sdks.azure_mgmt_compute.models._models_py3 import SharingProfileGroup, SharingUpdate, SharingProfileGroupTypes

--- a/src/image-gallery/setup.py
+++ b/src/image-gallery/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
-VERSION = '1.0.0b2'
+VERSION = '1.1.0'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Migration from mgmt.compute to aaz-based
Remove `--marker` and `--show-next-marker` from `sig image-definition list-community` and `sig image-version list-community`. AAZ have its own handling for pagination.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install azdev` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
