### PR TITLE
[CosmosDB] Fix #8080: `az cosmosdb`: Fix malformed `redistribute-partition-throughput` help examples

### DIFF
--- a/src/cosmosdb-preview/HISTORY.rst
+++ b/src/cosmosdb-preview/HISTORY.rst
@@ -2,6 +2,10 @@
 Release History
 ===============
 
+1.7.1
+++++++
+* Fix stray brackets in redistribute-partition-throughput help examples.
+
 1.7.0
 ++++++
 * Add ``--skip-safe-rotation`` to ``az cosmosdb keys regenerate`` to optionally bypass the account keys last usage check during key regeneration.

--- a/src/cosmosdb-preview/azext_cosmosdb_preview/_help.py
+++ b/src/cosmosdb-preview/azext_cosmosdb_preview/_help.py
@@ -965,7 +965,7 @@ helps['cosmosdb sql container redistribute-partition-throughput'] = """
                az cosmosdb sql container redistribute-partition-throughput --account-name account_name --database-name db_name --name container_name  --resource-group rg_name --evenly-distribute
       - name: Redistributes the partition throughput for a sql container from source partitions to target partitions
         text: |-
-               az cosmosdb sql container redistribute-partition-throughput --account-name account_name --database-name db_name --name container_name  --resource-group rg_name --target-partition-info 8=1200 6=1200]' --source-partition-info 9]'
+               az cosmosdb sql container redistribute-partition-throughput --account-name account_name --database-name db_name --name container_name  --resource-group rg_name --target-partition-info 8=1200 6=1200 --source-partition-info 9
 """
 
 helps['cosmosdb mongodb collection retrieve-partition-throughput'] = """
@@ -989,7 +989,7 @@ helps['cosmosdb mongodb collection redistribute-partition-throughput'] = """
                az cosmosdb mongodb collection redistribute-partition-throughput --account-name account_name --database-name db_name --name container_name  --resource-group rg_name --evenly-distribute
       - name: Redistributes the partition throughput for a mongodb collection from source partitions to target partitions
         text: |-
-               az cosmosdb mongodb collection redistribute-partition-throughput --account-name account_name --database-name db_name --name container_name  --resource-group rg_name --target-partition-info 8=1200 6=1200' --source-partition-info 9'
+               az cosmosdb mongodb collection redistribute-partition-throughput --account-name account_name --database-name db_name --name container_name  --resource-group rg_name --target-partition-info 8=1200 6=1200 --source-partition-info 9
 """
 
 # in-account restore of a deleted sql database

--- a/src/cosmosdb-preview/setup.py
+++ b/src/cosmosdb-preview/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
-VERSION = '1.7.0'
+VERSION = '1.7.1'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ❌ Action needed

| Breaking Changes |
| :--: |
| ❌ 1 |

<!-- act-bot:section title="Azure CLI Extensions Breaking Change Test" category="breaking_change" label="Breaking Changes" status="Failed" summary="1" -->
<!-- Azure CLI Extensions Breaking Change Test --><details>
<summary>❌Azure CLI Extensions Breaking Change Test</summary>

><details>
> <summary>❌quantum</summary>
>
>|rule|cmd_name|rule_message|suggest_message|
>|---|---|---|---|
>|❌ [1002 - CmdRemove](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1002.md) |quantum workspace user list|cmd `quantum workspace user list` removed|please confirm cmd `quantum workspace user list` removed|
>
></details>
</details>

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

## Summary
Fixes #8080

Removes the stray `]'` / `'` characters from the Cosmos DB redistribute-partition-throughput help examples for SQL containers and MongoDB collections so the sample commands are valid.

## Test plan
* [ ] Confirm the SQL container redistribute example no longer ends values with `]'`
* [ ] Confirm the MongoDB collection redistribute example no longer ends values with a trailing `'`