### PR TITLE
Quantum Add 'az quantum suite-offers target list' to list provider-account targets and status

### DIFF
--- a/src/quantum/HISTORY.rst
+++ b/src/quantum/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+1.0.0b21
++++++++++++++++
+* Added the ``az quantum suite-offers target list`` command to list targets and their status from a suite offer, without requiring a workspace.
+
 1.0.0b20
 +++++++++++++++
 * Added the ``az quantum workspace user create`` and ``az quantum workspace user delete`` commands to manage user access to an Azure Quantum workspace.

--- a/src/quantum/azext_quantum/_client_factory.py
+++ b/src/quantum/azext_quantum/_client_factory.py
@@ -6,11 +6,12 @@
 # pylint: disable=line-too-long,protected-access
 
 import os
+from azure.core.rest import HttpRequest
 from ._location_helper import normalize_location
 from .__init__ import CLI_REPORTED_VERSION
 from .vendored_sdks.azure_quantum_python._client import WorkspaceClient
 from .vendored_sdks.azure_mgmt_quantum import AzureQuantumMgmtClient
-from .vendored_sdks.azure_mgmt_quantum.operations import WorkspacesOperations, OfferingsOperations
+from .vendored_sdks.azure_mgmt_quantum.operations import WorkspacesOperations, OfferingsOperations, SuiteOffersOperations
 
 
 def is_env(name):
@@ -26,6 +27,16 @@ def base_url(location):
     if is_env('dogfood'):
         return f"https://{normalized_location}.quantum-test.azure.com/"
     return f"https://{normalized_location}.quantum.azure.com/"
+
+
+def base_url_v2(location):
+    # Suite offers are a V2 concept whose data plane is served from a
+    # '-v2'-suffixed regional host (for example, 'westus-v2.quantum.azure.com'). An explicit
+    # AZURE_QUANTUM_BASEURL override is honored verbatim.
+    url = base_url(location)
+    if 'AZURE_QUANTUM_BASEURL' in os.environ:
+        return url
+    return url.replace('.quantum', '-v2.quantum', 1)
 
 
 def _get_data_credentials(cli_ctx, subscription_id=None):
@@ -57,6 +68,10 @@ def cf_offerings(cli_ctx, *_) -> OfferingsOperations:
     return cf_quantum_mgmt(cli_ctx).offerings
 
 
+def cf_suite_offers(cli_ctx, *_) -> SuiteOffersOperations:
+    return cf_quantum_mgmt(cli_ctx).suite_offers
+
+
 # Data Plane clients
 
 def cf_quantum(cli_ctx, subscription: str, resource_group: str, ws_name: str, endpoint: str | None) -> WorkspaceClient:
