### PR TITLE
{CI} Support pyproject.toml builds and add migration guide

### DIFF
--- a/.azure-pipelines/templates/azdev_setup.yml
+++ b/.azure-pipelines/templates/azdev_setup.yml
@@ -13,7 +13,10 @@ steps:
       source ./env/bin/activate
       git clone -q --single-branch -b dev https://github.com/Azure/azure-cli.git ../azure-cli
       python -m pip install -U pip
-      pip install --upgrade "git+https://github.com/Azure/azure-cli-dev-tools.git@bb196e370ef0c0c8fcb01ab2e73bf2db7b5821a2#egg=azdev"
+      pip install --upgrade azdev==0.2.13
+      # wheel is unpinned on purpose. setuptools' legacy backend still needs it for the extensions
+      # that haven't moved to pyproject.toml yet, and it can go once they all have.
+      pip install build wheel
       azdev --version
       azdev setup -c $CLI_REPO_PATH -r $CLI_EXT_REPO_PATH --debug
       pip list -v

--- a/.github/actions/env-setup/action.yml
+++ b/.github/actions/env-setup/action.yml
@@ -43,9 +43,8 @@ runs:
         python -m venv env
         chmod +x env/bin/activate
         source ./env/bin/activate
-        # Pinned to the azdev commit that fixes `azdev extension add` losing egg-info under
-        # --no-build-isolation (Azure/azure-cli-dev-tools#554); switch to azdev==0.2.13 once released.
-        pip install --upgrade "git+https://github.com/Azure/azure-cli-dev-tools.git@bb196e370ef0c0c8fcb01ab2e73bf2db7b5821a2#egg=azdev"
+        # Pin azdev to 0.2.13 (azure-cli-dev-tools egg-info #554 + wheel-build #555 fixes).
+        pip install --upgrade azdev==0.2.13
         azdev --version
         cd ../
         azdev setup -c azure-cli -r azure-cli-extensions --debug

--- a/.github/azure-client-tools-bot/config.yml
+++ b/.github/azure-client-tools-bot/config.yml
@@ -2,9 +2,10 @@ files_check:
   - files:
       - "src/.*/HISTORY.rst"
       - "src/.*/setup.py"
+      - "src/.*/pyproject.toml"
     comment: |
       Please write the description of changes which can be perceived by customers into HISTORY.rst.
-      If you want to release a new extension version, please update the version in setup.py as well.
+      If you want to release a new extension version, please update the version in pyproject.toml (or setup.py, if the extension has not migrated yet) as well.
     is_regex: true
     type: necessary
 allowed_branches:

--- a/.github/workflows/VersionCalPRComment.yml
+++ b/.github/workflows/VersionCalPRComment.yml
@@ -114,9 +114,8 @@ jobs:
            python -m venv env
            chmod +x env/bin/activate
            source ./env/bin/activate
-           # Pinned to the azdev commit that fixes `azdev extension add` losing egg-info under
-           # --no-build-isolation (Azure/azure-cli-dev-tools#554); switch to azdev==0.2.13 once released.
-           pip install --upgrade "git+https://github.com/Azure/azure-cli-dev-tools.git@bb196e370ef0c0c8fcb01ab2e73bf2db7b5821a2#egg=azdev"
+           # Pin azdev to 0.2.13 (azure-cli-dev-tools egg-info #554 + wheel-build #555 fixes).
+           pip install --upgrade azdev==0.2.13
            azdev --version
            cd ../
            azdev setup -c azure-cli -r azure-cli-extensions --debug

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
+.migration_tmp/
 nosetests.xml
 coverage.xml
 *.cover

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,7 +79,7 @@ jobs:
   - bash: |
       #!/usr/bin/env bash
       set -ev
-      pip install --upgrade "git+https://github.com/Azure/azure-cli-dev-tools.git@bb196e370ef0c0c8fcb01ab2e73bf2db7b5821a2#egg=azdev"
+      pip install --upgrade azdev==0.2.13
       pip install requests packaging setuptools
       export CI="ADO"
       python ./scripts/ci/test_index.py -v

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,4 +18,6 @@ Doc Sections
 
 - [Extension Metadata](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/metadata.md) - How to add additional extension metadata
 
+- [Migrating to pyproject.toml](pyproject-migration.md) - How to move an extension from `setup.py` to a PEP 517 build
+
 - [FAQ](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/faq.md) - Commonly asked questions

