### PR TITLE
Quantum: add 'az quantum job delete' command

### DIFF
--- a/src/quantum/HISTORY.rst
+++ b/src/quantum/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+1.0.0b19
++++++++++++++++
+* Added the ``az quantum job delete`` command to delete a job from an Azure Quantum workspace.
+
 1.0.0b18
 +++++++++++++++
 * Added support for the explicit V1 and V2 workspace creation through the ``--workspace-kind`` parameter on ``az quantum workspace create``.

--- a/src/quantum/azext_quantum/_help.py
+++ b/src/quantum/azext_quantum/_help.py
@@ -156,6 +156,16 @@ helps['quantum job cancel'] = """
                 -j yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy
 """
 
+helps['quantum job delete'] = """
+    type: command
+    short-summary: Delete a job from an Azure Quantum workspace.
+    examples:
+      - name: Delete an Azure Quantum job by id.
+        text: |-
+            az quantum job delete -g MyResourceGroup -w MyWorkspace \\
+                -j yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy
+"""
+
 helps['quantum offerings'] = """
     type: group
     short-summary: Manage provider offerings for Azure Quantum.

--- a/src/quantum/azext_quantum/commands.py
+++ b/src/quantum/azext_quantum/commands.py
@@ -149,6 +149,7 @@ def load_command_table(self, _):
         j.command('wait', 'wait', validator=validate_workspace_info, table_transformer=transform_job)
         j.command('output', 'output', validator=validate_workspace_info, table_transformer=transform_output)
         j.command('cancel', 'cancel', validator=validate_workspace_info, table_transformer=transform_job)
+        j.command('delete', 'delete', validator=validate_workspace_info, confirmation=True)
 
     with self.command_group('quantum', job_ops, is_preview=True) as q:
         q.command('run', 'run', validator=validate_workspace_and_target_info, table_transformer=transform_output)

--- a/src/quantum/azext_quantum/operations/job.py
+++ b/src/quantum/azext_quantum/operations/job.py
@@ -452,6 +452,16 @@ def cancel(cmd, job_id, resource_group_name, workspace_name):
     return wait(cmd, job_id, info.resource_group, info.name)
 
 
+def delete(cmd, job_id, resource_group_name, workspace_name):
+    """
+    Delete a job from an Azure Quantum workspace.
+    """
+    info = WorkspaceInfo(cmd, resource_group_name, workspace_name)
+    client = cf_jobs(cmd.cli_ctx, info.subscription, info.resource_group, info.name, info.endpoint)
+    client.delete(info.subscription, info.resource_group, info.name, job_id)
+    print(f"Job {job_id} has been deleted.")
+
+
 def _get_job_output(job):
 
     import tempfile

--- a/src/quantum/azext_quantum/operations/job.py
+++ b/src/quantum/azext_quantum/operations/job.py
@@ -459,7 +459,7 @@ def delete(cmd, job_id, resource_group_name, workspace_name):
     info = WorkspaceInfo(cmd, resource_group_name, workspace_name)
     client = cf_jobs(cmd.cli_ctx, info.subscription, info.resource_group, info.name, info.endpoint)
     client.delete(info.subscription, info.resource_group, info.name, job_id)
-    print(f"Job {job_id} has been deleted.")
+    logger.warning("Deleted job %s.", job_id)
 
 
 def _get_job_output(job):

--- a/src/quantum/azext_quantum/tests/latest/test_quantum_jobs.py
+++ b/src/quantum/azext_quantum/tests/latest/test_quantum_jobs.py
@@ -46,6 +46,7 @@ class QuantumJobsScenarioTest(ScenarioTest):
 
     def test_job_errors(self):
         issue_cmd_with_param_missing(self, "az quantum job cancel", "az quantum job cancel -g MyResourceGroup -w MyWorkspace -j yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy\nCancel an Azure Quantum job by id.")
+        issue_cmd_with_param_missing(self, "az quantum job delete", "az quantum job delete -g MyResourceGroup -w MyWorkspace -j yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy\nDelete an Azure Quantum job by id.")
         issue_cmd_with_param_missing(self, "az quantum job output", "az quantum job output -g MyResourceGroup -w MyWorkspace -j yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy -o table\nPrint the results of a successful Azure Quantum job.")
         issue_cmd_with_param_missing(self, "az quantum job show", "az quantum job show -g MyResourceGroup -w MyWorkspace -j yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy --query status\nGet the status of an Azure Quantum job.")
         issue_cmd_with_param_missing(self, "az quantum job wait", "az quantum job wait -g MyResourceGroup -w MyWorkspace -j yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy --max-poll-wait-secs 60 -o table\nWait for completion of a job, check at 60 second intervals.")

--- a/src/quantum/setup.py
+++ b/src/quantum/setup.py
@@ -17,7 +17,7 @@ except ImportError:
 # This version should match the latest entry in HISTORY.rst
 # Also, when updating this, please review the version used by the extension to
 # submit requests, which can be found at './azext_quantum/__init__.py'
-VERSION = '1.0.0b18'
+VERSION = '1.0.0b19'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ⚠️ Review suggested

| Breaking Changes |
| :--: |
| ⚠️ None |

<!-- act-bot:section title="Azure CLI Extensions Breaking Change Test" category="breaking_change" label="Breaking Changes" status="Warning" summary="None" -->
<!-- Azure CLI Extensions Breaking Change Test --><details>
<summary>⚠️Azure CLI Extensions Breaking Change Test</summary>

><details>
> <summary>⚠️quantum</summary>
>
>|rule|cmd_name|rule_message|suggest_message|
>|---|---|---|---|
>|⚠️ [1001 - CmdAdd](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1001.md)|quantum job delete|cmd `quantum job delete` added||
>
></details>
</details>

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

## Summary

Adds a new `az quantum job delete` command to delete a job from an Azure Quantum workspace by its id.
This service supports this via the new `Jobs_Delete` data-plane operation, where an HTTP `DELETE` now performs a real delete. But there was no way to trigger it from the CLI, so users had to call the API directly.

## Changes

- Added `az quantum job delete -g <rg> -w <workspace> -j <job-id>`, calling the vendored SDK's `jobs.delete` operation (HTTP `DELETE` -> `204`).
- Registered the command with confirmation, which adds a `--yes/y` flag, `j/--job-id` is inherited from the existing `quantum job` argument group`.
- Added command help and an example
- Bumped version

## Testing
- All offline unit tests pass locally; added a unit test covering the missing-parameter path.
- Manually verified end-to-end against a personal Azure subscription