### PR TITLE
Quantum: Add `az quantum workspace user create/delete` commands

### DIFF
--- a/linter_exclusions.yml
+++ b/linter_exclusions.yml
@@ -3050,6 +3050,11 @@ quantum job submit:
     program_args:
       rule_exclusions:
         - no_positional_parameters
+quantum workspace user create:
+  parameters:
+    assignee_principal_type:
+      rule_exclusions:
+        - option_length_too_long
 repos import create:
   parameters:
     git_service_endpoint_id:

--- a/src/quantum/HISTORY.rst
+++ b/src/quantum/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+1.0.0b20
++++++++++++++++
+* Added the ``az quantum workspace user create`` and ``az quantum workspace user delete`` commands to manage user access to an Azure Quantum workspace.
+
 1.0.0b19
 +++++++++++++++
 * Added the ``az quantum job delete`` command to delete a job from an Azure Quantum workspace.

--- a/src/quantum/azext_quantum/_help.py
+++ b/src/quantum/azext_quantum/_help.py
@@ -341,6 +341,46 @@ helps['quantum workspace keys'] = """
     short-summary: Manage Azure Quantum Workspace api keys.
 """
 
+helps['quantum workspace user'] = """
+    type: group
+    short-summary: Manage users of an Azure Quantum workspace.
+"""
+
+helps['quantum workspace user create'] = """
+    type: command
+    short-summary: Grant a user, group, or service principal access to an Azure Quantum workspace.
+    long-summary: >-
+        Assigns the 'Quantum Workspace Data Contributor' role (by default) at the scope of the given
+        (or current) Azure Quantum workspace.
+    examples:
+      - name: Grant a user access to a workspace using their sign-in name.
+        text: |-
+            az quantum workspace user create -g MyResourceGroup -w MyWorkspace \\
+                --assignee user@contoso.com
+      - name: Grant a user access to a workspace using their object id.
+        text: |-
+            az quantum workspace user create -g MyResourceGroup -w MyWorkspace \\
+                --assignee-object-id 00000000-0000-0000-0000-000000000000
+      - name: Grant a group access to a workspace using its object id and principal type.
+        text: |-
+            az quantum workspace user create -g MyResourceGroup -w MyWorkspace \\
+                --assignee-object-id 00000000-0000-0000-0000-000000000000 --assignee-principal-type Group
+"""
+
+helps['quantum workspace user delete'] = """
+    type: command
+    short-summary: Remove a user, group, or service principal's access to an Azure Quantum workspace.
+    examples:
+      - name: Remove a user's access to a workspace using their sign-in name.
+        text: |-
+            az quantum workspace user delete -g MyResourceGroup -w MyWorkspace \\
+                --assignee user@contoso.com
+      - name: Remove a user's access to a workspace using their object id.
+        text: |-
+            az quantum workspace user delete -g MyResourceGroup -w MyWorkspace \\
+                --assignee-object-id 00000000-0000-0000-0000-000000000000
+"""
+
 helps['quantum workspace keys list'] = """
     type: command
     short-summary: List api keys for the given (or current) Azure Quantum workspace.

--- a/src/quantum/azext_quantum/_params.py
+++ b/src/quantum/azext_quantum/_params.py
@@ -8,6 +8,7 @@
 import argparse
 from knack.arguments import CLIArgumentType
 from azure.cli.core.azclierror import InvalidArgumentValueError, CLIError
+from azure.cli.core.commands.parameters import get_enum_type
 from azure.cli.core.util import shell_safe_json_parse
 
 
@@ -67,6 +68,10 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals
     top_type = CLIArgumentType(options_list=['--top'], help='The number of jobs listed per page.')
     orderby_type = CLIArgumentType(options_list=['--orderby'], help='The field on which to order the list.')
     order_type = CLIArgumentType(options_list=['--order'], help='How to order the list: `asc` or `desc`')
+    assignee_type = CLIArgumentType(options_list=['--assignee'], help='Represents a user, group, or service principal. Supported formats: object id, user sign-in name, or service principal name.')
+    assignee_object_id_type = CLIArgumentType(options_list=['--assignee-object-id'], help="Use this parameter instead of '--assignee' to bypass Graph API invocation in case of insufficient privileges. This parameter only works with object ids for users, groups, service principals, and managed identities. For managed identities use the principal id. For service principals, use the object id and not the app id.")
+    role_type = CLIArgumentType(options_list=['--role'], help="Role name or id. For 'create', the role granted to the user; for 'delete', the role assignment to remove. Defaults to the 'Quantum Workspace Data Contributor' role.")
+    assignee_principal_type_type = CLIArgumentType(options_list=['--assignee-principal-type'], arg_type=get_enum_type(['User', 'Group', 'ServicePrincipal', 'ForeignGroup']), help="Use with '--assignee-object-id' to avoid errors caused by propagation latency in Microsoft Graph.")
 
     with self.argument_context('quantum workspace') as c:
         c.argument('workspace_name', workspace_name_type)
@@ -77,6 +82,15 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals
         c.argument('auto_accept', auto_accept_type)
         c.argument('skip_autoadd', skip_autoadd_type)
         c.argument('workspace_kind', workspace_kind_type)
+
+    with self.argument_context('quantum workspace user') as c:
+        c.argument('workspace_name', workspace_name_type)
+        c.argument('assignee', assignee_type)
+        c.argument('assignee_object_id', assignee_object_id_type)
+        c.argument('role', role_type)
+
+    with self.argument_context('quantum workspace user create') as c:
+        c.argument('assignee_principal_type', assignee_principal_type_type)
 
     with self.argument_context('quantum target') as c:
         c.argument('workspace_name', workspace_name_type)

--- a/src/quantum/azext_quantum/commands.py
+++ b/src/quantum/azext_quantum/commands.py
@@ -136,6 +136,10 @@ def load_command_table(self, _):
         w.command('keys regenerate', 'regenerate_keys')
         w.command('update', 'enable_keys')
 
+    with self.command_group('quantum workspace user', workspace_ops) as u:
+        u.command('create', 'add_user', validator=validate_workspace_info)
+        u.command('delete', 'remove_user', validator=validate_workspace_info, confirmation=True)
+
     with self.command_group('quantum target', target_ops) as t:
         t.command('list', 'list', validator=validate_workspace_info, table_transformer=transform_targets)
         t.show_command('show', 'target_show', validator=validate_target_info)

--- a/src/quantum/azext_quantum/operations/workspace.py
+++ b/src/quantum/azext_quantum/operations/workspace.py
@@ -18,7 +18,8 @@ from azure.mgmt.resource import ResourceManagementClient
 from azure.mgmt.resource.deployments.models import DeploymentMode
 
 from azure.cli.core.azclierror import (InvalidArgumentValueError, AzureInternalError,
-                                       RequiredArgumentMissingError, ResourceNotFoundError)
+                                       RequiredArgumentMissingError, ResourceNotFoundError,
+                                       MutuallyExclusiveArgumentError)
 
 from .._client_factory import cf_workspaces, cf_quotas, cf_offerings, _get_data_credentials
 from .._list_helper import repack_response_json
@@ -38,6 +39,10 @@ DEPLOYMENT_NAME_PREFIX = 'Microsoft.AzureQuantum-'
 POLLING_TIME_DURATION = 3  # Seconds
 MAX_RETRIES_ROLE_ASSIGNMENT = 20
 MAX_POLLS_CREATE_WORKSPACE = 300
+
+# Built-in "Quantum Workspace Data Contributor" role. This is the role granted to
+# users when they are added to a workspace in the Azure Quantum portal.
+QUANTUM_WORKSPACE_DATA_CONTRIBUTOR_ROLE_ID = "c1410b24-3e69-4857-8f86-4d0a2e603250"
 
 C4A_TERMS_ACCEPTANCE_MESSAGE = "\nBy continuing you accept the Azure Quantum terms and conditions and privacy policy and agree that " \
                                "Microsoft can share your account details with the provider for their transactional purposes.\n\n" \
@@ -452,3 +457,43 @@ def enable_keys(cmd, resource_group_name=None, workspace_name=None, enable_key=N
         ws = lropoller.result()
         info.save(cmd, ws.properties.endpoint_uri)
     return ws
+
+
+def _get_workspace_resource_id(info):
+    return (f"/subscriptions/{info.subscription}"
+            f"/resourceGroups/{info.resource_group}"
+            f"/providers/Microsoft.Quantum/Workspaces/{info.name}")
+
+
+def _validate_assignee_args(assignee, assignee_object_id):
+    if not assignee and not assignee_object_id:
+        raise RequiredArgumentMissingError("Please provide either '--assignee' or '--assignee-object-id'.")
+    if assignee and assignee_object_id:
+        raise MutuallyExclusiveArgumentError("Only one of '--assignee' or '--assignee-object-id' can be specified.")
+
+
+def add_user(cmd, resource_group_name=None, workspace_name=None, assignee=None, assignee_object_id=None, assignee_principal_type=None, role=None):
+    """
+    Grant a user, group, or service principal access to an Azure Quantum workspace.
+    """
+    from azure.cli.command_modules.role.custom import create_role_assignment
+
+    _validate_assignee_args(assignee, assignee_object_id)
+    info = WorkspaceInfo(cmd, resource_group_name, workspace_name)
+    scope = _get_workspace_resource_id(info)
+    role = role or QUANTUM_WORKSPACE_DATA_CONTRIBUTOR_ROLE_ID
+    return create_role_assignment(cmd, role=role, scope=scope, assignee=assignee, assignee_object_id=assignee_object_id,
+                                  assignee_principal_type=assignee_principal_type)
+
+
+def remove_user(cmd, resource_group_name=None, workspace_name=None, assignee=None, assignee_object_id=None, role=None):
+    """
+    Remove a user, group, or service principal's access to an Azure Quantum workspace.
+    """
+    from azure.cli.command_modules.role.custom import delete_role_assignments
+
+    _validate_assignee_args(assignee, assignee_object_id)
+    info = WorkspaceInfo(cmd, resource_group_name, workspace_name)
+    scope = _get_workspace_resource_id(info)
+    role = role or QUANTUM_WORKSPACE_DATA_CONTRIBUTOR_ROLE_ID
+    return delete_role_assignments(cmd, role=role, scope=scope, assignee=assignee, assignee_object_id=assignee_object_id)

--- a/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
+++ b/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
@@ -283,6 +283,47 @@ class QuantumWorkspacesScenarioTest(ScenarioTest):
             self.check("properties.provisioningState", "Deleting")
         ])
 
+    @live_only()
+    def test_workspace_user(self):
+        import random
+        # initialize values
+        test_location = get_test_workspace_location()
+        test_resource_group = get_test_resource_group()
+        test_workspace_temp = get_test_workspace_random_name()
+        test_storage_account = get_test_workspace_storage()
+        test_provider_sku_list = get_test_workspace_provider_sku_list()
+        test_identity_name = "e2e-test-id" + str(random.randint(1000000, 9999999))
+
+        # create a workspace to manage users on
+        self.cmd(f'az quantum workspace create --auto-accept -g {test_resource_group} -w {test_workspace_temp} -l {test_location} -a {test_storage_account} -r {test_provider_sku_list} -o json', checks=[
+            self.check("properties.provisioningState", "Succeeded")
+        ])
+
+        # Create a user-assigned managed identity to use as the assignee. Using its
+        # object id (and '--assignee-object-id') keeps the test runnable under both
+        # user and service-principal logins, since no Microsoft Graph lookup is needed.
+        identity = self.cmd(f'az identity create -g {test_resource_group} -n {test_identity_name} -l {test_location} -o json').get_output_in_json()
+        test_object_id = identity["principalId"]
+
+        # grant access using the object id, relying on the default role. Verify the
+        # default 'Quantum Workspace Data Contributor' role was assigned.
+        self.cmd(f'az quantum workspace user create -g {test_resource_group} --workspace-name {test_workspace_temp} --assignee-object-id {test_object_id} -o json', checks=[
+            self.check("principalId", test_object_id),
+            self.check("ends_with(roleDefinitionId, 'c1410b24-3e69-4857-8f86-4d0a2e603250')", True)
+        ])
+
+        # remove access using the object id and an explicit role
+        self.cmd(f'az quantum workspace user delete -g {test_resource_group} --workspace-name {test_workspace_temp} --assignee-object-id {test_object_id} --role c1410b24-3e69-4857-8f86-4d0a2e603250 --yes')
+
+        # clean up the managed identity
+        self.cmd(f'az identity delete -g {test_resource_group} -n {test_identity_name}')
+
+        # delete the workspace
+        self.cmd(f'az quantum workspace delete -g {test_resource_group} -w {test_workspace_temp} -o json', checks=[
+            self.check("name", test_workspace_temp),
+            self.check("properties.provisioningState", "Deleting")
+        ])
+
     # @pytest.fixture(autouse=True)
     # def _pass_fixtures(self, capsys):
     #     self.capsys = capsys
@@ -362,3 +403,16 @@ class QuantumWorkspacesScenarioTest(ScenarioTest):
         workspace_location = None
         _autoadd_providers(cmd, providers_in_region, providers_selected, workspace_location, True)
         assert providers_selected[0] == {"provider_id": "foo", "sku": "foo_credits_for_all_plan", "offer_id": "foo_offer", "publisher_id": "foo0123456789"}
+
+    def test_get_workspace_resource_id(self):
+        print("test_get_workspace_resource_id")
+        from ...operations.workspace import _get_workspace_resource_id
+
+        class TestWorkspaceInfo(object):
+            subscription = "00000000-0000-0000-0000-000000000000"
+            resource_group = "MyResourceGroup"
+            name = "MyWorkspace"
+            __test__ = False
+
+        resource_id = _get_workspace_resource_id(TestWorkspaceInfo())
+        assert resource_id == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MyResourceGroup/providers/Microsoft.Quantum/Workspaces/MyWorkspace"

--- a/src/quantum/setup.py
+++ b/src/quantum/setup.py
@@ -17,7 +17,7 @@ except ImportError:
 # This version should match the latest entry in HISTORY.rst
 # Also, when updating this, please review the version used by the extension to
 # submit requests, which can be found at './azext_quantum/__init__.py'
-VERSION = '1.0.0b19'
+VERSION = '1.0.0b20'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ⚠️ Review suggested

| Breaking Changes |
| :--: |
| ⚠️ None |

<!-- act-bot:section title="Azure CLI Extensions Breaking Change Test" category="breaking_change" label="Breaking Changes" status="Warning" summary="None" -->
<!-- Azure CLI Extensions Breaking Change Test --><details>
<summary>⚠️Azure CLI Extensions Breaking Change Test</summary>

><details>
> <summary>⚠️quantum</summary>
>
>|rule|cmd_name|rule_message|suggest_message|
>|---|---|---|---|
>|⚠️ [1011 - SubgroupAdd](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1011.md)|quantum workspace user|sub group `quantum workspace user` added||
>
></details>
</details>

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

## Summary 
Adds two new commands to manage user access to an Azure Quantum workspace:
- `az quantum workspace user create` - granted a user, group, or service principal access to a workspace 
- `az quantum workspace user delete` - removes that access 

## Changes
- Added the `quantum workspace user` command group with create and delete commands
- "create" assigns the Quantum Workspace Data Contributor role (defualt) at the workspace scope. "delete" removes it (with confirmation)
- Added `--assignee`, `--assignee-object-id` , and optional `--role` override.
- Added help entries with examples and unit + live scenario test coverage.
- Bumped the extension version

## Testing
- `azdev style` and `azdev linter` pass for the new commands
- Unit test validates the workspace scope construction 
- Verified end-to-end against a live workspace
