### PR TITLE
Quantum: Add Provider Status column to 'az quantum target list' output

### DIFF
--- a/src/quantum/HISTORY.rst
+++ b/src/quantum/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+1.0.0b19
++++++++++++++++
+* Added a ``Provider Status`` column to the ``az quantum target list`` table output showing the current availability of each provider account.
+
 1.0.0b18
 +++++++++++++++
 * Added support for the explicit V1 and V2 workspace creation through the ``--workspace-kind`` parameter on ``az quantum workspace create``.

--- a/src/quantum/azext_quantum/commands.py
+++ b/src/quantum/azext_quantum/commands.py
@@ -17,14 +17,15 @@ logger = logging.getLogger(__name__)
 def transform_targets(providers):
     def one(provider, target):
         return OrderedDict([
-            ('Provider', provider),
+            ('Provider', provider['id']),
+            ('Provider Status', provider['currentAvailability']),
             ('Target-id', target['id']),
             ('Current Availability', target['currentAvailability']),
             ('Average Queue Time (seconds)', target['averageQueueTime'])
         ])
 
     return [
-        one(provider['id'], target)
+        one(provider, target)
         for provider in providers
         for target in provider['targets']
     ]

--- a/src/quantum/azext_quantum/tests/latest/test_quantum_targets.py
+++ b/src/quantum/azext_quantum/tests/latest/test_quantum_targets.py
@@ -14,6 +14,7 @@ from .utils import (get_test_resource_group, get_test_workspace, get_test_worksp
                     get_test_workspace_random_name, get_test_workspace_storage, get_test_target_provider_sku_list,
                     get_test_target_provider, get_test_target_target)
 from ...operations.target import get_provider
+from ...commands import transform_targets
 
 TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))
 
@@ -50,9 +51,49 @@ class QuantumTargetsScenarioTest(ScenarioTest):
             self.check("targetId", "ionq.simulator")
         ])
 
+    @live_only()
+    def test_target_list_provider_status(self):
+        # set current workspace:
+        self.cmd(f'az quantum workspace set -g {get_test_resource_group()} -w {get_test_workspace()}')
+
+        # The JSON output that feeds the table should expose the provider account's
+        # current availability, which is the source of the "Provider Status" column.
+        providers = self.cmd('az quantum target list -o json').get_output_in_json()
+        assert len(providers) > 0
+        for provider in providers:
+            assert "currentAvailability" in provider
+
+        # The table view should surface the provider status as a dedicated column.
+        table_output = self.cmd('az quantum target list -o table').output
+        assert "Provider Status" in table_output
+
     def test_target_errors(self):
         self.cmd('az quantum target clear')
         issue_cmd_with_param_missing(self, "az quantum target set", "az quantum target set -t target-id\nSelect a default when submitting jobs to Azure Quantum.")
+
+    def test_transform_targets(self):
+        providers = [
+            {
+                "id": "atom-dev",
+                "currentAvailability": "Available",
+                "targets": [
+                    {
+                        "id": "atom.qpu.vb-dev.physical",
+                        "currentAvailability": "Degraded",
+                        "averageQueueTime": 7
+                    }
+                ]
+            }
+        ]
+
+        table = transform_targets(providers)
+        self.assertEqual(len(table), 1)
+        row = table[0]
+        self.assertEqual(row['Provider'], "atom-dev")
+        self.assertEqual(row['Provider Status'], "Available")
+        self.assertEqual(row['Target-id'], "atom.qpu.vb-dev.physical")
+        self.assertEqual(row['Current Availability'], "Degraded")
+        self.assertEqual(row['Average Queue Time (seconds)'], 7)
 
     @live_only()
     def test_get_provider(self):

--- a/src/quantum/setup.py
+++ b/src/quantum/setup.py
@@ -17,7 +17,7 @@ except ImportError:
 # This version should match the latest entry in HISTORY.rst
 # Also, when updating this, please review the version used by the extension to
 # submit requests, which can be found at './azext_quantum/__init__.py'
-VERSION = '1.0.0b18'
+VERSION = '1.0.0b19'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
## Summary

Adds a Provider Status column to the `az quantum target list` table output, showing the current availability of each provider account.
Previously the table view showed only per-target status, even though the underlying data-plane response already includes the provider account's own `currentAvailability`. This surfaces that provider-account status so users can see at a glance whether the provider account itself is available, alongside each of its targets.

## Testing 
- Added unit test covering the table transform
- Added a live e2e test that runs `az quantum target list` against a real V2 workspace and asserts the provider status flows through to both JSON and the table column.
- Verified live: V2 workspace shows the new `Provider Status` column; V1 workspaces are unaffected.
- Ran `azdev style quantum` and `python scripts/ci/test_index.py -q` locally (passed).


