### PR TITLE
Pin azdev in GitHub Actions workflows to the egg-info fix commit

### DIFF
--- a/.github/actions/env-setup/action.yml
+++ b/.github/actions/env-setup/action.yml
@@ -43,7 +43,9 @@ runs:
         python -m venv env
         chmod +x env/bin/activate
         source ./env/bin/activate
-        pip install azdev
+        # Pinned to the azdev commit that fixes `azdev extension add` losing egg-info under
+        # --no-build-isolation (Azure/azure-cli-dev-tools#554); switch to azdev==0.2.13 once released.
+        pip install --upgrade "git+https://github.com/Azure/azure-cli-dev-tools.git@bb196e370ef0c0c8fcb01ab2e73bf2db7b5821a2#egg=azdev"
         azdev --version
         cd ../
         azdev setup -c azure-cli -r azure-cli-extensions --debug

--- a/.github/workflows/VersionCalPRComment.yml
+++ b/.github/workflows/VersionCalPRComment.yml
@@ -114,7 +114,9 @@ jobs:
            python -m venv env
            chmod +x env/bin/activate
            source ./env/bin/activate
-           pip install azdev
+           # Pinned to the azdev commit that fixes `azdev extension add` losing egg-info under
+           # --no-build-isolation (Azure/azure-cli-dev-tools#554); switch to azdev==0.2.13 once released.
+           pip install --upgrade "git+https://github.com/Azure/azure-cli-dev-tools.git@bb196e370ef0c0c8fcb01ab2e73bf2db7b5821a2#egg=azdev"
            azdev --version
            cd ../
            azdev setup -c azure-cli -r azure-cli-extensions --debug


### PR DESCRIPTION
#10080 pinned the Azure DevOps pipeline, but the GitHub Actions azdev linter/style (via .github/actions/env-setup) and VersionCalPRComment still ran a bare `pip install azdev` (0.2.12), which no-ops `azdev extension add` and fails with `unrecognized modules`. Pin both to azure-cli-dev-tools@bb196e3.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install azdev` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
