### PR TITLE
[appnet-preview] Auto-detect --member-location from member cluster on member join

### DIFF
--- a/src/appnet-preview/HISTORY.rst
+++ b/src/appnet-preview/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+1.0.0b3
+++++++
+* Make `--member-location` optional on `az appnet member join`; when omitted it defaults to the location of the member cluster referenced by `--member-resource-id`.
+
 1.0.0b2
 ++++++
 * Add `--east-west-gateway` to `az appnet member join` and `az appnet member update`

--- a/src/appnet-preview/azext_appnet_preview/custom.py
+++ b/src/appnet-preview/azext_appnet_preview/custom.py
@@ -16,6 +16,7 @@ from azure.cli.core.azclierror import ArgumentUsageError, RequiredArgumentMissin
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.profiles import ResourceType
 from azure.mgmt.core.tools import is_valid_resource_id
+from azure.core.exceptions import HttpResponseError
 
 logger = get_logger(__name__)
 
@@ -85,5 +86,13 @@ class MemberJoin(Join):
         if not is_valid_resource_id(resource_id):
             return None
         client = get_mgmt_service_client(self.cli_ctx, ResourceType.MGMT_RESOURCE_RESOURCES)
-        cluster = client.resources.get_by_id(resource_id, MANAGED_CLUSTER_API_VERSION)
+        try:
+            cluster = client.resources.get_by_id(resource_id, MANAGED_CLUSTER_API_VERSION)
+        except HttpResponseError as ex:
+            # Reading the cluster is best-effort: if it can't be reached (404/403/etc.),
+            # treat the location as unavailable so an explicitly provided --member-location
+            # still works, and the auto-detect path surfaces the actionable
+            # RequiredArgumentMissingError instead of a raw ARM error.
+            logger.debug("Could not read location from member cluster '%s': %s", resource_id, ex)
+            return None
         return cluster.location

--- a/src/appnet-preview/azext_appnet_preview/custom.py
+++ b/src/appnet-preview/azext_appnet_preview/custom.py
@@ -7,16 +7,41 @@
 
 # pylint: disable=too-many-lines
 # pylint: disable=too-many-statements
+# pylint: disable=protected-access
 
 from knack.log import get_logger
 from .aaz.latest.appnet.member._join import Join
-from azure.cli.core.aaz import has_value
-from azure.cli.core.azclierror import ArgumentUsageError
+from azure.cli.core.aaz import has_value, AAZResourceLocationArgFormat
+from azure.cli.core.azclierror import ArgumentUsageError, RequiredArgumentMissingError
+from azure.cli.core.commands.client_factory import get_mgmt_service_client
+from azure.cli.core.profiles import ResourceType
+from azure.mgmt.core.tools import is_valid_resource_id
 
 logger = get_logger(__name__)
 
+# `location` is part of the common ARM resource envelope and is returned by every
+# Microsoft.ContainerService/managedClusters API version, so a pinned stable version is
+# safe here purely for reading the cluster's `.location`.
+MANAGED_CLUSTER_API_VERSION = "2023-09-01"
+
 
 class MemberJoin(Join):
+
+    @classmethod
+    def _build_arguments_schema(cls, *args, **kwargs):
+        args_schema = super()._build_arguments_schema(*args, **kwargs)
+        # --member-location is derived from the member cluster (--member-resource-id) when
+        # not supplied, so it is no longer required on the command line. Replace the format
+        # so AAZ does NOT auto-fill it from the resource group's location before
+        # pre_operations runs; an empty value must reach our detection logic below.
+        args_schema.member_location._required = False
+        args_schema.member_location._fmt = AAZResourceLocationArgFormat()
+        args_schema.member_location._help["short-summary"] = (
+            "The geo-location where the member resource lives. Defaults to the location "
+            "of the member cluster referenced by --member-resource-id."
+        )
+        return args_schema
+
     def pre_operations(self):
         super().pre_operations()
 
@@ -28,3 +53,37 @@ class MemberJoin(Join):
         elif args.upgrade_mode == 'FullyManaged':
             if has_value(args.version):
                 raise ArgumentUsageError('Cannot use --version when using "--upgrade-mode FullyManaged"')
