### PR TITLE
[AKS] Add allowedSubjects support to identity bindings

### DIFF
--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -11,6 +11,7 @@ To release a new version, please select a new version number (usually plus 1 to 
 
 Pending
 +++++++
+* Add `--allowed-subjects-from-file` to `az aks identity-binding create` and add a new `az aks identity-binding update` command to manage the `allowedSubjects` list on identity bindings.
 
 21.0.0b11
 ++++++++

--- a/src/aks-preview/azext_aks_preview/_help.py
+++ b/src/aks-preview/azext_aks_preview/_help.py
@@ -4811,6 +4811,49 @@ helps['aks identity-binding create'] = """
         - name: --managed-identity-resource-id
           type: string
           short-summary: The resource ID of the managed identity to use.
+        - name: --allowed-subjects-from-file
+          type: string
+          short-summary: Path to a JSON file with the list of subjects authorized to use this identity binding for token exchange.
+          long-summary: |
+              The file must contain a JSON array (max 100 entries). Each entry has a required
+              'namespaceSelector' and an optional 'serviceAccountSelector', each a Kubernetes label
+              selector supporting 'matchLabels' (an array of "key=value" strings) and/or
+              'matchExpressions'. Use the built-in 'kubernetes.io/metadata.name' label to target
+              specific namespaces by name. When omitted, authorization falls back to
+              ClusterRole/ClusterRoleBinding evaluation.
+    examples:
+        - name: Create an identity binding with allowed subjects targeting specific namespaces by name.
+          text: |-
+              az aks identity-binding create --resource-group myRG --cluster-name myCluster \\
+                --name my-identity-binding \\
+                --managed-identity-resource-id /subscriptions/.../userAssignedIdentities/myMI \\
+                --allowed-subjects-from-file allowed-subjects.json
+"""
+helps['aks identity-binding update'] = """
+    type: command
+    short-summary: Update an existing identity binding in a managed Kubernetes cluster.
+    parameters:
+        - name: --cluster-name
+          type: string
+          short-summary: Name of the managed Kubernetes cluster.
+        - name: --name -n
+          type: string
+          short-summary: Name of the identity binding to update.
+        - name: --allowed-subjects-from-file
+          type: string
+          short-summary: Path to a JSON file with the list of subjects authorized to use this identity binding for token exchange.
+          long-summary: |
+              The file must contain a JSON array (max 100 entries). Each entry has a required
+              'namespaceSelector' and an optional 'serviceAccountSelector', each a Kubernetes label
+              selector supporting 'matchLabels' (an array of "key=value" strings) and/or
+              'matchExpressions'. Use the built-in 'kubernetes.io/metadata.name' label to target
+              specific namespaces by name. Providing this replaces the existing allowed subjects list.
+    examples:
+        - name: Update the allowed subjects on an existing identity binding.
+          text: |-
+              az aks identity-binding update --resource-group myRG --cluster-name myCluster \\
+                --name my-identity-binding \\
+                --allowed-subjects-from-file updated-subjects.json
 """
 helps['aks identity-binding delete'] = """
     type: command

--- a/src/aks-preview/azext_aks_preview/_help.py
+++ b/src/aks-preview/azext_aks_preview/_help.py
@@ -4807,11 +4807,11 @@ helps['aks identity-binding create'] = """
           short-summary: Name of the managed Kubernetes cluster.
         - name: --name -n
           type: string
-          short-summary: Name of the identity binding to show.
+          short-summary: Name of the identity binding to create.
         - name: --managed-identity-resource-id
           type: string
           short-summary: The resource ID of the managed identity to use.
-        - name: --allowed-subjects-from-file
+        - name: --allowed-subjects-from-file -f
           type: string
           short-summary: Path to a JSON file with the list of subjects authorized to use this identity binding for token exchange.
           long-summary: |
@@ -4839,7 +4839,7 @@ helps['aks identity-binding update'] = """
         - name: --name -n
           type: string
           short-summary: Name of the identity binding to update.
-        - name: --allowed-subjects-from-file
+        - name: --allowed-subjects-from-file -f
           type: string
           short-summary: Path to a JSON file with the list of subjects authorized to use this identity binding for token exchange.
           long-summary: |
@@ -4864,7 +4864,7 @@ helps['aks identity-binding delete'] = """
           short-summary: Name of the managed Kubernetes cluster.
         - name: --name -n
           type: string
-          short-summary: Name of the identity binding to show.
+          short-summary: Name of the identity binding to delete.
 """
 
 helps['aks jwtauthenticator'] = """

--- a/src/aks-preview/azext_aks_preview/_params.py
+++ b/src/aks-preview/azext_aks_preview/_params.py
@@ -3668,14 +3668,19 @@ def load_arguments(self, _):
                        help='Path to the JSON configuration file containing JWT authenticator properties.')
 
     # aks identity-binding commands
