### PR TITLE
Quantum: Add Support for Explicit V1/V2 workspace creation

### DIFF
--- a/src/quantum/HISTORY.rst
+++ b/src/quantum/HISTORY.rst
@@ -6,7 +6,6 @@ Release History
 1.0.0b18
 +++++++++++++++
 * Added support for the explicit V1 and V2 workspace creation through the ``--workspace-kind`` parameter on ``az quantum workspace create``.
-* Preserved legacy workspace creation behavior when ``--workspace-kind`` is not specified.
 
 1.0.0b17
 +++++++++++++++

--- a/src/quantum/HISTORY.rst
+++ b/src/quantum/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+1.0.0b18
++++++++++++++++
+* Added support for the explicit V1 and V2 workspace creation through the ``--workspace-kind`` parameter on ``az quantum workspace create``.
+* Preserved legacy workspace creation behavior when ``--workspace-kind`` is not specified.
+
 1.0.0b17
 +++++++++++++++
 * Fixed bug where Quantum workspace creation flow uses plain (JSON-serializable) primitive values instead of SDK enum objects in ARM-template deployment parameters, preventing serialization issues and test failures.

--- a/src/quantum/azext_quantum/_params.py
+++ b/src/quantum/azext_quantum/_params.py
@@ -55,6 +55,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals
     job_output_format_type = CLIArgumentType(help='The expected job output format')
     entry_point_type = CLIArgumentType(help='The entry point for the QIR program or circuit. Required for some provider QIR jobs.')
     skip_autoadd_type = CLIArgumentType(help='If specified, the plans that offer free credits will not automatically be added.')
+    workspace_kind_type = CLIArgumentType(options_list=['--workspace-kind'], help='The kind of the workspace to create.', choices=['V1', 'V2'])
     key_type = CLIArgumentType(options_list=['--key-type'], help='The api keys to be regenerated, should be Primary and/or Secondary.')
     enable_key_type = CLIArgumentType(options_list=['--enable-api-key'], help='Enable or disable API key authentication.')
     job_type_type = CLIArgumentType(options_list=['--job-type'], help='Job type to be listed, example "QuantumComputing".')
@@ -75,6 +76,8 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals
         c.argument('provider_sku_list', provider_sku_list_type)
         c.argument('auto_accept', auto_accept_type)
         c.argument('skip_autoadd', skip_autoadd_type)
+        c.argument('workspace_kind', workspace_kind_type)
+
 
     with self.argument_context('quantum target') as c:
         c.argument('workspace_name', workspace_name_type)

--- a/src/quantum/azext_quantum/_params.py
+++ b/src/quantum/azext_quantum/_params.py
@@ -78,7 +78,6 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals
         c.argument('skip_autoadd', skip_autoadd_type)
         c.argument('workspace_kind', workspace_kind_type)
 
-
     with self.argument_context('quantum target') as c:
         c.argument('workspace_name', workspace_name_type)
         c.argument('target_id', target_id_type)

--- a/src/quantum/azext_quantum/operations/templates/create-workspace-and-assign-role.json
+++ b/src/quantum/azext_quantum/operations/templates/create-workspace-and-assign-role.json
@@ -69,12 +69,25 @@
             "metadata": {
                 "description": "Whether to allow shared key access on the storage account. Defaults to false (secure) for new accounts; existing accounts should pass their current value to avoid breaking changes."
             }