+
+        self._resolve_member_location(args)
+
+    def _resolve_member_location(self, args):
+        cluster_location = self._get_member_cluster_location(args)
+
+        if not has_value(args.member_location):
+            if not cluster_location:
+                raise RequiredArgumentMissingError(
+                    "Unable to determine the member location automatically. Provide "
+                    "--member-location explicitly, or pass --member-resource-id pointing "
+                    "to an existing cluster whose location can be read."
+                )
+            args.member_location = cluster_location
+            logger.info("Using member cluster location '%s' for --member-location.", cluster_location)
+            return
+
+        member_location = args.member_location.to_serialized_data()
+        if cluster_location and member_location.lower() != cluster_location.lower():
+            logger.warning(
+                "--member-location '%s' differs from the member cluster location '%s'. "
+                "A member should normally be in the same region as its cluster.",
+                member_location, cluster_location,
+            )
+
+    def _get_member_cluster_location(self, args):
+        if not has_value(args.member_resource_id):
+            return None
+        resource_id = args.member_resource_id.to_serialized_data()
+        if not is_valid_resource_id(resource_id):
+            return None
+        client = get_mgmt_service_client(self.cli_ctx, ResourceType.MGMT_RESOURCE_RESOURCES)
+        cluster = client.resources.get_by_id(resource_id, MANAGED_CLUSTER_API_VERSION)
+        return cluster.location

--- a/src/appnet-preview/azext_appnet_preview/custom.py
+++ b/src/appnet-preview/azext_appnet_preview/custom.py
@@ -16,7 +16,7 @@ from azure.cli.core.azclierror import ArgumentUsageError, RequiredArgumentMissin
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.profiles import ResourceType
 from azure.mgmt.core.tools import is_valid_resource_id
-from azure.core.exceptions import HttpResponseError
+from azure.core.exceptions import AzureError
 
 logger = get_logger(__name__)
 
@@ -37,6 +37,10 @@ class MemberJoin(Join):
         # pre_operations runs; an empty value must reach our detection logic below.
         args_schema.member_location._required = False
         args_schema.member_location._fmt = AAZResourceLocationArgFormat()
