### PR TITLE
{Packaging} idempotent extension checksum addition/updation

### DIFF
--- a/scripts/ci/idempotent_release.py
+++ b/scripts/ci/idempotent_release.py
@@ -141,17 +141,18 @@ def step_build_index(authoritative_whl, blob_url, github_repo='Azure/azure-cli-e
         github_token = os.environ.get('GITHUB_TOKEN')
         remote_index = fetch_github_index(github_repo, github_branch, github_token)
         remote_entries = remote_index.get('extensions', {}).get(extension_name, [])
-        remote_sha = remote_entries[0].get('sha256Digest') if remote_entries else None
-        if remote_sha == computed_hash:
+        # Find the entry matching this specific wheel filename (not just [0])
+        remote_entry = next((e for e in remote_entries if e.get('filename') == whl_filename), None)
+        if remote_entry and remote_entry.get('sha256Digest') == computed_hash:
             print("[Step 2] Remote GitHub index.json already has correct SHA-256 "
-                  "for '{}' -> ALREADY_UP_TO_DATE".format(extension_name))
+                  "for '{}' ({}) -> ALREADY_UP_TO_DATE".format(extension_name, whl_filename))
             return extension_name, computed_hash, ALREADY_UP_TO_DATE
-        if remote_sha:
-            print("[Step 2] Remote SHA '{}' differs from computed '{}'".format(
-                remote_sha, computed_hash))
+        if remote_entry:
+            print("[Step 2] Remote SHA '{}' differs from computed '{}' for {}".format(
+                remote_entry.get('sha256Digest'), computed_hash, whl_filename))
         else:
-            print("[Step 2] Extension '{}' not found in remote index (new or missing)".format(
-                extension_name))
+            print("[Step 2] Filename '{}' not found in remote index for '{}'".format(
+                whl_filename, extension_name))
     except Exception as exc:
         # Non-fatal: if we can't reach GitHub, fall through to the local check.
         print("[Step 2] WARNING: Could not check remote index.json: {}".format(exc))
@@ -162,7 +163,7 @@ def step_build_index(authoritative_whl, blob_url, github_repo='Azure/azure-cli-e
     metadata = get_ext_metadata(ext_dir, authoritative_whl, extension_name)
 
     # Read current local index.json.
-    index_path = os.path.join('src', 'index.json')
+    index_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'src', 'index.json'))
     with open(index_path, 'r') as f:
         original_content = f.read()
     curr_index = json.loads(original_content)
@@ -175,21 +176,33 @@ def step_build_index(authoritative_whl, blob_url, github_repo='Azure/azure-cli-e
             extension_name))
         return extension_name, computed_hash, NEW_EXTENSION
 
-    # Check if the SHA-256 already matches — if so, no update needed.
+    # Check if this specific filename's SHA-256 already matches.
     entry = curr_index['extensions'][extension_name]
-    existing_sha = entry[0].get('sha256Digest')
-    if existing_sha == computed_hash:
-        print("[Step 2] index.json already has correct SHA-256 for '{}' -> ALREADY_UP_TO_DATE".format(
-            extension_name))
+    existing_entry = next((e for e in entry if e.get('filename') == whl_filename), None)
+    if existing_entry and existing_entry.get('sha256Digest') == computed_hash:
+        print("[Step 2] index.json already has correct SHA-256 for '{}' ({}) -> ALREADY_UP_TO_DATE".format(
+            extension_name, whl_filename))
         return extension_name, computed_hash, ALREADY_UP_TO_DATE
 
-    # Update the entry.
-    print("[Step 2] Updating index.json: existing SHA '{}' -> '{}'".format(
-        existing_sha, computed_hash))
-    entry[0]['downloadUrl'] = blob_url
-    entry[0]['sha256Digest'] = computed_hash
-    entry[0]['filename'] = whl_filename
-    entry[0]['metadata'] = metadata
+    # Update or append the entry for this filename.
+    if existing_entry:
+        # Same filename exists but with different SHA — update in place.
+        print("[Step 2] Updating index.json: existing SHA '{}' -> '{}'".format(
+            existing_entry.get('sha256Digest'), computed_hash))
+        existing_entry['downloadUrl'] = blob_url
+        existing_entry['sha256Digest'] = computed_hash
+        existing_entry['filename'] = whl_filename
+        existing_entry['metadata'] = metadata
+    else:
+        # New version of an existing extension — prepend to the list.
+        print("[Step 2] Adding new version '{}' to index.json for '{}'".format(
+            whl_filename, extension_name))
+        entry.insert(0, {
+            'downloadUrl': blob_url,
+            'sha256Digest': computed_hash,
+            'filename': whl_filename,
+            'metadata': metadata,
+        })
 
     curr_index['extensions'][extension_name] = entry
     with open(index_path, 'w') as f:

