### PR TITLE
[AKS] Fix aks-preview tests with latest CLI

### DIFF
--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -11,6 +11,7 @@ To release a new version, please select a new version number (usually plus 1 to 
 
 Pending
 +++++++
+* `az aks nodepool update`: Avoid applying VirtualMachines autoscaler profile conversions twice with newer Azure CLI versions while preserving compatibility with older CLI versions.
 
 21.0.0b13
 ++++++++

--- a/src/aks-preview/azext_aks_preview/agentpool_decorator.py
+++ b/src/aks-preview/azext_aks_preview/agentpool_decorator.py
@@ -2156,8 +2156,9 @@ class AKSPreviewAgentPoolUpdateDecorator(AKSAgentPoolUpdateDecorator):
         # update local DNS profile
         agentpool = self.update_localdns_profile(agentpool)
 
-        # update auto scaler related properties for vms pool
-        agentpool = self.update_auto_scaler_properties_vms(agentpool)
+        # Older CLI versions do not handle VMS autoscaler properties in the default update flow.
+        if not hasattr(AKSAgentPoolUpdateDecorator, "update_auto_scaler_properties_vms"):
+            agentpool = self.update_auto_scaler_properties_vms(agentpool)
 
         # update upgrade strategy
         agentpool = self.update_upgrade_strategy(agentpool)
@@ -2179,6 +2180,8 @@ class AKSPreviewAgentPoolUpdateDecorator(AKSAgentPoolUpdateDecorator):
 
         return agentpool
 
+    # TODO: Remove this override after azext.minCliCoreVersion is raised to the first
+    # Azure CLI release containing cf7097eb97 (expected 2.90.0).
     def update_auto_scaler_properties(self, agentpool: AgentPool) -> AgentPool:
         """Update auto scaler related properties for vmss Agentpool object.
 

--- a/src/aks-preview/azext_aks_preview/tests/latest/recordings/test_aks_create_and_update_outbound_ips.yaml
+++ b/src/aks-preview/azext_aks_preview/tests/latest/recordings/test_aks_create_and_update_outbound_ips.yaml
@@ -66,7 +66,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.74.0 (DOCKER) azsdk-python-core/1.31.0 Python/3.11.8 (Linux-6.6.87.1-microsoft-standard-WSL2-x86_64-with)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliakstest000003?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliakstest000003?api-version=2025-07-01
   response:
     body:
       string: '{"name":"cliakstest000003","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliakstest000003","etag":"W/\"09b373d0-89bf-4921-8c0b-d6b5c24513aa\"","location":"westus2","properties":{"provisioningState":"Updating","resourceGuid":"d73e655b-ea56-4973-a647-b4082fd28400","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -172,7 +172,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.74.0 (DOCKER) azsdk-python-core/1.31.0 Python/3.11.8 (Linux-6.6.87.1-microsoft-standard-WSL2-x86_64-with)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliakstest000003?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliakstest000003?api-version=2025-07-01
   response:
     body:
       string: '{"name":"cliakstest000003","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliakstest000003","etag":"W/\"25b6decf-963f-45e2-b2ec-5df4461a5702\"","location":"westus2","properties":{"provisioningState":"Succeeded","resourceGuid":"d73e655b-ea56-4973-a647-b4082fd28400","ipAddress":"20.114.52.52","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -222,7 +222,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.74.0 (DOCKER) azsdk-python-core/1.31.0 Python/3.11.8 (Linux-6.6.87.1-microsoft-standard-WSL2-x86_64-with)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliakstest000003?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliakstest000003?api-version=2025-07-01
   response:
     body:
       string: '{"name":"cliakstest000003","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliakstest000003","etag":"W/\"25b6decf-963f-45e2-b2ec-5df4461a5702\"","location":"westus2","properties":{"provisioningState":"Succeeded","resourceGuid":"d73e655b-ea56-4973-a647-b4082fd28400","ipAddress":"20.114.52.52","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -323,7 +323,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.74.0 (DOCKER) azsdk-python-core/1.31.0 Python/3.11.8 (Linux-6.6.87.1-microsoft-standard-WSL2-x86_64-with)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliakstest000004?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliakstest000004?api-version=2025-07-01
   response:
     body:
       string: '{"name":"cliakstest000004","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliakstest000004","etag":"W/\"298be15c-3a8f-4838-8463-7b58e0c5f89b\"","location":"westus2","properties":{"provisioningState":"Updating","resourceGuid":"02300e96-f564-40be-9d8e-1fe12f21e7b6","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -429,7 +429,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.74.0 (DOCKER) azsdk-python-core/1.31.0 Python/3.11.8 (Linux-6.6.87.1-microsoft-standard-WSL2-x86_64-with)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliakstest000004?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliakstest000004?api-version=2025-07-01
   response:
     body:
       string: '{"name":"cliakstest000004","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliakstest000004","etag":"W/\"527aa9c0-d29f-45df-ad9c-c8cceefe7bc6\"","location":"westus2","properties":{"provisioningState":"Succeeded","resourceGuid":"02300e96-f564-40be-9d8e-1fe12f21e7b6","ipAddress":"4.155.107.91","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'
@@ -479,7 +479,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.74.0 (DOCKER) azsdk-python-core/1.31.0 Python/3.11.8 (Linux-6.6.87.1-microsoft-standard-WSL2-x86_64-with)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliakstest000004?api-version=2024-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliakstest000004?api-version=2025-07-01
   response:
     body:
       string: '{"name":"cliakstest000004","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Network/publicIPAddresses/cliakstest000004","etag":"W/\"527aa9c0-d29f-45df-ad9c-c8cceefe7bc6\"","location":"westus2","properties":{"provisioningState":"Succeeded","resourceGuid":"02300e96-f564-40be-9d8e-1fe12f21e7b6","ipAddress":"4.155.107.91","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ddosSettings":{"protectionMode":"VirtualNetworkInherited"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Standard","tier":"Regional"}}'

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_update_agentpool_profile_preview.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_update_agentpool_profile_preview.py
@@ -159,7 +159,7 @@ class TestUpdateAgentPoolProfilePreview(unittest.TestCase):
         decorator.update_ssh_access.assert_called_once_with(agentpool)
         decorator.update_vm_size.assert_called_once_with(agentpool)
         decorator.update_localdns_profile.assert_called_once_with(agentpool)
-        decorator.update_auto_scaler_properties_vms.assert_called_once_with(agentpool)
+        decorator.update_auto_scaler_properties_vms.assert_not_called()
         decorator.update_upgrade_strategy.assert_called_once_with(agentpool)
         decorator.update_blue_green_upgrade_settings.assert_called_once_with(agentpool)
         decorator.update_gpu_profile.assert_called_once_with(agentpool)
@@ -402,7 +402,7 @@ class TestUpdateAgentPoolProfilePreview(unittest.TestCase):
         decorator.update_ssh_access.assert_called_once_with(agentpool)
         decorator.update_vm_size.assert_called_once_with(agentpool)
         decorator.update_localdns_profile.assert_called_once_with(agentpool)
-        decorator.update_auto_scaler_properties_vms.assert_called_once_with(agentpool)
+        decorator.update_auto_scaler_properties_vms.assert_not_called()
         decorator.update_upgrade_strategy.assert_called_once_with(agentpool)
         decorator.update_blue_green_upgrade_settings.assert_called_once_with(agentpool)
         decorator.update_gpu_profile.assert_called_once_with(agentpool)
@@ -476,7 +476,6 @@ class TestUpdateAgentPoolProfilePreview(unittest.TestCase):
             "update_ssh_access",
             "update_vm_size",
             "update_localdns_profile",
-            "update_auto_scaler_properties_vms",
             "update_upgrade_strategy",
             "update_blue_green_upgrade_settings",
             "update_gpu_profile",
@@ -485,6 +484,7 @@ class TestUpdateAgentPoolProfilePreview(unittest.TestCase):
             "update_prepared_image_specification",
         ]
         self.assertEqual(call_order, expected_order)
+        decorator.update_auto_scaler_properties_vms.assert_not_called()
 
     def test_update_agentpool_profile_preview_preserves_agentpool_reference(self):
         """Test that the method preserves agentpool object reference throughout the chain."""
@@ -597,13 +597,14 @@ class TestUpdateAgentPoolProfilePreview(unittest.TestCase):
                 update_methods = [
                     'update_network_profile', 'update_artifact_streaming', 'update_managed_gpu',
                     'update_secure_boot', 'update_vtpm', 'update_os_sku', 'update_fips_image',
-                    'update_ssh_access', 'update_vm_size', 'update_localdns_profile', 'update_auto_scaler_properties_vms', 
+                    'update_ssh_access', 'update_vm_size', 'update_localdns_profile',
                     'update_upgrade_strategy', 'update_blue_green_upgrade_settings', 'update_gpu_profile',
                     'update_gpu_mig_strategy', 'update_crg', 'update_prepared_image_specification'
                 ]
 
                 for method_name in update_methods:
                     setattr(decorator, method_name, Mock(return_value=agentpool))
+                decorator.update_auto_scaler_properties_vms = Mock(return_value=agentpool)
 
                 # Act
                 result = decorator.update_agentpool_profile_preview()
@@ -617,6 +618,7 @@ class TestUpdateAgentPoolProfilePreview(unittest.TestCase):
                 else:
                     for method_name in update_methods:
                         getattr(decorator, method_name).assert_not_called()
+                decorator.update_auto_scaler_properties_vms.assert_not_called()
 
 
 class TestUpdateAgentPoolProfilePreviewManagedClusterMode(TestUpdateAgentPoolProfilePreview):

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_update_agentpool_profile_preview.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_update_agentpool_profile_preview.py
@@ -23,7 +23,10 @@ from azure.cli.command_modules.acs._consts import (
     AgentPoolDecoratorMode,
     DecoratorMode,
 )
-from azure.cli.command_modules.acs.agentpool_decorator import AKSAgentPoolParamDict
+from azure.cli.command_modules.acs.agentpool_decorator import (
+    AKSAgentPoolParamDict,
+    AKSAgentPoolUpdateDecorator,
+)
 from azure.cli.command_modules.acs.tests.latest.mocks import (
     MockCLI,
     MockClient,
@@ -34,6 +37,16 @@ from azure.cli.core.azclierror import CLIInternalError
 
 class TestUpdateAgentPoolProfilePreview(unittest.TestCase):
     """Test class for the update_agentpool_profile_preview method."""
+
+    base_handles_vms_autoscaler = hasattr(
+        AKSAgentPoolUpdateDecorator, "update_auto_scaler_properties_vms"
+    )
+
+    def _assert_vms_autoscaler_update(self, update_method, agentpool, expected):
+        if expected and not self.base_handles_vms_autoscaler:
+            update_method.assert_called_once_with(agentpool)
+        else:
+            update_method.assert_not_called()
 
     def setUp(self):
         """Set up test fixtures."""
@@ -159,7 +172,9 @@ class TestUpdateAgentPoolProfilePreview(unittest.TestCase):
         decorator.update_ssh_access.assert_called_once_with(agentpool)
         decorator.update_vm_size.assert_called_once_with(agentpool)
         decorator.update_localdns_profile.assert_called_once_with(agentpool)
-        decorator.update_auto_scaler_properties_vms.assert_not_called()
+        self._assert_vms_autoscaler_update(
+            decorator.update_auto_scaler_properties_vms, agentpool, expected=True
+        )
         decorator.update_upgrade_strategy.assert_called_once_with(agentpool)
         decorator.update_blue_green_upgrade_settings.assert_called_once_with(agentpool)
         decorator.update_gpu_profile.assert_called_once_with(agentpool)
@@ -402,7 +417,9 @@ class TestUpdateAgentPoolProfilePreview(unittest.TestCase):
         decorator.update_ssh_access.assert_called_once_with(agentpool)
         decorator.update_vm_size.assert_called_once_with(agentpool)
         decorator.update_localdns_profile.assert_called_once_with(agentpool)
-        decorator.update_auto_scaler_properties_vms.assert_not_called()
+        self._assert_vms_autoscaler_update(
+            decorator.update_auto_scaler_properties_vms, agentpool, expected=True
+        )
         decorator.update_upgrade_strategy.assert_called_once_with(agentpool)
         decorator.update_blue_green_upgrade_settings.assert_called_once_with(agentpool)
         decorator.update_gpu_profile.assert_called_once_with(agentpool)
@@ -483,8 +500,9 @@ class TestUpdateAgentPoolProfilePreview(unittest.TestCase):
             "update_crg",
             "update_prepared_image_specification",
         ]
+        if not self.base_handles_vms_autoscaler:
+            expected_order.insert(10, "update_auto_scaler_properties_vms")
         self.assertEqual(call_order, expected_order)
-        decorator.update_auto_scaler_properties_vms.assert_not_called()
 
     def test_update_agentpool_profile_preview_preserves_agentpool_reference(self):
         """Test that the method preserves agentpool object reference throughout the chain."""
@@ -618,7 +636,11 @@ class TestUpdateAgentPoolProfilePreview(unittest.TestCase):
                 else:
                     for method_name in update_methods:
                         getattr(decorator, method_name).assert_not_called()
-                decorator.update_auto_scaler_properties_vms.assert_not_called()
+                self._assert_vms_autoscaler_update(
+                    decorator.update_auto_scaler_properties_vms,
+                    agentpool,
+                    expected=case["expect_update_methods_called"],
+                )
 
 
 class TestUpdateAgentPoolProfilePreviewManagedClusterMode(TestUpdateAgentPoolProfilePreview):


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes |
| :--: |
| ️✔️ None |

<!-- act-bot:section title="Azure CLI Extensions Breaking Change Test" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

## Summary

- Avoid applying VirtualMachines autoscaler profile conversions twice when the base Azure CLI update flow already handles them.
- Preserve compatibility with older CLI versions that do not yet provide the base VMS autoscaler flow.
- Refresh the outbound public IP recording for Network API version `2025-07-01`.
- Document the fix under the pending `aks-preview` release notes.

### Related command

`az aks nodepool update --enable-cluster-autoscaler`

`az aks nodepool update --disable-cluster-autoscaler`

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install azdev` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [x] Not applicable; `aks-preview` is an existing extension.

### Validation

- `azdev test azext_aks_preview`: 1157 passed, 117 skipped, 6 subtests passed
- `azdev style aks-preview`: pylint and flake8 passed
- `python scripts/ci/test_index.py -q`: 9 tests passed, 2 skipped

### About Extension Publish

This is a non-release change. `HISTORY.rst` is updated under `Pending`, and the extension version remains `21.0.0b13`.
