### PR TITLE
Quantum: Add new update job operation

### DIFF
--- a/src/quantum/HISTORY.rst
+++ b/src/quantum/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+1.0.0b21
++++++++++++++++
+* Added the ``az quantum job update`` command to update a submitted job's name, priority, and tags.
+
 1.0.0b20
 +++++++++++++++
 * Added the ``az quantum workspace user create`` and ``az quantum workspace user delete`` commands to manage user access to an Azure Quantum workspace.

--- a/src/quantum/azext_quantum/_help.py
+++ b/src/quantum/azext_quantum/_help.py
@@ -166,6 +166,24 @@ helps['quantum job delete'] = """
                 -j yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy
 """
 
+helps['quantum job update'] = """
+    type: command
+    short-summary: Update a submitted job's name, priority, and/or tags.
+    examples:
+      - name: Rename an Azure Quantum job.
+        text: |-
+            az quantum job update -g MyResourceGroup -w MyWorkspace \\
+                -j yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy --job-name "My new job name"
+      - name: Change the priority of an Azure Quantum job.
+        text: |-
+            az quantum job update -g MyResourceGroup -w MyWorkspace \\
+                -j yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy --job-priority High
+      - name: Replace the tags of an Azure Quantum job.
+        text: |-
+            az quantum job update -g MyResourceGroup -w MyWorkspace \\
+                -j yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy --job-tags tag1 tag2
+"""
+
 helps['quantum offerings'] = """
     type: group
     short-summary: Manage provider offerings for Azure Quantum.

--- a/src/quantum/azext_quantum/_params.py
+++ b/src/quantum/azext_quantum/_params.py
@@ -39,8 +39,9 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals
     job_name_type = CLIArgumentType(help='A friendly name to give to this run of the program.')
     job_name_filter_type = CLIArgumentType(help='Job name to be listed (search by prefix), example "My Job".')
     job_id_type = CLIArgumentType(options_list=['--job-id', '-j'], help='Job unique identifier in GUID format.')
-    job_priority_type = CLIArgumentType(options_list=['--job-priority'], help='The updated priority of the job. Allowed values: Standard, High.')
-    job_tags_type = CLIArgumentType(options_list=['--job-tags'], help='Space-separated list of tags to associate with the job. Replaces any existing tags.', nargs='+')
+    job_name_update_type = CLIArgumentType(options_list=['--job-name'], help='The updated friendly name of the job.')
+    job_priority_type = CLIArgumentType(options_list=['--job-priority'], help='The updated priority of the job.', arg_type=get_enum_type(['Standard', 'High']))
+    job_tags_type = CLIArgumentType(options_list=['--job-tags'], help='Space-separated list of tags to associate with the job. Replaces any existing tags. Pass "" to clear all tags.', nargs='+')
     job_params_type = CLIArgumentType(options_list=['--job-params'], help='Job parameters passed to the target as a list of key=value pairs, json string, or `@{file}` with json content.', action=JobParamsAction, nargs='+')
     target_capability_type = CLIArgumentType(options_list=['--target-capability'], help='Target-capability parameter passed to the compiler.')
     shots_type = CLIArgumentType(help='The number of times to run the program on the given target.')
@@ -133,7 +134,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals
         c.argument('entry_point', entry_point_type)
 
     with self.argument_context('quantum job update') as c:
-        c.argument('job_name', options_list=['--job-name'], help='The updated friendly name of the job.')
+        c.argument('job_name', job_name_update_type)
         c.argument('job_priority', job_priority_type)
         c.argument('job_tags', job_tags_type)
 

--- a/src/quantum/azext_quantum/_params.py
+++ b/src/quantum/azext_quantum/_params.py
@@ -39,6 +39,8 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals
     job_name_type = CLIArgumentType(help='A friendly name to give to this run of the program.')
     job_name_filter_type = CLIArgumentType(help='Job name to be listed (search by prefix), example "My Job".')
     job_id_type = CLIArgumentType(options_list=['--job-id', '-j'], help='Job unique identifier in GUID format.')
+    job_priority_type = CLIArgumentType(options_list=['--job-priority'], help='The updated priority of the job. Allowed values: Standard, High.')
+    job_tags_type = CLIArgumentType(options_list=['--job-tags'], help='Space-separated list of tags to associate with the job. Replaces any existing tags.', nargs='+')
     job_params_type = CLIArgumentType(options_list=['--job-params'], help='Job parameters passed to the target as a list of key=value pairs, json string, or `@{file}` with json content.', action=JobParamsAction, nargs='+')
     target_capability_type = CLIArgumentType(options_list=['--target-capability'], help='Target-capability parameter passed to the compiler.')
     shots_type = CLIArgumentType(help='The number of times to run the program on the given target.')
@@ -129,6 +131,11 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals
         c.argument('job_input_format', job_input_format_type)
         c.argument('job_output_format', job_output_format_type)
         c.argument('entry_point', entry_point_type)
+
+    with self.argument_context('quantum job update') as c:
+        c.argument('job_name', options_list=['--job-name'], help='The updated friendly name of the job.')
+        c.argument('job_priority', job_priority_type)
+        c.argument('job_tags', job_tags_type)
 
     with self.argument_context('quantum execute') as c:
         c.argument('workspace_name', workspace_name_type)

--- a/src/quantum/azext_quantum/commands.py
+++ b/src/quantum/azext_quantum/commands.py
@@ -154,7 +154,7 @@ def load_command_table(self, _):
         j.command('output', 'output', validator=validate_workspace_info, table_transformer=transform_output)
         j.command('cancel', 'cancel', validator=validate_workspace_info, table_transformer=transform_job)
         j.command('delete', 'delete', validator=validate_workspace_info, confirmation=True)
-        j.command('update', 'job_update', validator=validate_workspace_info, table_transformer=transform_job)
+        j.command('update', 'update', validator=validate_workspace_info, table_transformer=transform_job)
 
     with self.command_group('quantum', job_ops, is_preview=True) as q:
         q.command('run', 'run', validator=validate_workspace_and_target_info, table_transformer=transform_output)

--- a/src/quantum/azext_quantum/commands.py
+++ b/src/quantum/azext_quantum/commands.py
@@ -154,6 +154,7 @@ def load_command_table(self, _):
         j.command('output', 'output', validator=validate_workspace_info, table_transformer=transform_output)
         j.command('cancel', 'cancel', validator=validate_workspace_info, table_transformer=transform_job)
         j.command('delete', 'delete', validator=validate_workspace_info, confirmation=True)
+        j.command('update', 'job_update', validator=validate_workspace_info, table_transformer=transform_job)
 
     with self.command_group('quantum', job_ops, is_preview=True) as q:
         q.command('run', 'run', validator=validate_workspace_and_target_info, table_transformer=transform_output)

--- a/src/quantum/azext_quantum/operations/job.py
+++ b/src/quantum/azext_quantum/operations/job.py
@@ -462,6 +462,34 @@ def delete(cmd, job_id, resource_group_name, workspace_name):
     logger.warning("Deleted job %s.", job_id)
 
 
+def job_update(cmd, job_id, resource_group_name, workspace_name, job_name=None, job_priority=None, job_tags=None):
+    """
+    Update a submitted job's name, priority, and/or tags.
+    """
+    info = WorkspaceInfo(cmd, resource_group_name, workspace_name)
+    client = cf_jobs(cmd.cli_ctx, info.subscription, info.resource_group, info.name, info.endpoint)
+
+    update_options = {}
+    if job_name is not None:
+        update_options["name"] = job_name
+    if job_priority is not None:
+        try:
+            update_options["priority"] = Priority(job_priority).value
+        except ValueError:
+            raise InvalidArgumentValueError(ERROR_MSG_INVALID_PRIORITY_ARGUMENT)
+    if job_tags is not None:
+        update_options["tags"] = job_tags
+
+    if not update_options:
+        raise RequiredArgumentMissingError("At least one of --job-name, --job-priority, or --job-tags must be specified.")
+
+    client.update(info.subscription, info.resource_group, info.name, job_id, update_options)
+
+    # Return the full, updated job so the user sees the current state after the patch.
+    job = client.get(info.subscription, info.resource_group, info.name, job_id)
+    return job.as_dict()
+
+
 def _get_job_output(job):
 
     import tempfile

--- a/src/quantum/azext_quantum/operations/job.py
+++ b/src/quantum/azext_quantum/operations/job.py
@@ -462,7 +462,7 @@ def delete(cmd, job_id, resource_group_name, workspace_name):
     logger.warning("Deleted job %s.", job_id)
 
 
-def job_update(cmd, job_id, resource_group_name, workspace_name, job_name=None, job_priority=None, job_tags=None):
+def update(cmd, job_id, resource_group_name, workspace_name, job_name=None, job_priority=None, job_tags=None):
     """
     Update a submitted job's name, priority, and/or tags.
     """
@@ -470,9 +470,7 @@ def job_update(cmd, job_id, resource_group_name, workspace_name, job_name=None, 
     client = cf_jobs(cmd.cli_ctx, info.subscription, info.resource_group, info.name, info.endpoint)
 
     update_options = {}
-    if job_name is not None:
-        if not job_name.strip():
-            raise InvalidArgumentValueError("The --job-name argument cannot be empty or whitespace.")
+    if job_name and job_name.strip():
         update_options["name"] = job_name.strip()
     if job_priority is not None:
         try:
@@ -480,10 +478,9 @@ def job_update(cmd, job_id, resource_group_name, workspace_name, job_name=None, 
         except ValueError:
             raise InvalidArgumentValueError(ERROR_MSG_INVALID_PRIORITY_ARGUMENT)
     if job_tags is not None:
-        tags = [tag.strip() for tag in job_tags if tag.strip()]
-        if not tags:
-            raise InvalidArgumentValueError("The --job-tags argument cannot be empty or whitespace. Provide one or more space-separated tags.")
-        update_options["tags"] = tags
+        # An explicit --job-tags value (even one that is only blank/whitespace, e.g. "")
+        # replaces the existing tags. Blank entries are dropped, so passing "" clears all tags.
+        update_options["tags"] = [tag.strip() for tag in job_tags if tag.strip()]
 
     if not update_options:
         raise RequiredArgumentMissingError("At least one of --job-name, --job-priority, or --job-tags must be specified.")

--- a/src/quantum/azext_quantum/operations/job.py
+++ b/src/quantum/azext_quantum/operations/job.py
@@ -471,21 +471,26 @@ def job_update(cmd, job_id, resource_group_name, workspace_name, job_name=None, 
 
     update_options = {}
     if job_name is not None:
-        update_options["name"] = job_name
+        if not job_name.strip():
+            raise InvalidArgumentValueError("The --job-name argument cannot be empty or whitespace.")
+        update_options["name"] = job_name.strip()
     if job_priority is not None:
         try:
             update_options["priority"] = Priority(job_priority).value
         except ValueError:
             raise InvalidArgumentValueError(ERROR_MSG_INVALID_PRIORITY_ARGUMENT)
     if job_tags is not None:
-        update_options["tags"] = job_tags
+        tags = [tag.strip() for tag in job_tags if tag.strip()]
+        if not tags:
+            raise InvalidArgumentValueError("The --job-tags argument cannot be empty or whitespace. Provide one or more space-separated tags.")
+        update_options["tags"] = tags
 
     if not update_options:
         raise RequiredArgumentMissingError("At least one of --job-name, --job-priority, or --job-tags must be specified.")
 
+    # The update (PATCH) response only echoes back the JobUpdateOptions that were sent, not the
+    # full job, so fetch the job afterwards to return its current state to the user.
     client.update(info.subscription, info.resource_group, info.name, job_id, update_options)
-
-    # Return the full, updated job so the user sees the current state after the patch.
     job = client.get(info.subscription, info.resource_group, info.name, job_id)
     return job.as_dict()
 

--- a/src/quantum/azext_quantum/tests/latest/test_quantum_jobs.py
+++ b/src/quantum/azext_quantum/tests/latest/test_quantum_jobs.py
@@ -19,7 +19,7 @@ from azure.cli.core.azclierror import InvalidArgumentValueError, RequiredArgumen
 from .utils import get_test_resource_group, get_test_workspace, get_test_workspace_location, issue_cmd_with_param_missing, get_test_workspace_storage, get_test_workspace_random_name
 from ...commands import transform_output
 from ...operations.job import (
-    job_update,
+    update,
     _validate_max_poll_wait_secs,
     _convert_numeric_params,
     _construct_filter_query,
@@ -70,25 +70,29 @@ class QuantumJobsScenarioTest(ScenarioTest):
 
         # Calling with no updatable fields should raise.
         with self.assertRaises(RequiredArgumentMissingError):
-            job_update(cmd, job_id, "rg", "ws")
+            update(cmd, job_id, "rg", "ws")
 
         # An invalid priority value should raise.
         with self.assertRaises(InvalidArgumentValueError) as context:
-            job_update(cmd, job_id, "rg", "ws", job_priority="NotAPriority")
+            update(cmd, job_id, "rg", "ws", job_priority="NotAPriority")
         self.assertEqual(str(context.exception), ERROR_MSG_INVALID_PRIORITY_ARGUMENT)
 
-        # An empty or whitespace-only job name should raise.
-        with self.assertRaises(InvalidArgumentValueError):
-            job_update(cmd, job_id, "rg", "ws", job_name="   ")
+        # An empty or whitespace-only job name is ignored, so with no other fields it should raise.
+        with self.assertRaises(RequiredArgumentMissingError):
+            update(cmd, job_id, "rg", "ws", job_name="   ")
 
-        # Tags that are all empty or whitespace should raise.
-        with self.assertRaises(InvalidArgumentValueError):
-            job_update(cmd, job_id, "rg", "ws", job_tags=["", "   "])
+        # Passing only blank/whitespace tags is an explicit request to clear all tags,
+        # which sends an empty list rather than raising.
+        result = update(cmd, job_id, "rg", "ws", job_tags=["", "   "])
+        client.update.assert_called_once_with("sub", "rg", "ws", job_id, {"tags": []})
+        self.assertEqual(result, {"id": "job-id"})
+        client.update.reset_mock()
+        client.get.reset_mock()
 
         # A valid update should build a merge-patch with only the provided fields
         # and return the refreshed job. Surrounding whitespace is trimmed and blank
         # tags are dropped.
-        result = job_update(cmd, job_id, "rg", "ws", job_name="  New name  ", job_priority="High", job_tags=["a", "  ", "b "])
+        result = update(cmd, job_id, "rg", "ws", job_name="  New name  ", job_priority="High", job_tags=["a", "  ", "b "])
         client.update.assert_called_once_with("sub", "rg", "ws", job_id, {"name": "New name", "priority": "High", "tags": ["a", "b"]})
         client.get.assert_called_once_with("sub", "rg", "ws", job_id)
         self.assertEqual(result, {"id": "job-id"})

--- a/src/quantum/azext_quantum/tests/latest/test_quantum_jobs.py
+++ b/src/quantum/azext_quantum/tests/latest/test_quantum_jobs.py
@@ -9,6 +9,7 @@ import pytest
 import random
 import time
 import unittest
+import unittest.mock
 from urllib.parse import urlparse, parse_qs
 
 from azure.cli.testsdk.scenario_tests import AllowLargeResponse, live_only
@@ -18,10 +19,12 @@ from azure.cli.core.azclierror import InvalidArgumentValueError, RequiredArgumen
 from .utils import get_test_resource_group, get_test_workspace, get_test_workspace_location, issue_cmd_with_param_missing, get_test_workspace_storage, get_test_workspace_random_name
 from ...commands import transform_output
 from ...operations.job import (
+    job_update,
     _validate_max_poll_wait_secs,
     _convert_numeric_params,
     _construct_filter_query,
     _construct_orderby_expression,
+    ERROR_MSG_INVALID_PRIORITY_ARGUMENT,
     ERROR_MSG_INVALID_ORDER_ARGUMENT,
     ERROR_MSG_MISSING_ORDERBY_ARGUMENT)
 
@@ -47,9 +50,39 @@ class QuantumJobsScenarioTest(ScenarioTest):
     def test_job_errors(self):
         issue_cmd_with_param_missing(self, "az quantum job cancel", "az quantum job cancel -g MyResourceGroup -w MyWorkspace -j yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy\nCancel an Azure Quantum job by id.")
         issue_cmd_with_param_missing(self, "az quantum job delete", "az quantum job delete -g MyResourceGroup -w MyWorkspace -j yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy\nDelete an Azure Quantum job by id.")
+        issue_cmd_with_param_missing(self, "az quantum job update", "az quantum job update -g MyResourceGroup -w MyWorkspace -j yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy --job-name 'My new name'\nUpdate an Azure Quantum job by id.")
         issue_cmd_with_param_missing(self, "az quantum job output", "az quantum job output -g MyResourceGroup -w MyWorkspace -j yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy -o table\nPrint the results of a successful Azure Quantum job.")
         issue_cmd_with_param_missing(self, "az quantum job show", "az quantum job show -g MyResourceGroup -w MyWorkspace -j yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy --query status\nGet the status of an Azure Quantum job.")
         issue_cmd_with_param_missing(self, "az quantum job wait", "az quantum job wait -g MyResourceGroup -w MyWorkspace -j yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy --max-poll-wait-secs 60 -o table\nWait for completion of a job, check at 60 second intervals.")
+
+    @unittest.mock.patch('azext_quantum.operations.job.cf_jobs')
+    @unittest.mock.patch('azext_quantum.operations.job.WorkspaceInfo')
+    def test_job_update(self, mock_workspace_info, mock_cf_jobs):
+        info = mock_workspace_info.return_value
+        info.subscription = "sub"
+        info.resource_group = "rg"
+        info.name = "ws"
+        info.endpoint = "endpoint"
+        client = mock_cf_jobs.return_value
+        client.get.return_value.as_dict.return_value = {"id": "job-id"}
+        cmd = unittest.mock.MagicMock()
+        job_id = "yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy"
+
+        # Calling with no updatable fields should raise.
+        with self.assertRaises(RequiredArgumentMissingError):
+            job_update(cmd, job_id, "rg", "ws")
+
+        # An invalid priority value should raise.
+        with self.assertRaises(InvalidArgumentValueError) as context:
+            job_update(cmd, job_id, "rg", "ws", job_priority="NotAPriority")
+        self.assertEqual(str(context.exception), ERROR_MSG_INVALID_PRIORITY_ARGUMENT)
+
+        # A valid update should build a merge-patch with only the provided fields
+        # and return the refreshed job.
+        result = job_update(cmd, job_id, "rg", "ws", job_name="New name", job_priority="High", job_tags=["a", "b"])
+        client.update.assert_called_once_with("sub", "rg", "ws", job_id, {"name": "New name", "priority": "High", "tags": ["a", "b"]})
+        client.get.assert_called_once_with("sub", "rg", "ws", job_id)
+        self.assertEqual(result, {"id": "job-id"})
 
     def test_transform_output(self):
         # Call with a good histogram

--- a/src/quantum/azext_quantum/tests/latest/test_quantum_jobs.py
+++ b/src/quantum/azext_quantum/tests/latest/test_quantum_jobs.py
@@ -77,9 +77,18 @@ class QuantumJobsScenarioTest(ScenarioTest):
             job_update(cmd, job_id, "rg", "ws", job_priority="NotAPriority")
         self.assertEqual(str(context.exception), ERROR_MSG_INVALID_PRIORITY_ARGUMENT)
 
+        # An empty or whitespace-only job name should raise.
+        with self.assertRaises(InvalidArgumentValueError):
+            job_update(cmd, job_id, "rg", "ws", job_name="   ")
+
+        # Tags that are all empty or whitespace should raise.
+        with self.assertRaises(InvalidArgumentValueError):
+            job_update(cmd, job_id, "rg", "ws", job_tags=["", "   "])
+
         # A valid update should build a merge-patch with only the provided fields
-        # and return the refreshed job.
-        result = job_update(cmd, job_id, "rg", "ws", job_name="New name", job_priority="High", job_tags=["a", "b"])
+        # and return the refreshed job. Surrounding whitespace is trimmed and blank
+        # tags are dropped.
+        result = job_update(cmd, job_id, "rg", "ws", job_name="  New name  ", job_priority="High", job_tags=["a", "  ", "b "])
         client.update.assert_called_once_with("sub", "rg", "ws", job_id, {"name": "New name", "priority": "High", "tags": ["a", "b"]})
         client.get.assert_called_once_with("sub", "rg", "ws", job_id)
         self.assertEqual(result, {"id": "job-id"})
@@ -251,9 +260,11 @@ class QuantumJobsScenarioTest(ScenarioTest):
         self.assert_contains_standard_sas_params(job["inputDataUri"])
         self.assert_contains_standard_sas_params(job["outputDataUri"])
 
-        # Update the submitted job's name, priority, and tags, then confirm the change
+        # Update the submitted job's name, priority, and tags, then confirm all three changes were applied
         updated_job = self.cmd(f'az quantum job update -j {results["id"]} --job-name "Updated job name" --job-priority High --job-tags tag1 tag2 -o json').get_output_in_json()
         self.assertEqual(updated_job["name"], "Updated job name")
+        self.assertEqual(updated_job["priority"], "High")
+        self.assertEqual(updated_job["tags"], ["tag1", "tag2"])
 
         # Run a Quil pass-through job on Rigetti
         results = self.cmd("az quantum run -t rigetti.sim.qvm --job-input-format rigetti.quil.v1 --job-input-file src/quantum/azext_quantum/tests/latest/input_data/bell-state.quil --job-output-format rigetti.quil-results.v1 -o json").get_output_in_json()

--- a/src/quantum/azext_quantum/tests/latest/test_quantum_jobs.py
+++ b/src/quantum/azext_quantum/tests/latest/test_quantum_jobs.py
@@ -251,6 +251,10 @@ class QuantumJobsScenarioTest(ScenarioTest):
         self.assert_contains_standard_sas_params(job["inputDataUri"])
         self.assert_contains_standard_sas_params(job["outputDataUri"])
 
+        # Update the submitted job's name, priority, and tags, then confirm the change
+        updated_job = self.cmd(f'az quantum job update -j {results["id"]} --job-name "Updated job name" --job-priority High --job-tags tag1 tag2 -o json').get_output_in_json()
+        self.assertEqual(updated_job["name"], "Updated job name")
+
         # Run a Quil pass-through job on Rigetti
         results = self.cmd("az quantum run -t rigetti.sim.qvm --job-input-format rigetti.quil.v1 --job-input-file src/quantum/azext_quantum/tests/latest/input_data/bell-state.quil --job-output-format rigetti.quil-results.v1 -o json").get_output_in_json()
         self.assertIn("ro", results)

--- a/src/quantum/setup.py
+++ b/src/quantum/setup.py
@@ -17,7 +17,7 @@ except ImportError:
 # This version should match the latest entry in HISTORY.rst
 # Also, when updating this, please review the version used by the extension to
 # submit requests, which can be found at './azext_quantum/__init__.py'
-VERSION = '1.0.0b20'
+VERSION = '1.0.0b21'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ⚠️ Review suggested

| Breaking Changes |
| :--: |
| ⚠️ None |

<!-- act-bot:section title="Azure CLI Extensions Breaking Change Test" category="breaking_change" label="Breaking Changes" status="Warning" summary="None" -->
<!-- Azure CLI Extensions Breaking Change Test --><details>
<summary>⚠️Azure CLI Extensions Breaking Change Test</summary>

><details>
> <summary>⚠️quantum</summary>
>
>|rule|cmd_name|rule_message|suggest_message|
>|---|---|---|---|
>|⚠️ [1001 - CmdAdd](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1001.md)|quantum job update|cmd `quantum job update` added||
>
></details>
</details>

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

## Summary

Adds a new `az quantum job update` command that lets users update a submitted job's name, priority, and/or tags after submission. This implements the CLI side of the merged Data Plane API Spec. Only the fields that user provides are sent in the patch, `--job-priority` is validated against the `Priority` enum, at least one updatable field is required, and the refreshed job is returned. Note that `--job-tags` replaces the job's existing tags rather than appending.

## What Changed

- Added the `az quantum job update` command, wired up with the workspace validator and job table transformer.
- Implemented the update operation using the data-plane jobs client's merge-patch API, which builds the patch from only the provided fields, validated priority, requires at least one updatable field, and returns the refreshed job.
- Added the `--job-priority` and `--job-tags` parameters
- Added command help with examples for renaming, changing priority, and replacing tags.
- Bumped the extension version and updated the changelog.
- Added unit and live scenario test coverage for the new command and its parameters.