### PR TITLE
[AKS] Release aks-preview version 21.0.0b12

### DIFF
--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -11,6 +11,9 @@ To release a new version, please select a new version number (usually plus 1 to 
 
 Pending
 +++++++
+
+21.0.0b12
+++++++++
 * Add `--allowed-subjects-from-file` to `az aks identity-binding create` and add a new `az aks identity-binding update` command to manage the `allowedSubjects` list on identity bindings.
 
 21.0.0b11

--- a/src/aks-preview/setup.py
+++ b/src/aks-preview/setup.py
@@ -9,7 +9,7 @@ from codecs import open as open1
 
 from setuptools import find_packages, setup
 
-VERSION = "21.0.0b11"
+VERSION = "21.0.0b12"
 
 CLASSIFIERS = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes |
| :--: |
| ️✔️ None |

<!-- act-bot:section title="Azure CLI Extensions Breaking Change Test" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

### Related command
`az aks identity-binding create` / `az aks identity-binding update`

### Description

Release `aks-preview` version `21.0.0b12`.

Bumps `VERSION` in `setup.py` from `21.0.0b11` to `21.0.0b12` and moves the *Pending* changelog entry into a new `21.0.0b12` section in `HISTORY.rst`.

This releases the `allowedSubjects` support for identity bindings that was merged in #10148:
* Add `--allowed-subjects-from-file` to `az aks identity-binding create`.
* Add a new `az aks identity-binding update` command to manage the `allowedSubjects` list on identity bindings.

### About Extension Publish

Only `setup.py` and `HISTORY.rst` are modified; `src/index.json` is intentionally left untouched (updated automatically by the publish pipeline after merge).