--- a/scripts/ci/idempotent_release.py
+++ b/scripts/ci/idempotent_release.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python
+
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+"""Idempotent extension release pipeline.
+
+This script implements a race-condition-safe release flow for Azure CLI
+extensions.  The key invariant is:
+
+    The blob in storage is IMMUTABLE and is the single source of truth.
+    The SHA-256 is always computed from that blob.
+    index.json must match storage — if it doesn't, we fix index.json.
+
+Steps:
+
+  Step 1 — Upload (no overwrite):
+      Upload the wheel to Azure Blob Storage *without* overwriting.
+        * Upload succeeds        -> the local wheel IS the authoritative copy.
+        * Upload fails (exists)  -> download the existing blob; use that.
+      Either way, the SHA-256 is computed from the file that actually lives
+      in storage — never from a local rebuild.
+
+  Step 2 — Build index.json:
+      Update the local ``src/index.json`` with the authoritative SHA-256,
+      download URL, filename and metadata extracted from the wheel.
+      Compare with the original file to determine if a commit is needed.
+
+Usage::
+
+    python idempotent_release.py \\
+        --wheel-path ./dist/my_ext-1.0.0-py3-none-any.whl \\
+        --storage-account azcliprod \\
+        --storage-container cli-extensions \\
+        [--blob-prefix edge] \\
+        [--github-repo Azure/azure-cli-extensions] \\
+        [--github-branch main]
+
+Exit codes::
+
+    0  — success (COMMIT_NEEDED or ALREADY_UP_TO_DATE)
+    2  — unexpected error
+"""
+
+from __future__ import print_function
+
+import argparse
+import json
+import logging
+import os
+import re
+import sys
+import tempfile
+
+# Ensure this script can import sibling modules when run from any cwd.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from util import (  # noqa: E402
+    download_blob,
+    fetch_github_index,
+    get_blob_url,
+    get_ext_metadata,
+    get_sha256sum,
+    upload_wheel_no_overwrite,
+)
+
+logger = logging.getLogger(__name__)
+
+NAME_REGEX = r'^(.*?)-\d+\.\d+\.\d+'
+
+# -- status constants ---------------------------------------------------------
+COMMIT_NEEDED = 'COMMIT_NEEDED'
+ALREADY_UP_TO_DATE = 'ALREADY_UP_TO_DATE'
+
+
+# =============================================================================
+# Step 1 — Upload
+# =============================================================================
+
+def step_upload(whl_path, storage_account, storage_container, blob_prefix):
+    """Upload the wheel without overwriting. Return (authoritative_whl_path, blob_url).
+
+    If the blob already exists the existing copy is downloaded to a temp
+    directory so the caller always gets the *authoritative* wheel — the one
+    that is actually in storage.
+    """
+    whl_file = os.path.basename(whl_path)
+    blob_name = '{}/{}'.format(blob_prefix, whl_file) if blob_prefix else whl_file
+
+    blob_url = upload_wheel_no_overwrite(
+        whl_path, storage_account, storage_container, blob_prefix)
+
+    if blob_url is not None:
+        # Upload succeeded — the local file IS the authoritative copy.
+        print("[Step 1] Upload succeeded: {}".format(blob_url))
+        return whl_path, blob_url
+
+    # Blob already existed — download the authoritative copy.
+    print("[Step 1] Blob already exists. Downloading authoritative copy...")
+    tmp_dir = tempfile.mkdtemp()
+    dest = os.path.join(tmp_dir, whl_file)
+    download_blob(storage_account, storage_container, blob_name, dest)
+    blob_url = get_blob_url(storage_account, storage_container, blob_name)
+    print("[Step 1] Using existing blob: {}".format(blob_url))
+    return dest, blob_url
+
+
+# =============================================================================
+# Step 2 — Build index.json and determine if commit is needed
+# =============================================================================
+
+def step_build_index(authoritative_whl, blob_url, github_repo='Azure/azure-cli-extensions',
+                     github_branch='main'):
+    """Update index.json from the authoritative wheel.
+
+    Compares the file before and after to determine if a commit is needed.
+
+    Returns:
+        tuple: (extension_name, computed_hash, decision)
+            decision is COMMIT_NEEDED or ALREADY_UP_TO_DATE
+    """
+    whl_filename = os.path.basename(blob_url)
+
+    # Parse extension name from the wheel filename.
+    match = re.match(NAME_REGEX, whl_filename)
+    if not match:
+        raise ValueError('Unable to parse extension name from {}'.format(whl_filename))
+    extension_name = match.group(1).replace('_', '-')
+
+    computed_hash = get_sha256sum(authoritative_whl)
+    print("[Step 2] Computed sha256Digest: {}".format(computed_hash))
+
+    # Check the remote GitHub index.json to see if it already has the correct
+    # SHA-256 for this extension. This handles the case where a concurrent
+    # pipeline already committed the update — we skip the local update entirely,
+    # avoiding a git conflict during the commit step.
+    try:
+        github_token = os.environ.get('GITHUB_TOKEN')
+        remote_index = fetch_github_index(github_repo, github_branch, github_token)
+        remote_entries = remote_index.get('extensions', {}).get(extension_name, [])
+        remote_sha = remote_entries[0].get('sha256Digest') if remote_entries else None
+        if remote_sha == computed_hash:
+            print("[Step 2] Remote GitHub index.json already has correct SHA-256 "
+                  "for '{}' -> ALREADY_UP_TO_DATE".format(extension_name))
+            return extension_name, computed_hash, ALREADY_UP_TO_DATE
+        if remote_sha:
+            print("[Step 2] Remote SHA '{}' differs from computed '{}'".format(
+                remote_sha, computed_hash))
+        else:
+            print("[Step 2] Extension '{}' not found in remote index (new or missing)".format(
+                extension_name))
+    except Exception as exc:
+        # Non-fatal: if we can't reach GitHub, fall through to the local check.
+        print("[Step 2] WARNING: Could not check remote index.json: {}".format(exc))
+
+    # Extract metadata from the wheel.
+    extensions_dir = tempfile.mkdtemp()
+    ext_dir = tempfile.mkdtemp(dir=extensions_dir)
+    metadata = get_ext_metadata(ext_dir, authoritative_whl, extension_name)
+
+    # Read current local index.json.
+    index_path = os.path.join('src', 'index.json')
+    with open(index_path, 'r') as f:
+        original_content = f.read()
+    curr_index = json.loads(original_content)
+
+    # If this is a brand-new extension (first release), add it to the index.
+    if extension_name not in curr_index.get('extensions', {}):
+        print("[Step 2] Extension '{}' is new — adding to index.json".format(extension_name))
+        curr_index['extensions'][extension_name] = [{
+            'downloadUrl': blob_url,
+            'sha256Digest': computed_hash,
+            'filename': whl_filename,
+            'metadata': metadata,
+        }]
+        with open(index_path, 'w') as f:
+            f.write(json.dumps(curr_index, indent=4, sort_keys=True))
+        print("[Step 2] Added new extension '{}' -> COMMIT_NEEDED".format(extension_name))
+        return extension_name, computed_hash, COMMIT_NEEDED
+
+    # Check if the SHA-256 already matches — if so, no update needed.
+    entry = curr_index['extensions'][extension_name]
+    existing_sha = entry[0].get('sha256Digest')
+    if existing_sha == computed_hash:
+        print("[Step 2] index.json already has correct SHA-256 for '{}' -> ALREADY_UP_TO_DATE".format(
+            extension_name))
+        return extension_name, computed_hash, ALREADY_UP_TO_DATE
+
+    # Update the entry.
+    print("[Step 2] Updating index.json: existing SHA '{}' -> '{}'".format(
+        existing_sha, computed_hash))
+    entry[0]['downloadUrl'] = blob_url
+    entry[0]['sha256Digest'] = computed_hash
+    entry[0]['filename'] = whl_filename
+    entry[0]['metadata'] = metadata
+
+    curr_index['extensions'][extension_name] = entry
+    with open(index_path, 'w') as f:
+        f.write(json.dumps(curr_index, indent=4, sort_keys=True))
+
+    print("[Step 2] Updated local index.json for '{}' -> COMMIT_NEEDED".format(extension_name))
+    return extension_name, computed_hash, COMMIT_NEEDED
+
+
+# =============================================================================
+# Main
+# =============================================================================
+
+def parse_args(argv=None):
+    p = argparse.ArgumentParser(
+        description='Idempotent extension release: upload, index, commit-decision.')
+    p.add_argument('--wheel-path', required=True,
+                   help='Local path to the built .whl file')
+    p.add_argument('--storage-account', required=True,
+                   help='Azure Storage account name')
+    p.add_argument('--storage-container', required=True,
+                   help='Azure Storage container name')
+    p.add_argument('--blob-prefix', default=None,
+                   help='Optional blob name prefix (e.g. "edge")')
+    p.add_argument('--github-repo', default='Azure/azure-cli-extensions',
+                   help='GitHub repo in owner/repo format (default: Azure/azure-cli-extensions)')
+    p.add_argument('--github-branch', default='main',
+                   help='Branch to check remote index.json from (default: main)')
+    return p.parse_args(argv)
+
+
+def main(argv=None):
+    logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
+    args = parse_args(argv)
+
+    if not os.path.isfile(args.wheel_path):
+        print("ERROR: Wheel file not found: {}".format(args.wheel_path), file=sys.stderr)
+        return 2
+
+    try:
+        # Step 1 — Upload (never overwrite)
+        authoritative_whl, blob_url = step_upload(
+            args.wheel_path,
+            args.storage_account,
+            args.storage_container,
+            args.blob_prefix,
+        )
+
+        # Step 2 — Build index.json from the authoritative wheel
+        extension_name, computed_hash, decision = step_build_index(
+            authoritative_whl, blob_url,
+            github_repo=args.github_repo,
+            github_branch=args.github_branch,
+        )
+
+        print("\n=== RESULT: {} ===".format(decision))
+        return 0
+
+    except Exception as exc:
+        print("ERROR: {}".format(exc), file=sys.stderr)
+        logger.exception("Unexpected error")
+        return 2
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/ci/idempotent_release.py
+++ b/scripts/ci/idempotent_release.py
@@ -73,6 +73,7 @@ NAME_REGEX = r'^(.*?)-\d+\.\d+\.\d+'
 # -- status constants ---------------------------------------------------------
 COMMIT_NEEDED = 'COMMIT_NEEDED'
 ALREADY_UP_TO_DATE = 'ALREADY_UP_TO_DATE'
