### PR TITLE
{CI} Fix KeyError: `Home` when updating the extension list

### DIFF
--- a/scripts/ci/avail-ext-doc/update_extension_list.py
+++ b/scripts/ci/avail-ext-doc/update_extension_list.py
@@ -11,6 +11,7 @@ The file content is list of all available latest extensions.
 """
 
 import os
+import string
 import sys
 
 import collections
@@ -33,6 +34,43 @@ TEMPLATE_FILE = os.path.join(AZURE_CLI_EXTENSIONS_REPO_PATH, 'scripts', 'ci', 'a
 sys.path.insert(0, os.path.join(AZURE_CLI_EXTENSIONS_REPO_PATH, 'scripts'))
 from ci.util import get_index_data, INDEX_PATH
 
+# azdev writes 'Home' for setup.py builds, derived from the deprecated Home-page field. It predates
+# PEP 753 and does not normalize to 'homepage', so it has to be matched separately. Ordered, because
+# the first match wins.
+LEGACY_HOME_LABELS = ('home',)
+
+
+def normalize_label(label):
+    removal_map = str.maketrans('', '', string.punctuation + string.whitespace)
+    return label.translate(removal_map).lower()
+
+
+def get_project_url(metadata):
+    """Return the extension's home page URL, or '' when it declares none.
+
+    Labels reach index.json in two shapes. Newer entries carry a project_urls mapping under
+    python.details; older ones carry the raw 'label, url' Project-URL line in project_url. Both
+    are normalized the same way so the lookup does not depend on which shape an extension used.
+    """
+    details = metadata.get('extensions', {}).get('python.details', {})
+    labelled = {}
+
+    raw = metadata.get('project_url') or []
+    for entry in [raw] if isinstance(raw, str) else raw:
+        label, _, url = entry.partition(',')
+        if url:
+            labelled[normalize_label(label)] = url.strip()
+
+    for label, url in (details.get('project_urls') or {}).items():
+        labelled[normalize_label(label)] = url
+
+    # Deliberately not falling back to 'source', 'repository' and friends. They carry different
+    # semantics, and rendering an issue tracker as the project URL is worse than rendering nothing.
+    for label in ('homepage', *LEGACY_HOME_LABELS):
+        if labelled.get(label):
+            return labelled[label]
+    return ''
+
 
 def get_extensions():
     extensions = []
@@ -42,18 +80,16 @@ def get_extensions():
         exts = sorted(exts, key=lambda c: Version(c['metadata']['version']), reverse=True)
 
         # some extension modules may not include 'HISTORY.rst'
-        # setup.py
-        if 'project_urls' in exts[0]['metadata']['extensions']['python.details']:
-            project_url = exts[0]['metadata']['extensions']['python.details']['project_urls']['Home']
-        # pyproject.toml
-        elif 'project_url' in exts[0]['metadata']:
-            project_url = exts[0]['metadata']['project_url'].replace('homepage,', '').strip()
-            print(f"Warning: extension {exts[0]['metadata']['name']} has migrated to pyproject.toml.")
-        else:
-            project_url = ''
+        project_url = get_project_url(exts[0]['metadata'])
+        if not project_url:
             print(f"Warning: No project_url found for extension {exts[0]['metadata']['name']}")
-        history_tmp = project_url + '/HISTORY.rst'
-        history = project_url if str(requests.get(history_tmp).status_code) == '404' else history_tmp
+
+        # requests.get('/HISTORY.rst') raises MissingSchema, so only probe when there is a URL.
+        if project_url:
+            history_tmp = project_url + '/HISTORY.rst'
+            history = project_url if str(requests.get(history_tmp).status_code) == '404' else history_tmp
+        else:
+            history = ''
         if exts[0]['metadata'].get('azext.isPreview'):
             status = 'Preview'
         elif exts[0]['metadata'].get('azext.isExperimental'):


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes |
| :--: |
| ️✔️ None |

<!-- act-bot:section title="Azure CLI Extensions Breaking Change Test" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

azdev only writes `project_urls['Home']` for setup.py builds. `azure-iot-ops 2.8.0` is built from `pyproject.toml` and declares `'homepage'` instead, so the docs job crashed.

Normalise the label per PEP 753 and look up `homepage`, keeping `home` for the entries already in index.json.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install azdev` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
