### PR TITLE
fix: declare ssh extension 2.0.9 minCliCoreVersion 2.71.0 and bump version

### DIFF
--- a/src/ssh/HISTORY.md
+++ b/src/ssh/HISTORY.md
@@ -1,5 +1,9 @@
 Release History
 ===============
+2.0.10
+------
+* Raise minimum CLI core version to 2.71.0 to match the AAZ-based compute (VM) commands introduced in 2.0.9
+
 2.0.9
 -----
 * Migrate code from Azure SDK to AAZ based commands for compute operations (VM)

--- a/src/ssh/azext_ssh/azext_metadata.json
+++ b/src/ssh/azext_ssh/azext_metadata.json
@@ -1,4 +1,4 @@
 {
     "azext.isPreview": false,
-    "azext.minCliCoreVersion": "2.45.0"
+    "azext.minCliCoreVersion": "2.71.0"
 }

--- a/src/ssh/setup.py
+++ b/src/ssh/setup.py
@@ -7,7 +7,7 @@
 
 from setuptools import setup, find_packages
 
-VERSION = "2.0.9"
+VERSION = "2.0.10"
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',


### PR DESCRIPTION
Fixes #10061

The `ssh` extension 2.0.9 migrated its compute (VM) code from the Azure SDK to AAZ-based commands (#9778), which import `azure.cli.command_modules.vm.operations.vm.VMShow`. That module path only exists in azure-cli core >= 2.71.0. However `src/ssh/azext_ssh/azext_metadata.json` still declared `azext.minCliCoreVersion` as `2.45.0`, so the extension compatibility resolver kept offering the 2.0.9 build to users on pinned azure-cli cores older than 2.71.0. On those cores `az ssh vm` crashes with `ModuleNotFoundError: No module named 'azure.cli.command_modules.vm.operations'`.

This change raises `azext.minCliCoreVersion` to `2.71.0` so the resolver stops offering the AAZ-based build to incompatible cores and instead installs the last compatible version (2.0.8) there. The metadata must ship under a new version for `az extension list-versions` to re-evaluate compatibility, so `setup.py` `VERSION` is bumped to `2.0.10` with a matching `HISTORY.md` entry. This is the maintainer-stated expected behavior in the issue; there is no runtime code change, only the extension's declared minimum core version.

### Related command
`az ssh vm`

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install azdev` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

This PR only updates the version information in `setup.py` and the historical information in `HISTORY.md`; `src/index.json` is left unchanged for the publish pipeline to update automatically after merge.
