### PR TITLE
Pin azdev to egg-info fix commit to unblock CI

### DIFF
--- a/.azure-pipelines/templates/azdev_setup.yml
+++ b/.azure-pipelines/templates/azdev_setup.yml
@@ -13,7 +13,7 @@ steps:
       source ./env/bin/activate
       git clone -q --single-branch -b dev https://github.com/Azure/azure-cli.git ../azure-cli
       python -m pip install -U pip
-      pip install --upgrade "azdev==0.2.12"
+      pip install --upgrade "git+https://github.com/Azure/azure-cli-dev-tools.git@bb196e370ef0c0c8fcb01ab2e73bf2db7b5821a2#egg=azdev"
       azdev --version
       azdev setup -c $CLI_REPO_PATH -r $CLI_EXT_REPO_PATH --debug
       pip list -v

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,9 +79,7 @@ jobs:
   - bash: |
       #!/usr/bin/env bash
       set -ev
-      # test_index.py imports scripts/ci/util.py, which reads wheel metadata via azdev's
-      # pkginfo-based metadata module (decoupled from wheel==0.30.0), so azdev must be installed here.
-      pip install --upgrade "azdev==0.2.12"
+      pip install --upgrade "git+https://github.com/Azure/azure-cli-dev-tools.git@bb196e370ef0c0c8fcb01ab2e73bf2db7b5821a2#egg=azdev"
       pip install requests packaging setuptools
       export CI="ADO"
       python ./scripts/ci/test_index.py -v


### PR DESCRIPTION
azdev 0.2.12's --no-build-isolation stopped `azdev extension add` from leaving an *.egg-info in the extension source tree, so integration tests, azdev style and azdev linter could not discover extensions. Pinned both installs to Azure/azure-cli-dev-tools@bb196e3 (0.2.12 + the fix, azure-cli-dev-tools#554).

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install azdev` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