-    for scope in ['aks identity-binding create',
-                  'aks identity-binding update']:
+    # --allowed-subjects-from-file is optional on create (omitting it falls back
+    # to ClusterRole/ClusterRoleBinding authorization), but required on update
+    # since it is the only mutable field today -- requiring it avoids a no-op
+    # full-PUT that would needlessly re-provision the binding.
+    for scope, is_required in [('aks identity-binding create', False),
+                               ('aks identity-binding update', True)]:
         with self.argument_context(scope) as c:
             c.argument(
                 "allowed_subjects_from_file",
                 options_list=["--allowed-subjects-from-file", "-f"],
                 type=file_type,
                 completer=FilesCompleter(),
+                required=is_required,
                 help="Path to a JSON file containing an array of subjects authorized to use this "
                      "identity binding for token exchange. Each entry has a required "
                      "'namespaceSelector' and an optional 'serviceAccountSelector', each a Kubernetes "

--- a/src/aks-preview/azext_aks_preview/_params.py
+++ b/src/aks-preview/azext_aks_preview/_params.py
@@ -3667,6 +3667,22 @@ def load_arguments(self, _):
             c.argument('config_file', options_list=['--config-file'], type=file_type, completer=FilesCompleter(),
                        help='Path to the JSON configuration file containing JWT authenticator properties.')
 
+    # aks identity-binding commands
+    for scope in ['aks identity-binding create',
+                  'aks identity-binding update']:
+        with self.argument_context(scope) as c:
+            c.argument(
+                "allowed_subjects_from_file",
+                options_list=["--allowed-subjects-from-file"],
+                type=file_type,
+                completer=FilesCompleter(),
+                help="Path to a JSON file containing an array of subjects authorized to use this "
+                     "identity binding for token exchange. Each entry has a required "
+                     "'namespaceSelector' and an optional 'serviceAccountSelector', each a Kubernetes "
+                     "label selector with 'matchLabels' (an array of \"key=value\" strings) and/or "
+                     "'matchExpressions'. Maximum 100 entries.",
+            )
+
     # aks list-vm-skus command
     with self.argument_context("aks list-vm-skus") as c:
         c.argument(

--- a/src/aks-preview/azext_aks_preview/_params.py
+++ b/src/aks-preview/azext_aks_preview/_params.py
@@ -3673,7 +3673,7 @@ def load_arguments(self, _):
         with self.argument_context(scope) as c:
             c.argument(
                 "allowed_subjects_from_file",
-                options_list=["--allowed-subjects-from-file"],
+                options_list=["--allowed-subjects-from-file", "-f"],
                 type=file_type,
                 completer=FilesCompleter(),
                 help="Path to a JSON file containing an array of subjects authorized to use this "

--- a/src/aks-preview/azext_aks_preview/aks_identity_binding/commands.py
+++ b/src/aks-preview/azext_aks_preview/aks_identity_binding/commands.py
@@ -92,7 +92,7 @@ def aks_ib_cmd_update(
     resource_group_name: str,
     cluster_name: str,
     name: str,
-    allowed_subjects_from_file=None,
+    allowed_subjects_from_file: str,
     no_wait: bool = False,
 ):
     from azure.cli.core.util import sdk_no_wait
@@ -103,10 +103,12 @@ def aks_ib_cmd_update(
         identity_binding_name=name,
     )
 
-    if allowed_subjects_from_file is not None:
-        instance.properties.allowed_subjects = _parse_allowed_subjects_from_file(
-            allowed_subjects_from_file
-        )
+    # allowed_subjects_from_file is required for update (enforced at argument
+    # registration), so it is always provided here. It is the only mutable
+    # field today; requiring it avoids a no-op full-PUT.
+    instance.properties.allowed_subjects = _parse_allowed_subjects_from_file(
+        allowed_subjects_from_file
+    )
 
     return sdk_no_wait(
         no_wait,

--- a/src/aks-preview/azext_aks_preview/aks_identity_binding/commands.py
+++ b/src/aks-preview/azext_aks_preview/aks_identity_binding/commands.py
@@ -4,6 +4,51 @@
 # --------------------------------------------------------------------------------------------
 
 
+def _parse_allowed_subjects_from_file(allowed_subjects_from_file):
+    """Load the --allowed-subjects-from-file payload into a list of AllowedSubject models.
+
+    The file is expected to contain a JSON array where each element matches the AllowedSubject
+    REST shape, e.g.:
+        [
+          {
+            "namespaceSelector": {"matchLabels": ["kubernetes.io/metadata.name=team-a"]},
+            "serviceAccountSelector": {"matchLabels": ["app=payments"]}
+          }
+        ]
+    Note: 'matchLabels' is an array of "key=value" strings, matching the AKS API contract.
+    """
+    if allowed_subjects_from_file is None:
+        return None
+
+    from azure.cli.core.util import get_file_json
+    from azure.cli.core.azclierror import InvalidArgumentValueError
+    from azext_aks_preview.vendored_sdks.azure_mgmt_preview_aks.models import (
+        AllowedSubject,
+    )
+
+    allowed_subjects = get_file_json(allowed_subjects_from_file)
+
+    if not isinstance(allowed_subjects, list):
+        raise InvalidArgumentValueError(
+            "--allowed-subjects-from-file must contain a JSON array of subject objects."
+        )
+
+    result = []
+    for index, subject in enumerate(allowed_subjects):
+        if not isinstance(subject, dict):
+            raise InvalidArgumentValueError(
+                f"allowed subject at index {index} must be a JSON object."
+            )
+        if not subject.get("namespaceSelector"):
+            raise InvalidArgumentValueError(
+                f"allowed subject at index {index} is missing the required 'namespaceSelector'."
+            )
+        # AllowedSubject (a rest _Model) accepts a raw JSON mapping and validates field shapes.
+        result.append(AllowedSubject(subject))
+
+    return result
+
+
 # `az aks identity-binding create` command
 def aks_ib_cmd_create(
     cmd, client,  # pylint: disable=unused-argument
@@ -11,6 +56,7 @@ def aks_ib_cmd_create(
     cluster_name: str,
     name: str,
     managed_identity_resource_id: str,
+    allowed_subjects_from_file=None,
     no_wait: bool = False,
 ):
     from azure.cli.core.util import sdk_no_wait
@@ -25,9 +71,42 @@ def aks_ib_cmd_create(
         properties=IdentityBindingProperties(
             managed_identity=IdentityBindingManagedIdentityProfile(
                 resource_id=managed_identity_resource_id,
-            )
+            ),
+            allowed_subjects=_parse_allowed_subjects_from_file(allowed_subjects_from_file),
         )
     )
+
+    return sdk_no_wait(
+        no_wait,
+        client.begin_create_or_update,
+        resource_group_name,
+        cluster_name,
+        name,
+        instance,
+    )
+
+
+# `az aks identity-binding update` command
+def aks_ib_cmd_update(
+    cmd, client,  # pylint: disable=unused-argument
+    resource_group_name: str,
+    cluster_name: str,
+    name: str,
+    allowed_subjects_from_file=None,
+    no_wait: bool = False,
+):
+    from azure.cli.core.util import sdk_no_wait
+
+    instance = client.get(
+        resource_group_name=resource_group_name,
+        resource_name=cluster_name,
+        identity_binding_name=name,
+    )
+
+    if allowed_subjects_from_file is not None:
+        instance.properties.allowed_subjects = _parse_allowed_subjects_from_file(
+            allowed_subjects_from_file
+        )
 
     return sdk_no_wait(
         no_wait,

--- a/src/aks-preview/azext_aks_preview/commands.py
+++ b/src/aks-preview/azext_aks_preview/commands.py
@@ -607,6 +607,7 @@ def load_command_table(self, _):
         "aks identity-binding", managed_clusters_sdk, client_factory=cf_identity_bindings
     ) as g:
         g.custom_command("create", "aks_identity_binding_create")
+        g.custom_command("update", "aks_identity_binding_update")
         g.custom_command("delete", "aks_identity_binding_delete")
         g.custom_show_command("show", "aks_identity_binding_show")
         g.custom_command("list", "aks_identity_binding_list")

--- a/src/aks-preview/azext_aks_preview/custom.py
+++ b/src/aks-preview/azext_aks_preview/custom.py
@@ -118,6 +118,7 @@ from azext_aks_preview.maintenancewindow import (
 )
 from azext_aks_preview.aks_identity_binding.commands import (
     aks_ib_cmd_create,
+    aks_ib_cmd_update,
     aks_ib_cmd_delete,
     aks_ib_cmd_show,
     aks_ib_cmd_list,
@@ -5947,6 +5948,7 @@ def aks_bastion(cmd, client, resource_group_name, name, bastion=None, port=None,
 
 
 aks_identity_binding_create = aks_ib_cmd_create
+aks_identity_binding_update = aks_ib_cmd_update
 aks_identity_binding_delete = aks_ib_cmd_delete
 aks_identity_binding_show = aks_ib_cmd_show
 aks_identity_binding_list = aks_ib_cmd_list

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_identity_binding.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_identity_binding.py
@@ -119,7 +119,8 @@ class IdentityBindingTestCases(ScenarioTest):
                 }
             },
         ]
-        _, allowed_subjects_file = tempfile.mkstemp(suffix=".json")
+        fd, allowed_subjects_file = tempfile.mkstemp(suffix=".json")
+        os.close(fd)
         self.addCleanup(os.remove, allowed_subjects_file)
         with open(allowed_subjects_file, "w", encoding="utf-8") as f:
             json.dump(allowed_subjects, f)

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_identity_binding.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_identity_binding.py
@@ -4,6 +4,10 @@
 # --------------------------------------------------------------------------------------------
 
 
+import json
+import os
+import tempfile
+
 from azure.cli.testsdk import ScenarioTest, live_only
 from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 
@@ -98,6 +102,45 @@ class IdentityBindingTestCases(ScenarioTest):
         show_identity_binding_cmd = ("aks identity-binding show --resource-group {resource_group} --cluster-name {aks_name} "
                                      "-n {identity_binding_name} -o json")
         self.cmd(show_identity_binding_cmd, checks=identity_binding_checks)
+
+        # update the identity binding with an allowed subjects list loaded from a file
+        allowed_subjects = [
+            {
+                "namespaceSelector": {
+                    "matchLabels": ["kubernetes.io/metadata.name=team-a"]
+                }
+            },
+            {
+                "namespaceSelector": {
+                    "matchLabels": ["team=backend"]
+                },
+                "serviceAccountSelector": {
+                    "matchLabels": ["app=my-workload"]
+                }
+            },
+        ]
+        _, allowed_subjects_file = tempfile.mkstemp(suffix=".json")
+        self.addCleanup(os.remove, allowed_subjects_file)
+        with open(allowed_subjects_file, "w", encoding="utf-8") as f:
+            json.dump(allowed_subjects, f)
+        self.kwargs.update({"allowed_subjects_file": allowed_subjects_file})
+
+        update_identity_binding_cmd = (
+            "aks identity-binding update --resource-group {resource_group} --cluster-name {aks_name} "
+            "-n {identity_binding_name} --allowed-subjects-from-file \"{allowed_subjects_file}\" -o json"
+        )
+        self.cmd(update_identity_binding_cmd, checks=[
+            self.check("properties.provisioningState", "Succeeded"),
+            self.check("length(properties.allowedSubjects)", 2),
+            self.check(
+                "properties.allowedSubjects[0].namespaceSelector.matchLabels[0]",
+                "kubernetes.io/metadata.name=team-a",
+            ),
+            self.check(
+                "properties.allowedSubjects[1].serviceAccountSelector.matchLabels[0]",
+                "app=my-workload",
+            ),
+        ])
 
         delete_identity_binding_cmd = ("aks identity-binding delete --resource-group {resource_group} --cluster-name {aks_name} "
                                        "-n {identity_binding_name} -o json")

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_identity_binding_unit.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_identity_binding_unit.py
@@ -1,0 +1,96 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import json
+import os
+import tempfile
+import unittest
+
+from azure.cli.core.azclierror import InvalidArgumentValueError
+
+from azext_aks_preview.aks_identity_binding.commands import (
+    _parse_allowed_subjects_from_file,
+)
+
+
+class AllowedSubjectsParsingTestCase(unittest.TestCase):
+    def _write_json(self, payload):
+        fd, path = tempfile.mkstemp(suffix=".json")
+        os.close(fd)
+        self.addCleanup(os.remove, path)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(payload, f)
+        return path
+
+    def test_none_returns_none(self):
+        self.assertIsNone(_parse_allowed_subjects_from_file(None))
+
+    def test_valid_payload_builds_models(self):
+        path = self._write_json([
+            {
+                "namespaceSelector": {
+                    "matchLabels": ["kubernetes.io/metadata.name=team-a"]
+                }
+            },
+            {
+                "namespaceSelector": {"matchLabels": ["team=backend"]},
+                "serviceAccountSelector": {"matchLabels": ["app=my-workload"]},
+            },
+        ])
+
+        result = _parse_allowed_subjects_from_file(path)
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(
+            result[0].namespace_selector.match_labels,
+            ["kubernetes.io/metadata.name=team-a"],
+        )
+        self.assertIsNone(result[0].service_account_selector)
+        self.assertEqual(
+            result[1].service_account_selector.match_labels, ["app=my-workload"]
+        )
+
+    def test_match_expressions_are_parsed(self):
+        path = self._write_json([
+            {
+                "namespaceSelector": {
+                    "matchExpressions": [
+                        {
+                            "key": "kubernetes.io/metadata.name",
+                            "operator": "In",
+                            "values": ["team-a", "team-b"],
+                        }
+                    ]
+                }
+            }
+        ])
+
+        result = _parse_allowed_subjects_from_file(path)
+
+        expr = result[0].namespace_selector.match_expressions[0]
+        self.assertEqual(expr.key, "kubernetes.io/metadata.name")
+        self.assertEqual(expr.operator, "In")
+        self.assertEqual(expr.values_property, ["team-a", "team-b"])
+
+    def test_non_array_payload_raises(self):
+        path = self._write_json({"namespaceSelector": {}})
+        with self.assertRaises(InvalidArgumentValueError):
+            _parse_allowed_subjects_from_file(path)
+
+    def test_entry_not_object_raises(self):
+        path = self._write_json(["not-an-object"])
+        with self.assertRaises(InvalidArgumentValueError):
+            _parse_allowed_subjects_from_file(path)
+
+    def test_missing_namespace_selector_raises(self):
+        path = self._write_json([
+            {"serviceAccountSelector": {"matchLabels": ["app=x"]}}
+        ])
+        with self.assertRaises(InvalidArgumentValueError):
+            _parse_allowed_subjects_from_file(path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ⚠️ Review suggested

| Breaking Changes |
| :--: |
| ⚠️ None |

<!-- act-bot:section title="Azure CLI Extensions Breaking Change Test" category="breaking_change" label="Breaking Changes" status="Warning" summary="None" -->
<!-- Azure CLI Extensions Breaking Change Test --><details>
<summary>⚠️Azure CLI Extensions Breaking Change Test</summary>

><details>
> <summary>⚠️aks-preview</summary>
>
>|rule|cmd_name|rule_message|suggest_message|
>|---|---|---|---|
>|⚠️ [1006 - ParaAdd](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1006.md)|aks identity-binding create|cmd `aks identity-binding create` added parameter `allowed_subjects_from_file`||
>|⚠️ [1001 - CmdAdd](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1001.md)|aks identity-binding update|cmd `aks identity-binding update` added||
>
></details>
</details>

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

### Related command
`az aks identity-binding create` / `az aks identity-binding update`

### Description

Adds `allowedSubjects` support to AKS identity bindings so operators can control which namespaces (and optionally service accounts) may use a managed identity for token exchange directly through ARM/CLI, without needing Kubernetes API access to configure ClusterRole/ClusterRoleBinding objects.

Changes:
- Add `--allowed-subjects-from-file` to `az aks identity-binding create`.
- Add a new `az aks identity-binding update` command to manage `allowedSubjects` on an existing identity binding.

The file contains a JSON array of subjects, each with a required `namespaceSelector` and an optional `serviceAccountSelector` (Kubernetes label selectors; `matchLabels` is an array of `"key=value"` strings and/or `matchExpressions`). Entries are deserialized into the vendored SDK `AllowedSubject` models (API version `2026-05-02-preview`). Maximum 100 entries.

Example:
```bash
az aks identity-binding update \
  --resource-group myRG --cluster-name myCluster \
  --name my-identity-binding \
  --allowed-subjects-from-file allowed-subjects.json
```

### Testing
- Added unit tests for the file parser (`test_identity_binding_unit.py`).
- Extended the live E2E scenario (`test_identity_binding.py`) to cover create + update with `allowedSubjects`. Ran the live E2E test successfully against a test subscription.

### History notes
Added a `HISTORY.rst` entry under *Pending*.