### PR TITLE
{workload-orchestration-preview} Rename command group to avoid collision with GA extension

### DIFF
--- a/src/service_name.json
+++ b/src/service_name.json
@@ -1045,6 +1045,11 @@
     "URL": "https://learn.microsoft.com/en-us/azure/azure-arc/workload-orchestration"
   },
   {
+    "Command": "az workload-orchestration-preview",
+    "AzureServiceName": "Workload Orchestration Manager",
+    "URL": "https://learn.microsoft.com/en-us/azure/azure-arc/workload-orchestration"
+  },
+  {
     "Command": "az arize-ai",
     "AzureServiceName": "Arize AI",
     "URL": "https://learn.microsoft.com/en-us/azure/partner-solutions/arize-ai/"

--- a/src/workload-orchestration-preview/HISTORY.rst
+++ b/src/workload-orchestration-preview/HISTORY.rst
@@ -2,12 +2,18 @@
 
 Release History
 ===============
+0.1.0b2
+++++++
+* Renamed the command group from ``workload-orchestration`` to ``workload-orchestration-preview``
+  so the preview extension no longer collides with the GA ``workload-orchestration`` extension.
+  Preview commands are now invoked as ``az workload-orchestration-preview ...``.
+
 0.1.0b1
 ++++++
 * Initial preview release.
-* Added ``az workload-orchestration solution-deployment create`` command
-* Added ``az workload-orchestration solution-deployment show`` command
-* Added ``az workload-orchestration solution-deployment list`` command
-* Added ``az workload-orchestration solution-deployment delete`` command
+* Added ``az workload-orchestration-preview solution-deployment create`` command
+* Added ``az workload-orchestration-preview solution-deployment show`` command
+* Added ``az workload-orchestration-preview solution-deployment list`` command
+* Added ``az workload-orchestration-preview solution-deployment delete`` command
 * Multi-target deployment support
 * Configuration accepts string or JSON

--- a/src/workload-orchestration-preview/README.md
+++ b/src/workload-orchestration-preview/README.md
@@ -62,7 +62,7 @@ Key features of the public preview release include end-to-end flows for applicat
 ### 1. Install Extension & Login
 
 ```sh
-az extension add --source <path-to-extension-file-workload-orchestration.whl>
+az extension add --source <path-to-extension-file-workload-orchestration-preview.whl>
 az login
 ```
 
@@ -71,7 +71,7 @@ az login
 ### 2. Create/Update Context
 
 ```sh
-az workload-orchestration context create \
+az workload-orchestration-preview context create \
   --subscription <subscription-id> \
   --resource-group <resource-group> \
   --location <location> \
@@ -85,7 +85,7 @@ az workload-orchestration context create \
 ### 3. Create Site Reference
 
 ```sh
-az workload-orchestration context.site-reference create \
+az workload-orchestration-preview context.site-reference create \
   --subscription <subscription-id> \
   --resource-group <resource-group> \
   --context-name <context-name> \
@@ -98,7 +98,7 @@ az workload-orchestration context.site-reference create \
 ### 4. Create Target
 
 ```sh
-az workload-orchestration target create \
+az workload-orchestration-preview target create \
   --resource-group <resource-group> \
   --location <location> \
   --name <target-name> \
@@ -116,7 +116,7 @@ az workload-orchestration target create \
 ### 5. Create Schema
 
 ```sh
-az workload-orchestration schema create \
+az workload-orchestration-preview schema create \
   --resource-group <resource-group> \
   --version "1.0.0" \
   --schema-name <schema-name> \
@@ -131,7 +131,7 @@ Or, if version is in the file, omit `--version`.
 ### 6. Create Solution Template and Version
 
 ```sh
-az workload-orchestration solution-template create \
+az workload-orchestration-preview solution-template create \
   --solution-template-name <solution-template-name> \
   -g <resource-group> \
   -l <location> \
@@ -143,7 +143,7 @@ az workload-orchestration solution-template create \
 ```
 
 ```sh
-az workload-orchestration solution-template-version create \
+az workload-orchestration-preview solution-template-version create \
   --template-name <solution-template-name> \
   --version 1.0.0 \
   --file solution-template-version.yaml
@@ -154,7 +154,7 @@ az workload-orchestration solution-template-version create \
 ### 7. Set Configuration Values
 
 ```sh
-az workload-orchestration configuration set \
+az workload-orchestration-preview configuration set \
   -g <resource-group> \
   --solution-template-name <solution-template-name> \
   --target-name <target-name>
@@ -165,7 +165,7 @@ az workload-orchestration configuration set \
 ### 8. Resolve and Review
 
 ```sh
-az workload-orchestration target review \
+az workload-orchestration-preview target review \
   --solution-template-name <solution-template-name> \
   --solution-template-version 1.0.0 \
   --resource-group <resource-group> \
@@ -179,7 +179,7 @@ az workload-orchestration target review \
 
 **Publish:**
 ```sh
-az workload-orchestration target publish \
+az workload-orchestration-preview target publish \
   --solution-name <solution-template-name> \
   --solution-version <new-version> \
   --review-id <review-id> \
@@ -189,7 +189,7 @@ az workload-orchestration target publish \
 
 **Install:**
 ```sh
-az workload-orchestration target install \
+az workload-orchestration-preview target install \
   --solution-name <solution-template-name> \
   --solution-version <new-version> \
   --resource-group <resource-group> \

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/_help.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/_help.py
@@ -11,12 +11,12 @@
 from knack.help_files import helps  # pylint: disable=unused-import
 
 
-helps['workload-orchestration support'] = """
+helps['workload-orchestration-preview support'] = """
 type: group
 short-summary: Commands for troubleshooting and diagnostics of workload orchestration deployments.
 """
 
-helps['workload-orchestration support create-bundle'] = """
+helps['workload-orchestration-preview support create-bundle'] = """
 type: command
 short-summary: Create a support bundle for troubleshooting workload orchestration issues.
 long-summary: |
@@ -34,15 +34,15 @@ long-summary: |
     - Prerequisite checks (K8s version, node capacity, DNS, storage, RBAC)
 examples:
   - name: Create a support bundle with defaults
-    text: az workload-orchestration support create-bundle
+    text: az workload-orchestration-preview support create-bundle
   - name: Create a named bundle
-    text: az workload-orchestration support create-bundle --bundle-name my-cluster-debug
+    text: az workload-orchestration-preview support create-bundle --bundle-name my-cluster-debug
   - name: Create a bundle in a specific directory
-    text: az workload-orchestration support create-bundle --output-dir /tmp/bundles
+    text: az workload-orchestration-preview support create-bundle --output-dir /tmp/bundles
   - name: Collect full logs (no tail) for WO namespace only
-    text: az workload-orchestration support create-bundle --full-logs --namespaces workloadorchestration
+    text: az workload-orchestration-preview support create-bundle --full-logs --namespaces workloadorchestration
   - name: Run checks only, skip log collection
-    text: az workload-orchestration support create-bundle --skip-logs
+    text: az workload-orchestration-preview support create-bundle --skip-logs
   - name: Use a specific kubeconfig and context
-    text: az workload-orchestration support create-bundle --kube-config ~/.kube/prod-config --kube-context my-cluster
+    text: az workload-orchestration-preview support create-bundle --kube-config ~/.kube/prod-config --kube-context my-cluster
 """

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/_params.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/_params.py
@@ -10,7 +10,7 @@
 
 
 def load_arguments(self, _):  # pylint: disable=unused-argument
-    with self.argument_context('workload-orchestration support create-bundle') as c:
+    with self.argument_context('workload-orchestration-preview support create-bundle') as c:
         c.argument(
             'bundle_name',
             options_list=['--bundle-name', '-n'],

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/__cmd_group.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/__cmd_group.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command_group(
-    "workload-orchestration",
+    "workload-orchestration-preview",
 )
 class __CMDGroup(AAZCommandGroup):
     """Manage workload orchestration resources

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/_sync.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/_sync.py
@@ -28,13 +28,13 @@ def _log_step(msg, *args):
 
 
 @register_command(
-    "workload-orchestration sync",
+    "workload-orchestration-preview sync",
 )
 class Sync(AAZCommand):
     """Sync workload orchestration resources for a custom location
 
     :example: Sync resources for a custom location
-        az workload-orchestration sync --custom-location /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.ExtendedLocation/customLocations/myCustomLocation
+        az workload-orchestration-preview sync --custom-location /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.ExtendedLocation/customLocations/myCustomLocation
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/cluster/__cmd_group.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/cluster/__cmd_group.py
@@ -10,7 +10,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command_group(
-    "workload-orchestration cluster",
+    "workload-orchestration-preview cluster",
 )
 class __CMDGroup(AAZCommandGroup):
     """Prepare an Arc-connected Kubernetes cluster for Workload Orchestration."""

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/cluster/_init.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/cluster/_init.py
@@ -6,7 +6,7 @@
 # pylint: skip-file
 # flake8: noqa
 
-"""AAZ command for `workload-orchestration cluster init`.
+"""AAZ command for `workload-orchestration-preview cluster init`.
 
 Hand-authored AAZ command class that owns argument parsing and delegates the
 orchestration to the existing custom target_prepare() function.
@@ -16,7 +16,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration cluster init",
+    "workload-orchestration-preview cluster init",
 )
 class Init(AAZCommand):
     """Prepare an Arc-connected Kubernetes cluster for Workload Orchestration.
@@ -31,23 +31,23 @@ class Init(AAZCommand):
       4. Create Custom Location (validates cluster binding if already exists)
 
     :example: Initialize a cluster with defaults
-        az workload-orchestration cluster init -c my-cluster -g my-rg -l eastus2euap
+        az workload-orchestration-preview cluster init -c my-cluster -g my-rg -l eastus2euap
     :example: Use a specific release train
-        az workload-orchestration cluster init -c my-cluster -g my-rg -l eastus2euap --release-train dev
+        az workload-orchestration-preview cluster init -c my-cluster -g my-rg -l eastus2euap --release-train dev
     :example: Pin a specific WO extension version
-        az workload-orchestration cluster init -c my-cluster -g my-rg -l eastus2euap --extension-version 2.1.28
+        az workload-orchestration-preview cluster init -c my-cluster -g my-rg -l eastus2euap --extension-version 2.1.28
     :example: Pin a dependency extension (partial-value shorthand)
-        az workload-orchestration cluster init -c my-cluster -g my-rg -l eastus2euap --extension-dependency-version iotplatform=0.7.6
+        az workload-orchestration-preview cluster init -c my-cluster -g my-rg -l eastus2euap --extension-dependency-version iotplatform=0.7.6
     :example: Pin a dependency extension (full-value shorthand)
-        az workload-orchestration cluster init -c my-cluster -g my-rg -l eastus2euap --extension-dependency-version "{iotplatform:0.7.6}"
+        az workload-orchestration-preview cluster init -c my-cluster -g my-rg -l eastus2euap --extension-dependency-version "{iotplatform:0.7.6}"
     :example: Pin dependencies from a JSON file
-        az workload-orchestration cluster init -c my-cluster -g my-rg -l eastus2euap --extension-dependency-version deps.json
+        az workload-orchestration-preview cluster init -c my-cluster -g my-rg -l eastus2euap --extension-dependency-version deps.json
     :example: Custom location name
-        az workload-orchestration cluster init -c my-cluster -g my-rg -l eastus2euap --custom-location-name my-cl
+        az workload-orchestration-preview cluster init -c my-cluster -g my-rg -l eastus2euap --custom-location-name my-cl
     :example: Custom location in a different resource group
-        az workload-orchestration cluster init -c my-cluster -g cluster-rg -l eastus2euap --custom-location-resource-group cl-rg
+        az workload-orchestration-preview cluster init -c my-cluster -g cluster-rg -l eastus2euap --custom-location-resource-group cl-rg
     :example: Custom location in a different region
-        az workload-orchestration cluster init -c my-cluster -g my-rg -l eastus2euap --custom-location-location westus2
+        az workload-orchestration-preview cluster init -c my-cluster -g my-rg -l eastus2euap --custom-location-location westus2
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/config_template/__cmd_group.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/config_template/__cmd_group.py
@@ -12,10 +12,10 @@ from azure.cli.core.aaz import *
 
 
 @register_command_group(
-    "workload-orchestration config-template",
+    "workload-orchestration-preview config-template",
 )
 class __CMDGroup(AAZCommandGroup):
-    """workload-orchestration config-template helps to manage Config Templates
+    """workload-orchestration-preview config-template helps to manage Config Templates
     """
     pass
 

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/config_template/_create.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/config_template/_create.py
@@ -13,12 +13,12 @@ from azure.cli.core.azclierror import ValidationError
 import yaml
 
 @register_command(
-    "workload-orchestration config-template create",
+    "workload-orchestration-preview config-template create",
 )
 class Create(AAZCommand):
     """Create a Config Template Resource
     :example: Create a Config Template 
-        az workload-orchestration config-template create -g rg1 -n ct1 --description "test" --location eastus --version 1.0.0 --config-template-file config.yaml
+        az workload-orchestration-preview config-template create -g rg1 -n ct1 --description "test" --location eastus --version 1.0.0 --config-template-file config.yaml
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/config_template/_delete.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/config_template/_delete.py
@@ -12,14 +12,14 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration config-template delete",
+    "workload-orchestration-preview config-template delete",
     is_preview=False,
     confirmation="Are you sure you want to perform this operation?",
 )
 class Delete(AAZCommand):
     """Delete a Config Template Resource
        :example: Delete a Config Template 
-        az workload-orchestration config-template delete -n myConfigTemplate -g myResourceGroup
+        az workload-orchestration-preview config-template delete -n myConfigTemplate -g myResourceGroup
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/config_template/_delete_version.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/config_template/_delete_version.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration config-template delete-version",
+    "workload-orchestration-preview config-template delete-version",
 )
 class DeleteVersion(AAZCommand):
     """Delete Config Template Version Resource

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/config_template/_link.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/config_template/_link.py
@@ -13,12 +13,12 @@ from azext_workload_orchestration_preview.aaz.latest.workload_orchestration._res
 
 
 @register_command(
-    "workload-orchestration config-template link",
+    "workload-orchestration-preview config-template link",
 )
 class Link(AAZCommand):
     """Link a Config Template to hierarchies
     :example: Link a Config Template to hierarchies
-        az workload-orchestration config-template link -g rg1 -n configTemplatename --hierarchy-ids "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Edge/sites/site1" --context-id "context123"
+        az workload-orchestration-preview config-template link -g rg1 -n configTemplatename --hierarchy-ids "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Edge/sites/site1" --context-id "context123"
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/config_template/_list.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/config_template/_list.py
@@ -12,12 +12,12 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration config-template list",
+    "workload-orchestration-preview config-template list",
 )
 class List(AAZCommand):
     """List by subscription
     :example: List Config Templates by subscription
-        az workload-orchestration config-template list --subscription mySubscription
+        az workload-orchestration-preview config-template list --subscription mySubscription
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/config_template/_remove_version.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/config_template/_remove_version.py
@@ -12,12 +12,12 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration config-template remove-version",
+    "workload-orchestration-preview config-template remove-version",
 )
 class RemoveVersion(AAZCommand):
     """Remove Config Template Version Resource
     :example: Remove a Config Template Version
-        az workload-orchestration config-template remove-version -n myConfigTemplate -g myResource
+        az workload-orchestration-preview config-template remove-version -n myConfigTemplate -g myResource
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/config_template/_show.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/config_template/_show.py
@@ -12,12 +12,12 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration config-template show",
+    "workload-orchestration-preview config-template show",
 )
 class Show(AAZCommand):
     """Get a Config Template Resource
     :example: Show a Config Template
-        az workload-orchestration config-template show -n myConfigTemplate -g myResourceGroup
+        az workload-orchestration-preview config-template show -n myConfigTemplate -g myResourceGroup
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/config_template/_unlink.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/config_template/_unlink.py
@@ -11,12 +11,12 @@
 from azure.cli.core.aaz import *
 
 @register_command(
-    "workload-orchestration config-template unlink",
+    "workload-orchestration-preview config-template unlink",
 )
 class Unlink(AAZCommand):
     """Unlink a Config Template from hierarchies
     :example: Unlink a Config Template from hierarchies
-        az workload-orchestration config-template unlink -g rg1 -n configTemplatename --hierarchy-ids "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Edge/sites/site1" --context-id "context123"
+        az workload-orchestration-preview config-template unlink -g rg1 -n configTemplatename --hierarchy-ids "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Edge/sites/site1" --context-id "context123"
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/config_template/_update.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/config_template/_update.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration config-template update",
+    "workload-orchestration-preview config-template update",
 )
 class Update(AAZCommand):
     """Update a Config Template Resource

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/config_template/_wait.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/config_template/_wait.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration config-template wait",
+    "workload-orchestration-preview config-template wait",
 )
 class Wait(AAZWaitCommand):
     """Place the CLI in a waiting state until a condition is met.

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/config_template/hierarchy/__cmd_group.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/config_template/hierarchy/__cmd_group.py
@@ -12,10 +12,10 @@ from azure.cli.core.aaz import *
 
 
 @register_command_group(
-    "workload-orchestration config-template hierarchy",
+    "workload-orchestration-preview config-template hierarchy",
 )
 class __CMDGroup(AAZCommandGroup):
-    """workload-orchestration config-template hierarchy helps to manage config template hierarchies
+    """workload-orchestration-preview config-template hierarchy helps to manage config template hierarchies
     """
     pass
 

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/config_template/hierarchy/_show.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/config_template/hierarchy/_show.py
@@ -12,12 +12,12 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration config-template hierarchy show",
+    "workload-orchestration-preview config-template hierarchy show",
 )
 class Show(AAZCommand):
     """Show linked hierarchies for a config template
     :example: Show linked hierarchies for a config template
-        az workload-orchestration config-template hierarchy show -g rg1 -n configTemplateName
+        az workload-orchestration-preview config-template hierarchy show -g rg1 -n configTemplateName
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/config_template/version/__cmd_group.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/config_template/version/__cmd_group.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command_group(
-    "workload-orchestration config-template version",
+    "workload-orchestration-preview config-template version",
 )
 class __CMDGroup(AAZCommandGroup):
     """Manage workload orchestration config template versions.

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/config_template/version/_list.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/config_template/version/_list.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration config-template version list",
+    "workload-orchestration-preview config-template version list",
 )
 class List(AAZCommand):
     """List Config Template Version Resources

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/config_template/version/_show.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/config_template/version/_show.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration config-template version show",
+    "workload-orchestration-preview config-template version show",
 )
 class Show(AAZCommand):
     """Get a Config Template Version Resource

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/configuration/__cmd_group.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/configuration/__cmd_group.py
@@ -12,10 +12,10 @@ from azure.cli.core.aaz import *
 
 
 @register_command_group(
-    "workload-orchestration configuration",
+    "workload-orchestration-preview configuration",
 )
 class __CMDGroup(AAZCommandGroup):
-    """workload-orchestration configuration helps to manage configurations
+    """workload-orchestration-preview configuration helps to manage configurations
     """
     pass
 

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/configuration/_config_download.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/configuration/_config_download.py
@@ -15,15 +15,15 @@ from ._config_helper import ConfigurationHelper
 
 
 @register_command(
-    "workload-orchestration configuration download",
+    "workload-orchestration-preview configuration download",
     is_preview=False,
 )
 class Download(AAZCommand):
     """Download configurations available at specified hierarchical entity
     :example: Download configuration
-              az workload-orchestration configuration download --hierarchy-id "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Edge/sites/site1" --template-rg rg1 --template-name template1 --version 1.0.0
+              az workload-orchestration-preview configuration download --hierarchy-id "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Edge/sites/site1" --template-rg rg1 --template-name template1 --version 1.0.0
     :example: Download a Solution Template Configuration  
-              az workload-orchestration configuration download --hierarchy-id "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Edge/sites/site1" --template-rg rg1 --template-name solutionTemplate1 --version 1.0.0 --solution
+              az workload-orchestration-preview configuration download --hierarchy-id "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Edge/sites/site1" --template-rg rg1 --template-name solutionTemplate1 --version 1.0.0 --solution
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/configuration/_config_helper.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/configuration/_config_helper.py
@@ -430,7 +430,7 @@ class ConfigurationHelper:
                     break
             
             if not hierarchy_found:
-                raise CLIInternalError(f"Config template '{template_name}' is not linked to hierarchy: {hierarchy_id_str}. Please link the config template to this hierarchy first using the 'az workload-orchestration config-template link' command.")
+                raise CLIInternalError(f"Config template '{template_name}' is not linked to hierarchy: {hierarchy_id_str}. Please link the config template to this hierarchy first using the 'az workload-orchestration-preview config-template link' command.")
                 
         except CLIInternalError:
             # Re-raise CLI errors as-is

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/configuration/_config_set.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/configuration/_config_set.py
@@ -18,17 +18,17 @@ from azure.cli.core.azclierror import CLIInternalError
 from ._config_helper import ConfigurationHelper
 
 @register_command(
-    "workload-orchestration configuration set",
+    "workload-orchestration-preview configuration set",
     is_preview=False,
 )
 class ShowConfig2(AAZCommand):
     """To set the values to configurations available at specified hierarchical entity
     :example: Set a Configuration through editor
-              az workload-orchestration configuration set --hierarchy-id \"/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Edge/sites/site1\" --template-rg rg1 --template-name template1 --version 1.0.0
+              az workload-orchestration-preview configuration set --hierarchy-id \"/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Edge/sites/site1\" --template-rg rg1 --template-name template1 --version 1.0.0
     :example: Set a Configuration through file
-              az workload-orchestration configuration set --hierarchy-id "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Edge/sites/site1" --template-rg rg1 --template-name template1 --version 1.0.0 --file /path/to/config.yaml
+              az workload-orchestration-preview configuration set --hierarchy-id "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Edge/sites/site1" --template-rg rg1 --template-name template1 --version 1.0.0 --file /path/to/config.yaml
     :example: Set a Solution Template Configuration
-              az workload-orchestration configuration set --hierarchy-id "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Edge/sites/site1" --template-rg rg1 --template-name solutionTemplate1 --version 1.0.0 --solution
+              az workload-orchestration-preview configuration set --hierarchy-id "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Edge/sites/site1" --template-rg rg1 --template-name solutionTemplate1 --version 1.0.0 --solution
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/configuration/_config_show.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/configuration/_config_show.py
@@ -14,15 +14,15 @@ from ._config_helper import ConfigurationHelper
 
 
 @register_command(
-    "workload-orchestration configuration show",
+    "workload-orchestration-preview configuration show",
     is_preview=False,
 )
 class ShowConfig(AAZCommand):
     """To get a configurations available at specified hierarchical entity
     :example: Show a Configuration
-              az workload-orchestration configuration show --hierarchy-id "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Edge/sites/site1" --template-rg rg1 --template-name template1 --version 1.0.0
+              az workload-orchestration-preview configuration show --hierarchy-id "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Edge/sites/site1" --template-rg rg1 --template-name template1 --version 1.0.0
     :example: Show a Solution Template Configuration
-              az workload-orchestration configuration show --hierarchy-id "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Edge/sites/site1" --template-rg rg1 --template-name solutionTemplate1 --version 1.0.0 --solution
+              az workload-orchestration-preview configuration show --hierarchy-id "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Edge/sites/site1" --template-rg rg1 --template-name solutionTemplate1 --version 1.0.0 --solution
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/configuration/schema/__cmd_group.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/configuration/schema/__cmd_group.py
@@ -12,10 +12,10 @@ from azure.cli.core.aaz import *
 
 
 @register_command_group(
-    "workload-orchestration configuration schema",
+    "workload-orchestration-preview configuration schema",
 )
 class __CMDGroup(AAZCommandGroup):
-    """workload-orchestration configuration schema helps to manage configuration template schemas
+    """workload-orchestration-preview configuration schema helps to manage configuration template schemas
     """
     pass
 

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/configuration/schema/_show.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/configuration/schema/_show.py
@@ -13,17 +13,17 @@ from azure.cli.core.azclierror import CLIInternalError
 from .._config_helper import ConfigurationHelper
 
 @register_command(
-    "workload-orchestration configuration schema show",
+    "workload-orchestration-preview configuration schema show",
     is_preview=False,
 )
 class Show(AAZCommand):
     """Show the schema placeholder for a configuration template or solution template
     :example: Show schema for a Configuration Template
-              az workload-orchestration configuration schema show --template-rg rg1 --template-name template1 --version 1.0.0
+              az workload-orchestration-preview configuration schema show --template-rg rg1 --template-name template1 --version 1.0.0
     :example: Show schema for a Solution Template
-              az workload-orchestration configuration schema show --template-rg rg1 --template-name solutionTemplate1 --version 1.0.0 --solution
+              az workload-orchestration-preview configuration schema show --template-rg rg1 --template-name solutionTemplate1 --version 1.0.0 --solution
     :example: Show schema for a template in different subscription
-              az workload-orchestration configuration schema show --template-subscription sub1 --template-rg rg1 --template-name template1 --version 1.0.0
+              az workload-orchestration-preview configuration schema show --template-subscription sub1 --template-rg rg1 --template-name template1 --version 1.0.0
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/__cmd_group.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/__cmd_group.py
@@ -12,10 +12,10 @@ from azure.cli.core.aaz import *
 
 
 @register_command_group(
-    "workload-orchestration context",
+    "workload-orchestration-preview context",
 )
 class __CMDGroup(AAZCommandGroup):
-    """workload-orchestration context helps to manage contexts
+    """workload-orchestration-preview context helps to manage contexts
     """
     pass
 

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/_create.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/_create.py
@@ -13,12 +13,12 @@ from azure.cli.core.azclierror import CLIInternalError as CLIError
 
 
 @register_command(
-    "workload-orchestration context create",
+    "workload-orchestration-preview context create",
 )
 class Create(AAZCommand):
     """Create Context Resource
     :example: Create Context Resource
-        az workload-orchestration context create -g MyResourceGroup -n MyContext --location eastus --capabilities '[{"description":"description","name":"name"}]' --hierarchies '[{"description":"description","name":"name"}]'
+        az workload-orchestration-preview context create -g MyResourceGroup -n MyContext --location eastus --capabilities '[{"description":"description","name":"name"}]' --hierarchies '[{"description":"description","name":"name"}]'
     """
 
     _aaz_info = {
@@ -179,7 +179,7 @@ class Create(AAZCommand):
             from azext_workload_orchestration_preview.common.utils import invoke_cli_command, CmdProxy
             cmd_proxy = CmdProxy(self.ctx.cli_ctx)
             invoke_cli_command(cmd_proxy, [
-                "workload-orchestration", "context", "site-reference", "create",
+                "workload-orchestration-preview", "context", "site-reference", "create",
                 "-g", rg,
                 "--context-name", context_name,
                 "--site-reference-name", ref_name,

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/_current_context.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/_current_context.py
@@ -9,12 +9,12 @@
 from azure.cli.core.aaz import *
 
 @register_command(
-    "workload-orchestration context current",
+    "workload-orchestration-preview context current",
 )
 class CurrentContext(AAZCommand):
     """Show current context information
     :example: Show current context
-        az workload-orchestration context current
+        az workload-orchestration-preview context current
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/_delete.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/_delete.py
@@ -12,13 +12,13 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration context delete",
+    "workload-orchestration-preview context delete",
     confirmation="Are you sure you want to perform this operation?",
 )
 class Delete(AAZCommand):
     """Delete Context Resource
     :example: Delete a Context
-        az workload-orchestration context delete -n myContext -g myResourceGroup
+        az workload-orchestration-preview context delete -n myContext -g myResourceGroup
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/_execute.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/_execute.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration context execute",
+    "workload-orchestration-preview context execute",
 )
 class Execute(AAZCommand):
     """Post request to execute

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/_list.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/_list.py
@@ -12,12 +12,12 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration context list-subscriptions",
+    "workload-orchestration-preview context list-subscriptions",
 )
 class List(AAZCommand):
     """List by subscription
     :example: List Contexts by Subscription
-        az workload-orchestration context list-subscriptions
+        az workload-orchestration-preview context list-subscriptions
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/_list_untitled1.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/_list_untitled1.py
@@ -12,13 +12,13 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration context list",
+    "workload-orchestration-preview context list",
     is_preview=False,
 )
 class ListUntitled1(AAZCommand):
     """List by specified resource group
     :example: List Contexts
-        az workload-orchestration context list -g myResourceGroup
+        az workload-orchestration-preview context list -g myResourceGroup
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/_publish.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/_publish.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration context publish",
+    "workload-orchestration-preview context publish",
 )
 class Publish(AAZCommand):
     """Post request to publish

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/_resolve.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/_resolve.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration context resolve",
+    "workload-orchestration-preview context resolve",
 )
 class Resolve(AAZCommand):
     """Post request to resolve configuration

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/_review.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/_review.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration context review",
+    "workload-orchestration-preview context review",
 )
 class Review(AAZCommand):
     """Post request to review configuration

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/_set_context.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/_set_context.py
@@ -9,12 +9,12 @@
 from azure.cli.core.aaz import *
 
 @register_command(
-    "workload-orchestration context set",
+    "workload-orchestration-preview context set",
 )
 class SetContext(AAZCommand):
     """Set current context using context ID
     :example: Set a Context using ID
-        az workload-orchestration context set --id /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.Edge/contexts/myContext
+        az workload-orchestration-preview context set --id /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.Edge/contexts/myContext
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/_show.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/_show.py
@@ -12,12 +12,12 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration context show",
+    "workload-orchestration-preview context show",
 )
 class Show(AAZCommand):
     """Get Context Resource
     :example: Show a Context
-        az workload-orchestration context show -n myContext -g myResourceGroup
+        az workload-orchestration-preview context show -n myContext -g myResourceGroup
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/_update.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/_update.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration context update",
+    "workload-orchestration-preview context update",
 )
 class Update(AAZCommand):
     """Update Context Resource

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/_use_context.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/_use_context.py
@@ -13,12 +13,12 @@ from azure.cli.core.aaz import *
 from azure.cli.core.azclierror import CLIInternalError
 
 @register_command(
-    "workload-orchestration context use",
+    "workload-orchestration-preview context use",
 )
 class UseContext(AAZCommand):
     """Use Context by name
     :example: Use a Context
-        az workload-orchestration context use -n myContext -g myResourceGroup
+        az workload-orchestration-preview context use -n myContext -g myResourceGroup
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/_wait.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/_wait.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration context wait",
+    "workload-orchestration-preview context wait",
 )
 class Wait(AAZWaitCommand):
     """Place the CLI in a waiting state until a condition is met.

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/capability/_add.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/capability/_add.py
@@ -6,7 +6,7 @@
 # pylint: skip-file
 # flake8: noqa
 
-"""AAZ command for `workload-orchestration context add-capability`.
+"""AAZ command for `workload-orchestration-preview context add-capability`.
 
 Idempotent — at most ONE ARM PATCH call. Skips the call entirely if all
 requested capabilities already exist.
@@ -16,7 +16,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration context add-capability",
+    "workload-orchestration-preview context add-capability",
 )
 class AddCapability(AAZCommand):
     """Add capabilities to a context (idempotent).
@@ -28,16 +28,16 @@ class AddCapability(AAZCommand):
     If description is omitted for a capability, it defaults to the name.
 
     :example: Add a single capability
-        az workload-orchestration context add-capability -g Mehoopany -n Mehoopany-Context --capabilities "[{name:soap,description:'Soap line'}]"
+        az workload-orchestration-preview context add-capability -g Mehoopany -n Mehoopany-Context --capabilities "[{name:soap,description:'Soap line'}]"
 
     :example: Add multiple capabilities (shorthand)
-        az workload-orchestration context add-capability -g Mehoopany -n Mehoopany-Context --capabilities "[{name:soap,description:Soap},{name:shampoo,description:Shampoo}]"
+        az workload-orchestration-preview context add-capability -g Mehoopany -n Mehoopany-Context --capabilities "[{name:soap,description:Soap},{name:shampoo,description:Shampoo}]"
 
     :example: Add capability without description (defaults to name)
-        az workload-orchestration context add-capability -g Mehoopany -n Mehoopany-Context --capabilities "[{name:detergent}]"
+        az workload-orchestration-preview context add-capability -g Mehoopany -n Mehoopany-Context --capabilities "[{name:detergent}]"
 
     :example: Add capabilities from a JSON file
-        az workload-orchestration context add-capability -g Mehoopany -n Mehoopany-Context --capabilities @new-caps.json
+        az workload-orchestration-preview context add-capability -g Mehoopany -n Mehoopany-Context --capabilities @new-caps.json
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/capability/_remove.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/capability/_remove.py
@@ -6,13 +6,13 @@
 # pylint: skip-file
 # flake8: noqa
 
-"""AAZ command for `workload-orchestration context remove-capability`."""
+"""AAZ command for `workload-orchestration-preview context remove-capability`."""
 
 from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration context remove-capability",
+    "workload-orchestration-preview context remove-capability",
     confirmation="Are you sure you want to remove the specified capability(ies) from the context?",
 )
 class RemoveCapability(AAZCommand):
@@ -22,10 +22,10 @@ class RemoveCapability(AAZCommand):
     The context must retain at least one capability after removal.
 
     :example: Remove a single capability
-        az workload-orchestration context remove-capability -g Mehoopany -n Mehoopany-Context --capabilities "[soap]" --yes
+        az workload-orchestration-preview context remove-capability -g Mehoopany -n Mehoopany-Context --capabilities "[soap]" --yes
 
     :example: Remove multiple capabilities
-        az workload-orchestration context remove-capability -g Mehoopany -n Mehoopany-Context --capabilities "[soap,shampoo,detergent]" --yes
+        az workload-orchestration-preview context remove-capability -g Mehoopany -n Mehoopany-Context --capabilities "[soap,shampoo,detergent]" --yes
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/site_reference/__cmd_group.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/site_reference/__cmd_group.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command_group(
-    "workload-orchestration context site-reference",
+    "workload-orchestration-preview context site-reference",
 )
 class __CMDGroup(AAZCommandGroup):
     """Manage workload orchestration site reference context.

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/site_reference/_create.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/site_reference/_create.py
@@ -13,12 +13,12 @@ from azext_workload_orchestration_preview.aaz.latest.workload_orchestration._res
 
 
 @register_command(
-    "workload-orchestration context site-reference create",
+    "workload-orchestration-preview context site-reference create",
 )
 class Create(AAZCommand):
     """Create Site Reference Resource
     :example: Create a Site Reference
-        az workload-orchestration context site-reference create -g {rg} -n {site_reference_name} --context-name {context_name} --site-id {site_id}
+        az workload-orchestration-preview context site-reference create -g {rg} -n {site_reference_name} --context-name {context_name} --site-id {site_id}
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/site_reference/_delete.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/site_reference/_delete.py
@@ -12,13 +12,13 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration context site-reference delete",
+    "workload-orchestration-preview context site-reference delete",
     confirmation="Are you sure you want to perform this operation?",
 )
 class Delete(AAZCommand):
     """Delete Site Reference Resource
     :example: Delete a Site Reference
-        az workload-orchestration context site-reference delete -n mySiteReference -g myResourceGroup --context-name myContext
+        az workload-orchestration-preview context site-reference delete -n mySiteReference -g myResourceGroup --context-name myContext
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/site_reference/_list.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/site_reference/_list.py
@@ -12,12 +12,12 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration context site-reference list",
+    "workload-orchestration-preview context site-reference list",
 )
 class List(AAZCommand):
     """List Site Reference Resources
     :example: List Site References
-        az workload-orchestration context site-reference list --context-name myContext -g myResourceGroup
+        az workload-orchestration-preview context site-reference list --context-name myContext -g myResourceGroup
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/site_reference/_show.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/site_reference/_show.py
@@ -12,12 +12,12 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration context site-reference show",
+    "workload-orchestration-preview context site-reference show",
 )
 class Show(AAZCommand):
     """Get Site Reference Resource
     :example: Show a Site Reference
-        az workload-orchestration context site-reference show -n mySiteReference -g myResourceGroup --context-name myContext
+        az workload-orchestration-preview context site-reference show -n mySiteReference -g myResourceGroup --context-name myContext
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/site_reference/_update.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/site_reference/_update.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration context site-reference update",
+    "workload-orchestration-preview context site-reference update",
 )
 class Update(AAZCommand):
     """Update Site Reference Resource

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/site_reference/_wait.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/context/site_reference/_wait.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration context site-reference wait",
+    "workload-orchestration-preview context site-reference wait",
 )
 class Wait(AAZWaitCommand):
     """Place the CLI in a waiting state until a condition is met.

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/diagnostic/__cmd_group.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/diagnostic/__cmd_group.py
@@ -12,10 +12,10 @@ from azure.cli.core.aaz import *
 
 
 @register_command_group(
-    "workload-orchestration diagnostic",
+    "workload-orchestration-preview diagnostic",
 )
 class __CMDGroup(AAZCommandGroup):
-    """workload-orchestration diagnostic helps to manage Diagnostics
+    """workload-orchestration-preview diagnostic helps to manage Diagnostics
     """
     pass
 

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/diagnostic/_create.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/diagnostic/_create.py
@@ -12,12 +12,12 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration diagnostic create",
+    "workload-orchestration-preview diagnostic create",
 )
 class Create(AAZCommand):
     """Create new or updates existing Diagnostic resource.
       :example: Create a new Diagnostic resource.
-        az workload-orchestration diagnostic create -n MyDiagnostic -g MyResourceGroup --location eastus --extended-location name=MyCustomLocation type=CustomLocation
+        az workload-orchestration-preview diagnostic create -n MyDiagnostic -g MyResourceGroup --location eastus --extended-location name=MyCustomLocation type=CustomLocation
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/diagnostic/_delete.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/diagnostic/_delete.py
@@ -12,13 +12,13 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration diagnostic delete",
+    "workload-orchestration-preview diagnostic delete",
     confirmation="Are you sure you want to perform this operation?",
 )
 class Delete(AAZCommand):
     """Delete specified Diagnostic resource.
     :example: Delete a Diagnostic
-        az workload-orchestration diagnostic delete -n myDiagnostic -g myResourceGroup
+        az workload-orchestration-preview diagnostic delete -n myDiagnostic -g myResourceGroup
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/diagnostic/_list.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/diagnostic/_list.py
@@ -12,12 +12,12 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration diagnostic list",
+    "workload-orchestration-preview diagnostic list",
 )
 class List(AAZCommand):
     """List Diagnostics resources within an Azure subscription.
     :example: List Diagnostics by subscription
-        az workload-orchestration diagnostic list --subscription mySubscription
+        az workload-orchestration-preview diagnostic list --subscription mySubscription
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/diagnostic/_show.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/diagnostic/_show.py
@@ -12,12 +12,12 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration diagnostic show",
+    "workload-orchestration-preview diagnostic show",
 )
 class Show(AAZCommand):
     """Get details of specified Diagnostic resource.
     :example: Show a Diagnostic         
-        az workload-orchestration diagnostic show -n myDiagnostic -g myResourceGroup
+        az workload-orchestration-preview diagnostic show -n myDiagnostic -g myResourceGroup
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/diagnostic/_update.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/diagnostic/_update.py
@@ -12,12 +12,12 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration diagnostic update",
+    "workload-orchestration-preview diagnostic update",
 )
 class Update(AAZCommand):
     """Update new or updates existing Diagnostic resource.
        :example: Update a Diagnostic resource.
-             az workload-orchestration diagnostic update -n MyDiagnostic -g MyResourceGroup
+             az workload-orchestration-preview diagnostic update -n MyDiagnostic -g MyResourceGroup
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/diagnostic/_wait.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/diagnostic/_wait.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration diagnostic wait",
+    "workload-orchestration-preview diagnostic wait",
 )
 class Wait(AAZWaitCommand):
     """Place the CLI in a waiting state until a condition is met.

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/hierarchy/__cmd_group.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/hierarchy/__cmd_group.py
@@ -10,10 +10,10 @@ from azure.cli.core.aaz import *
 
 
 @register_command_group(
-    "workload-orchestration hierarchy",
+    "workload-orchestration-preview hierarchy",
 )
 class __CMDGroup(AAZCommandGroup):
-    """Manage workload-orchestration hierarchies (Site + Configuration + ConfigurationReference)."""
+    """Manage workload-orchestration-preview hierarchies (Site + Configuration + ConfigurationReference)."""
     pass
 
 

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/hierarchy/_create.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/hierarchy/_create.py
@@ -6,7 +6,7 @@
 # pylint: skip-file
 # flake8: noqa
 
-"""AAZ command for `workload-orchestration hierarchy create`.
+"""AAZ command for `workload-orchestration-preview hierarchy create`.
 
 Hand-authored AAZ command class that owns argument parsing (giving us native
 shorthand / @file / JSON / YAML support from AAZShortHandSyntaxParser for
@@ -17,7 +17,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration hierarchy create",
+    "workload-orchestration-preview hierarchy create",
 )
 class Create(AAZCommand):
     """Create a hierarchy: Site + Configuration + ConfigurationReference (and ServiceGroup ancestors if type=ServiceGroup).
@@ -26,13 +26,13 @@ class Create(AAZCommand):
     (nested, up to 3 levels) hierarchy types.
 
     :example: Create RG hierarchy from YAML file
-        az workload-orchestration hierarchy create -g my-rg -l eastus2euap --hierarchy-spec hierarchy.yaml
+        az workload-orchestration-preview hierarchy create -g my-rg -l eastus2euap --hierarchy-spec hierarchy.yaml
     :example: Create RG hierarchy with inline shorthand
-        az workload-orchestration hierarchy create -g my-rg -l eastus2euap --hierarchy-spec "{name:Mehoopany,level:factory}"
+        az workload-orchestration-preview hierarchy create -g my-rg -l eastus2euap --hierarchy-spec "{name:Mehoopany,level:factory}"
     :example: Create ServiceGroup hierarchy from JSON file
-        az workload-orchestration hierarchy create -g my-rg -l eastus2euap --hierarchy-spec sg-hierarchy.json
+        az workload-orchestration-preview hierarchy create -g my-rg -l eastus2euap --hierarchy-spec sg-hierarchy.json
     :example: Create ServiceGroup hierarchy with inline shorthand (children as array)
-        az workload-orchestration hierarchy create -g my-rg -l eastus2euap --hierarchy-spec "{type:ServiceGroup,name:India,level:country,children:[{name:Karnataka,level:region,children:[{name:BangaloreSouth,level:factory}]}]}"
+        az workload-orchestration-preview hierarchy create -g my-rg -l eastus2euap --hierarchy-spec "{type:ServiceGroup,name:India,level:country,children:[{name:Karnataka,level:region,children:[{name:BangaloreSouth,level:factory}]}]}"
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/schema/__cmd_group.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/schema/__cmd_group.py
@@ -12,10 +12,10 @@ from azure.cli.core.aaz import *
 
 
 @register_command_group(
-    "workload-orchestration schema",
+    "workload-orchestration-preview schema",
 )
 class __CMDGroup(AAZCommandGroup):
-    """workload-orchestration schema helps to manage Schemas
+    """workload-orchestration-preview schema helps to manage Schemas
     """
     pass
 

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/schema/_create.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/schema/_create.py
@@ -13,12 +13,12 @@ from azure.cli.core.azclierror import ValidationError
 import yaml
 
 @register_command(
-    "workload-orchestration schema create",
+    "workload-orchestration-preview schema create",
 )
 class Create(AAZCommand):
     """Create a Schema Resource
     :example: Create a Schema
-        az workload-orchestration schema create -n mySchema -g myResourceGroup --location eastus --version 1.0.0 --schema-file ./schema.yaml
+        az workload-orchestration-preview schema create -n mySchema -g myResourceGroup --location eastus --version 1.0.0 --schema-file ./schema.yaml
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/schema/_delete.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/schema/_delete.py
@@ -12,13 +12,13 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration schema delete",
+    "workload-orchestration-preview schema delete",
     confirmation="Are you sure you want to perform this operation?",
 )
 class Delete(AAZCommand):
     """Delete a Schema Resource
     :example: Delete a Schema
-        az workload-orchestration schema delete -n mySchema -g myResourceGroup --version
+        az workload-orchestration-preview schema delete -n mySchema -g myResourceGroup --version
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/schema/_list.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/schema/_list.py
@@ -12,12 +12,12 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration schema list",
+    "workload-orchestration-preview schema list",
 )
 class List(AAZCommand):
     """List by subscription
     :example: List Schemas
-        az workload-orchestration schema list
+        az workload-orchestration-preview schema list
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/schema/_list_untitled1.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/schema/_list_untitled1.py
@@ -12,12 +12,12 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration schema list-untitled1",
+    "workload-orchestration-preview schema list-untitled1",
 )
 class ListUntitled1(AAZCommand):
     """List by subscription
     :example: List Schemas
-        az workload-orchestration schema list-untitled1
+        az workload-orchestration-preview schema list-untitled1
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/schema/_remove_version.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/schema/_remove_version.py
@@ -12,12 +12,12 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration schema remove-version",
+    "workload-orchestration-preview schema remove-version",
 )
 class RemoveVersion(AAZCommand):
     """Remove Schema Version Resource
     :example: Remove a Schema Version
-        az workload-orchestration schema remove-version -n mySchema -g myResourceGroup --version 1.0
+        az workload-orchestration-preview schema remove-version -n mySchema -g myResourceGroup --version 1.0
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/schema/_show.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/schema/_show.py
@@ -12,12 +12,12 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration schema show",
+    "workload-orchestration-preview schema show",
 )
 class Show(AAZCommand):
     """Get a Schema Resource
     :example: Show a Schema
-        az workload-orchestration schema show -n mySchema -g myResourceGroup
+        az workload-orchestration-preview schema show -n mySchema -g myResourceGroup
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/schema/_update.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/schema/_update.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration schema update",
+    "workload-orchestration-preview schema update",
 )
 class Update(AAZCommand):
     """Update a Schema Resource

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/schema/_wait.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/schema/_wait.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration schema wait",
+    "workload-orchestration-preview schema wait",
 )
 class Wait(AAZWaitCommand):
     """Place the CLI in a waiting state until a condition is met.

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/schema/version/__cmd_group.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/schema/version/__cmd_group.py
@@ -12,10 +12,10 @@ from azure.cli.core.aaz import *
 
 
 @register_command_group(
-    "workload-orchestration schema version",
+    "workload-orchestration-preview schema version",
 )
 class __CMDGroup(AAZCommandGroup):
-    """workload-orchestration schema version helps to manage Schemas
+    """workload-orchestration-preview schema version helps to manage Schemas
     """
     pass
 

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/schema/version/_list.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/schema/version/_list.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration schema version list",
+    "workload-orchestration-preview schema version list",
 )
 class List(AAZCommand):
     """List by specified resource group

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/schema/version/_show.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/schema/version/_show.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration schema version show",
+    "workload-orchestration-preview schema version show",
 )
 class Show(AAZCommand):
     """Get a Schema Version Resource

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/schema/version/_wait.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/schema/version/_wait.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration schema version wait",
+    "workload-orchestration-preview schema version wait",
 )
 class Wait(AAZWaitCommand):
     """Place the CLI in a waiting state until a condition is met.

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/schema_reference/__cmd_group.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/schema_reference/__cmd_group.py
@@ -12,10 +12,10 @@ from azure.cli.core.aaz import *
 
 
 # @register_command_group(
-#     "workload-orchestration schema-reference",
+#     "workload-orchestration-preview schema-reference",
 # )
 class __CMDGroup(AAZCommandGroup):
-    """workload-orchestration schema-reference helps to manage SchemaReference
+    """workload-orchestration-preview schema-reference helps to manage SchemaReference
     """
     pass
 

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/schema_reference/_create.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/schema_reference/_create.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration schema-reference create",
+    "workload-orchestration-preview schema-reference create",
 )
 class Create(AAZCommand):
     """Create a Schema Reference Resource

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/schema_reference/_delete.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/schema_reference/_delete.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration schema-reference delete",
+    "workload-orchestration-preview schema-reference delete",
     confirmation="Are you sure you want to perform this operation?",
 )
 class Delete(AAZCommand):

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/schema_reference/_list.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/schema_reference/_list.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration schema-reference list",
+    "workload-orchestration-preview schema-reference list",
 )
 class List(AAZCommand):
     """List by specified resource group

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/schema_reference/_show.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/schema_reference/_show.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration schema-reference show",
+    "workload-orchestration-preview schema-reference show",
 )
 class Show(AAZCommand):
     """Get a Schema Reference Resource

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/schema_reference/_update.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/schema_reference/_update.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration schema-reference update",
+    "workload-orchestration-preview schema-reference update",
 )
 class Update(AAZCommand):
     """Update a Schema Reference Resource

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/schema_reference/_wait.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/schema_reference/_wait.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration schema-reference wait",
+    "workload-orchestration-preview schema-reference wait",
 )
 class Wait(AAZWaitCommand):
     """Place the CLI in a waiting state until a condition is met.

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_deployment/__cmd_group.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_deployment/__cmd_group.py
@@ -12,10 +12,10 @@ from azure.cli.core.aaz import *
 
 
 @register_command_group(
-    "workload-orchestration solution-deployment",
+    "workload-orchestration-preview solution-deployment",
 )
 class __CMDGroup(AAZCommandGroup):
-    """workload-orchestration solution-deployment helps to manage Solution Deployments
+    """workload-orchestration-preview solution-deployment helps to manage Solution Deployments
     """
     pass
 

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_deployment/_create.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_deployment/_create.py
@@ -12,16 +12,16 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration solution-deployment create",
+    "workload-orchestration-preview solution-deployment create",
 )
 class Create(AAZCommand):
     """Create or update a SolutionDeployment Resource
 
     :example: Create a Solution Deployment
-        az workload-orchestration solution-deployment create -g myResourceGroup -n mySolutionDeployment --location eastus --solution-template-name mySolutionTemplate --solution-template-version 1.0.0 --target-ids "/subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Edge/targets/{target}"
+        az workload-orchestration-preview solution-deployment create -g myResourceGroup -n mySolutionDeployment --location eastus --solution-template-name mySolutionTemplate --solution-template-version 1.0.0 --target-ids "/subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Edge/targets/{target}"
 
     :example: Create a Solution Deployment with multiple targetIds
-        az workload-orchestration solution-deployment create -g myResourceGroup -n mySolutionDeployment --location eastus --solution-template-name mySolutionTemplate --solution-template-version 1.0.0 --target-ids "/subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Edge/targets/{target1}" "/subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Edge/targets/{target2}"
+        az workload-orchestration-preview solution-deployment create -g myResourceGroup -n mySolutionDeployment --location eastus --solution-template-name mySolutionTemplate --solution-template-version 1.0.0 --target-ids "/subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Edge/targets/{target1}" "/subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Edge/targets/{target2}"
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_deployment/_delete.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_deployment/_delete.py
@@ -12,14 +12,14 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration solution-deployment delete",
+    "workload-orchestration-preview solution-deployment delete",
     confirmation="Are you sure you want to perform this operation?",
 )
 class Delete(AAZCommand):
     """Delete a SolutionDeployment Resource
 
     :example: Delete a Solution Deployment
-        az workload-orchestration solution-deployment delete -g myResourceGroup -n mySolutionDeployment
+        az workload-orchestration-preview solution-deployment delete -g myResourceGroup -n mySolutionDeployment
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_deployment/_list.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_deployment/_list.py
@@ -12,13 +12,13 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration solution-deployment list",
+    "workload-orchestration-preview solution-deployment list",
 )
 class List(AAZCommand):
     """List SolutionDeployment Resources
 
     :example: List Solution Deployments
-        az workload-orchestration solution-deployment list -g myResourceGroup
+        az workload-orchestration-preview solution-deployment list -g myResourceGroup
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_deployment/_show.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_deployment/_show.py
@@ -12,13 +12,13 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration solution-deployment show",
+    "workload-orchestration-preview solution-deployment show",
 )
 class Show(AAZCommand):
     """Get a SolutionDeployment Resource
 
     :example: Show a Solution Deployment
-        az workload-orchestration solution-deployment show -n mySolutionDeployment -g myResourceGroup
+        az workload-orchestration-preview solution-deployment show -n mySolutionDeployment -g myResourceGroup
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_deployment/_wait.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_deployment/_wait.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration solution-deployment wait",
+    "workload-orchestration-preview solution-deployment wait",
 )
 class Wait(AAZWaitCommand):
     """Place the CLI in a waiting state until a condition is met.

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_template/__cmd_group.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_template/__cmd_group.py
@@ -12,10 +12,10 @@ from azure.cli.core.aaz import *
 
 
 @register_command_group(
-    "workload-orchestration solution-template",
+    "workload-orchestration-preview solution-template",
 )
 class __CMDGroup(AAZCommandGroup):
-    """workload-orchestration solution-template helps to manage Solution Templates
+    """workload-orchestration-preview solution-template helps to manage Solution Templates
     """
     pass
 

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_template/_bulk_deploy_solution.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_template/_bulk_deploy_solution.py
@@ -12,12 +12,12 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration solution-template bulk-deploy",
+    "workload-orchestration-preview solution-template bulk-deploy",
 )
 class BulkDeploySolution(AAZCommand):
     """Post request for bulk deploy
     :example: Create a BulkDeploySolution
-              az workload-orchestration solution-template bulk-deploy --targets "@targets.json" --name "<solution-template-name>" --version "<solution-template-version>" -g <rg>
+              az workload-orchestration-preview solution-template bulk-deploy --targets "@targets.json" --name "<solution-template-name>" --version "<solution-template-version>" -g <rg>
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_template/_bulk_publish_solution.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_template/_bulk_publish_solution.py
@@ -12,12 +12,12 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration solution-template bulk-publish",
+    "workload-orchestration-preview solution-template bulk-publish",
 )
 class BulkPublishSolution(AAZCommand):
     """Post request for bulk publish
     :example: Bulk publish solution for multiple targets.
-        az workload-orchestration solution-template bulk-publish --resource-group myResourceGroup --solution-template-name myTemplate --solution-template-version 1.0.0 --targets "@targets.json" 
+        az workload-orchestration-preview solution-template bulk-publish --resource-group myResourceGroup --solution-template-name myTemplate --solution-template-version 1.0.0 --targets "@targets.json" 
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_template/_bulk_review_solution.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_template/_bulk_review_solution.py
@@ -12,12 +12,12 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration solution-template bulk-review",
+    "workload-orchestration-preview solution-template bulk-review",
 )
 class BulkReviewSolution(AAZCommand):
     """Post request for bulk review
     :example: Bulk review solution for multiple targets.
-        az workload-orchestration solution-template bulk-review --resource-group myResourceGroup --solution-template-name myTemplate --solution-template-version 1.0.0 --targets "@targets.json" 
+        az workload-orchestration-preview solution-template bulk-review --resource-group myResourceGroup --solution-template-name myTemplate --solution-template-version 1.0.0 --targets "@targets.json" 
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_template/_create.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_template/_create.py
@@ -18,12 +18,12 @@ logger = get_logger(__name__)
 
 
 @register_command(
-    "workload-orchestration solution-template create",
+    "workload-orchestration-preview solution-template create",
 )
 class Create(AAZCommand):
     """Create a Solution Template Resource
     :example: Create Solution Template
-        az workload-orchestration solution-template create -n mySolutionTemplate --description "My Solution Template" --capabilities "capability1" --location eastus --resource-group myResourceGroup --config-template-file ./solution_template.yaml --specification @./specification.json --enable-external-validation true
+        az workload-orchestration-preview solution-template create -n mySolutionTemplate --description "My Solution Template" --capabilities "capability1" --location eastus --resource-group myResourceGroup --config-template-file ./solution_template.yaml --specification @./specification.json --enable-external-validation true
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_template/_delete.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_template/_delete.py
@@ -12,13 +12,13 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration solution-template delete",
+    "workload-orchestration-preview solution-template delete",
     confirmation="Are you sure you want to perform this operation?",
 )
 class Delete(AAZCommand):
     """Delete a Solution Template Resource
     :example: Delete a Solution Template
-        az workload-orchestration solution-template delete -n mySolutionTemplate -g myResourceGroup
+        az workload-orchestration-preview solution-template delete -n mySolutionTemplate -g myResourceGroup
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_template/_delete_version.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_template/_delete_version.py
@@ -12,13 +12,13 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration solution-template delete-version",
+    "workload-orchestration-preview solution-template delete-version",
     confirmation="Are you sure you want to perform this operation?",
 )
 class DeleteVersion(AAZCommand):
     """Delete Solution Template Version Resource
     :example: Delete a Solution Template Version
-        az workload-orchestration solution-template delete-version -n mySolutionTemplate -g myResourceGroup --version 1.0.0
+        az workload-orchestration-preview solution-template delete-version -n mySolutionTemplate -g myResourceGroup --version 1.0.0
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_template/_list.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_template/_list.py
@@ -12,12 +12,12 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration solution-template list-subscriptions",
+    "workload-orchestration-preview solution-template list-subscriptions",
 )
 class List(AAZCommand):
     """List by subscription
     :example: List Solution Templates
-        az workload-orchestration solution-template list-subscriptions
+        az workload-orchestration-preview solution-template list-subscriptions
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_template/_list_untitled1.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_template/_list_untitled1.py
@@ -12,13 +12,13 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration solution-template list",
+    "workload-orchestration-preview solution-template list",
     is_preview=False,
 )
 class ListUntitled1(AAZCommand):
     """List by specified resource group
     :example: List Solution Templates
-        az workload-orchestration solution-template list -g myResourceGroup
+        az workload-orchestration-preview solution-template list -g myResourceGroup
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_template/_remove_version.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_template/_remove_version.py
@@ -12,12 +12,12 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration solution-template remove-version",
+    "workload-orchestration-preview solution-template remove-version",
 )
 class RemoveVersion(AAZCommand):
     """Remove Solution Template Version Resource
     :example: Remove a Solution Template Version
-        az workload-orchestration solution-template remove-version -n mySolutionTemplate -g myResourceGroup --version 1.0.0
+        az workload-orchestration-preview solution-template remove-version -n mySolutionTemplate -g myResourceGroup --version 1.0.0
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_template/_show.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_template/_show.py
@@ -12,12 +12,12 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration solution-template show",
+    "workload-orchestration-preview solution-template show",
 )
 class Show(AAZCommand):
     """Get a Solution Template Resource
     :example: Show a Solution Template
-        az workload-orchestration solution-template show -n mySolutionTemplate -g myResourceGroup 
+        az workload-orchestration-preview solution-template show -n mySolutionTemplate -g myResourceGroup 
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_template/_update.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_template/_update.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration solution-template update",
+    "workload-orchestration-preview solution-template update",
 )
 class Update(AAZCommand):
     """Update a Solution Template Resource

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_template/_update_capabilities.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_template/_update_capabilities.py
@@ -12,13 +12,13 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration solution-template update-capabilities",
+    "workload-orchestration-preview solution-template update-capabilities",
 )
 class UpdateCapabilities(AAZCommand):
     """Update the capabilities of a Solution Template Resource
 
     :example: Update Solution Template Capabilities
-        az workload-orchestration solution-template update-capabilities -n mySolutionTemplate --capabilities "capability1" "capability2" "capability3" --location eastus --resource-group myResourceGroup
+        az workload-orchestration-preview solution-template update-capabilities -n mySolutionTemplate --capabilities "capability1" "capability2" "capability3" --location eastus --resource-group myResourceGroup
     """
 
     _aaz_info = {

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_template/_wait.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_template/_wait.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration solution-template wait",
+    "workload-orchestration-preview solution-template wait",
 )
 class Wait(AAZWaitCommand):
     """Place the CLI in a waiting state until a condition is met.

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_template/version/__cmd_group.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_template/version/__cmd_group.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command_group(
-    "workload-orchestration solution-template version",
+    "workload-orchestration-preview solution-template version",
 )
 class __CMDGroup(AAZCommandGroup):
     """Manage solution template versions in workload orchestration.

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_template/version/_list.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_template/version/_list.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration solution-template version list",
+    "workload-orchestration-preview solution-template version list",
 )
 class List(AAZCommand):
     """List Solution Template Version Resources

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_template/version/_show.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/solution_template/version/_show.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration solution-template version show",
+    "workload-orchestration-preview solution-template version show",
 )
 class Show(AAZCommand):
     """Get a Solution Template Version Resource

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/target_template/__cmd_group.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/target_template/__cmd_group.py
@@ -12,10 +12,10 @@ from azure.cli.core.aaz import *
 
 
 # @register_command_group(
-#     "workload-orchestration target-template",
+#     "workload-orchestration-preview target-template",
 # )
 class __CMDGroup(AAZCommandGroup):
-    """workload-orchestration target-template helps to manage Target Templates
+    """workload-orchestration-preview target-template helps to manage Target Templates
     """
     pass
 

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/target_template/_create.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/target_template/_create.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration target-template create",
+    "workload-orchestration-preview target-template create",
 )
 class Create(AAZCommand):
     """Create a Target Template Resource

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/target_template/_delete.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/target_template/_delete.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration target-template delete",
+    "workload-orchestration-preview target-template delete",
     confirmation="Are you sure you want to perform this operation?",
 )
 class Delete(AAZCommand):

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/target_template/_list.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/target_template/_list.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration target-template list",
+    "workload-orchestration-preview target-template list",
 )
 class List(AAZCommand):
     """List by subscription

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/target_template/_show.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/target_template/_show.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration target-template show",
+    "workload-orchestration-preview target-template show",
 )
 class Show(AAZCommand):
     """Get a Target Template Resource

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/target_template/_update.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/target_template/_update.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration target-template update",
+    "workload-orchestration-preview target-template update",
 )
 class Update(AAZCommand):
     """Update a Target Template Resource

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/target_template/_wait.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/target_template/_wait.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration target-template wait",
+    "workload-orchestration-preview target-template wait",
 )
 class Wait(AAZWaitCommand):
     """Place the CLI in a waiting state until a condition is met.

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/__cmd_group.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/__cmd_group.py
@@ -12,11 +12,11 @@ from azure.cli.core.aaz import *
 
 
 # @register_command_group(
-#     "workload-orchestration workflow",
+#     "workload-orchestration-preview workflow",
 #     is_preview=False,
 # )
 class __CMDGroup(AAZCommandGroup):
-    """workload-orchestration workflow helps to manage Workflows
+    """workload-orchestration-preview workflow helps to manage Workflows
     """
     pass
 

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/_create.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/_create.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 # @register_command(
-#     "workload-orchestration workflow create",
+#     "workload-orchestration-preview workflow create",
 # # )
 class Create(AAZCommand):
     """Create a Workflow resource

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/_delete.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/_delete.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration workflow delete",
+    "workload-orchestration-preview workflow delete",
     confirmation="Are you sure you want to perform this operation?",
 )
 class Delete(AAZCommand):

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/_list.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/_list.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration workflow list",
+    "workload-orchestration-preview workflow list",
 )
 class List(AAZCommand):
     """List by subscription

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/_show.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/_show.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration workflow show",
+    "workload-orchestration-preview workflow show",
 )
 class Show(AAZCommand):
     """Get a Workflow resource

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/_update.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/_update.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration workflow update",
+    "workload-orchestration-preview workflow update",
 )
 class Update(AAZCommand):
     """Update a Workflow resource

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/_wait.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/_wait.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration workflow wait",
+    "workload-orchestration-preview workflow wait",
 )
 class Wait(AAZWaitCommand):
     """Place the CLI in a waiting state until a condition is met.

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/version/__cmd_group.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/version/__cmd_group.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 # @register_command_group(
-#     "workload-orchestration workflow version",
+#     "workload-orchestration-preview workflow version",
 # # )
 class __CMDGroup(AAZCommandGroup):
     """This is for edge Config-Manager

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/version/_create.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/version/_create.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration workflow version create",
+    "workload-orchestration-preview workflow version create",
 )
 class Create(AAZCommand):
     """Create a Workflow Version Resource

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/version/_delete.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/version/_delete.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration workflow version delete",
+    "workload-orchestration-preview workflow version delete",
     confirmation="Are you sure you want to perform this operation?",
 )
 class Delete(AAZCommand):

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/version/_list.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/version/_list.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration workflow version list",
+    "workload-orchestration-preview workflow version list",
 )
 class List(AAZCommand):
     """List Workflow Version Resources

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/version/_show.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/version/_show.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration workflow version show",
+    "workload-orchestration-preview workflow version show",
 )
 class Show(AAZCommand):
     """Get a Workflow Version Resource

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/version/_update.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/version/_update.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration workflow version update",
+    "workload-orchestration-preview workflow version update",
 )
 class Update(AAZCommand):
     """Update a Workflow Version Resource

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/version/_wait.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/version/_wait.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration workflow version wait",
+    "workload-orchestration-preview workflow version wait",
 )
 class Wait(AAZWaitCommand):
     """Place the CLI in a waiting state until a condition is met.

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/version/execution/__cmd_group.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/version/execution/__cmd_group.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 # @register_command_group(
-#     "workload-orchestration workflow version execution",
+#     "workload-orchestration-preview workflow version execution",
 # # )
 class __CMDGroup(AAZCommandGroup):
     """This is for edge Config-Manager

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/version/execution/_create.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/version/execution/_create.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration workflow version execution create",
+    "workload-orchestration-preview workflow version execution create",
 )
 class Create(AAZCommand):
     """Create Execution Resource

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/version/execution/_delete.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/version/execution/_delete.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration workflow version execution delete",
+    "workload-orchestration-preview workflow version execution delete",
     confirmation="Are you sure you want to perform this operation?",
 )
 class Delete(AAZCommand):

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/version/execution/_list.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/version/execution/_list.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration workflow version execution list",
+    "workload-orchestration-preview workflow version execution list",
 )
 class List(AAZCommand):
     """List Execution Resources

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/version/execution/_show.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/version/execution/_show.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration workflow version execution show",
+    "workload-orchestration-preview workflow version execution show",
 )
 class Show(AAZCommand):
     """Get Execution Resource

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/version/execution/_update.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/version/execution/_update.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration workflow version execution update",
+    "workload-orchestration-preview workflow version execution update",
 )
 class Update(AAZCommand):
     """Update Execution Resource

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/version/execution/_wait.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow/version/execution/_wait.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration workflow version execution wait",
+    "workload-orchestration-preview workflow version execution wait",
 )
 class Wait(AAZWaitCommand):
     """Place the CLI in a waiting state until a condition is met.

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow_template/__cmd_group.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow_template/__cmd_group.py
@@ -12,10 +12,10 @@ from azure.cli.core.aaz import *
 
 
 # @register_command_group(
-#     "workload-orchestration workflow-template",
+#     "workload-orchestration-preview workflow-template",
 # )
 class __CMDGroup(AAZCommandGroup):
-    """workload-orchestration workflow-template helps to manage Workflow Templates
+    """workload-orchestration-preview workflow-template helps to manage Workflow Templates
     """
     pass
 

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow_template/_create.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow_template/_create.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration workflow-template create",
+    "workload-orchestration-preview workflow-template create",
 )
 class Create(AAZCommand):
     """Create a Workflow Template Resource

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow_template/_delete.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow_template/_delete.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration workflow-template delete",
+    "workload-orchestration-preview workflow-template delete",
     confirmation="Are you sure you want to perform this operation?",
 )
 class Delete(AAZCommand):

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow_template/_list.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow_template/_list.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration workflow-template list",
+    "workload-orchestration-preview workflow-template list",
 )
 class List(AAZCommand):
     """List by subscription

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow_template/_list_untitled1.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow_template/_list_untitled1.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration workflow-template list-untitled1",
+    "workload-orchestration-preview workflow-template list-untitled1",
 )
 class ListUntitled1(AAZCommand):
     """List by specified resource group

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow_template/_show.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow_template/_show.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration workflow-template show",
+    "workload-orchestration-preview workflow-template show",
 )
 class Show(AAZCommand):
     """Get a Workflow Template Resource

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow_template/_update.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow_template/_update.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration workflow-template update",
+    "workload-orchestration-preview workflow-template update",
 )
 class Update(AAZCommand):
     """Update a Workflow Template Resource

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow_template/_wait.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow_template/_wait.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration workflow-template wait",
+    "workload-orchestration-preview workflow-template wait",
 )
 class Wait(AAZWaitCommand):
     """Place the CLI in a waiting state until a condition is met.

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow_template/version/__cmd_group.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow_template/version/__cmd_group.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 # @register_command_group(
-#     "workload-orchestration workflow-template version",
+#     "workload-orchestration-preview workflow-template version",
 # )
 class __CMDGroup(AAZCommandGroup):
     """This is for edge Config-Manager

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow_template/version/_create.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow_template/version/_create.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration workflow-template version create",
+    "workload-orchestration-preview workflow-template version create",
 )
 class Create(AAZCommand):
     """Create a Workflow Template Version Resource

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow_template/version/_delete.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow_template/version/_delete.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration workflow-template version delete",
+    "workload-orchestration-preview workflow-template version delete",
     confirmation="Are you sure you want to perform this operation?",
 )
 class Delete(AAZCommand):

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow_template/version/_list.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow_template/version/_list.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration workflow-template version list",
+    "workload-orchestration-preview workflow-template version list",
 )
 class List(AAZCommand):
     """List Workflow Template Version Resources

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow_template/version/_show.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow_template/version/_show.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration workflow-template version show",
+    "workload-orchestration-preview workflow-template version show",
 )
 class Show(AAZCommand):
     """Get a Workflow Template Version Resource

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow_template/version/_update.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow_template/version/_update.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration workflow-template version update",
+    "workload-orchestration-preview workflow-template version update",
 )
 class Update(AAZCommand):
     """Update a Workflow Template Version Resource

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow_template/version/_wait.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/aaz/latest/workload_orchestration/workflow_template/version/_wait.py
@@ -12,7 +12,7 @@ from azure.cli.core.aaz import *
 
 
 @register_command(
-    "workload-orchestration workflow-template version wait",
+    "workload-orchestration-preview workflow-template version wait",
 )
 class Wait(AAZWaitCommand):
     """Place the CLI in a waiting state until a condition is met.

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/commands.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/commands.py
@@ -10,5 +10,5 @@
 
 
 def load_command_table(self, _):  # pylint: disable=unused-argument
-    with self.command_group('workload-orchestration support', is_preview=True) as g:
+    with self.command_group('workload-orchestration-preview support', is_preview=True) as g:
         g.custom_command('create-bundle', 'create_support_bundle')

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/common/context.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/common/context.py
@@ -180,7 +180,7 @@ def _normalize_names_input(name, names):
 def _fetch_context(cli_ctx, resource_group, context_name, subscription=None):
     """GET the context resource. Returns (context_dict, subscription_id)."""
     cmd = CmdProxy(cli_ctx)
-    args = ["workload-orchestration", "context", "show",
+    args = ["workload-orchestration-preview", "context", "show",
             "-g", resource_group, "--name", context_name]
     if subscription:
         args.extend(["--subscription", subscription])

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/common/utils.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/common/utils.py
@@ -162,7 +162,7 @@ def print_step(step_num, total, message, status=""):
 # CLI extension dependency check
 # ---------------------------------------------------------------------------
 
-# az CLI extensions that workload-orchestration calls at runtime via
+# az CLI extensions that workload-orchestration-preview calls at runtime via
 # invoke_cli_command. These MUST be installed before `cluster init` runs,
 # otherwise sub-command invocations fail with opaque "command not recognized"
 # errors. Mirrors the azext_vme.utils.check_and_add_cli_extension pattern.

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/support/__init__.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/support/__init__.py
@@ -3,9 +3,9 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-"""Support bundle package for workload-orchestration CLI extension.
+"""Support bundle package for workload-orchestration-preview CLI extension.
 
-This package provides the ``az workload-orchestration support create-bundle`` command
+This package provides the ``az workload-orchestration-preview support create-bundle`` command
 which collects Kubernetes cluster diagnostics, runs prerequisite validation checks,
 and packages everything into a zip bundle for troubleshooting.
 

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/support/collectors.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/support/collectors.py
@@ -6,7 +6,7 @@
 # pylint: disable=import-outside-toplevel,too-many-branches,too-many-statements
 # pylint: disable=too-many-locals,too-many-arguments,too-many-positional-arguments
 
-"""Data collectors for the workload-orchestration support bundle feature."""
+"""Data collectors for the workload-orchestration-preview support bundle feature."""
 
 import os
 from concurrent.futures import ThreadPoolExecutor, as_completed

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/support/consts.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/support/consts.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-"""Constants for the workload-orchestration support bundle feature."""
+"""Constants for the workload-orchestration-preview support bundle feature."""
 
 # Bundle defaults
 DEFAULT_TAIL_LINES = 1000

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/support/utils.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/support/utils.py
@@ -7,7 +7,7 @@
 # pylint: disable=raise-missing-from,too-many-locals,broad-exception-caught
 # pylint: disable=too-many-arguments,too-many-positional-arguments
 
-"""Utility functions for the workload-orchestration support bundle feature."""
+"""Utility functions for the workload-orchestration-preview support bundle feature."""
 
 import json
 import os

--- a/src/workload-orchestration-preview/azext_workload_orchestration_preview/support/validators.py
+++ b/src/workload-orchestration-preview/azext_workload_orchestration_preview/support/validators.py
@@ -5,7 +5,7 @@
 
 # pylint: disable=unused-argument,import-outside-toplevel,too-many-locals
 
-"""Prerequisite validators for the workload-orchestration support bundle feature.
+"""Prerequisite validators for the workload-orchestration-preview support bundle feature.
 
 Each check function has the same signature (clients, bundle_dir, cluster_info, capabilities)
 for consistency. Not all checks use all arguments.

--- a/src/workload-orchestration-preview/linter_exclusions.yml
+++ b/src/workload-orchestration-preview/linter_exclusions.yml
@@ -1,4 +1,4 @@
-workload-orchestration solution-template create:
+workload-orchestration-preview solution-template create:
   parameters:
     configuration-template-file:
       rule_exclusions:
@@ -7,13 +7,13 @@ workload-orchestration solution-template create:
       rule_exclusions:
       - option_length_too_long
       
-workload-orchestration solution-template version show:
+workload-orchestration-preview solution-template version show:
   parameters:
     solution-template-version-name:
       rule_exclusions:
       - option_length_too_long
 
-workload-orchestration target resolve:
+workload-orchestration-preview target resolve:
   parameters:
     solution-template-name:
       rule_exclusions:
@@ -22,7 +22,7 @@ workload-orchestration target resolve:
       rule_exclusions:
       - option_length_too_long
 
-workload-orchestration target review:
+workload-orchestration-preview target review:
   parameters:
     solution-template-name:
       rule_exclusions:
@@ -34,13 +34,13 @@ workload-orchestration target review:
       rule_exclusions:
       - option_length_too_long
 
-workload-orchestration sync:
+workload-orchestration-preview sync:
   parameters:
     local_connected_registry_ip:
       rule_exclusions:
       - option_length_too_long
 
-workload-orchestration solution-deployment create:
+workload-orchestration-preview solution-deployment create:
   parameters:
     solution_template_subscription:
       rule_exclusions:
@@ -49,7 +49,7 @@ workload-orchestration solution-deployment create:
       rule_exclusions:
       - option_length_too_long
 
-workload-orchestration solution-deployment update:
+workload-orchestration-preview solution-deployment update:
   parameters:
     solution_template_subscription:
       rule_exclusions:
@@ -58,7 +58,7 @@ workload-orchestration solution-deployment update:
       rule_exclusions:
       - option_length_too_long
 
-workload-orchestration cluster init:
+workload-orchestration-preview cluster init:
   parameters:
     extension-dependency-version:
       rule_exclusions:

--- a/src/workload-orchestration-preview/setup.py
+++ b/src/workload-orchestration-preview/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 
 
 # HISTORY.rst entry.
-VERSION = '0.1.0b1'
+VERSION = '0.1.0b2'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
@@ -48,7 +48,7 @@ setup(
     license='MIT',
     author='Microsoft Corporation',
     author_email='azpycli@microsoft.com',
-    url='https://github.com/Azure/azure-cli-extensions/tree/main/src/workload-orchestration',
+    url='https://github.com/Azure/azure-cli-extensions/tree/main/src/workload-orchestration-preview',
     classifiers=CLASSIFIERS,
     packages=find_packages(exclude=["tests"]),
     package_data={'azext_workload_orchestration_preview': ['azext_metadata.json']},


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes |
| :--: |
| ️✔️ None |

<!-- act-bot:section title="Azure CLI Extensions Breaking Change Test" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

### Summary

The `workload-orchestration-preview` extension registered the **same** `workload-orchestration` CLI command group as the GA `workload-orchestration` extension. When both are installed the command tables collide (later-loaded extension's table wins), which broke a downstream pipeline. This was not caught pre-merge because the pipeline was green at merge time.

Per the CLI team's recommendation, this PR makes the command groups distinct: the preview extension now exposes `az workload-orchestration-preview ...`. The GA `workload-orchestration` extension is untouched.

### Customer impact

None. Public documentation covers only GA commands; preview commands have no documented customer usage. The preview command surface is unchanged apart from the group prefix.

### Changes

- Renamed the root command group and all sub-groups/commands from `workload-orchestration` to `workload-orchestration-preview` across all AAZ `register_command` / `register_command_group` definitions.
- Updated all `az workload-orchestration` help examples to `az workload-orchestration-preview`.
- Renamed the custom `support` command group and updated the internal `context show` invocation used by the support-bundle feature.
- Updated `linter_exclusions.yml` keys to match the new command names.
- Updated `README.md`, `HISTORY.rst`, and `setup.py` (url); bumped version `0.1.0b1` -> `0.1.0b2`.

### Validation

- Extension loads cleanly under `az workload-orchestration-preview` (all sub-groups + custom `support create-bundle` command build with no duplicate-registration errors).
- No changes to GA `workload-orchestration`.
