### PR TITLE
{AKS} Stabilize aks-preview live tests

### DIFF
--- a/src/aks-preview/azext_aks_preview/_helpers.py
+++ b/src/aks-preview/azext_aks_preview/_helpers.py
@@ -97,22 +97,33 @@ def validate_flexnodes_options(
 
 def reset_agentpool_to_name_and_mode(agentpool, mode):
     """Remove all agent pool fields except the resource name and pool mode."""
-    name = agentpool.name
+    if isinstance(agentpool, MutableMapping):
+        name = agentpool["name"]
+        properties = agentpool.get("properties")
+        agentpool.clear()
+        agentpool["name"] = name
+        if isinstance(properties, MutableMapping):
+            properties.clear()
+            properties["mode"] = mode
+            agentpool["properties"] = properties
+        else:
+            agentpool["mode"] = mode
+        return agentpool
+
     properties = getattr(agentpool, "properties", None)
     if isinstance(properties, MutableMapping):
         properties.clear()
         properties["mode"] = mode
-        agentpool.clear()
-        agentpool["name"] = name
-        agentpool["properties"] = properties
-    elif isinstance(agentpool, MutableMapping):
-        agentpool.clear()
-        agentpool["name"] = name
-        agentpool["mode"] = mode
+        preserved_attributes = ("name", "properties")
     else:
         agentpool.mode = mode
+        preserved_attributes = ("name", "mode")
     for attr in list(vars(agentpool)):
-        if attr not in ("name", "mode") and not attr.startswith("_") and hasattr(agentpool, attr):
+        if (
+            attr not in preserved_attributes
+            and not attr.startswith("_")
+            and hasattr(agentpool, attr)
+        ):
             setattr(agentpool, attr, None)
     return agentpool
 

--- a/src/aks-preview/azext_aks_preview/_helpers.py
+++ b/src/aks-preview/azext_aks_preview/_helpers.py
@@ -105,15 +105,13 @@ def reset_agentpool_to_name_and_mode(agentpool, mode):
         agentpool.clear()
         agentpool["name"] = name
         agentpool["properties"] = properties
-        return agentpool
-    if isinstance(agentpool, MutableMapping):
+    elif isinstance(agentpool, MutableMapping):
         agentpool.clear()
         agentpool["name"] = name
         agentpool["mode"] = mode
-        return agentpool
-
-    agentpool.mode = mode
-    for attr in vars(agentpool):
+    else:
+        agentpool.mode = mode
+    for attr in list(vars(agentpool)):
         if attr not in ("name", "mode") and not attr.startswith("_") and hasattr(agentpool, attr):
             setattr(agentpool, attr, None)
     return agentpool

--- a/src/aks-preview/azext_aks_preview/_helpers.py
+++ b/src/aks-preview/azext_aks_preview/_helpers.py
@@ -2,6 +2,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
+from collections.abc import MutableMapping
+
 import errno
 import os
 import platform
@@ -91,6 +93,30 @@ def validate_flexnodes_options(
                 ", ".join(unsupported_options), ", ".join(supported_parameters.values())
             )
         )
+
+
+def reset_agentpool_to_name_and_mode(agentpool, mode):
+    """Remove all agent pool fields except the resource name and pool mode."""
+    name = agentpool.name
+    properties = getattr(agentpool, "properties", None)
+    if isinstance(properties, MutableMapping):
+        properties.clear()
+        properties["mode"] = mode
+        agentpool.clear()
+        agentpool["name"] = name
+        agentpool["properties"] = properties
+        return agentpool
+    if isinstance(agentpool, MutableMapping):
+        agentpool.clear()
+        agentpool["name"] = name
+        agentpool["mode"] = mode
+        return agentpool
+
+    agentpool.mode = mode
+    for attr in vars(agentpool):
+        if attr not in ("name", "mode") and not attr.startswith("_") and hasattr(agentpool, attr):
+            setattr(agentpool, attr, None)
+    return agentpool
 
 
 def which(binary):

--- a/src/aks-preview/azext_aks_preview/_helpers.py
+++ b/src/aks-preview/azext_aks_preview/_helpers.py
@@ -95,19 +95,26 @@ def validate_flexnodes_options(
         )
 
 
+def _reset_mapping_fields(model, preserved_fields):
+    model.clear()
+    for field, value in preserved_fields.items():
+        model[field] = value
+    for attr in list(getattr(model, "__dict__", {})):
+        if not attr.startswith("_"):
+            setattr(model, attr, preserved_fields.get(attr))
+
+
 def reset_agentpool_to_name_and_mode(agentpool, mode):
     """Remove all agent pool fields except the resource name and pool mode."""
     if isinstance(agentpool, MutableMapping):
         name = agentpool["name"]
         properties = agentpool.get("properties")
-        agentpool.clear()
-        agentpool["name"] = name
         if isinstance(properties, MutableMapping):
-            properties.clear()
-            properties["mode"] = mode
-            agentpool["properties"] = properties
+            _reset_mapping_fields(properties, {"mode": mode})
+            preserved_fields = {"name": name, "properties": properties}
         else:
-            agentpool["mode"] = mode
+            preserved_fields = {"name": name, "mode": mode}
+        _reset_mapping_fields(agentpool, preserved_fields)
         return agentpool
 
     properties = getattr(agentpool, "properties", None)