+        # AAZResourceLocationArg defaults configured_default='location', so a user with
+        # `az configure --defaults location=...` would get that value and auto-detect would
+        # never run. Clear it so an unspecified --member-location stays unset.
+        args_schema.member_location._configured_default = None
         args_schema.member_location._help["short-summary"] = (
             "The geo-location where the member resource lives. Defaults to the location "
             "of the member cluster referenced by --member-resource-id."
@@ -88,8 +92,9 @@ class MemberJoin(Join):
         client = get_mgmt_service_client(self.cli_ctx, ResourceType.MGMT_RESOURCE_RESOURCES)
         try:
             cluster = client.resources.get_by_id(resource_id, MANAGED_CLUSTER_API_VERSION)
-        except HttpResponseError as ex:
-            # Reading the cluster is best-effort: if it can't be reached (404/403/etc.),
+        except AzureError as ex:
+            # Reading the cluster is best-effort: if it can't be reached (404/403, or a
+            # connection/timeout failure such as ServiceRequestError/ServiceResponseError),
             # treat the location as unavailable so an explicitly provided --member-location
             # still works, and the auto-detect path surfaces the actionable
             # RequiredArgumentMissingError instead of a raw ARM error.

--- a/src/appnet-preview/azext_appnet_preview/tests/latest/test_member_location.py
+++ b/src/appnet-preview/azext_appnet_preview/tests/latest/test_member_location.py
@@ -1,0 +1,118 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from azure.cli.core.azclierror import RequiredArgumentMissingError
+
+from azext_appnet_preview.custom import MemberJoin
+
+
+class _FakeArg:
+    """Minimal stand-in for an AAZ arg value used by the resolution logic."""
+
+    def __init__(self, value, has=True):
+        self._value = value
+        self._has = has
+
+    def to_serialized_data(self):
+        return self._value
+
+
+def _has_value(arg):
+    return isinstance(arg, _FakeArg) and arg._has
+
+
+def _make_member(location_arg, resource_id_arg):
+    # Build a MemberJoin without running the full AAZCommand __init__; the
+    # resolution helpers only rely on self.cli_ctx and self.ctx.args.
+    member = object.__new__(MemberJoin)
+    member.cli_ctx = mock.MagicMock()
+    args = SimpleNamespace(member_location=location_arg, member_resource_id=resource_id_arg)
+    member.ctx = SimpleNamespace(args=args)
+    return member, args
+
+
+VALID_ID = (
+    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/"
+    "providers/Microsoft.ContainerService/managedClusters/cluster1"
+)
+
+
+class MemberLocationResolutionTest(unittest.TestCase):
+
+    @mock.patch("azext_appnet_preview.custom.has_value", side_effect=_has_value)
+    @mock.patch("azext_appnet_preview.custom.is_valid_resource_id", return_value=True)
+    @mock.patch("azext_appnet_preview.custom.get_mgmt_service_client")
+    def test_location_defaults_to_cluster_location(self, mock_client_factory, _mock_valid, _mock_has):
+        mock_client_factory.return_value.resources.get_by_id.return_value = SimpleNamespace(location="eastus2")
+        member, args = _make_member(
+            location_arg=_FakeArg(None, has=False),
+            resource_id_arg=_FakeArg(VALID_ID),
+        )
+
+        member._resolve_member_location(args)
+
+        self.assertEqual(args.member_location, "eastus2")
+
+    @mock.patch("azext_appnet_preview.custom.has_value", side_effect=_has_value)
+    def test_missing_location_and_cluster_raises(self, _mock_has):
+        member, args = _make_member(
+            location_arg=_FakeArg(None, has=False),
+            resource_id_arg=_FakeArg(None, has=False),
+        )
+
+        with self.assertRaises(RequiredArgumentMissingError):
+            member._resolve_member_location(args)
+
+    @mock.patch("azext_appnet_preview.custom.logger")
+    @mock.patch("azext_appnet_preview.custom.has_value", side_effect=_has_value)
+    @mock.patch("azext_appnet_preview.custom.is_valid_resource_id", return_value=True)
+    @mock.patch("azext_appnet_preview.custom.get_mgmt_service_client")
+    def test_explicit_location_matching_cluster_no_warning(
+            self, mock_client_factory, _mock_valid, _mock_has, mock_logger):
+        mock_client_factory.return_value.resources.get_by_id.return_value = SimpleNamespace(location="eastus2")
+        member, args = _make_member(
+            location_arg=_FakeArg("EastUS2"),
+            resource_id_arg=_FakeArg(VALID_ID),
+        )
+
+        member._resolve_member_location(args)
+
+        self.assertEqual(args.member_location.to_serialized_data(), "EastUS2")
+        mock_logger.warning.assert_not_called()
+
+    @mock.patch("azext_appnet_preview.custom.logger")
+    @mock.patch("azext_appnet_preview.custom.has_value", side_effect=_has_value)
+    @mock.patch("azext_appnet_preview.custom.is_valid_resource_id", return_value=True)
+    @mock.patch("azext_appnet_preview.custom.get_mgmt_service_client")
+    def test_explicit_location_mismatch_warns(
+            self, mock_client_factory, _mock_valid, _mock_has, mock_logger):
+        mock_client_factory.return_value.resources.get_by_id.return_value = SimpleNamespace(location="eastus2")
+        member, args = _make_member(
+            location_arg=_FakeArg("westus2"),
+            resource_id_arg=_FakeArg(VALID_ID),
+        )
+
+        member._resolve_member_location(args)
+
+        self.assertEqual(args.member_location.to_serialized_data(), "westus2")
+        mock_logger.warning.assert_called_once()
+
+    @mock.patch("azext_appnet_preview.custom.has_value", side_effect=_has_value)
+    @mock.patch("azext_appnet_preview.custom.is_valid_resource_id", return_value=False)
+    def test_invalid_resource_id_returns_none(self, _mock_valid, _mock_has):
+        member, args = _make_member(
+            location_arg=_FakeArg(None, has=False),
+            resource_id_arg=_FakeArg("not-a-resource-id"),
+        )
+
+        self.assertIsNone(member._get_member_cluster_location(args))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/appnet-preview/azext_appnet_preview/tests/latest/test_member_location.py
+++ b/src/appnet-preview/azext_appnet_preview/tests/latest/test_member_location.py
@@ -8,7 +8,7 @@ from types import SimpleNamespace
 from unittest import mock
 
 from azure.cli.core.azclierror import RequiredArgumentMissingError
-from azure.core.exceptions import HttpResponseError
+from azure.core.exceptions import HttpResponseError, ServiceRequestError
 
 from azext_appnet_preview.custom import MemberJoin
 
@@ -114,11 +114,35 @@ class MemberLocationResolutionTest(unittest.TestCase):
 
         self.assertIsNone(member._get_member_cluster_location(args))
 
+    def test_member_location_schema_is_optional_and_not_configured_defaulted(self):
+        schema = MemberJoin._build_arguments_schema()
+        ml = schema.member_location
+        self.assertFalse(ml._required)
+        # The resource-group location auto-fill and the 'location' configured default must
+        # both be cleared, otherwise an omitted --member-location would silently resolve to
+        # the RG location or `az configure --defaults location=...` and skip auto-detect.
+        self.assertIsNone(getattr(ml._fmt, "_resource_group_arg", None))
+        self.assertIsNone(ml._configured_default)
+
     @mock.patch("azext_appnet_preview.custom.has_value", side_effect=_has_value)
     @mock.patch("azext_appnet_preview.custom.is_valid_resource_id", return_value=True)
     @mock.patch("azext_appnet_preview.custom.get_mgmt_service_client")
     def test_arm_read_failure_returns_none(self, mock_client_factory, _mock_valid, _mock_has):
         mock_client_factory.return_value.resources.get_by_id.side_effect = HttpResponseError(message="not found")
+        member, args = _make_member(
+            location_arg=_FakeArg(None, has=False),
+            resource_id_arg=_FakeArg(VALID_ID),
+        )
+
+        self.assertIsNone(member._get_member_cluster_location(args))
+
+    @mock.patch("azext_appnet_preview.custom.has_value", side_effect=_has_value)
+    @mock.patch("azext_appnet_preview.custom.is_valid_resource_id", return_value=True)
+    @mock.patch("azext_appnet_preview.custom.get_mgmt_service_client")
+    def test_arm_transport_failure_returns_none(self, mock_client_factory, _mock_valid, _mock_has):
+        # ServiceRequestError subclasses AzureError but NOT HttpResponseError; connection
+        # and timeout failures must also be treated as location-unavailable.
+        mock_client_factory.return_value.resources.get_by_id.side_effect = ServiceRequestError(message="conn reset")
         member, args = _make_member(
             location_arg=_FakeArg(None, has=False),
             resource_id_arg=_FakeArg(VALID_ID),

--- a/src/appnet-preview/azext_appnet_preview/tests/latest/test_member_location.py
+++ b/src/appnet-preview/azext_appnet_preview/tests/latest/test_member_location.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from unittest import mock
 
 from azure.cli.core.azclierror import RequiredArgumentMissingError
+from azure.core.exceptions import HttpResponseError
 
 from azext_appnet_preview.custom import MemberJoin
 
@@ -112,6 +113,35 @@ class MemberLocationResolutionTest(unittest.TestCase):
         )
 
         self.assertIsNone(member._get_member_cluster_location(args))
+
+    @mock.patch("azext_appnet_preview.custom.has_value", side_effect=_has_value)
+    @mock.patch("azext_appnet_preview.custom.is_valid_resource_id", return_value=True)
+    @mock.patch("azext_appnet_preview.custom.get_mgmt_service_client")
+    def test_arm_read_failure_returns_none(self, mock_client_factory, _mock_valid, _mock_has):
+        mock_client_factory.return_value.resources.get_by_id.side_effect = HttpResponseError(message="not found")
+        member, args = _make_member(
+            location_arg=_FakeArg(None, has=False),
+            resource_id_arg=_FakeArg(VALID_ID),
+        )
+
+        self.assertIsNone(member._get_member_cluster_location(args))
+
+    @mock.patch("azext_appnet_preview.custom.has_value", side_effect=_has_value)
+    @mock.patch("azext_appnet_preview.custom.is_valid_resource_id", return_value=True)
+    @mock.patch("azext_appnet_preview.custom.get_mgmt_service_client")
+    def test_explicit_location_honored_when_cluster_unreadable(
+            self, mock_client_factory, _mock_valid, _mock_has):
+        # ARM read fails, but the user supplied --member-location explicitly: it must be
+        # honored without raising and without a spurious mismatch warning.
+        mock_client_factory.return_value.resources.get_by_id.side_effect = HttpResponseError(message="forbidden")
+        member, args = _make_member(
+            location_arg=_FakeArg("westus2"),
+            resource_id_arg=_FakeArg(VALID_ID),
+        )
+
+        member._resolve_member_location(args)
+
+        self.assertEqual(args.member_location.to_serialized_data(), "westus2")
 
 
 if __name__ == "__main__":

--- a/src/appnet-preview/setup.py
+++ b/src/appnet-preview/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 
 
 # HISTORY.rst entry.
-VERSION = '1.0.0b2'
+VERSION = '1.0.0b3'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes |
| :--: |
| ️✔️ None |

<!-- act-bot:section title="Azure CLI Extensions Breaking Change Test" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

### Summary
Make `--member-location` optional on `az appnet member join`. When omitted, it now defaults to the **location of the member cluster** referenced by `--member-resource-id`, removing a redundant region input that had to be kept in sync with the cluster by hand. An explicit `--member-location` is still honored; a warning is logged if it differs from the cluster's region.

### Changes
- `custom.py` – `MemberJoin` overrides `_build_arguments_schema` to make `--member-location` optional and strip the resource-group location auto-fill (so an omitted value reaches the detection logic instead of silently defaulting to the RG location). `pre_operations` resolves the location from the cluster via a generic ARM GET on `--member-resource-id`.
- Existing upgrade-mode validation in `pre_operations` is preserved.
- New unit tests (`tests/latest/test_member_location.py`) covering default / explicit-mismatch-warning / missing-both-raises / invalid-resource-id paths. No live ARM calls.
- Version bump `1.0.0b2` -> `1.0.0b3` and `HISTORY.rst` entry.

### Notes
- The AAZ-generated `_join.py` is intentionally **not** edited; the behavior change is applied through the `MemberJoin` command subclass in `custom.py`.
- `--member-resource-id` remains optional at the CLI layer, but if both `--member-location` and a resolvable `--member-resource-id` are absent, the command now fails fast with `RequiredArgumentMissingError` rather than silently using the resource group's location.

Drafted with GitHub Copilot CLI.