+NEW_EXTENSION = 'NEW_EXTENSION'
 
 
 # =============================================================================
@@ -166,19 +167,13 @@ def step_build_index(authoritative_whl, blob_url, github_repo='Azure/azure-cli-e
         original_content = f.read()
     curr_index = json.loads(original_content)
 
-    # If this is a brand-new extension (first release), add it to the index.
+    # If this is a brand-new extension (first release), signal the caller
+    # to use azdev extension update-index — the proven tool for creating
+    # new index entries with the correct structure.
     if extension_name not in curr_index.get('extensions', {}):
-        print("[Step 2] Extension '{}' is new — adding to index.json".format(extension_name))
-        curr_index['extensions'][extension_name] = [{
-            'downloadUrl': blob_url,
-            'sha256Digest': computed_hash,
-            'filename': whl_filename,
-            'metadata': metadata,
-        }]
-        with open(index_path, 'w') as f:
-            f.write(json.dumps(curr_index, indent=4, sort_keys=True))
-        print("[Step 2] Added new extension '{}' -> COMMIT_NEEDED".format(extension_name))
-        return extension_name, computed_hash, COMMIT_NEEDED
+        print("[Step 2] Extension '{}' is new — needs azdev extension update-index".format(
+            extension_name))
+        return extension_name, computed_hash, NEW_EXTENSION
 
     # Check if the SHA-256 already matches — if so, no update needed.
     entry = curr_index['extensions'][extension_name]

--- a/scripts/ci/util.py
+++ b/scripts/ci/util.py
@@ -125,9 +125,13 @@ def fetch_github_index(repo, branch, token=None):
         try:
             return r.json()
         except ValueError as exc:
-            raise RuntimeError("Failed to parse index.json from GitHub: {}".format(exc))
+            raise RuntimeError(
+                "Failed to parse index.json from GitHub ({}): {}".format(url, exc)
+            ) from exc
     except requests.exceptions.RequestException as exc:
-        raise RuntimeError("Failed to fetch index.json from GitHub: {}".format(exc))
+        raise RuntimeError(
+            "Failed to fetch index.json from GitHub ({}): {}".format(url, exc)
+        ) from exc
 
 
 def upload_wheel_no_overwrite(whl_path, storage_account, storage_container, blob_prefix=None):

--- a/scripts/ci/util.py
+++ b/scripts/ci/util.py
@@ -89,6 +89,131 @@ def get_whl_from_url(url, filename, tmp_dir, whl_cache=None):
     return ext_file
 
 
+def get_sha256sum(a_file):
+    """Compute the SHA-256 hex digest of a file."""
+    import hashlib
+    sha256 = hashlib.sha256()
+    with open(a_file, 'rb') as f:
+        for chunk in iter(lambda: f.read(65536), b''):
+            sha256.update(chunk)
+    return sha256.hexdigest()
+
+
+def fetch_github_index(repo, branch, token=None):
+    """Fetch index.json from GitHub raw content.
+
+    Args:
+        repo: GitHub repo in owner/repo format (e.g. 'Azure/azure-cli-extensions')
+        branch: Branch name (e.g. 'main')
+        token: Optional GitHub PAT for private repos
+
+    Returns:
+        dict: Parsed index.json content
+
+    Raises:
+        RuntimeError: If the fetch fails
+    """
+    import requests
+    url = 'https://raw.githubusercontent.com/{}/{}/src/index.json'.format(repo, branch)
+    headers = {}
+    if token:
+        headers['Authorization'] = 'token {}'.format(token)
+    try:
+        r = requests.get(url, headers=headers, timeout=30)
+        if r.status_code != 200:
+            raise RuntimeError("Failed to fetch index.json from GitHub: HTTP {}".format(r.status_code))
+        return r.json()
+    except requests.exceptions.RequestException as exc:
+        raise RuntimeError("Failed to fetch index.json from GitHub: {}".format(exc))
+
+
+def upload_wheel_no_overwrite(whl_path, storage_account, storage_container, blob_prefix=None):
+    """Upload a wheel to Azure Blob Storage without overwriting.
+
+    Returns:
+        str: The blob URL if upload succeeded (new blob created).
+        None: If the blob already exists (upload was rejected).
+
+    Raises:
+        RuntimeError: On unexpected upload failure.
+    """
+    from subprocess import run as subprocess_run
+    whl_file = os.path.basename(whl_path)
+    blob_name = '{}/{}'.format(blob_prefix, whl_file) if blob_prefix else whl_file
+
+    cmd = [
+        'az', 'storage', 'blob', 'upload',
+        '--container-name', storage_container,
+        '--account-name', storage_account,
+        '--name', blob_name,
+        '--file', os.path.abspath(whl_path),
+        '--auth-mode', 'login',
+        '--overwrite', 'false',
+    ]
+    logger.info("Uploading wheel (no overwrite): %s", whl_file)
+    result = subprocess_run(cmd, capture_output=True, text=True)
+
+    if result.returncode == 0:
+        url = get_blob_url(storage_account, storage_container, blob_name)
+        return url
+
+    stderr = result.stderr or ''
+    # Azure CLI returns error when blob already exists with --overwrite false
+    if 'BlobAlreadyExists' in stderr or 'ResourceExistsError' in stderr or '409' in stderr:
+        logger.info("Blob '%s' already exists. Skipping upload.", blob_name)
+        return None
+
+    raise RuntimeError("Failed to upload '{}': {}".format(whl_file, stderr))
+
+
+def download_blob(storage_account, storage_container, blob_name, dest_path):
+    """Download a blob from Azure Blob Storage to a local path.
+
+    Raises:
+        RuntimeError: On download failure.
+    """
+    from subprocess import run as subprocess_run
+    cmd = [
+        'az', 'storage', 'blob', 'download',
+        '--container-name', storage_container,
+        '--account-name', storage_account,
+        '--name', blob_name,
+        '--file', dest_path,
+        '--auth-mode', 'login',
+    ]
+    logger.info("Downloading blob '%s' to '%s'", blob_name, dest_path)
+    result = subprocess_run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError("Failed to download blob '{}': {}".format(
+            blob_name, result.stderr))
+    logger.info("Download complete: %s", dest_path)
+
+
+def get_blob_url(storage_account, storage_container, blob_name):
+    """Get the public URL of a blob.
+
+    Returns:
+        str: The blob URL.
+
+    Raises:
+        RuntimeError: On failure.
+    """
+    from subprocess import run as subprocess_run
+    cmd = [
+        'az', 'storage', 'blob', 'url',
+        '--container-name', storage_container,
+        '--account-name', storage_account,
+        '--name', blob_name,
+        '--auth-mode', 'login',
+        '-otsv',
+    ]
+    result = subprocess_run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError("Failed to get blob URL for '{}': {}".format(
+            blob_name, result.stderr))
+    return result.stdout.strip()
+
+
 SRC_PATH = os.path.join(get_repo_root(), 'src')
 INDEX_PATH = os.path.join(SRC_PATH, 'index.json')
 

--- a/scripts/ci/util.py
+++ b/scripts/ci/util.py
@@ -114,6 +114,7 @@ def fetch_github_index(repo, branch, token=None):
         RuntimeError: If the fetch fails
     """
     import requests
+    # external-url-exempt: This function fetches index.json from GitHub raw content, which is necessary for the operation of the script. It is called in pipeline code only.
     url = 'https://raw.githubusercontent.com/{}/{}/src/index.json'.format(repo, branch)
     headers = {}
     if token:

--- a/scripts/ci/util.py
+++ b/scripts/ci/util.py
@@ -122,7 +122,10 @@ def fetch_github_index(repo, branch, token=None):
         r = requests.get(url, headers=headers, timeout=30)
         if r.status_code != 200:
             raise RuntimeError("Failed to fetch index.json from GitHub: HTTP {}".format(r.status_code))
-        return r.json()
+        try:
+            return r.json()
+        except ValueError as exc:
+            raise RuntimeError("Failed to parse index.json from GitHub: {}".format(exc))
     except requests.exceptions.RequestException as exc:
         raise RuntimeError("Failed to fetch index.json from GitHub: {}".format(exc))
 


### PR DESCRIPTION
Since the build and release process for the extension can fail for various reasons, we tried to make every step idempotent. However, the condition to check whether a package has already been published isn't quite right.

You can find the details below.

How it works today
Step 1 — Upload:
We fetch the latest index.json and check whether this extension version is
already published. If not, we upload the wheel to storage — using overwrite.

Step 2 — Build index.json:
We use azdev update-index, which downloads the wheel from AME, computes its
SHA-256, and updates index.json.

Step 3 — Commit:
We commit index.json to GitHub.

**What went wrong (the concurrency problem)**

- Our GitHub token (PAT) expires every 7 days. When it expired, our pipeline failed to commit index.json to GitHub.
- Multiple colleagues re-ran the pipeline at the same time.

This caused a race condition between two pipelines: both saw that index.json
had not been updated and tried to publish the same extension. The second
pipeline overwrote the package uploaded by the first, but could not update
index.json due to a code conflict. As a result, the package in blob storage
and the SHA-256 in index.json no longer match.

The fix
Step 1 — Upload:
Upload the wheel, but never overwrite an existing one.
- Upload succeeds → use the wheel we just uploaded to build index.json.
- Upload fails (already exists) → the online wheel wins; use that one to build index.json.

Step 2 — Build index.json from the latest copy:
Fetch the newest index.json and check whether this SHA-256 is already there,
to decide whether index.json needs to be regenerated and commit.

Step 3 — Commit only when correct:
Look up this extension's SHA-256 in the latest index.json:
- Not there → azdev update-index and commit.
- There, same SHA → already done, skip.
- There, different SHA → sees GitHub has wrong hash → commits correction

<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ❌ Action needed

| Breaking Changes |
| :--: |
| ❌ 1 |

<!-- act-bot:section title="Azure CLI Extensions Breaking Change Test" category="breaking_change" label="Breaking Changes" status="Failed" summary="1" -->
<!-- Azure CLI Extensions Breaking Change Test --><details>
<summary>❌Azure CLI Extensions Breaking Change Test</summary>

><details>
> <summary>❌quantum</summary>
>
>|rule|cmd_name|rule_message|suggest_message|
>|---|---|---|---|
>|❌ [1007 - ParaRemove](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1007.md) |quantum workspace create|cmd `quantum workspace create` removed parameter `workspace_kind`|please add back parameter `workspace_kind` for cmd `quantum workspace create`|
>
></details>
</details>

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->