--- a/src/aks-preview/azext_aks_preview/_loadbalancer.py
+++ b/src/aks-preview/azext_aks_preview/_loadbalancer.py
@@ -172,10 +172,13 @@ def configure_load_balancer_profile(
                 profile.managed_outbound_i_ps = (
                     ManagedClusterLoadBalancerProfileManagedOutboundIPs()
                 )
-            if managed_outbound_ip_count is not None:
-                profile.managed_outbound_i_ps.count = managed_outbound_ip_count
-            elif profile.managed_outbound_i_ps.count is None:
-                profile.managed_outbound_i_ps.count = 1
+            existing_count = profile.managed_outbound_i_ps.count
+            existing_or_default_count = existing_count if existing_count is not None else 1
+            profile.managed_outbound_i_ps.count = (
+                managed_outbound_ip_count
+                if managed_outbound_ip_count is not None
+                else existing_or_default_count
+            )
             if managed_outbound_ipv6_count is not None:
                 profile.managed_outbound_i_ps.count_ipv6 = managed_outbound_ipv6_count
         else:

--- a/src/aks-preview/azext_aks_preview/_loadbalancer.py
+++ b/src/aks-preview/azext_aks_preview/_loadbalancer.py
@@ -172,13 +172,11 @@ def configure_load_balancer_profile(
                 profile.managed_outbound_i_ps = (
                     ManagedClusterLoadBalancerProfileManagedOutboundIPs()
                 )
-            if managed_outbound_ip_count is not None:
-                profile.managed_outbound_i_ps.count = managed_outbound_ip_count
-            elif (
-                managed_outbound_ipv6_count is not None
-                and not profile.managed_outbound_i_ps.count
-            ):
-                profile.managed_outbound_i_ps.count = 1
+            profile.managed_outbound_i_ps.count = (
+                managed_outbound_ip_count
+                if managed_outbound_ip_count is not None
+                else profile.managed_outbound_i_ps.count or 1
+            )
             if managed_outbound_ipv6_count is not None:
                 profile.managed_outbound_i_ps.count_ipv6 = managed_outbound_ipv6_count
         else:

--- a/src/aks-preview/azext_aks_preview/_loadbalancer.py
+++ b/src/aks-preview/azext_aks_preview/_loadbalancer.py
@@ -172,11 +172,10 @@ def configure_load_balancer_profile(
                 profile.managed_outbound_i_ps = (
                     ManagedClusterLoadBalancerProfileManagedOutboundIPs()
                 )
-            profile.managed_outbound_i_ps.count = (
-                managed_outbound_ip_count
-                if managed_outbound_ip_count is not None
-                else profile.managed_outbound_i_ps.count or 1
-            )
+            if managed_outbound_ip_count is not None:
+                profile.managed_outbound_i_ps.count = managed_outbound_ip_count
+            elif profile.managed_outbound_i_ps.count is None:
+                profile.managed_outbound_i_ps.count = 1
             if managed_outbound_ipv6_count is not None:
                 profile.managed_outbound_i_ps.count_ipv6 = managed_outbound_ipv6_count
         else:

--- a/src/aks-preview/azext_aks_preview/_loadbalancer.py
+++ b/src/aks-preview/azext_aks_preview/_loadbalancer.py
@@ -174,6 +174,11 @@ def configure_load_balancer_profile(
                 )
             if managed_outbound_ip_count is not None:
                 profile.managed_outbound_i_ps.count = managed_outbound_ip_count
+            elif (
+                managed_outbound_ipv6_count is not None
+                and not profile.managed_outbound_i_ps.count
+            ):
+                profile.managed_outbound_i_ps.count = 1
             if managed_outbound_ipv6_count is not None:
                 profile.managed_outbound_i_ps.count_ipv6 = managed_outbound_ipv6_count
         else:

--- a/src/aks-preview/azext_aks_preview/agentpool_decorator.py
+++ b/src/aks-preview/azext_aks_preview/agentpool_decorator.py
@@ -59,6 +59,7 @@ from azext_aks_preview._helpers import (
     filter_hard_taints,
     process_dns_overrides,
     validate_flexnodes_options,
+    reset_agentpool_to_name_and_mode,
 )
 
 logger = get_logger(__name__)
@@ -1666,14 +1667,9 @@ class AKSPreviewAgentPoolAddDecorator(AKSAgentPoolAddDecorator):
             if agentpool is None:
                 raise CLIInternalError("agentpool cannot be None for ManagedSystem mode")
 
-            # Instead of creating a new instance, modify the existing one
-            # Keep name and set mode to ManagedSystem
-            agentpool.mode = CONST_NODEPOOL_MODE_MANAGEDSYSTEM
-            # Make sure all other attributes are None
-            for attr in vars(agentpool):
-                if attr != 'name' and attr != 'mode' and not attr.startswith('_'):
-                    if hasattr(agentpool, attr):
-                        setattr(agentpool, attr, None)
+            agentpool = reset_agentpool_to_name_and_mode(
+                agentpool, CONST_NODEPOOL_MODE_MANAGEDSYSTEM
+            )
 
         return agentpool
 
@@ -1687,28 +1683,9 @@ class AKSPreviewAgentPoolAddDecorator(AKSAgentPoolAddDecorator):
 
         mode = self.context.get_mode()
         if mode == CONST_NODEPOOL_MODE_MACHINES:
-            agentpool.mode = CONST_NODEPOOL_MODE_MACHINES
-            # Make sure all other attributes are None
-            # Check properties sub-model first (AgentPool), then flat fields (ManagedClusterAgentPoolProfile)
-            props = getattr(agentpool, 'properties', None)
-            rest_fields = getattr(props, '_attr_to_rest_field', None) if props is not None else None
-            if rest_fields is not None:
-                target, fields = props, rest_fields
-            else:
-                rest_fields = getattr(agentpool, '_attr_to_rest_field', None)
-                if rest_fields is not None and 'mode' in rest_fields:
-                    target, fields = agentpool, rest_fields
-                else:
-                    target, fields = None, None
-            if target is not None:
-                for attr in list(fields.keys()):
-                    if attr not in ('name', 'mode'):
-                        setattr(agentpool, attr, None)
-            else:
-                for attr in vars(agentpool):
-                    if attr != 'name' and attr != 'mode' and not attr.startswith('_'):
-                        if hasattr(agentpool, attr):
-                            setattr(agentpool, attr, None)
+            agentpool = reset_agentpool_to_name_and_mode(
+                agentpool, CONST_NODEPOOL_MODE_MACHINES
+            )
 
         return agentpool
 
@@ -2190,12 +2167,9 @@ class AKSPreviewAgentPoolUpdateDecorator(AKSAgentPoolUpdateDecorator):
 
         # Check if agentpool is in ManagedSystem mode and handle special case
         if agentpool.mode == CONST_NODEPOOL_MODE_MANAGEDSYSTEM:
-            # Make sure all other attributes are None
-            for attr in vars(agentpool):
-                if attr != 'name' and attr != 'mode' and not attr.startswith('_'):
-                    if hasattr(agentpool, attr):
-                        setattr(agentpool, attr, None)
-            return agentpool
+            return reset_agentpool_to_name_and_mode(
+                agentpool, CONST_NODEPOOL_MODE_MANAGEDSYSTEM
+            )
 
         # update network profile
         agentpool = self.update_network_profile(agentpool)

--- a/src/aks-preview/azext_aks_preview/aks_diagnostics.py
+++ b/src/aks-preview/azext_aks_preview/aks_diagnostics.py
@@ -3,6 +3,8 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+from collections.abc import Mapping
+
 import datetime
 import json
 import os
@@ -43,6 +45,16 @@ logger = get_logger(__name__)
 class ClusterFeatures(Flag):
     NONE = 0
     WIN_HPC = auto()
+
+
+def _get_storage_account_key(storage_account_keys):
+    keys = (
+        storage_account_keys["keys"]
+        if isinstance(storage_account_keys, Mapping)
+        else storage_account_keys.keys
+    )
+    first_key = keys[0]
+    return first_key["value"] if isinstance(first_key, Mapping) else first_key.value
 
 
 # pylint: disable=line-too-long
@@ -99,17 +111,18 @@ def aks_kollect_cmd(cmd,    # pylint: disable=too-many-statements,too-many-local
             cmd.cli_ctx, parsed_storage_account['subscription'])
         storage_account_keys = storage_client.storage_accounts.list_keys(parsed_storage_account['resource_group'],
                                                                          storage_account_name)
+        storage_account_key = _get_storage_account_key(storage_account_keys)
 
         t_generate_blob_service_sas = get_sdk(cmd.cli_ctx, ResourceType.DATA_STORAGE_BLOB, '#generate_account_sas')
 
         sas_token = t_generate_blob_service_sas(storage_account_name,
-                                                storage_account_keys.keys[0].value,
+                                                storage_account_key,
                                                 resource_types='sco',
                                                 permission='rwdlacup',
                                                 expiry=datetime.datetime.utcnow() + datetime.timedelta(days=1))
 
         readonly_sas_token = t_generate_blob_service_sas(storage_account_name,
-                                                         storage_account_keys.keys[0].value,
+                                                         storage_account_key,
                                                          resource_types='sco',
                                                          permission='rl',
                                                          expiry=datetime.datetime.utcnow() + datetime.timedelta(days=1))

--- a/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
+++ b/src/aks-preview/azext_aks_preview/managed_cluster_decorator.py
@@ -68,6 +68,7 @@ from azext_aks_preview._helpers import (
     get_cluster_snapshot_by_snapshot_id,
     get_monitoring_addon_key,
     filter_hard_taints,
+    reset_agentpool_to_name_and_mode,
 )
 from azext_aks_preview._loadbalancer import create_load_balancer_profile
 from azext_aks_preview._loadbalancer import (
@@ -6312,26 +6313,9 @@ class AKSPreviewManagedClusterUpdateDecorator(AKSManagedClusterUpdateDecorator):
             # Check if agentpool is in ManagedSystem mode and handle special case
             if agentpool.mode != CONST_NODEPOOL_MODE_MANAGEDSYSTEM:
                 continue
-            # Make sure all other attributes are None
-            # Check properties sub-model first (AgentPool), then flat fields (ManagedClusterAgentPoolProfile)
-            props = getattr(agentpool, 'properties', None)
-            rest_fields = getattr(props, '_attr_to_rest_field', None) if props is not None else None
-            if rest_fields is not None:
-                target, fields = props, rest_fields
-            else:
-                rest_fields = getattr(agentpool, '_attr_to_rest_field', None)
-                if rest_fields is not None and 'mode' in rest_fields:
-                    target, fields = agentpool, rest_fields
-                else:
-                    target, fields = None, None
-            if target is not None:
-                for attr in list(fields.keys()):
-                    if attr not in ('name', 'mode'):
-                        setattr(agentpool, attr, None)
-            else:
-                for attr in vars(agentpool):
-                    if attr not in ('name', 'mode') and not attr.startswith('_') and hasattr(agentpool, attr):
-                        setattr(agentpool, attr, None)
+            reset_agentpool_to_name_and_mode(
+                agentpool, CONST_NODEPOOL_MODE_MANAGEDSYSTEM
+            )
         return mc
 
     def init_models(self) -> None:

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_agentpool_decorator.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_agentpool_decorator.py
@@ -2085,12 +2085,12 @@ class AKSPreviewAgentPoolAddDecoratorCommonTestCase(unittest.TestCase):
         # Verify that name is preserved
         self.assertEqual(dec_agentpool_1.name, original_name)
 
-        # Verify that all other properties are reset to None
-        for attr_name in vars(dec_agentpool_1):
-            if attr_name not in ['name', 'mode'] and not attr_name.startswith('_'):
-                attr_value = getattr(dec_agentpool_1, attr_name)
-                self.assertIsNone(attr_value,
-                    f"Attribute '{attr_name}' should be None but was '{attr_value}'")
+        self.assertIsNone(dec_agentpool_1.count)
+        self.assertIsNone(dec_agentpool_1.vm_size)
+        self.assertIsNone(dec_agentpool_1.os_type)
+        self.assertIsNone(dec_agentpool_1.enable_auto_scaling)
+        self.assertIsNone(dec_agentpool_1.min_count)
+        self.assertIsNone(dec_agentpool_1.max_count)
 
         # Test case 2: mode is not ManagedSystem - should return agentpool unchanged
         dec_2 = AKSPreviewAgentPoolAddDecorator(
@@ -2169,11 +2169,12 @@ class AKSPreviewAgentPoolAddDecoratorCommonTestCase(unittest.TestCase):
         dec_agentpool_1 = dec_1.set_up_machines_mode(agentpool_1)
         self.assertEqual(dec_agentpool_1.name, original_name)
         self.assertEqual(dec_agentpool_1.mode, CONST_NODEPOOL_MODE_MACHINES)
-        for attr_name in vars(dec_agentpool_1):
-            if attr_name not in ['name', 'mode'] and not attr_name.startswith('_'):
-                attr_value = getattr(dec_agentpool_1, attr_name)
-                self.assertIsNone(attr_value,
-                    f"Attribute '{attr_name}' should be None but was '{attr_value}'")
+        self.assertIsNone(dec_agentpool_1.count)
+        self.assertIsNone(dec_agentpool_1.vm_size)
+        self.assertIsNone(dec_agentpool_1.os_type)
+        self.assertIsNone(dec_agentpool_1.enable_auto_scaling)
+        self.assertIsNone(dec_agentpool_1.min_count)
+        self.assertIsNone(dec_agentpool_1.max_count)
 
     def common_construct_agentpool_profile_preview_with_managed_system_mode(self):
         """Test that construct_agentpool_profile_preview properly handles ManagedSystem mode"""

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -272,7 +272,10 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
     def _get_versions(self, location):
         """Return the previous and current Kubernetes minor release versions, such as ("1.11.6", "1.12.4")."""
         supported_versions = self.cmd(
-            "az aks get-versions -l {} --query 'values[*].patchVersions.keys(@)[]'".format(location)
+            "az aks get-versions -l {} "
+            "--query \"values[?contains(capabilities.supportPlan, 'KubernetesOfficial')].patchVersions.keys(@)[]\"".format(
+                location
+            )
         ).get_output_in_json()
         sorted_supported_versions = sorted(supported_versions, key=version_to_tuple, reverse=True)
         upgrade_version = sorted_supported_versions[0]
@@ -295,6 +298,20 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             if version > min_version and version < max_version:
                 return version
         return ""
+
+    def _get_version_at_least(self, location: str, min_version: str) -> str:
+        """Return the latest community-supported version at or above the minimum."""
+        versions = self.cmd(
+            "az aks get-versions -l {} "
+            "--query \"values[?contains(capabilities.supportPlan, 'KubernetesOfficial')].patchVersions.keys(@)[]\"".format(
+                location
+            )
+        ).get_output_in_json()
+        versions = sorted(versions, key=version_to_tuple, reverse=True)
+        minimum = version_to_tuple(min_version)
+        return next(
+            version for version in versions if version_to_tuple(version) >= minimum
+        )
 
     def _get_lts_version(self, location):
         """Return the latest LTS version in the given location."""
@@ -4359,7 +4376,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         create_cmd = (
             "aks create --resource-group={resource_group} --name={name} "
             "--node-count 1 --ssh-key-value={ssh_key_value} --generate-ssh-keys "
-            "--kubernetes-version 1.33.0"  # k8s version > 1.33 to support localDNS
         )
         self.cmd(create_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -4368,7 +4384,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             "aks nodepool add --resource-group={resource_group} --cluster-name={name} "
             "--name={nodepool_name} --node-count 1 --localdns-config={localdns_config} "
             "--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/LocalDNSPreview "
-            "--kubernetes-version 1.33.0"  # k8s version > 1.33 to support localDNS
         )
         self.cmd(add_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -4405,7 +4420,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         create_cmd = (
             "aks create --resource-group={resource_group} --name={name} "
             "--node-count 1 --ssh-key-value={ssh_key_value} --generate-ssh-keys "
-            "--kubernetes-version 1.33.0"
         )
         self.cmd(create_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -4414,7 +4428,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             "aks nodepool add --resource-group={resource_group} --cluster-name={name} "
             "--name={nodepool_name} --node-count 1 --localdns-config={required_config} "
             "--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/LocalDNSPreview "
-            "--kubernetes-version 1.33.0"
         )
         self.cmd(add_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -4450,7 +4463,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         create_cmd = (
             "aks create --resource-group={resource_group} --name={name} "
             "--node-count 1 --ssh-key-value={ssh_key_value} --generate-ssh-keys "
-            "--kubernetes-version 1.33.0"
         )
         self.cmd(create_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -4458,7 +4470,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             "aks nodepool add --resource-group={resource_group} --cluster-name={name} "
             "--name={nodepool_name} --node-count 1 --localdns-config={vnetdns_config} "
             "--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/LocalDNSPreview "
-            "--kubernetes-version 1.33.0"
         )
 
         with self.assertRaises(HttpResponseError) as context:
@@ -4491,7 +4502,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         create_cmd = (
             "aks create --resource-group={resource_group} --name={name} "
             "--node-count 1 --ssh-key-value={ssh_key_value} --generate-ssh-keys "
-            "--kubernetes-version 1.33.0"
         )
         self.cmd(create_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -4499,7 +4509,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             "aks nodepool add --resource-group={resource_group} --cluster-name={name} "
             "--name={nodepool_name} --node-count 1 --localdns-config={kubedns_config} "
             "--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/LocalDNSPreview "
-            "--kubernetes-version 1.33.0"
         )
         
         # This should fail because kubedns config without vnetdns should be rejected
@@ -4534,7 +4543,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         create_cmd = (
             "aks create --resource-group={resource_group} --name={name} "
             "--node-count 1 --ssh-key-value={ssh_key_value} --generate-ssh-keys "
-            "--kubernetes-version 1.33.0"
         )
         self.cmd(create_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -4543,7 +4551,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             "aks nodepool add --resource-group={resource_group} --cluster-name={name} "
             "--name={nodepool_name} --node-count 1 --localdns-config={required_config} "
             "--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/LocalDNSPreview "
-            "--kubernetes-version 1.33.0"
         )
 
         with self.assertRaises(HttpResponseError) as context:
@@ -4578,7 +4585,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         create_cmd = (
             "aks create --resource-group={resource_group} --name={name} "
             "--node-count 1 --ssh-key-value={ssh_key_value} --generate-ssh-keys "
-            "--kubernetes-version 1.33.0"
         )
         self.cmd(create_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -4587,7 +4593,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             "aks nodepool add --resource-group={resource_group} --cluster-name={name} "
             "--name={nodepool_name} --node-count 1 --localdns-config={required_config} "
             "--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/LocalDNSPreview "
-            "--kubernetes-version 1.33.0"
         )
         self.cmd(add_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -4624,7 +4629,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         create_cmd = (
             "aks create --resource-group={resource_group} --name={name} "
             "--node-count 1 --ssh-key-value={ssh_key_value} --generate-ssh-keys "
-            "--kubernetes-version 1.33.0"
         )
         self.cmd(create_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -4633,7 +4637,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             "aks nodepool add --resource-group={resource_group} --cluster-name={name} "
             "--name={nodepool_name} --node-count 1 --localdns-config={required_config} "
             "--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/LocalDNSPreview "
-            "--kubernetes-version 1.33.0"
         )
         self.cmd(add_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -4670,7 +4673,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         create_cmd = (
             "aks create --resource-group={resource_group} --name={name} "
             "--node-count 1 --ssh-key-value={ssh_key_value} --generate-ssh-keys "
-            "--kubernetes-version 1.33.0" # k8s version > 1.33 to support localDNS
         )
         self.cmd(create_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -4678,7 +4680,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         add_cmd = (
             "aks nodepool add --resource-group={resource_group} --cluster-name={name} "
             "--name={nodepool_name} --node-count 1 "
-            "--kubernetes-version 1.33.0"  # k8s version > 1.33 to support localDNS
         )
         self.cmd(add_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -4726,7 +4727,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         create_cmd = (
             "aks create --resource-group={resource_group} --name={name} "
             "--node-count 1 --ssh-key-value={ssh_key_value} --generate-ssh-keys "
-            "--kubernetes-version 1.33.0"
         )
         self.cmd(create_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -4735,7 +4735,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             "aks nodepool add --resource-group={resource_group} --cluster-name={name} "
             "--name={nodepool_name} --node-count 1 --localdns-config={valid_dns_overrides} "
             "--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/LocalDNSPreview "
-            "--kubernetes-version 1.33.0"
         )
         self.cmd(add_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -4792,7 +4791,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         create_cmd = (
             "aks create --resource-group={resource_group} --name={name} "
             "--node-count 1 --ssh-key-value={ssh_key_value} --generate-ssh-keys "
-            "--kubernetes-version 1.33.0"  # k8s version > 1.33 to support localDNS
         )
         self.cmd(create_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -4801,7 +4799,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             "aks nodepool add --resource-group={resource_group} --cluster-name={name} "
             "--name={nodepool_name} --node-count 1 --localdns-config={required_config} "
             "--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/LocalDNSPreview "
-            "--kubernetes-version 1.33.0"  # k8s version > 1.33 to support localDNS
         )
         self.cmd(add_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -4854,7 +4851,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         create_cmd = (
             "aks create --resource-group={resource_group} --name={name} "
             "--node-count 1 --ssh-key-value={ssh_key_value} --generate-ssh-keys "
-            "--kubernetes-version 1.33.0"  # k8s version > 1.33 to support localDNS
         )
         self.cmd(create_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -4863,7 +4859,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             "aks nodepool add --resource-group={resource_group} --cluster-name={name} "
             "--name={nodepool_name} --node-count 1 --localdns-config={disabled_config} "
             "--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/LocalDNSPreview "
-            "--kubernetes-version 1.33.0"  # k8s version > 1.33 to support localDNS
         )
         self.cmd(add_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -4916,7 +4911,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         create_cmd = (
             "aks create --resource-group={resource_group} --name={name} "
             "--node-count 1 --ssh-key-value={ssh_key_value} --generate-ssh-keys "
-            "--kubernetes-version 1.33.0"  # k8s version > 1.33 to support localDNS
         )
         self.cmd(create_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -4925,7 +4919,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             "aks nodepool add --resource-group={resource_group} --cluster-name={name} "
             "--name={nodepool_name} --node-count 1 --localdns-config={required_config} "
             "--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/LocalDNSPreview "
-            "--kubernetes-version 1.33.0"  # k8s version > 1.33 to support localDNS
         )
         self.cmd(add_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -4978,7 +4971,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         create_cmd = (
             "aks create --resource-group={resource_group} --name={name} "
             "--node-count 1 --ssh-key-value={ssh_key_value} --generate-ssh-keys "
-            "--kubernetes-version 1.33.0"  # k8s version > 1.33 to support localDNS
         )
         self.cmd(create_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -4987,7 +4979,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             "aks nodepool add --resource-group={resource_group} --cluster-name={name} "
             "--name={nodepool_name} --node-count 1 --localdns-config={required_config} "
             "--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/LocalDNSPreview "
-            "--kubernetes-version 1.33.0"  # k8s version > 1.33 to support localDNS
         )
         self.cmd(add_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -5041,7 +5032,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         create_cmd = (
             "aks create --resource-group={resource_group} --name={name} "
             "--node-count 1 --ssh-key-value={ssh_key_value} --generate-ssh-keys "
-            "--kubernetes-version 1.33.0"
         )
         self.cmd(create_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -5049,7 +5039,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             "aks nodepool add --resource-group={resource_group} --cluster-name={name} "
             "--name={nodepool_name} --node-count 1 --localdns-config={valid_config} "
             "--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/LocalDNSPreview "
-            "--kubernetes-version 1.33.0"
         )
         self.cmd(add_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -5092,7 +5081,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         create_cmd = (
             "aks create --resource-group={resource_group} --name={name} "
             "--node-count 1 --ssh-key-value={ssh_key_value} --generate-ssh-keys "
-            "--kubernetes-version 1.33.0"
         )
         self.cmd(create_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -5100,7 +5088,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             "aks nodepool add --resource-group={resource_group} --cluster-name={name} "
             "--name={nodepool_name} --node-count 1 --localdns-config={valid_config} "
             "--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/LocalDNSPreview "
-            "--kubernetes-version 1.33.0"
         )
 
         self.cmd(add_cmd, checks=[self.check("provisioningState", "Succeeded")])
@@ -5141,7 +5128,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         create_cmd = (
             "aks create --resource-group={resource_group} --name={name} "
             "--node-count 1 --ssh-key-value={ssh_key_value} --generate-ssh-keys "
-            "--kubernetes-version 1.33.0"
         )
         self.cmd(create_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -5149,7 +5135,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             "aks nodepool add --resource-group={resource_group} --cluster-name={name} "
             "--name={nodepool_name} --node-count 1 --localdns-config={valid_config} "
             "--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/LocalDNSPreview "
-            "--kubernetes-version 1.33.0"
         )
         self.cmd(add_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -5191,7 +5176,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         create_cmd = (
             "aks create --resource-group={resource_group} --name={name} "
             "--node-count 1 --ssh-key-value={ssh_key_value} --generate-ssh-keys "
-            "--kubernetes-version 1.33.0"
         )
         self.cmd(create_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -5199,7 +5183,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             "aks nodepool add --resource-group={resource_group} --cluster-name={name} "
             "--name={nodepool_name} --node-count 1 --localdns-config={valid_config} "
             "--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/LocalDNSPreview "
-            "--kubernetes-version 1.33.0"
         )
         self.cmd(add_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -5239,7 +5222,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         create_cmd = (
             "aks create --resource-group={resource_group} --name={name} "
             "--node-count 1 --ssh-key-value={ssh_key_value} --generate-ssh-keys "
-            "--kubernetes-version 1.33.0"
         )
         self.cmd(create_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -5247,7 +5229,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             "aks nodepool add --resource-group={resource_group} --cluster-name={name} "
             "--name={nodepool_name} --node-count 1 --localdns-config={missing_mode_config} "
             "--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/LocalDNSPreview "
-            "--kubernetes-version 1.33.0"
         )
         with self.assertRaises(HttpResponseError) as context:
             self.cmd(add_cmd)
@@ -5280,7 +5261,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         create_cmd = (
             "aks create --resource-group={resource_group} --name={name} "
             "--node-count 1 --ssh-key-value={ssh_key_value} --generate-ssh-keys "
-            "--kubernetes-version 1.33.0"
         )
         self.cmd(create_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -5288,7 +5268,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             "aks nodepool add --resource-group={resource_group} --cluster-name={name} "
             "--name={nodepool_name} --node-count 1 --localdns-config={empty_overrides_config} "
             "--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/LocalDNSPreview "
-            "--kubernetes-version 1.33.0"
         )
 
         with self.assertRaises(Exception) as context:
@@ -5320,7 +5299,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         create_cmd = (
             "aks create --resource-group={resource_group} --name={name} "
             "--node-count 1 --ssh-key-value={ssh_key_value} --generate-ssh-keys "
-            "--kubernetes-version 1.33.0"
         )
         self.cmd(create_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -5328,7 +5306,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             "aks nodepool add --resource-group={resource_group} --cluster-name={name} "
             "--name={nodepool_name} --node-count 1 --localdns-config={partial_invalid_config} "
             "--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/LocalDNSPreview "
-            "--kubernetes-version 1.33.0"
         )
 
         # Attempt to update nodepool with null DNS overrides - should fail
@@ -5360,7 +5337,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         create_cmd = (
             "aks create --resource-group={resource_group} --name={name} "
             "--node-count 1 --ssh-key-value={ssh_key_value} --generate-ssh-keys "
-            "--kubernetes-version 1.33.0"
         )
         self.cmd(create_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -5368,7 +5344,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             "aks nodepool add --resource-group={resource_group} --cluster-name={name} "
             "--name={nodepool_name} --node-count 1 --localdns-config={empty_mode_config} "
             "--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/LocalDNSPreview "
-            "--kubernetes-version 1.33.0"
         )
         with self.assertRaises(HttpResponseError) as context:
             self.cmd(add_cmd)
@@ -5398,7 +5373,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         create_cmd = (
             "aks create --resource-group={resource_group} --name={name} "
             "--node-count 1 --ssh-key-value={ssh_key_value} --generate-ssh-keys "
-            "--kubernetes-version 1.33.0"
         )
         self.cmd(create_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -5406,7 +5380,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             "aks nodepool add --resource-group={resource_group} --cluster-name={name} "
             "--name={nodepool_name} --node-count 1 --localdns-config={null_mode_config} "
             "--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/LocalDNSPreview "
-            "--kubernetes-version 1.33.0"
         )
         with self.assertRaises(HttpResponseError) as context:
             self.cmd(add_cmd)
@@ -5438,7 +5411,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         create_cmd = (
             "aks create --resource-group={resource_group} --name={name} "
             "--node-count 1 --ssh-key-value={ssh_key_value} --generate-ssh-keys "
-            "--kubernetes-version 1.33.0"
         )
         self.cmd(create_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -5446,7 +5418,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             "aks nodepool add --resource-group={resource_group} --cluster-name={name} "
             "--name={nodepool_name} --node-count 1 --localdns-config={empty_config} "
             "--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/LocalDNSPreview "
-            "--kubernetes-version 1.33.0"
         )
         with self.assertRaises(HttpResponseError) as context:
             self.cmd(add_cmd)
@@ -5479,7 +5450,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         create_cmd = (
             "aks create --resource-group={resource_group} --name={name} "
             "--node-count 1 --ssh-key-value={ssh_key_value} --generate-ssh-keys "
-            "--kubernetes-version 1.33.0"
         )
         self.cmd(create_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -5487,7 +5457,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             "aks nodepool add --resource-group={resource_group} --cluster-name={name} "
             "--name={nodepool_name} --node-count 1 --localdns-config={null_config} "
             "--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/LocalDNSPreview "
-            "--kubernetes-version 1.33.0"
         )
         with self.assertRaises(InvalidArgumentValueError) as context:
             self.cmd(add_cmd)
@@ -5519,7 +5488,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         create_cmd = (
             "aks create --resource-group={resource_group} --name={name} "
             "--node-count 1 --ssh-key-value={ssh_key_value} --generate-ssh-keys "
-            "--kubernetes-version 1.33.0"
         )
         self.cmd(create_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -5527,7 +5495,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             "aks nodepool add --resource-group={resource_group} --cluster-name={name} "
             "--name={nodepool_name} --node-count 1 --localdns-config={valid_config} "
             "--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/LocalDNSPreview "
-            "--kubernetes-version 1.33.0"
         )
         self.cmd(add_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -5571,7 +5538,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         create_cmd = (
             "aks create --resource-group={resource_group} --name={name} "
             "--node-count 1 --ssh-key-value={ssh_key_value} --generate-ssh-keys "
-            "--kubernetes-version 1.33.0"
         )
         self.cmd(create_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -5579,7 +5545,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             "aks nodepool add --resource-group={resource_group} --cluster-name={name} "
             "--name={nodepool_name} --node-count 1 --localdns-config={valid_config} "
             "--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/LocalDNSPreview "
-            "--kubernetes-version 1.33.0"
         )
         self.cmd(add_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -5622,7 +5587,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         create_cmd = (
             "aks create --resource-group={resource_group} --name={name} "
             "--node-count 1 --ssh-key-value={ssh_key_value} --generate-ssh-keys "
-            "--kubernetes-version 1.33.0"
         )
         self.cmd(create_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -5632,7 +5596,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
                 "aks nodepool add --resource-group={resource_group} --cluster-name={name} "
                 "--name={nodepool_name} --node-count 1 --localdns-config={config_path} "
                 "--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/LocalDNSPreview "
-                "--kubernetes-version 1.33.0"
             )
 
         # Verify the error message
@@ -5664,7 +5627,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         create_cmd = (
             "aks create --resource-group={resource_group} --name={name} "
             "--node-count 1 --ssh-key-value={ssh_key_value} --generate-ssh-keys "
-            "--kubernetes-version 1.33.0"
         )
         self.cmd(create_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -5674,7 +5636,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
                 "aks nodepool add --resource-group={resource_group} --cluster-name={name} "
                 "--name={nodepool_name} --node-count 1 --localdns-config={config_path} "
                 "--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/LocalDNSPreview "
-                "--kubernetes-version 1.33.0"
             )
         
         # Verify the error message
@@ -5706,7 +5667,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         create_cmd = (
             "aks create --resource-group={resource_group} --name={name} "
             "--node-count 1 --ssh-key-value={ssh_key_value} --generate-ssh-keys "
-            "--kubernetes-version 1.33.0"
         )
         self.cmd(create_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -5714,7 +5674,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         add_cmd = (
             "aks nodepool add --resource-group={resource_group} --cluster-name={name} "
             "--name={nodepool_name} --node-count 1 "
-            "--kubernetes-version 1.33.0"
         )
         self.cmd(add_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -5755,7 +5714,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         create_cmd = (
             "aks create --resource-group={resource_group} --name={name} "
             "--node-count 1 --ssh-key-value={ssh_key_value} --generate-ssh-keys "
-            "--kubernetes-version 1.33.0"
         )
         self.cmd(create_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -5763,7 +5721,6 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         add_cmd = (
             "aks nodepool add --resource-group={resource_group} --cluster-name={name} "
             "--name={nodepool_name} --node-count 1 "
-            "--kubernetes-version 1.33.0"
         )
         self.cmd(add_cmd, checks=[self.check("provisioningState", "Succeeded")])
 
@@ -13612,7 +13569,9 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         aks_name = self.create_random_name("cliakstest", 16)
         kv_name = self.create_random_name("cliakstestkv", 16)
         identity_name = self.create_random_name("cliakstestidentity", 24)
-        k8s_version = self._get_version_in_range(location=resource_group_location, min_version="1.33.0", max_version="1.34.0")
+        k8s_version = self._get_version_at_least(
+            location=resource_group_location, min_version="1.33.0"
+        )
         self.kwargs.update(
             {
                 "resource_group": resource_group,
@@ -13777,7 +13736,9 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         aks_name = self.create_random_name("cliakstest", 16)
         kv_name = self.create_random_name("cliakstestkv", 16)
         identity_name = self.create_random_name("cliakstestidentity", 24)
-        k8s_version = self._get_version_in_range(location=resource_group_location, min_version="1.33.0", max_version="1.34.0")
+        k8s_version = self._get_version_at_least(
+            location=resource_group_location, min_version="1.33.0"
+        )
         self.kwargs.update(
             {
                 "resource_group": resource_group,
@@ -13925,7 +13886,9 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         aks_name = self.create_random_name("cliakstest", 16)
         kv_name = self.create_random_name("cliakstestkv", 16)
         identity_name = self.create_random_name("cliakstestidentity", 24)
-        k8s_version = self._get_version_in_range(location=resource_group_location, min_version="1.33.0", max_version="1.34.0")
+        k8s_version = self._get_version_at_least(
+            location=resource_group_location, min_version="1.33.0"
+        )
         self.kwargs.update(
             {
                 "resource_group": resource_group,
@@ -14093,7 +14056,9 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         aks_name = self.create_random_name("cliakstest", 16)
         kv_name = self.create_random_name("cliakstestkv", 16)
         identity_name = self.create_random_name("cliakstestidentity", 24)
-        k8s_version = self._get_version_in_range(location=resource_group_location, min_version="1.33.0", max_version="1.34.0")
+        k8s_version = self._get_version_at_least(
+            location=resource_group_location, min_version="1.33.0"
+        )
         self.kwargs.update(
             {
                 "resource_group": resource_group,
@@ -14231,7 +14196,9 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         self, resource_group, resource_group_location
     ):
         aks_name = self.create_random_name("cliakstest", 16)
-        k8s_version = self._get_version_in_range(location=resource_group_location, min_version="1.33.0", max_version="1.34.0")
+        k8s_version = self._get_version_at_least(
+            location=resource_group_location, min_version="1.33.0"
+        )
         self.kwargs.update(
             {
                 "resource_group": resource_group,

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -5,6 +5,7 @@
 
 import os
 import pty
+import random
 import semver
 import subprocess
 import tempfile
@@ -42,6 +43,193 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         super(AzureKubernetesServiceScenarioTest, self).__init__(
             method_name, recording_processors=[KeyReplacer()]
         )
+        self._retry_live_without_recording = (
+            self.is_live and
+            os.environ.get("AZURE_CLI_TEST_RETRY_PROVISIONING_CHECK") == "true"
+        )
+        if self._retry_live_without_recording:
+            # Poll/refetch requests make retry-enabled cassettes incompatible
+            # with normal replay, so runner validation must not save them.
+            self.disable_recording = True
+
+    def _save_recording_file(self, *args):
+        if self._retry_live_without_recording:
+            # Preparers temporarily override disable_recording. Mark the
+            # cassette clean before its context exits so none of that traffic
+            # can produce a partial, unreplayable recording.
+            self.cassette.dirty = False
+            if os.path.exists(self.temp_recording_file):
+                os.remove(self.temp_recording_file)
+            return
+        return super()._save_recording_file(*args)
+
+    def cmd(self, command, checks=None, expect_failure=False):
+        if (self.is_live and
+            os.environ.get("AZURE_CLI_TEST_RETRY_PROVISIONING_CHECK") == "true"):
+            if checks is None:
+                normalized_checks = []
+            elif isinstance(checks, (list, tuple)):
+                normalized_checks = checks
+            else:
+                normalized_checks = [checks]
+            return self._cmd_with_retry(command, normalized_checks, expect_failure)
+        return super().cmd(command, checks=checks, expect_failure=expect_failure)
+
+    @staticmethod
+    def _is_provisioning_state_check(check):
+        from azure.cli.testsdk.checkers import JMESPathCheck
+        return (
+            isinstance(check, JMESPathCheck) and
+            check._query == "provisioningState" and
+            check._expected_result == "Succeeded"
+        )
+
+    @staticmethod
+    def _should_retry_for_provisioning_state(result):
+        if not hasattr(result, "get_output_in_json"):
+            return False, None
+        data = result.get_output_in_json()
+        if not isinstance(data, dict) or "id" not in data:
+            return False, None
+        provisioning_state = data.get("provisioningState")
+        if not provisioning_state:
+            return False, None
+        if provisioning_state in {"Failed", "Canceled"}:
+            raise AssertionError(f"provisioningState is {provisioning_state}")
+        if provisioning_state == "Succeeded":
+            return False, None
+        return True, data["id"]
+
+    @staticmethod
+    def _is_transient_operation_conflict(ex):
+        message = str(ex)
+        return (
+            "Another operation is in progress" in message or
+            "Operation is not allowed because there's an in-progress" in message or
+            "in-progress PutExtensionAddonHandler.PUT operation" in message or
+            "is in Updating state, please wait for it to succeed" in message or
+            "ProvisioningState of extension: Updating" in message
+        )
+
+    def _execute_with_transient_conflict_retry(self, command, expect_failure):
+        from azure.cli.testsdk.base import execute
+        import logging
+
+        max_retries = max(1, int(os.environ.get("AZURE_CLI_TEST_OPERATION_MAX_RETRIES", "10")))
+        base_delay = float(os.environ.get("AZURE_CLI_TEST_OPERATION_BASE_DELAY", "5.0"))
+        max_delay = float(os.environ.get("AZURE_CLI_TEST_OPERATION_MAX_DELAY", "60.0"))
+
+        for attempt in range(max_retries):
+            try:
+                return execute(self.cli_ctx, command, expect_failure=expect_failure)
+            except (HttpResponseError, CLIError) as ex:
+                if (
+                    expect_failure or
+                    not self._is_transient_operation_conflict(ex) or
+                    attempt == max_retries - 1
+                ):
+                    raise
+                delay = min(base_delay * (2 ** attempt), max_delay) + random.uniform(0, 1)
+                logging.warning(
+                    "AKS operation is still in progress; retrying command in %.1f seconds (%d/%d)",
+                    delay,
+                    attempt + 1,
+                    max_retries,
+                )
+                time.sleep(delay)
+
+        raise AssertionError("unreachable")
+
+    def _refetch_settled_aks_result(self, resource_id, fallback_result):
+        from azure.cli.testsdk.base import execute
+
+        resource_parts = resource_id.strip("/").split("/")
+        normalized_parts = [part.lower() for part in resource_parts]
+        try:
+            resource_group = resource_parts[normalized_parts.index("resourcegroups") + 1]
+            cluster_index = normalized_parts.index("managedclusters")
+            cluster_name = resource_parts[cluster_index + 1]
+        except (ValueError, IndexError):
+            return fallback_result
+
+        remaining_parts = normalized_parts[cluster_index + 2:]
+        if not remaining_parts:
+            show_command = f"aks show --resource-group {resource_group} --name {cluster_name}"
+        elif len(remaining_parts) == 2 and remaining_parts[0] == "agentpools":
+            try:
+                nodepool_name = resource_parts[normalized_parts.index("agentpools") + 1]
+            except IndexError:
+                return fallback_result
+            show_command = (
+                f"aks nodepool show --resource-group {resource_group} "
+                f"--cluster-name {cluster_name} --name {nodepool_name}"
+            )
+        else:
+            return fallback_result
+
+        return execute(self.cli_ctx, show_command, expect_failure=False)
+
+    def _cmd_with_retry(self, command, checks, expect_failure):
+        from azure.cli.testsdk.base import execute
+        import logging
+
+        command = self._apply_kwargs(command)
+        result = self._execute_with_transient_conflict_retry(command, expect_failure)
+
+        provisioning_checks = [c for c in checks if self._is_provisioning_state_check(c)]
+        other_checks = [c for c in checks if not self._is_provisioning_state_check(c)]
+
+        if provisioning_checks:
+            should_retry, resource_id = self._should_retry_for_provisioning_state(result)
+            if should_retry:
+                initial_data = result.get_output_in_json()
+                initial_etag = initial_data.get("etag")
+                last_seen_etag = initial_etag
+                max_retries = max(1, int(os.environ.get("AZURE_CLI_TEST_PROVISIONING_MAX_RETRIES", "10")))
+                base_delay = float(os.environ.get("AZURE_CLI_TEST_PROVISIONING_BASE_DELAY", "2.0"))
+                max_delay = float(os.environ.get("AZURE_CLI_TEST_PROVISIONING_MAX_DELAY", "60.0"))
+
+                for attempt in range(max_retries):
+                    delay = min(base_delay * (2 ** attempt), max_delay) + random.uniform(0, 1)
+                    time.sleep(delay)
+                    poll_result = execute(
+                        self.cli_ctx,
+                        f"resource show --ids {resource_id}",
+                        expect_failure=False,
+                    )
+                    poll_data = poll_result.get_output_in_json()
+                    poll_properties = poll_data.get("properties") or {}
+                    current_provisioning_state = (
+                        poll_data.get("provisioningState") or
+                        poll_properties.get("provisioningState")
+                    )
+                    current_etag = poll_data.get("etag")
+
+                    if current_etag and last_seen_etag and current_etag != last_seen_etag:
+                        logging.warning("ETag changed during polling (external modification detected)")
+                    last_seen_etag = current_etag
+
+                    if current_provisioning_state == "Succeeded":
+                        result = self._refetch_settled_aks_result(resource_id, result)
+                        break
+                    if current_provisioning_state in {"Failed", "Canceled"}:
+                        raise AssertionError(
+                            f"provisioningState reached terminal failure: {current_provisioning_state}"
+                        )
+                else:
+                    final_etag_msg = ""
+                    if initial_etag and last_seen_etag:
+                        final_etag_msg = f" (initial etag: {initial_etag}, final: {last_seen_etag})"
+                    raise TimeoutError(
+                        f"provisioningState did not reach 'Succeeded' after {max_retries} retries. "
+                        f"Final state: {current_provisioning_state}{final_etag_msg}"
+                    )
+            result.assert_with_checks(provisioning_checks)
+
+        if other_checks:
+            result.assert_with_checks(other_checks)
+
+        return result
 
     def _create_log_analytics_workspace(self, resource_group_location):
         workspace_name = self.create_random_name("clilaw", 16)

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_diagnostics.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_diagnostics.py
@@ -4,6 +4,8 @@
 # --------------------------------------------------------------------------------------------
 
 import unittest
+from types import SimpleNamespace
+
 import azext_aks_preview.aks_diagnostics as commands
 
 
@@ -25,6 +27,18 @@ class TestGenerateContainerName(unittest.TestCase):
         expected_container_name = 'abcdef-dns-ed55ba6d-e48fe2bd-b4bc-4aac-bc23-29bc44154fe1-privat'
         trim_container_name = commands._generate_container_name(None, private_fqdn)
         self.assertEqual(expected_container_name, trim_container_name)
+
+
+class TestGetStorageAccountKey(unittest.TestCase):
+    def test_mapping_sdk_model(self):
+        response = {"keys": [{"value": "mapping-key"}]}
+
+        self.assertEqual("mapping-key", commands._get_storage_account_key(response))
+
+    def test_attribute_sdk_model(self):
+        response = SimpleNamespace(keys=[SimpleNamespace(value="attribute-key")])
+
+        self.assertEqual("attribute-key", commands._get_storage_account_key(response))
 
 
 if __name__ == "__main__":

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_provisioning_retry.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_provisioning_retry.py
@@ -1,0 +1,263 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+from azure.cli.testsdk.checkers import JMESPathCheck
+from knack.util import CLIError
+
+
+class MockExecutionResult:
+    def __init__(self, output_json):
+        self._json = output_json
+        self.output = json.dumps(output_json)
+        self.json_value = None
+
+    def get_output_in_json(self):
+        return self._json
+
+    def assert_with_checks(self, *args):
+        checks = []
+        for each in args:
+            if isinstance(each, list):
+                checks.extend(each)
+            elif callable(each):
+                checks.append(each)
+        for check in checks:
+            check(self)
+        return self
+
+
+class AKSRetryTestCase(unittest.TestCase):
+    def _make_instance(self):
+        from azext_aks_preview.tests.latest.test_aks_commands import (
+            AzureKubernetesServiceScenarioTest,
+        )
+        instance = object.__new__(AzureKubernetesServiceScenarioTest)
+        instance.kwargs = {}
+        instance._apply_kwargs = lambda command: command
+        instance.cli_ctx = MagicMock()
+        return instance
+
+    @staticmethod
+    def _result(data):
+        return MockExecutionResult(data)
+
+
+class TestCmdRetryDispatch(AKSRetryTestCase):
+    @patch.dict(os.environ, {
+        "AZURE_TEST_RUN_LIVE": "true",
+        "AZURE_CLI_TEST_RETRY_PROVISIONING_CHECK": "true",
+    })
+    def test_retry_enabled_live_instance_disables_recording(self):
+        from azext_aks_preview.tests.latest.test_aks_commands import (
+            AzureKubernetesServiceScenarioTest,
+        )
+
+        instance = AzureKubernetesServiceScenarioTest(
+            "test_aks_addon_list_available"
+        )
+
+        self.assertTrue(instance.disable_recording)
+
+    @patch.dict(os.environ, {
+        "AZURE_TEST_RUN_LIVE": "true",
+        "AZURE_CLI_TEST_RETRY_PROVISIONING_CHECK": "true",
+    })
+    def test_retry_enabled_live_instance_never_saves_cassette(self):
+        from azext_aks_preview.tests.latest.test_aks_commands import (
+            AzureKubernetesServiceScenarioTest,
+        )
+        instance = AzureKubernetesServiceScenarioTest(
+            "test_aks_addon_list_available"
+        )
+        instance.cassette = MagicMock()
+        instance.cassette.dirty = True
+        fd, temp_recording_file = tempfile.mkstemp()
+        os.close(fd)
+        instance.temp_recording_file = temp_recording_file
+
+        instance._save_recording_file()
+
+        self.assertFalse(instance.cassette.dirty)
+        self.assertFalse(os.path.exists(temp_recording_file))
+
+    @patch.dict(os.environ, {"AZURE_CLI_TEST_RETRY_PROVISIONING_CHECK": "true"})
+    def test_live_command_without_checks_uses_retry_path(self):
+        instance = self._make_instance()
+        instance.is_live = True
+        instance._cmd_with_retry = MagicMock()
+
+        instance.cmd("aks delete", checks=None, expect_failure=False)
+
+        instance._cmd_with_retry.assert_called_once_with("aks delete", [], False)
+
+
+class TestProvisioningStateRetry(AKSRetryTestCase):
+    @patch.dict(os.environ, {
+        "AZURE_CLI_TEST_PROVISIONING_MAX_RETRIES": "2",
+        "AZURE_CLI_TEST_PROVISIONING_BASE_DELAY": "0.01",
+    })
+    @patch("time.sleep", return_value=None)
+    @patch("random.uniform", return_value=0)
+    @patch("azure.cli.testsdk.base.execute")
+    def test_polls_nested_arm_state_then_refetches_native_result(
+        self, mock_execute, _mock_random, _mock_sleep
+    ):
+        resource_id = (
+            "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.ContainerService/"
+            "managedClusters/cluster"
+        )
+        initial_result = self._result({
+            "id": resource_id,
+            "provisioningState": "Updating",
+        })
+        settled_result = self._result({
+            "id": resource_id,
+            "provisioningState": "Succeeded",
+            "feature": {"enabled": True},
+        })
+        mock_execute.side_effect = [
+            initial_result,
+            self._result({"properties": {"provisioningState": "Updating"}}),
+            self._result({"properties": {"provisioningState": "Succeeded"}}),
+        ]
+        instance = self._make_instance()
+        instance._refetch_settled_aks_result = MagicMock(return_value=settled_result)
+
+        result = instance._cmd_with_retry(
+            "aks update",
+            [
+                JMESPathCheck("provisioningState", "Succeeded"),
+                JMESPathCheck("feature.enabled", True),
+            ],
+            False,
+        )
+
+        self.assertIs(result, settled_result)
+        instance._refetch_settled_aks_result.assert_called_once_with(
+            resource_id, initial_result
+        )
+
+    @patch.dict(os.environ, {
+        "AZURE_CLI_TEST_PROVISIONING_MAX_RETRIES": "2",
+        "AZURE_CLI_TEST_PROVISIONING_BASE_DELAY": "0.01",
+    })
+    @patch("time.sleep", return_value=None)
+    @patch("random.uniform", return_value=0)
+    @patch("azure.cli.testsdk.base.execute")
+    def test_times_out_when_state_never_settles(
+        self, mock_execute, _mock_random, _mock_sleep
+    ):
+        poll = self._result({"properties": {"provisioningState": "Updating"}})
+        mock_execute.side_effect = [
+            self._result({
+                "id": "/subscriptions/sub/resourceGroups/rg/providers/"
+                      "Microsoft.ContainerService/managedClusters/cluster",
+                "provisioningState": "Updating",
+            }),
+            poll,
+            poll,
+        ]
+
+        with self.assertRaises(TimeoutError):
+            self._make_instance()._cmd_with_retry(
+                "aks update",
+                [JMESPathCheck("provisioningState", "Succeeded")],
+                False,
+            )
+
+
+class TestTransientConflictRetry(AKSRetryTestCase):
+    @patch.dict(os.environ, {
+        "AZURE_CLI_TEST_OPERATION_MAX_RETRIES": "2",
+        "AZURE_CLI_TEST_OPERATION_BASE_DELAY": "0.01",
+    })
+    @patch("time.sleep", return_value=None)
+    @patch("random.uniform", return_value=0)
+    @patch("azure.cli.testsdk.base.execute")
+    def test_retries_only_known_transient_conflicts(
+        self, mock_execute, _mock_random, mock_sleep
+    ):
+        messages = [
+            "Operation is not allowed: Another operation is in progress.",
+            "Operation is not allowed because there's an in-progress update managed cluster operation",
+            "Operation is not allowed: in-progress PutExtensionAddonHandler.PUT operation",
+            "The managed cluster test is in Updating state, please wait for it to succeed.",
+            "ProvisioningState of extension: Updating",
+        ]
+        for message in messages:
+            with self.subTest(message=message):
+                expected = self._result({"provisioningState": "Succeeded"})
+                mock_execute.reset_mock()
+                mock_sleep.reset_mock()
+                mock_execute.side_effect = [CLIError(message), expected]
+
+                result = self._make_instance()._execute_with_transient_conflict_retry(
+                    "aks update", False
+                )
+
+                self.assertIs(result, expected)
+                self.assertEqual(mock_execute.call_count, 2)
+                mock_sleep.assert_called_once()
+
+    @patch.dict(os.environ, {"AZURE_CLI_TEST_OPERATION_MAX_RETRIES": "2"})
+    @patch("time.sleep", return_value=None)
+    @patch("azure.cli.testsdk.base.execute")
+    def test_does_not_retry_other_errors(self, mock_execute, mock_sleep):
+        mock_execute.side_effect = CLIError("Invalid parameter")
+
+        with self.assertRaisesRegex(CLIError, "Invalid parameter"):
+            self._make_instance()._execute_with_transient_conflict_retry(
+                "aks update", False
+            )
+
+        mock_execute.assert_called_once()
+        mock_sleep.assert_not_called()
+
+    @patch.dict(os.environ, {"AZURE_CLI_TEST_OPERATION_MAX_RETRIES": "2"})
+    @patch("time.sleep", return_value=None)
+    @patch("azure.cli.testsdk.base.execute")
+    def test_does_not_retry_expected_failure(self, mock_execute, mock_sleep):
+        mock_execute.side_effect = CLIError(
+            "Operation is not allowed: Another operation is in progress."
+        )
+
+        with self.assertRaises(CLIError):
+            self._make_instance()._execute_with_transient_conflict_retry(
+                "aks update", True
+            )
+
+        mock_execute.assert_called_once()
+        mock_sleep.assert_not_called()
+
+
+class TestRefetchSettledResult(AKSRetryTestCase):
+    @patch("azure.cli.testsdk.base.execute")
+    def test_refetches_agentpool_with_native_show(self, mock_execute):
+        expected = self._result({"provisioningState": "Succeeded"})
+        mock_execute.return_value = expected
+        resource_id = (
+            "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.ContainerService/"
+            "managedClusters/cluster/agentPools/pool"
+        )
+        instance = self._make_instance()
+
+        result = instance._refetch_settled_aks_result(resource_id, MagicMock())
+
+        self.assertIs(result, expected)
+        mock_execute.assert_called_once_with(
+            instance.cli_ctx,
+            "aks nodepool show --resource-group rg --cluster-name cluster --name pool",
+            expect_failure=False,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_provisioning_retry.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_provisioning_retry.py
@@ -7,7 +7,7 @@ import json
 import os
 import tempfile
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, PropertyMock
 
 from azure.cli.testsdk.checkers import JMESPathCheck
 from knack.util import CLIError
@@ -51,11 +51,15 @@ class AKSRetryTestCase(unittest.TestCase):
 
 
 class TestCmdRetryDispatch(AKSRetryTestCase):
-    @patch.dict(os.environ, {
-        "AZURE_TEST_RUN_LIVE": "true",
+    @patch.dict("os.environ", {
         "AZURE_CLI_TEST_RETRY_PROVISIONING_CHECK": "true",
     })
-    def test_retry_enabled_live_instance_disables_recording(self):
+    @patch(
+        "azure.cli.testsdk.scenario_tests.config.TestConfig.record_mode",
+        new_callable=PropertyMock,
+        return_value=True,
+    )
+    def test_retry_enabled_live_instance_disables_recording(self, _record_mode):
         from azext_aks_preview.tests.latest.test_aks_commands import (
             AzureKubernetesServiceScenarioTest,
         )
@@ -66,11 +70,15 @@ class TestCmdRetryDispatch(AKSRetryTestCase):
 
         self.assertTrue(instance.disable_recording)
 
-    @patch.dict(os.environ, {
-        "AZURE_TEST_RUN_LIVE": "true",
+    @patch.dict("os.environ", {
         "AZURE_CLI_TEST_RETRY_PROVISIONING_CHECK": "true",
     })
-    def test_retry_enabled_live_instance_never_saves_cassette(self):
+    @patch(
+        "azure.cli.testsdk.scenario_tests.config.TestConfig.record_mode",
+        new_callable=PropertyMock,
+        return_value=True,
+    )
+    def test_retry_enabled_live_instance_never_saves_cassette(self, _record_mode):
         from azext_aks_preview.tests.latest.test_aks_commands import (
             AzureKubernetesServiceScenarioTest,
         )
@@ -88,7 +96,7 @@ class TestCmdRetryDispatch(AKSRetryTestCase):
         self.assertFalse(instance.cassette.dirty)
         self.assertFalse(os.path.exists(temp_recording_file))
 
-    @patch.dict(os.environ, {"AZURE_CLI_TEST_RETRY_PROVISIONING_CHECK": "true"})
+    @patch.dict("os.environ", {"AZURE_CLI_TEST_RETRY_PROVISIONING_CHECK": "true"})
     def test_live_command_without_checks_uses_retry_path(self):
         instance = self._make_instance()
         instance.is_live = True
@@ -100,7 +108,7 @@ class TestCmdRetryDispatch(AKSRetryTestCase):
 
 
 class TestProvisioningStateRetry(AKSRetryTestCase):
-    @patch.dict(os.environ, {
+    @patch.dict("os.environ", {
         "AZURE_CLI_TEST_PROVISIONING_MAX_RETRIES": "2",
         "AZURE_CLI_TEST_PROVISIONING_BASE_DELAY": "0.01",
     })
@@ -145,7 +153,7 @@ class TestProvisioningStateRetry(AKSRetryTestCase):
             resource_id, initial_result
         )
 
-    @patch.dict(os.environ, {
+    @patch.dict("os.environ", {
         "AZURE_CLI_TEST_PROVISIONING_MAX_RETRIES": "2",
         "AZURE_CLI_TEST_PROVISIONING_BASE_DELAY": "0.01",
     })
@@ -175,7 +183,7 @@ class TestProvisioningStateRetry(AKSRetryTestCase):
 
 
 class TestTransientConflictRetry(AKSRetryTestCase):
-    @patch.dict(os.environ, {
+    @patch.dict("os.environ", {
         "AZURE_CLI_TEST_OPERATION_MAX_RETRIES": "2",
         "AZURE_CLI_TEST_OPERATION_BASE_DELAY": "0.01",
     })
@@ -207,7 +215,7 @@ class TestTransientConflictRetry(AKSRetryTestCase):
                 self.assertEqual(mock_execute.call_count, 2)
                 mock_sleep.assert_called_once()
 
-    @patch.dict(os.environ, {"AZURE_CLI_TEST_OPERATION_MAX_RETRIES": "2"})
+    @patch.dict("os.environ", {"AZURE_CLI_TEST_OPERATION_MAX_RETRIES": "2"})
     @patch("time.sleep", return_value=None)
     @patch("azure.cli.testsdk.base.execute")
     def test_does_not_retry_other_errors(self, mock_execute, mock_sleep):
@@ -221,7 +229,7 @@ class TestTransientConflictRetry(AKSRetryTestCase):
         mock_execute.assert_called_once()
         mock_sleep.assert_not_called()
 
-    @patch.dict(os.environ, {"AZURE_CLI_TEST_OPERATION_MAX_RETRIES": "2"})
+    @patch.dict("os.environ", {"AZURE_CLI_TEST_OPERATION_MAX_RETRIES": "2"})
     @patch("time.sleep", return_value=None)
     @patch("azure.cli.testsdk.base.execute")
     def test_does_not_retry_expected_failure(self, mock_execute, mock_sleep):

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_helpers.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_helpers.py
@@ -79,6 +79,9 @@ class TestValidateFlexNodesOptions(unittest.TestCase):
 
 
 class TestResetAgentPoolToNameAndMode(unittest.TestCase):
+    class HybridAgentPool(dict):
+        pass
+
     def test_resets_attribute_style_model(self):
         agentpool = SimpleNamespace(
             name="pool1",
@@ -129,6 +132,58 @@ class TestResetAgentPoolToNameAndMode(unittest.TestCase):
             },
         )
         self.assertIs(result["properties"], properties)
+
+    def test_resets_hybrid_mapping_and_attribute_model(self):
+        agentpool = self.HybridAgentPool(
+            name="pool1",
+            mode="ManagedSystem",
+            type="VirtualMachineScaleSets",
+        )
+        agentpool.name = "pool1"
+        agentpool.mode = "ManagedSystem"
+        agentpool.type_properties_type = "VirtualMachineScaleSets"
+
+        result = reset_agentpool_to_name_and_mode(agentpool, "ManagedSystem")
+
+        self.assertIs(result, agentpool)
+        self.assertEqual(
+            result,
+            {"name": "pool1", "mode": "ManagedSystem"},
+        )
+        self.assertEqual(result.name, "pool1")
+        self.assertEqual(result.mode, "ManagedSystem")
+        self.assertIsNone(result.type_properties_type)
+
+    def test_resets_hybrid_nested_properties(self):
+        properties = self.HybridAgentPool(
+            mode="System",
+            count=3,
+        )
+        properties.mode = "System"
+        properties.count = 3
+        agentpool = self.HybridAgentPool(
+            name="pool1",
+            location="eastus",
+            properties=properties,
+        )
+        agentpool.name = "pool1"
+        agentpool.location = "eastus"
+        agentpool.properties = properties
+
+        result = reset_agentpool_to_name_and_mode(agentpool, "ManagedSystem")
+
+        self.assertIs(result, agentpool)
+        self.assertEqual(
+            result,
+            {
+                "name": "pool1",
+                "properties": {"mode": "ManagedSystem"},
+            },
+        )
+        self.assertIs(result.properties, properties)
+        self.assertEqual(result.properties.mode, "ManagedSystem")
+        self.assertIsNone(result.properties.count)
+        self.assertIsNone(result.location)
 
     def test_resets_attribute_model_with_mapping_properties(self):
         properties = {

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_helpers.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_helpers.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import unittest
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 from azext_aks_preview._helpers import (
@@ -16,6 +17,7 @@ from azext_aks_preview._helpers import (
     get_nodepool_snapshot_by_snapshot_id,
     process_message_for_run_command,
     filter_hard_taints,
+    reset_agentpool_to_name_and_mode,
     validate_flexnodes_options,
 )
 from azext_aks_preview.__init__ import register_aks_preview_resource_type
@@ -74,6 +76,78 @@ class TestValidateFlexNodesOptions(unittest.TestCase):
         self.assertNotIn("--resource-group", str(err.exception))
         self.assertNotIn("--machine-name", str(err.exception))
         self.assertNotIn("--no-wait", str(err.exception))
+
+
+class TestResetAgentPoolToNameAndMode(unittest.TestCase):
+    def test_resets_attribute_style_model(self):
+        agentpool = SimpleNamespace(
+            name="pool1",
+            mode="System",
+            count=3,
+            vm_size="Standard_D2s_v3",
+        )
+
+        result = reset_agentpool_to_name_and_mode(agentpool, "ManagedSystem")
+
+        self.assertIs(result, agentpool)
+        self.assertEqual(result.name, "pool1")
+        self.assertEqual(result.mode, "ManagedSystem")
+        self.assertIsNone(result.count)
+        self.assertIsNone(result.vm_size)
+
+    def test_resets_flat_mapping_model(self):
+        agentpool = {
+            "name": "pool1",
+            "mode": "System",
+            "count": 3,
+        }
+
+        result = reset_agentpool_to_name_and_mode(agentpool, "Machines")
+
+        self.assertIs(result, agentpool)
+        self.assertEqual(result, {"name": "pool1", "mode": "Machines"})
+
+    def test_resets_mapping_model_with_properties(self):
+        properties = {
+            "mode": "System",
+            "count": 3,
+        }
+        agentpool = {
+            "name": "pool1",
+            "location": "eastus",
+            "properties": properties,
+        }
+
+        result = reset_agentpool_to_name_and_mode(agentpool, "ManagedSystem")
+
+        self.assertIs(result, agentpool)
+        self.assertEqual(
+            result,
+            {
+                "name": "pool1",
+                "properties": {"mode": "ManagedSystem"},
+            },
+        )
+        self.assertIs(result["properties"], properties)
+
+    def test_resets_attribute_model_with_mapping_properties(self):
+        properties = {
+            "mode": "System",
+            "count": 3,
+        }
+        agentpool = SimpleNamespace(
+            name="pool1",
+            location="eastus",
+            properties=properties,
+        )
+
+        result = reset_agentpool_to_name_and_mode(agentpool, "ManagedSystem")
+
+        self.assertIs(result, agentpool)
+        self.assertEqual(result.name, "pool1")
+        self.assertEqual(result.properties, {"mode": "ManagedSystem"})
+        self.assertIs(result.properties, properties)
+        self.assertIsNone(result.location)
 
 
 class GetNodepoolSnapShotTestCase(unittest.TestCase):

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_loadbalancer.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_loadbalancer.py
@@ -121,6 +121,30 @@ class TestLoadBalancer(unittest.TestCase):
         self.assertEqual(result.managed_outbound_i_ps.count, 1)
         self.assertEqual(result.managed_outbound_i_ps.count_ipv6, 2)
 
+    def test_configure_ipv6_count_preserves_existing_zero_ipv4_count(self):
+        profile = self.load_balancer_models.ManagedClusterLoadBalancerProfile()
+        profile.managed_outbound_i_ps = (
+            self.load_balancer_models.ManagedClusterLoadBalancerProfileManagedOutboundIPs(
+                count=0
+            )
+        )
+
+        result = loadbalancer.configure_load_balancer_profile(
+            None,
+            2,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            profile,
+            self.load_balancer_models,
+        )
+
+        self.assertEqual(result.managed_outbound_i_ps.count, 0)
+        self.assertEqual(result.managed_outbound_i_ps.count_ipv6, 2)
+
     def test_configure_load_balancer_profile_error(self):
         managed_outbound_ip_count = 5
         managed_outbound_ipv6_count = 3

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_loadbalancer.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_loadbalancer.py
@@ -102,6 +102,25 @@ class TestLoadBalancer(unittest.TestCase):
         self.assertEqual(p.idle_timeout_in_minutes, 3600)
         self.assertEqual(p.backend_pool_type, "nodeIP")
 
+    def test_configure_ipv6_count_defaults_ipv4_count(self):
+        profile = self.load_balancer_models.ManagedClusterLoadBalancerProfile()
+
+        result = loadbalancer.configure_load_balancer_profile(
+            None,
+            2,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            profile,
+            self.load_balancer_models,
+        )
+
+        self.assertEqual(result.managed_outbound_i_ps.count, 1)
+        self.assertEqual(result.managed_outbound_i_ps.count_i_pv6, 2)
+
     def test_configure_load_balancer_profile_error(self):
         managed_outbound_ip_count = 5
         managed_outbound_ipv6_count = 3

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_loadbalancer.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_loadbalancer.py
@@ -119,7 +119,7 @@ class TestLoadBalancer(unittest.TestCase):
         )
 
         self.assertEqual(result.managed_outbound_i_ps.count, 1)
-        self.assertEqual(result.managed_outbound_i_ps.count_i_pv6, 2)
+        self.assertEqual(result.managed_outbound_i_ps.count_ipv6, 2)
 
     def test_configure_load_balancer_profile_error(self):
         managed_outbound_ip_count = 5


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes |
| :--: |
| ️✔️ None |

<!-- act-bot:section title="Azure CLI Extensions Breaking Change Test" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command

`az aks`

### Description

Stabilize `aks-preview` live tests after the Azure CLI and CLI Runner fixes have landed.

#### Extension-specific retry handling

Port the bounded AKS live-test retry adapter into the `aks-preview` scenario base:

- retry only known transient AKS operation conflicts;
- poll non-terminal responses, including generic ARM `properties.provisioningState`;
- refetch settled clusters and agent pools through native AKS show commands before assertions;
- never retry expected-failure tests or unrelated errors;
- enable only for live runs with `AZURE_CLI_TEST_RETRY_PROVISIONING_CHECK=true`;
- prevent retry-enabled runs from writing partial/unreplayable cassettes.

The Azure CLI core retry fix does not automatically cover this extension because the extension scenario class derives directly from `ScenarioTest`, not the core AKS scenario class. The merged CLI Runner switch now activates this adapter for extension runs.

#### Deterministic fixes

- select community-supported Kubernetes versions instead of hard-coded versions that moved to LTS-only;
- preserve an IPv4 managed outbound count for dual-stack profiles;
- handle mapping-based SDK models in ManagedSystem, Machines, and Kollect flows;
- update related tests for current SDK model names.

The previous broad live-matrix reduction has been removed. The runner now permits 12 hours, uses 10 workers, and the prior untrimmed extension run completed in 7h49m, so retaining full live coverage is preferable.

### Testing

```bash
VIRTUAL_ENV=/workspace/aenv /workspace/aenv/bin/azdev test aks-preview --no-exitfirst
```

Result: `1174 passed, 117 skipped, 11 subtests passed`.

Also passed:

- `VIRTUAL_ENV=/workspace/aenv /workspace/aenv/bin/azdev style aks-preview`
- `python scripts/ci/test_index.py -q` (`9 passed, 2 skipped`)
- `git diff --check`
- final focused code review

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install azdev` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).

### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`.


### Live validation

Subscription: `79a7390d-3a85-432d-9f6f-a11a703c8b83` (AKS CLI PR Gate).

```bash
AZURE_CLI_TEST_RETRY_PROVISIONING_CHECK=true azdev test --live --series \
  azext_aks_preview.test_aks_nodepool_update_with_localdns_config
```

Result: `1 passed in 625.97s (0:10:25)`.

A ManagedSystem scenario was also attempted, but the service rejected it because this subscription is not whitelisted for the ManagedSystem preview. The test resource group entered deletion normally.