+        },
+        "workspaceKind": {
+            "type" : "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The kind of workspace to create: V1 or V2. Leave empty to preserve legacy behavior by omitting workspaceKind."
+            }
         }
     },
     "functions": [],
     "variables": {
         "storageAccountContributorRoleId": "17d1049b-9a84-46fb-8f53-869881c3d3ab",
-        "storageBlobDataContributorRoleId": "ba92f5b4-2d11-453d-a403-e96b0029c9fe"
+        "storageBlobDataContributorRoleId": "ba92f5b4-2d11-453d-a403-e96b0029c9fe",
+        "workspacePropertiesBase" : {
+            "providers" : "[parameters('providers')]",
+            "storageAccount" : "[parameters('storageAccountId')]"
+        },
+        "workspaceKindProperty" : "[if(empty(parameters('workspaceKind')), createObject(), createObject('workspaceKind', parameters('workspaceKind')))]",
+        "workspaceProperties" : "[union(variables('workspacePropertiesBase'), variables('workspaceKindProperty'))]"
     },
     "resources": [
         {
@@ -86,10 +99,7 @@
             "identity": {
                 "type": "SystemAssigned"
             },
-            "properties": {
-                "providers": "[parameters('providers')]",
-                "storageAccount": "[parameters('storageAccountId')]"
-            }
+            "properties": "[variables('workspaceProperties')]"
         },
         {
             "apiVersion": "2019-10-01",

--- a/src/quantum/azext_quantum/operations/workspace.py
+++ b/src/quantum/azext_quantum/operations/workspace.py
@@ -201,7 +201,7 @@ def _enum_to_value(value):
 
 
 def create(cmd, resource_group_name, workspace_name, location, storage_account, skip_role_assignment=False,
-           provider_sku_list=None, auto_accept=False, skip_autoadd=False):
+           provider_sku_list=None, auto_accept=False, skip_autoadd=False, workspace_kind=None):
     """
     Create a new Azure Quantum workspace.
     """
@@ -221,6 +221,8 @@ def create(cmd, resource_group_name, workspace_name, location, storage_account, 
     if skip_role_assignment:
         _add_quantum_providers(cmd, quantum_workspace, provider_sku_list, auto_accept, skip_autoadd)
         quantum_workspace.properties.api_key_enabled = True
+        if workspace_kind:
+            quantum_workspace.properties.workspace_kind = workspace_kind
         poller = client.begin_create_or_update(info.resource_group, info.name, quantum_workspace, polling=False)
         while not poller.done():
             time.sleep(POLLING_TIME_DURATION)
@@ -277,6 +279,11 @@ def create(cmd, resource_group_name, workspace_name, location, storage_account, 
         'storageAccountAllowSharedKeyAccess': storage_account_allow_shared_key_access,
         'storageAccountDeploymentName': "Microsoft.StorageAccount-" + time.strftime("%d-%b-%Y-%H-%M-%S", time.gmtime())
     }
+
+    if workspace_kind:
+        parameters['workspaceKind'] = workspace_kind
+
+
     parameters = {k: {'value': v} for k, v in parameters.items()}
 
     deployment_properties = {

--- a/src/quantum/azext_quantum/operations/workspace.py
+++ b/src/quantum/azext_quantum/operations/workspace.py
@@ -283,7 +283,6 @@ def create(cmd, resource_group_name, workspace_name, location, storage_account, 
     if workspace_kind:
         parameters['workspaceKind'] = workspace_kind
 
-
     parameters = {k: {'value': v} for k, v in parameters.items()}
 
     deployment_properties = {

--- a/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
+++ b/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
@@ -151,6 +151,18 @@ class QuantumWorkspacesScenarioTest(ScenarioTest):
                 self.check("properties.provisioningState", "Deleting")
             ])
 
+            # Create a V2 workspace and verify workspaceKind
+            test_workspace_temp = get_test_workspace_random_name()
+            self.cmd(f'az quantum workspace create --workspace-kind V2 --auto-accept -g {test_resource_group} -w {test_workspace_temp} -l {test_location} -a {test_storage_account} -r {test_provider_sku_list} -o json', checks=[
+                self.check("name", DEPLOYMENT_NAME_PREFIX + test_workspace_temp),
+            ])
+            self.cmd(f'az quantum workspace show -g {test_resource_group} -w {test_workspace_temp} -o json', checks =[
+                self.check("properties.workspaceKind", "V2")
+            ])
+            self.cmd(f'az quantum workspace delete -g {test_resource_group} -w {test_workspace_temp} -o json', checks=[
+                self.check("properties.provisioningState", "Deleting")
+            ])
+
             # Create a workspace specifying "--skip-autoadd"
             test_workspace_temp = get_test_workspace_random_name()
             self.cmd(f'az quantum workspace create --auto-accept --skip-autoadd -g {test_resource_group} -w {test_workspace_temp} -l {test_location} -a {test_storage_account} -r {test_provider_sku_list} -o json', checks=[

--- a/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
+++ b/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
@@ -156,13 +156,23 @@ class QuantumWorkspacesScenarioTest(ScenarioTest):
             self.cmd(f'az quantum workspace create --workspace-kind V2 --auto-accept -g {test_resource_group} -w {test_workspace_temp} -l {test_location} -a {test_storage_account} -r {test_provider_sku_list} -o json', checks=[
                 self.check("name", DEPLOYMENT_NAME_PREFIX + test_workspace_temp),
             ])
-            self.cmd(f'az quantum workspace show -g {test_resource_group} -w {test_workspace_temp} -o json', checks =[
+            self.cmd(f'az quantum workspace show -g {test_resource_group} -w {test_workspace_temp} -o json', checks=[
                 self.check("properties.workspaceKind", "V2")
             ])
             self.cmd(f'az quantum workspace delete -g {test_resource_group} -w {test_workspace_temp} -o json', checks=[
                 self.check("properties.provisioningState", "Deleting")
             ])
 
+            # Create a V2 workspace via the "--skip-role-assignment" code path and verify workspaceKind
+            test_workspace_temp = get_test_workspace_random_name()
+            self.cmd(f'az quantum workspace create --workspace-kind V2 --auto-accept -g {test_resource_group} -w {test_workspace_temp} -l {test_location} -a {test_storage_account} -r {test_provider_sku_list} -o json --skip-role-assignment', checks=[
+                self.check("name", test_workspace_temp),
+                self.check("properties.workspaceKind", "V2"),
+                self.check("properties.provisioningState", "Accepted")
+            ])
+            self.cmd(f'az quantum workspace delete -g {test_resource_group} -w {test_workspace_temp} -o json', checks=[
+                self.check("properties.provisioningState", "Deleting")
+            ])
             # Create a workspace specifying "--skip-autoadd"
             test_workspace_temp = get_test_workspace_random_name()
             self.cmd(f'az quantum workspace create --auto-accept --skip-autoadd -g {test_resource_group} -w {test_workspace_temp} -l {test_location} -a {test_storage_account} -r {test_provider_sku_list} -o json', checks=[

--- a/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
+++ b/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
@@ -11,7 +11,7 @@ import time
 from azure.cli.testsdk.scenario_tests import AllowLargeResponse, live_only
 from azure.cli.testsdk import (ScenarioTest, ResourceGroupPreparer)
 from azure.cli.core.azclierror import RequiredArgumentMissingError, ResourceNotFoundError, InvalidArgumentValueError
-from .utils import get_test_resource_group, get_test_workspace, get_test_workspace_location, get_test_workspace_storage, get_test_workspace_storage_grs, get_test_workspace_random_name, get_test_workspace_random_long_name, get_test_capabilities, get_test_workspace_provider_sku_list, all_providers_are_in_capabilities, issue_cmd_with_param_missing
+from .utils import get_test_resource_group, get_test_workspace, get_test_workspace_location, get_test_workspace_storage, get_test_workspace_storage_grs, get_test_workspace_random_name, get_test_workspace_random_long_name, get_test_capabilities, get_test_workspace_provider_sku_list, get_test_workspace_v2_provider_sku_list, all_providers_are_in_capabilities, issue_cmd_with_param_missing
 from ..._version_check_helper import check_version
 from datetime import datetime
 from ...__init__ import CLI_REPORTED_VERSION
@@ -195,37 +195,41 @@ class QuantumWorkspacesScenarioTest(ScenarioTest):
         test_location = get_test_workspace_location()
         test_resource_group = get_test_resource_group()
         test_storage_account = get_test_workspace_storage()
-        test_provider_sku_list = get_test_workspace_provider_sku_list()
+        # V2 workspaces use a different provider model than V1. The e2e pipeline
+        # supplies the V2 providers per-location via AZURE_QUANTUM_WORKSPACE_V2_PROVIDERS
+        # (each paired with the "default" SKU), not via the V1 provider/capabilities
+        # variables. Use those params so this test creates the same kind of V2
+        # workspace the pipeline expects.
+        test_provider_sku_list = get_test_workspace_v2_provider_sku_list()
 
-        if all_providers_are_in_capabilities(test_provider_sku_list, get_test_capabilities()):
-            # Create V2 workspace via ARM template path
+        if not test_provider_sku_list:
+            self.skipTest(f"Skipping test_workspace_v2_create_destroy: No V2 providers configured for location '{test_location}' in AZURE_QUANTUM_WORKSPACE_V2_PROVIDERS")
 
-            test_workspace_temp = get_test_workspace_random_name()
-            self.cmd(f'az quantum workspace create --workspace-kind V2 --auto-accept -g {test_resource_group} -w {test_workspace_temp} -l {test_location} -a {test_storage_account} -r {test_provider_sku_list} -o json', checks=[
-                self.check("name", DEPLOYMENT_NAME_PREFIX + test_workspace_temp)
-            ])
-            self.cmd(f'az quantum workspace show -g {test_resource_group} -w {test_workspace_temp} -o json', checks=[
-                self.check("properties.workspaceKind","V2")
-            ])
-            self.cmd(f'az quantum workspace delete -g {test_resource_group} -w {test_workspace_temp} -o json', checks=[
-                self.check("properties.provisioningState", "Deleting")
-            ])
+        # Create V2 workspace via ARM template path
+        test_workspace_temp = get_test_workspace_random_name()
+        self.cmd(f'az quantum workspace create --workspace-kind V2 --auto-accept -g {test_resource_group} -w {test_workspace_temp} -l {test_location} -a {test_storage_account} -r "{test_provider_sku_list}" -o json', checks=[
+            self.check("name", DEPLOYMENT_NAME_PREFIX + test_workspace_temp)
+        ])
+        self.cmd(f'az quantum workspace show -g {test_resource_group} -w {test_workspace_temp} -o json', checks=[
+            self.check("properties.workspaceKind", "V2")
+        ])
+        self.cmd(f'az quantum workspace delete -g {test_resource_group} -w {test_workspace_temp} -o json', checks=[
+            self.check("properties.provisioningState", "Deleting")
+        ])
 
-            # Create a V2 workspace via --skip-role-assignment path
-            test_workspace_temp = get_test_workspace_random_name()
-            self.cmd(f'az quantum workspace create --workspace-kind V2 --auto-accept --skip-role-assignment -g {test_resource_group} -w {test_workspace_temp} -l {test_location} -a {test_storage_account} -r {test_provider_sku_list} -o json', checks=[
-                self.check("name", test_workspace_temp),
-                self.check("properties.provisioningState", "Accepted")
-            ])
-            self.cmd(f'az quantum workspace show -g {test_resource_group} -w {test_workspace_temp} -o json', checks=[
-                self.check("properties.workspaceKind", "V2")
-            ])
-            self.cmd(f'az quantum workspace delete -g {test_resource_group} -w {test_workspace_temp} -o json', checks=[
-                self.check("name", test_workspace_temp),
-                self.check("properties.provisioningState", "Deleting")
-            ])
-        else:
-            self.skipTest(f"Skipping test_workspace_v2_create_destroy: One or more providers in '{test_provider_sku_list}' not found in AZURE_QUANTUM_CAPABILITIES")
+        # Create a V2 workspace via --skip-role-assignment path
+        test_workspace_temp = get_test_workspace_random_name()
+        self.cmd(f'az quantum workspace create --workspace-kind V2 --auto-accept --skip-role-assignment -g {test_resource_group} -w {test_workspace_temp} -l {test_location} -a {test_storage_account} -r "{test_provider_sku_list}" -o json', checks=[
+            self.check("name", test_workspace_temp),
+            self.check("properties.provisioningState", "Accepted")
+        ])
+        self.cmd(f'az quantum workspace show -g {test_resource_group} -w {test_workspace_temp} -o json', checks=[
+            self.check("properties.workspaceKind", "V2")
+        ])
+        self.cmd(f'az quantum workspace delete -g {test_resource_group} -w {test_workspace_temp} -o json', checks=[
+            self.check("name", test_workspace_temp),
+            self.check("properties.provisioningState", "Deleting")
+        ])
 
 
     @live_only()

--- a/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
+++ b/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
@@ -151,28 +151,6 @@ class QuantumWorkspacesScenarioTest(ScenarioTest):
                 self.check("properties.provisioningState", "Deleting")
             ])
 
-            # Create a V2 workspace and verify workspaceKind
-            test_workspace_temp = get_test_workspace_random_name()
-            self.cmd(f'az quantum workspace create --workspace-kind V2 --auto-accept -g {test_resource_group} -w {test_workspace_temp} -l {test_location} -a {test_storage_account} -r {test_provider_sku_list} -o json', checks=[
-                self.check("name", DEPLOYMENT_NAME_PREFIX + test_workspace_temp),
-            ])
-            self.cmd(f'az quantum workspace show -g {test_resource_group} -w {test_workspace_temp} -o json', checks=[
-                self.check("properties.workspaceKind", "V2")
-            ])
-            self.cmd(f'az quantum workspace delete -g {test_resource_group} -w {test_workspace_temp} -o json', checks=[
-                self.check("properties.provisioningState", "Deleting")
-            ])
-
-            # Create a V2 workspace via the "--skip-role-assignment" code path and verify workspaceKind
-            test_workspace_temp = get_test_workspace_random_name()
-            self.cmd(f'az quantum workspace create --workspace-kind V2 --auto-accept -g {test_resource_group} -w {test_workspace_temp} -l {test_location} -a {test_storage_account} -r {test_provider_sku_list} -o json --skip-role-assignment', checks=[
-                self.check("name", test_workspace_temp),
-                self.check("properties.workspaceKind", "V2"),
-                self.check("properties.provisioningState", "Accepted")
-            ])
-            self.cmd(f'az quantum workspace delete -g {test_resource_group} -w {test_workspace_temp} -o json', checks=[
-                self.check("properties.provisioningState", "Deleting")
-            ])
             # Create a workspace specifying "--skip-autoadd"
             test_workspace_temp = get_test_workspace_random_name()
             self.cmd(f'az quantum workspace create --auto-accept --skip-autoadd -g {test_resource_group} -w {test_workspace_temp} -l {test_location} -a {test_storage_account} -r {test_provider_sku_list} -o json', checks=[
@@ -210,6 +188,45 @@ class QuantumWorkspacesScenarioTest(ScenarioTest):
             ])
         else:
             self.skipTest(f"Skipping test_workspace_create_destroy: One or more providers in '{test_provider_sku_list}' not found in AZURE_QUANTUM_CAPABILITIES")
+
+    @live_only()
+    def test_workspace_v2_create_destroy(self):
+        # initialize values
+        test_location = get_test_workspace_location()
+        test_resource_group = get_test_resource_group()
+        test_storage_account = get_test_workspace_storage()
+        test_provider_sku_list = get_test_workspace_provider_sku_list()
+
+        if all_providers_are_in_capabilities(test_provider_sku_list, get_test_capabilities()):
+            # Create V2 workspace via ARM template path
+
+            test_workspace_temp = get_test_workspace_random_name()
+            self.cmd(f'az quantum workspace create --workspace-kind V2 --auto-accept -g {test_resource_group} -w {test_workspace_temp} -l {test_location} -a {test_storage_account} -r {test_provider_sku_list} -o json', checks=[
+                self.check("name", DEPLOYMENT_NAME_PREFIX + test_workspace_temp)
+            ])
+            self.cmd(f'az quantum workspace show -g {test_resource_group} -w {test_workspace_temp} -o json', checks=[
+                self.check("properties.workspaceKind","V2")
+            ])
+            self.cmd(f'az quantum workspace delete -g {test_resource_group} -w {test_workspace_temp} -o json', checks=[
+                self.check("properties.provisioningState", "Deleting")
+            ])
+
+            # Create a V2 workspace via --skip-role-assignment path
+            test_workspace_temp = get_test_workspace_random_name()
+            self.cmd(f'az quantum workspace create --workspace-kind V2 --auto-accept --skip-role-assignment -g {test_resource_group} -w {test_workspace_temp} -l {test_location} -a {test_storage_account} -r {test_provider_sku_list} -o json', checks=[
+                self.check("name", test_workspace_temp),
+                self.check("properties.provisioningState", "Accepted")
+            ])
+            self.cmd(f'az quantum workspace show -g {test_resource_group} -w {test_workspace_temp} -o json', checks=[
+                self.check("properties.workspaceKind", "V2")
+            ])
+            self.cmd(f'az quantum workspace delete -g {test_resource_group} -w {test_workspace_temp} -o json', checks=[
+                self.check("name", test_workspace_temp),
+                self.check("properties.provisioningState", "Deleting")
+            ])
+        else:
+            self.skipTest(f"Skipping test_workspace_v2_create_destroy: One or more providers in '{test_provider_sku_list}' not found in AZURE_QUANTUM_CAPABILITIES")
+
 
     @live_only()
     def test_workspace_keys(self):

--- a/src/quantum/azext_quantum/tests/latest/utils.py
+++ b/src/quantum/azext_quantum/tests/latest/utils.py
@@ -10,6 +10,12 @@ TEST_WORKSPACE_DEFAULT_LOCATION = "eastus"
 TEST_WORKSPACE_DEFAULT_STORAGE = "qwe2etestswus2"
 TEST_WORKSPACE_DEFAULT_STORAGE_GRS = "qwe2etestsgrswus2"
 TEST_WORKSPACE_DEFAULT_PROVIDER_SKU_LIST = "quantinuum/basic1"
+# V2 workspaces use a different provider model than V1. The e2e pipeline supplies
+# these per-location via the AZURE_QUANTUM_WORKSPACE_V2_PROVIDERS variable, where
+# each provider is paired with the "default" SKU. Keep this default in sync with
+# the 'e2e.workspace.v2.providers' default in the *-clients e2e pipeline.
+TEST_WORKSPACE_DEFAULT_V2_PROVIDERS = '{"westus":[{"id":"atom-boulder","targets":["msft.sim.ac1000.physical"]}],"eastus":[{"id":"atom-dev","targets":["msft.sim.ac1000-dev.physical"]}],"eastus2euap":[{"id":"az-sim-test-1","targets":["microsoft.sim.canary-001"]}]}'
+TEST_WORKSPACE_DEFAULT_V2_PROVIDER_SKU = "default"
 TEST_CAPABILITIES_DEFAULT = "new.quantinuum;submit.quantinuum"
 TEST_TARGET_DEFAULT_PROVIDER_SKU_LIST = "quantinuum/basic1"
 TEST_TARGET_DEFAULT_PROVIDER = "quantinuum"
@@ -47,6 +53,24 @@ def get_test_workspace_storage_grs():
 
 def get_test_workspace_provider_sku_list():
     return get_from_os_environment("AZURE_QUANTUM_WORKSPACE_PROVIDER_SKU_LIST", TEST_WORKSPACE_DEFAULT_PROVIDER_SKU_LIST)
+
+
+def get_test_workspace_v2_provider_sku_list():
+    # Returns the Provider/SKU list (in the '-r' command format) for creating a V2
+    # workspace in the current test location, or None if no V2 providers are
+    # configured for that location. The e2e pipeline passes a location-keyed JSON
+    # map via AZURE_QUANTUM_WORKSPACE_V2_PROVIDERS; each provider is paired with the
+    # "default" SKU, matching how the pipeline's ARM deployment builds the providers.
+    import json
+    providers_map_raw = get_from_os_environment("AZURE_QUANTUM_WORKSPACE_V2_PROVIDERS", TEST_WORKSPACE_DEFAULT_V2_PROVIDERS)
+    try:
+        providers_map = json.loads(providers_map_raw)
+    except (ValueError, TypeError):
+        return None
+    location_providers = providers_map.get(get_test_workspace_location())
+    if not location_providers:
+        return None
+    return ", ".join(f"{provider['id']}/{TEST_WORKSPACE_DEFAULT_V2_PROVIDER_SKU}" for provider in location_providers if provider.get('id'))
 
 
 def get_test_capabilities():

--- a/src/quantum/setup.py
+++ b/src/quantum/setup.py
@@ -17,7 +17,7 @@ except ImportError:
 # This version should match the latest entry in HISTORY.rst
 # Also, when updating this, please review the version used by the extension to
 # submit requests, which can be found at './azext_quantum/__init__.py'
-VERSION = '1.0.0b17'
+VERSION = '1.0.0b18'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
### Summary 

This PR adds support for the option `--workspace-kind` parameter on `az quantum workspace create`, enabling explicit creation of V1 and V2 Azure Quantum workspaces from the CLI.
Azure Quantum already supports workspace type selection through the `workspaceKind` field in the service API, but there was previously no way to specify it from the CLI. This change allows users to explicitly create V1 or V2 workspaces while preserving compatibility with existing workskpace creation flows by omitting `workspaceKind` when the parameter is not provided.

### Changes 

- Added support for omitting `workspaceKind` from workspace creation requests when the user does not explicitly specify a workspace type.
- Updated both workspace creation code paths:
- - Direct API path (--skip-role-assignment)
- - ARM template deployment path 
- Updated the ARM template so that `workspaceKind` is only included when specified rather than defaulting to a value. 
- Added/ updated release notes and extension version information.

### Testing 

- Manually validated the following scenarios:
- - No `workspaceKind` specified -> request omits `workspaceKind` and preserves legacy behavior
- - `workspaceKind=V1` -> workspace created as V1
- - `workspaceKind=V2` -> workspace created as V2
- Verified workspace creation, target discovery, and job submission behavior against a personal Azure subscription

<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ⚠️ Review suggested

| Breaking Changes |
| :--: |
| ⚠️ None |

<!-- act-bot:section title="Azure CLI Extensions Breaking Change Test" category="breaking_change" label="Breaking Changes" status="Warning" summary="None" -->
<!-- Azure CLI Extensions Breaking Change Test --><details>
<summary>⚠️Azure CLI Extensions Breaking Change Test</summary>

><details>
> <summary>⚠️quantum</summary>
>
>|rule|cmd_name|rule_message|suggest_message|
>|---|---|---|---|
>|⚠️ [1006 - ParaAdd](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1006.md)|quantum workspace create|cmd `quantum workspace create` added parameter `workspace_kind`||
>
></details>
</details>

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->