--- a/docs/pyproject-migration.md
+++ b/docs/pyproject-migration.md
@@ -1,0 +1,187 @@
+# Migrating an Azure CLI extension from `setup.py` to `pyproject.toml`
+
+If you own an Azure CLI extension, either here in `src/<name>` or in your own repo, this is how you
+move it off `setup.py` and onto a PEP 517 build.
+
+Tracking issue: [Azure/azure-cli-extensions#7740](https://github.com/Azure/azure-cli-extensions/issues/7740)
+
+## Why
+
+- `pip` dropped legacy editable installs (`setup.py develop`), so `pip install -e` now needs a real
+  build backend.
+- We've been stuck on `wheel==0.30.0` since 2019, because the extension index was built from the
+  `metadata.json` that only that version writes. The pin carries CVEs and blocks `setuptools`
+  upgrades.
+- Extension metadata now comes from `pkginfo` instead of `metadata.json`, so once extensions stop
+  depending on `setup.py` the pin can go.
+
+## Status
+
+CI here accepts either `pyproject.toml` or `setup.py`, so there's no rush and nothing breaks while
+both formats are in the tree. Don't add a `pyproject.toml` and leave `setup.py` as the actual build
+definition though. Pick one.
+
+## Template
+
+Replace `<name>` with your extension name and `azext_<name>` with your package directory.
+
+```toml
+[build-system]
+requires = ["setuptools>=70"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "<name>"
+version = "1.0.0"
+description = "Microsoft Azure Command-Line Tools <Name> Extension"
+authors = [{ name = "Microsoft Corporation", email = "azpycli@microsoft.com" }]
+license = { text = "MIT" }
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: System Administrators",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+]
+dependencies = [
+    # contents of the old install_requires / DEPENDENCIES list
+]
+dynamic = ["readme"]
+
+[project.urls]
+# Key must be "Home", not "Homepage". See "Metadata deltas" below.
+Home = "https://github.com/Azure/azure-cli-extensions/tree/main/src/<name>"
+
+[tool.setuptools.dynamic]
+readme = { file = ["README.md", "HISTORY.rst"], content-type = "text/markdown" }
+
+[tool.setuptools.packages.find]
+include = ["azext_<name>*"]
+
+[tool.setuptools.package-data]
+azext_<name> = ["azext_metadata.json"]
+```
+
+Then delete `setup.py`.
+
+## Field mapping
+
+| `setup.py` | `pyproject.toml` |
+| --- | --- |
+| `name=` | `[project] name` |
+| `VERSION` / `version=` | `[project] version` |
+| `description=` | `[project] description` |
+| `author=` / `author_email=` | `[project] authors` |
+| `url=` | `[project.urls] Home` |
+| `long_description=README + HISTORY` | `dynamic = ["readme"]` + `[tool.setuptools.dynamic] readme` |
+| `license=` | `[project] license` |
+| `classifiers=` | `[project] classifiers` |
+| `install_requires=` | `[project] dependencies` |
+| `extras_require=` | `[project.optional-dependencies]` |
+| `packages=find_packages()` | `[tool.setuptools.packages.find] include` |
+| `package_data=` | `[tool.setuptools.package-data]` |
+| `cmdclass` from `azure_bdist_wheel` | delete it (see below) |
+
+## Things that will bite you
+
+**`azure_bdist_wheel` / `cmdclass`.** Many extensions carry this block:
+
+```python
+try:
+    from azure_bdist_wheel import cmdclass
+except ImportError:
+    from distutils import log as logger
+    logger.warn("Wheel is not available, disabling bdist_wheel hook")
+```
+
+Delete it. All it did was set a universal (`py2.py3`) wheel tag. Without it your wheel comes out
+tagged `py3-none-any`, which is what you want anyway since extensions are Python 3 only.
+
+**`setup.py` that imports its own package.** If your `setup.py` does
+`from azext_<name>.something import ...` at module level, that import won't resolve under a default
+(isolated) PEP 517 build, because your package isn't installed in the build environment. Inline the
+values instead. Watch out for the pattern below in particular. It fails *silently*, so instead of an
+error you get a wheel with no dependencies:
+
+```python
+DEPENDENCIES = []
+try:
+    from azext_<name>.manual.dependency import DEPENDENCIES
+except ImportError:
+    pass
+```
+
+**Non-Python files.** Everything you were shipping through `package_data` (`azext_metadata.json`,
+bundled binaries, YAML templates, and so on) has to be listed under
+`[tool.setuptools.package-data]`. `azext_metadata.json` is not optional; the extension index can't
+be built without it.
+
+**Building locally.** Run the build with the source directory as an argument, not by `cd`-ing into
+it:
+
+```bash
+python -m build --wheel --outdir /tmp/out src/<name>     # correct
+cd src/<name> && python -m build --wheel                 # breaks on the second run
+```
+
+`setuptools` leaves a `build/` directory behind in the extension folder. The current directory is on
+`sys.path`, so that directory ends up shadowing the `build` module itself and every run after the
+first one dies with `No module named build.__main__`.
+
+## What changes in the metadata
+
+We built the same extension both ways and diffed the wheels. The file lists came out identical, and
+`name`, `version`, `summary`, `license`, `classifiers`, `run_requires` and `metadata_version` were
+all unchanged. Two fields do move:
+
+| Field | `setup.py` | `pyproject.toml` |
+| --- | --- | --- |
+| `description_content_type` | absent | `text/markdown` (or `text/x-rst`) |
+| `contacts` | `{name: "Microsoft Corporation", email: "azpycli@microsoft.com"}` | `{email: "Microsoft Corporation <email@microsoft.com>"}` |
+
+Both are expected. PEP 621 folds author name and email into a single field, and a content type is
+required for PyPI metadata 2.1+. Anyone reviewing `src/index.json` should know to expect them.
+
+One detail worth copying: use `Home` rather than `Homepage` in `[project.urls]`. `Home` keeps
+`project_urls` byte-identical to the old output, whereas `Homepage` changes the key and churns the
+index entry for no reason.
+
+## Verifying your migration
+
+Build the wheel before and after, then compare:
+
+```python
+import zipfile
+z_old = zipfile.ZipFile("old.whl")
+z_new = zipfile.ZipFile("new.whl")
+print("missing from new:", sorted(set(z_old.namelist()) - set(z_new.namelist())))
+```
+
+Anything in the old wheel that's missing from the new one is a regression. It's nearly always a
+`package_data` entry you forgot to carry over.
+
+Then check the extension still installs and loads:
+
+```bash
+azdev extension build <name>
+az extension add --source <path-to-wheel>
+az extension show -n <name>
+az <your-command-group> --help
+```
+
+## Checklist
+
+- [ ] `pyproject.toml` added, `setup.py` deleted
+- [ ] `azure_bdist_wheel` / `cmdclass` block removed
+- [ ] No build-time imports of your own `azext_*` package
+- [ ] `azext_metadata.json` listed in `[tool.setuptools.package-data]`
+- [ ] All other non-Python payload listed in `package-data`
+- [ ] Old and new wheel file lists compared, nothing missing
+- [ ] `az extension add` from the built wheel works and the commands load
+- [ ] Extension version left alone (repackaging on its own shouldn't publish a new version)
+
+## Questions
+
+Open an issue on [Azure/azure-cli-extensions](https://github.com/Azure/azure-cli-extensions/issues)
+and reference [#7740](https://github.com/Azure/azure-cli-extensions/issues/7740).

--- a/scripts/automation/build_package.py
+++ b/scripts/automation/build_package.py
@@ -13,12 +13,21 @@ from subprocess import check_call
 
 DEFAULT_DEST_FOLDER = "./dist"
 
+# A package declares its build through either a pyproject.toml or a legacy setup.py.
+BUILD_FILES = ('pyproject.toml', 'setup.py')
+
 def create_package(name, dest_folder=DEFAULT_DEST_FOLDER):
     # a package will exist in either one, or the other folder. this is why we can resolve both at the same time.
-    absdirs = [os.path.dirname(package) for package in (glob.glob('{}/setup.py'.format(name)) + glob.glob('sdk/*/{}/setup.py'.format(name)))]
+    absdirs = [
+        os.path.dirname(package)
+        for build_file in BUILD_FILES
+        for package in (glob.glob('{}/{}'.format(name, build_file)) + glob.glob('sdk/*/{}/{}'.format(name, build_file)))
+    ]
+    if not absdirs:
+        raise RuntimeError("Unable to locate a buildable package for {}: "
+                           "no pyproject.toml or setup.py found.".format(name))
     absdirpath = os.path.abspath(absdirs[0])
-    check_call(['python', 'setup.py', 'bdist_wheel', '-d', dest_folder], cwd=absdirpath)
-    check_call(['python', 'setup.py', "sdist", "--format", "zip", '-d', dest_folder], cwd=absdirpath)
+    check_call(['python', '-m', 'build', '--wheel', '--sdist', '--no-isolation', '--outdir', dest_folder], cwd=absdirpath)
 
 if __name__ == '__main__':
     """

--- a/scripts/ci/azdev_linter_style.py
+++ b/scripts/ci/azdev_linter_style.py
@@ -114,9 +114,9 @@ class AzdevExtensionHelper:
             raise ValueError(f"Underscores `_` are not allowed in the extension root directory, "
                              f"please change it to a hyphen `-`.")
         if metadata['name'] != extension_name:
-            raise ValueError(f"The name {metadata['name']} in setup.py "
+            raise ValueError(f"The name {metadata['name']} declared in pyproject.toml/setup.py "
                              f"is not the same as the extension name {extension_name}! \n"
-                             f"Please fix the name in setup.py!")
+                             f"Please fix the name in pyproject.toml/setup.py!")
 
 
 def find_modified_files_against_master_branch():
@@ -162,7 +162,8 @@ def contain_extension_code(files):
         if 'src/' in file and os.path.isfile(file) and os.path.isdir(os.path.dirname(file)):
             new_extension_home = os.path.dirname(file)
 
-            if os.path.isfile(os.path.join(new_extension_home, 'setup.py')):
+            # Accept both while extensions are migrating to pyproject.toml.
+            if os.path.isfile(os.path.join(new_extension_home, 'pyproject.toml')) or os.path.isfile(os.path.join(new_extension_home, 'setup.py')):
                 return True
 
     return False

--- a/scripts/ci/test_source.py
+++ b/scripts/ci/test_source.py
@@ -14,7 +14,7 @@ import tempfile
 import shutil
 import shlex
 
-from subprocess import check_output, CalledProcessError, run
+from subprocess import check_output, CalledProcessError, run, STDOUT
 from util import SRC_PATH
 
 logger = logging.getLogger(__name__)
@@ -93,12 +93,27 @@ def test_source_wheels():
     source_extensions = [os.path.join(SRC_PATH, n) for n in os.listdir(SRC_PATH)
                          if os.path.isdir(os.path.join(SRC_PATH, n))]
     for s in source_extensions:
-        if not os.path.isfile(os.path.join(s, 'setup.py')):
+        # Skip empty dirs left over from removed extensions. Git doesn't track empty dirs, so these
+        # only ever show up locally.
+        if not any(d.startswith('azext_') and os.path.isfile(os.path.join(s, d, '__init__.py'))
+                   for d in os.listdir(s)):
             continue
+        # An extension is buildable through either pyproject.toml or a legacy setup.py
+        if not any(os.path.isfile(os.path.join(s, f)) for f in ('pyproject.toml', 'setup.py')):
+            raise RuntimeError("Extension {} has neither pyproject.toml nor setup.py, "
+                               "so no wheel can be built for it.".format(os.path.basename(s)))
         try:
-            check_output(['python', 'setup.py', 'bdist_wheel', '-q', '-d', built_whl_dir], cwd=s)
+            # Pass the source dir as an argument instead of using cwd. With cwd set to the extension
+            # folder, the build/ dir setuptools drops there shadows the `build` module and every run
+            # after the first one fails.
+            # --no-isolation keeps parity with the old `setup.py bdist_wheel` behaviour, which
+            # extensions whose setup.py imports their own azext_* package still depend on.
+            # TODO: drop --no-isolation once those imports are gone.
+            check_output([sys.executable, '-m', 'build', '--wheel', '--no-isolation',
+                          '--outdir', built_whl_dir, s], stderr=STDOUT)
         except CalledProcessError as err:
-            raise("Unable to build extension {} : {}".format(s, err))
+            raise RuntimeError("Unable to build extension {} :\n{}".format(
+                s, err.output.decode('utf-8', 'replace'))) from err
     # Export built wheels so CI can publish them as artifacts
     wheels_out_dir = os.environ.get('WHEELS_OUTPUT_DIR')
     if wheels_out_dir:


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes |
| :--: |
| ️✔️ None |

<!-- act-bot:section title="Azure CLI Extensions Breaking Change Test" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

Build with python -m build and accept either pyproject.toml or setup.py, so extensions can migrate one at a time. Nothing is migrated here.

test_source.py silently skipped extensions that had no setup.py; it now fails. It also no longer runs the build with cwd inside the extension, where the build/ dir shadows the build module and breaks every run after the first.

sdist from build_package.py is now .tar.gz instead of .zip, since PEP 517 has no zip option.

Built all 210 extensions locally to check this.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install azdev` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