@@ -79,6 +94,23 @@ def cf_jobs(cli_ctx, subscription: str, resource_group: str, ws_name: str, endpo
 
 def cf_quotas(cli_ctx, subscription: str, resource_group: str, ws_name: str, endpoint: str | None):
     return cf_quantum(cli_ctx, subscription, resource_group, ws_name, endpoint).services.quotas
+
+
+def cf_suite_offer_status(cli_ctx, subscription: str, location: str, provider_id: str):
+    """
+    Fetch the suite offer status from the regional data plane, using the
+    generated WorkspaceClient's authenticated pipeline via a custom request.
+    """
+    creds = _get_data_credentials(cli_ctx, subscription)
+    client = WorkspaceClient(base_url_v2(location), creds)
+    request = HttpRequest(
+        method="GET",
+        url=f"/subscriptions/{subscription}/providers/Microsoft.Quantum/suiteoffers/{provider_id}/providerStatus",
+        params={"api-version": client._config.api_version},
+    )
+    response = client.send_request(request)
+    response.raise_for_status()
+    return response.json()
 
 
 # Helper clients

--- a/src/quantum/azext_quantum/_help.py
+++ b/src/quantum/azext_quantum/_help.py
@@ -224,6 +224,25 @@ helps['quantum target list'] = """
             az quantum target list -g MyResourceGroup -w MyWorkspace
 """
 
+helps['quantum suite-offers'] = """
+    type: group
+    short-summary: Manage suite offers in Azure Quantum.
+"""
+
+helps['quantum suite-offers target'] = """
+    type: group
+    short-summary: Manage targets available through an Azure Quantum suite offer.
+"""
+
+helps['quantum suite-offers target list'] = """
+    type: command
+    short-summary: Get the list of targets and their status available through a suite offer, without requiring a workspace.
+    examples:
+      - name: Get the list of targets available in a suite offer
+        text: |-
+            az quantum suite-offers target list -p MyProviderId
+"""
+
 helps['quantum target set'] = """
     type: command
     short-summary: Select the default target to use when submitting jobs to Azure Quantum.

--- a/src/quantum/azext_quantum/_params.py
+++ b/src/quantum/azext_quantum/_params.py
@@ -96,6 +96,9 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals
         c.argument('workspace_name', workspace_name_type)
         c.argument('target_id', target_id_type)
 
+    with self.argument_context('quantum suite-offers target list') as c:
+        c.argument('provider_id', provider_id_type, required=True)
+
     with self.argument_context('quantum target show') as c:
         c.argument('workspace_name', workspace_name_type)
         c.argument('target_id', target_id_type, required=False)

--- a/src/quantum/azext_quantum/commands.py
+++ b/src/quantum/azext_quantum/commands.py
@@ -123,6 +123,7 @@ def load_command_table(self, _):
     job_ops = CliCommandType(operations_tmpl='azext_quantum.operations.job#{}')
     target_ops = CliCommandType(operations_tmpl='azext_quantum.operations.target#{}')
     offerings_ops = CliCommandType(operations_tmpl='azext_quantum.operations.offerings#{}')
+    suiteoffers_ops = CliCommandType(operations_tmpl='azext_quantum.operations.suiteoffers#{}')
 
     with self.command_group('quantum workspace', workspace_ops) as w:
         w.command('create', 'create')
@@ -163,3 +164,6 @@ def load_command_table(self, _):
         o.command('list', 'list_offerings', table_transformer=transform_offerings)
         o.command('accept-terms', 'accept_terms', validator=validate_provider_and_sku_info)
         o.command('show-terms', 'show_terms', validator=validate_provider_and_sku_info)
+
+    with self.command_group('quantum suite-offers target', suiteoffers_ops) as s:
+        s.command('list', 'list_targets', table_transformer=transform_targets)

--- a/src/quantum/azext_quantum/operations/suiteoffers.py
+++ b/src/quantum/azext_quantum/operations/suiteoffers.py
@@ -1,0 +1,38 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+# pylint: disable=line-too-long
+
+from azure.cli.core.azclierror import InvalidArgumentValueError
+from .._client_factory import cf_suite_offers, cf_suite_offer_status
+
+
+def list_targets(cmd, provider_id):
+    """
+    Get the list of targets and their status available through a suite offer,
+    without requiring an Azure Quantum workspace.
+    """
+    from azure.cli.core.commands.client_factory import get_subscription_id
+
+    subscription = get_subscription_id(cmd.cli_ctx)
+    location = _get_suite_offer_location(cmd, provider_id)
+
+    status = cf_suite_offer_status(cmd.cli_ctx, subscription, location, provider_id)
+
+    # Suite offers that failed provisioning are omitted by the data-plane listing, so no
+    # additional filtering is required here. Normalize the response into a list of providers.
+    if isinstance(status, dict):
+        return status.get('value', [status])
+    return status
+
+
+def _get_suite_offer_location(cmd, provider_id):
+    """
+    Resolve the region for a suite offer from its subscription-level listing.
+    """
+    for offer in cf_suite_offers(cmd.cli_ctx).list_by_subscription():
+        if offer.properties.provider_id.lower() == provider_id.lower():
+            return offer.properties.location
+    raise InvalidArgumentValueError(f"Suite offer '{provider_id}' not found in the current subscription.")

--- a/src/quantum/azext_quantum/tests/latest/test_quantum_targets.py
+++ b/src/quantum/azext_quantum/tests/latest/test_quantum_targets.py
@@ -75,3 +75,63 @@ class QuantumTargetsScenarioTest(ScenarioTest):
         assert test_returned_provider == test_expected_provider
 
         self.cmd(f'az quantum workspace delete -g {test_resource_group} -w {test_workspace_temp}')
+
+
+class QuantumSuiteOffersTargetListTest(unittest.TestCase):
+    """Unit tests (no Azure required) for the suite offer target listing support."""
+
+    def test_transform_targets_suite_offer_shape(self):
+        from ...commands import transform_targets
+
+        # Data-plane suite offer status uses the same shape as the workspace providers list.
+        providers = [
+            {
+                'id': 'atom-boulder',
+                'currentAvailability': 'Available',
+                'targets': [
+                    {'id': 'atom.qpu', 'currentAvailability': 'Available', 'averageQueueTime': 42}
+                ]
+            }
+        ]
+        rows = transform_targets(providers)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]['Provider'], 'atom-boulder')
+        self.assertEqual(rows[0]['Target-id'], 'atom.qpu')
+        self.assertEqual(rows[0]['Current Availability'], 'Available')
+        self.assertEqual(rows[0]['Average Queue Time (seconds)'], 42)
+
+    def test_list_targets_normalizes_value_wrapper(self):
+        from unittest import mock
+        from ...operations import suiteoffers
+
+        status = {'value': [{'id': 'atom-boulder', 'currentAvailability': 'Available', 'targets': []}]}
+        with mock.patch.object(suiteoffers, 'cf_suite_offer_status', return_value=status), \
+                mock.patch.object(suiteoffers, '_get_suite_offer_location', return_value='westus'), \
+                mock.patch('azure.cli.core.commands.client_factory.get_subscription_id', return_value='sub'):
+            result = suiteoffers.list_targets(self._fake_cmd(), provider_id='atom-boulder')
+        self.assertEqual(result, status['value'])
+
+    def test_list_targets_wraps_single_object(self):
+        from unittest import mock
+        from ...operations import suiteoffers
+
+        status = {'id': 'atom-boulder', 'currentAvailability': 'Available', 'targets': []}
+        with mock.patch.object(suiteoffers, 'cf_suite_offer_status', return_value=status), \
+                mock.patch.object(suiteoffers, '_get_suite_offer_location', return_value='westus'), \
+                mock.patch('azure.cli.core.commands.client_factory.get_subscription_id', return_value='sub'):
+            result = suiteoffers.list_targets(self._fake_cmd(), provider_id='atom-boulder')
+        self.assertEqual(result, [status])
+
+    @staticmethod
+    def _fake_cmd():
+        class _Ctx:
+            pass
+
+        class _Cmd:
+            cli_ctx = _Ctx()
+
+        return _Cmd()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/quantum/setup.py
+++ b/src/quantum/setup.py
@@ -17,7 +17,7 @@ except ImportError:
 # This version should match the latest entry in HISTORY.rst
 # Also, when updating this, please review the version used by the extension to
 # submit requests, which can be found at './azext_quantum/__init__.py'
-VERSION = '1.0.0b20'
+VERSION = '1.0.0b21'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ⚠️ Review suggested

| Breaking Changes |
| :--: |
| ⚠️ None |

<!-- act-bot:section title="Azure CLI Extensions Breaking Change Test" category="breaking_change" label="Breaking Changes" status="Warning" summary="None" -->
<!-- Azure CLI Extensions Breaking Change Test --><details>
<summary>⚠️Azure CLI Extensions Breaking Change Test</summary>

><details>
> <summary>⚠️quantum</summary>
>
>|rule|cmd_name|rule_message|suggest_message|
>|---|---|---|---|
>|⚠️ [1011 - SubgroupAdd](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1011.md)|quantum suite-offers|sub group `quantum suite-offers` added||
>
></details>
</details>

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

## Summary 
Adds a new command for admin/research-lead users who operate in a provider-account (suite offer) context rather than a workspace. 
`az quantum suite-offers target list` lists a provider account's targets and their status without requiring a workspace.

## What changed
- New command `az quantum suite-offers target list -p <providerId> [-l <location>]` in a new `suite-offers target` command group.
- `--location/-l` is optional; when omitted it is resolved automatically from the provider account's suite offer.
- Provider-account status is read from the V2 regional data plane (`.../suiteoffers/{providerId}/providerStatus`) by reusing the generated client's authenticated pipeline via `send_request` .
- Version bumped to `1.0.0b21` with a HISTORY.rst entry.




