### PR TITLE
[AI Manager] Add namespace access key commands

### DIFF
--- a/src/aimanager/HISTORY.rst
+++ b/src/aimanager/HISTORY.rst
@@ -3,6 +3,13 @@
 Release History
 ===============
 
+1.2.1b1
++++++++
+* ``az aimanager namespace``: Add ``list-accesskeys`` and ``rotate-accesskeys`` commands to
+  read and rotate the namespace LLM gateway API keys.
+* ``az aimanager namespace``: Accept ``--aimanager-name`` as an alias of ``--manager``/``-m``
+  for consistency with ``az aimanager namespace modeldeployment``.
+
 1.2.0
 ++++++
 * Add ``az aimanager namespace modeldeployment`` commands to add, update, list, show, delete,

--- a/src/aimanager/HISTORY.rst
+++ b/src/aimanager/HISTORY.rst
@@ -5,6 +5,10 @@ Release History
 
 1.2.1b1
 +++++++
+* Add ``az aimanager model`` commands (``show``, ``list`` and ``calculate-cost``) to browse the
+  regional AI model catalog and estimate the cost of deploying a model.
+* Add ``az aimanager modelsource`` commands (``add``, ``update``, ``list``, ``show``,
+  ``delete`` and ``wait``) to manage the model sources of an AI Manager.
 * ``az aimanager namespace``: Add ``list-accesskeys`` and ``rotate-accesskeys`` commands to
   read and rotate the namespace LLM gateway API keys.
 * ``az aimanager namespace``: Accept ``--aimanager-name`` as an alias of ``--manager``/``-m``

--- a/src/aimanager/azext_aimanager/_help.py
+++ b/src/aimanager/azext_aimanager/_help.py
@@ -141,6 +141,33 @@ helps['aimanager namespace get-credentials'] = """
           text: az aimanager namespace get-credentials -m my-ai-manager -g myrg --name team-alpha -f -
 """
 
+helps['aimanager namespace list-accesskeys'] = """
+    type: command
+    short-summary: List the LLM gateway endpoint and API keys of an AI Manager namespace.
+    long-summary: |-
+        Returns the namespace-scoped, OpenAI-compatible inference gateway endpoint together with the
+        current primary and secondary API keys. Treat the keys as secrets: do not log them or persist
+        them in plaintext.
+    examples:
+        - name: List the access keys of a namespace
+          text: az aimanager namespace list-accesskeys -g myrg --aimanager-name my-ai-manager --name team-alpha
+        - name: Show only the gateway endpoint
+          text: az aimanager namespace list-accesskeys -g myrg --aimanager-name my-ai-manager --name team-alpha --query endpoint -o tsv
+"""
+
+helps['aimanager namespace rotate-accesskeys'] = """
+    type: command
+    short-summary: Rotate the LLM gateway API keys of an AI Manager namespace.
+    long-summary: |-
+        A new key is generated and installed as the primary key, and the previous primary key
+        overwrites the secondary key so clients can roll over without downtime. Returns the updated
+        access info. Any client still using the previous secondary key will stop being able to
+        authenticate.
+    examples:
+        - name: Rotate the access keys of a namespace
+          text: az aimanager namespace rotate-accesskeys -g myrg --aimanager-name my-ai-manager --name team-alpha
+"""
+
 helps['aimanager namespace modeldeployment'] = """
     type: group
     short-summary: Manage model deployments within an AI Manager namespace.

--- a/src/aimanager/azext_aimanager/_params.py
+++ b/src/aimanager/azext_aimanager/_params.py
@@ -54,7 +54,7 @@ def load_arguments(self, _):
                    help='Comma-separated key=value pairs to specify custom headers.')
 
     with self.argument_context('aimanager namespace') as c:
-        c.argument('ai_manager_name', options_list=['--manager', '-m'],
+        c.argument('ai_manager_name', options_list=['--aimanager-name', '--manager', '-m'],
                    validator=validate_ai_manager_name,
                    help='The name of the AI Manager resource.')
         c.argument('namespace_name', options_list=['--name', '-n'],
@@ -79,6 +79,11 @@ def load_arguments(self, _):
                    help='If specified, overwrite the default context name.')
         c.argument('aks_custom_headers', options_list=['--aks-custom-headers'],
                    help='Comma-separated key=value pairs to specify custom headers.')
+
+    for scope in ['aimanager namespace list-accesskeys', 'aimanager namespace rotate-accesskeys']:
+        with self.argument_context(scope) as c:
+            c.argument('aks_custom_headers', options_list=['--aks-custom-headers'],
+                       help='Comma-separated key=value pairs to specify custom headers.')
 
     with self.argument_context('aimanager namespace modeldeployment') as c:
         c.argument('ai_manager_name', options_list=['--aimanager-name'],

--- a/src/aimanager/azext_aimanager/azext_metadata.json
+++ b/src/aimanager/azext_aimanager/azext_metadata.json
@@ -1,5 +1,5 @@
 {
     "azext.isPreview": true,
     "azext.minCliCoreVersion": "2.61.0",
-    "version": "1.2.0"
+    "version": "1.2.1b1"
 }

--- a/src/aimanager/azext_aimanager/commands.py
+++ b/src/aimanager/azext_aimanager/commands.py
@@ -50,6 +50,8 @@ def load_command_table(self, _):
         g.custom_command("list", "list_aimanager_namespace")
         g.custom_command("delete", "delete_aimanager_namespace", supports_no_wait=True, confirmation=True)
         g.custom_command("get-credentials", "aimanager_namespace_get_credentials")
+        g.custom_command("list-accesskeys", "aimanager_namespace_list_accesskeys")
+        g.custom_command("rotate-accesskeys", "aimanager_namespace_rotate_accesskeys", confirmation=True)
         g.wait_command("wait")
 
     # aimanager namespace modeldeployment command group

--- a/src/aimanager/azext_aimanager/custom.py
+++ b/src/aimanager/azext_aimanager/custom.py
@@ -299,6 +299,30 @@ def aimanager_namespace_get_credentials(cmd,
         resource_group_name, ai_manager_name, namespace_name, headers=headers)
     _write_kubeconfig(credential_results, path, overwrite_existing, context_name)
 
+
+# pylint: disable=unused-argument
+def aimanager_namespace_list_accesskeys(cmd,
+                                        client,
+                                        resource_group_name,
+                                        ai_manager_name,
+                                        namespace_name,
+                                        aks_custom_headers=None):
+    headers = get_aks_custom_headers(aks_custom_headers)
+    return client.list_access_keys(
+        resource_group_name, ai_manager_name, namespace_name, headers=headers)
+
+
+# pylint: disable=unused-argument
+def aimanager_namespace_rotate_accesskeys(cmd,
+                                          client,
+                                          resource_group_name,
+                                          ai_manager_name,
+                                          namespace_name,
+                                          aks_custom_headers=None):
+    headers = get_aks_custom_headers(aks_custom_headers)
+    return client.rotate_keys(
+        resource_group_name, ai_manager_name, namespace_name, headers=headers)
+
 # endregion
 
 

--- a/src/aimanager/azext_aimanager/tests/latest/test_namespace_accesskeys.py
+++ b/src/aimanager/azext_aimanager/tests/latest/test_namespace_accesskeys.py
@@ -1,0 +1,52 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import unittest
+from unittest.mock import MagicMock
+
+from azext_aimanager import custom
+
+
+class MockCmd:
+    pass
+
+
+class TestNamespaceAccessKeys(unittest.TestCase):
+
+    def setUp(self):
+        self.cmd = MockCmd()
+        self.client = MagicMock()
+
+    def test_list_accesskeys(self):
+        self.client.list_access_keys.return_value = "access-info"
+
+        result = custom.aimanager_namespace_list_accesskeys(
+            self.cmd, self.client, "rg", "manager", "namespace")
+
+        self.assertEqual(result, "access-info")
+        self.client.list_access_keys.assert_called_once_with(
+            "rg", "manager", "namespace", headers={})
+
+    def test_rotate_accesskeys(self):
+        self.client.rotate_keys.return_value = "rotated"
+
+        result = custom.aimanager_namespace_rotate_accesskeys(
+            self.cmd, self.client, "rg", "manager", "namespace")
+
+        self.assertEqual(result, "rotated")
+        self.client.rotate_keys.assert_called_once_with(
+            "rg", "manager", "namespace", headers={})
+
+    def test_custom_headers_are_forwarded(self):
+        custom.aimanager_namespace_list_accesskeys(
+            self.cmd, self.client, "rg", "manager", "namespace",
+            aks_custom_headers="a=1,b=2")
+
+        self.client.list_access_keys.assert_called_once_with(
+            "rg", "manager", "namespace", headers={"a": "1", "b": "2"})
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/aimanager/azext_aimanager/tests/latest/test_namespace_accesskeys_scenario.py
+++ b/src/aimanager/azext_aimanager/tests/latest/test_namespace_accesskeys_scenario.py
@@ -1,0 +1,60 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from unittest.mock import MagicMock, patch
+
+from azure.cli.testsdk import ScenarioTest
+
+from azext_aimanager.vendored_sdks.v2026_05_02_preview import models
+
+
+class NamespaceAccessKeysScenarioTest(ScenarioTest):
+
+    def test_namespace_accesskeys_commands(self):
+        access_info = models.NamespaceAccessInfo({
+            'endpoint': 'https://team-alpha.example.eastus2.aksapp.io/v1',
+            'primaryKey': 'primary-key-value',
+            'secondaryKey': 'secondary-key-value',
+        })
+        rotated_info = models.NamespaceAccessInfo({
+            'endpoint': 'https://team-alpha.example.eastus2.aksapp.io/v1',
+            'primaryKey': 'new-primary-key-value',
+            'secondaryKey': 'primary-key-value',
+            'lastRotatedAt': '2026-08-14T00:00:00Z',
+        })
+
+        operations = MagicMock()
+        operations.list_access_keys.return_value = access_info
+        operations.rotate_keys.return_value = rotated_info
+        service_client = MagicMock()
+        service_client.ai_manager_namespaces = operations
+
+        command_prefix = 'aimanager namespace {} -g rg --aimanager-name manager -n namespace'
+
+        with patch('azext_aimanager._client_factory.get_aimanager_client',
+                   return_value=service_client):
+            self.cmd(
+                command_prefix.format('list-accesskeys'),
+                checks=[
+                    self.check('endpoint', 'https://team-alpha.example.eastus2.aksapp.io/v1'),
+                    self.check('primaryKey', 'primary-key-value'),
+                    self.check('secondaryKey', 'secondary-key-value'),
+                ])
+
+            # the previous primary key is demoted to the secondary key on rotation
+            self.cmd(
+                command_prefix.format('rotate-accesskeys') + ' --yes',
+                checks=[
+                    self.check('primaryKey', 'new-primary-key-value'),
+                    self.check('secondaryKey', 'primary-key-value'),
+                ])
+
+            # -m/--manager remains accepted for backwards compatibility
+            self.cmd(
+                'aimanager namespace list-accesskeys -g rg -m manager -n namespace',
+                checks=[self.check('primaryKey', 'primary-key-value')])
+
+        operations.list_access_keys.assert_called_with('rg', 'manager', 'namespace', headers={})
+        operations.rotate_keys.assert_called_once_with('rg', 'manager', 'namespace', headers={})

--- a/src/aimanager/azext_aimanager/tests/latest/test_namespace_accesskeys_scenario.py
+++ b/src/aimanager/azext_aimanager/tests/latest/test_namespace_accesskeys_scenario.py
@@ -56,5 +56,14 @@ class NamespaceAccessKeysScenarioTest(ScenarioTest):
                 'aimanager namespace list-accesskeys -g rg -m manager -n namespace',
                 checks=[self.check('primaryKey', 'primary-key-value')])
 
-        operations.list_access_keys.assert_called_with('rg', 'manager', 'namespace', headers={})
+            operations.list_access_keys.assert_called_with(
+                'rg', 'manager', 'namespace', headers={})
+
+            # --aks-custom-headers is parsed and forwarded to the request
+            self.cmd(
+                command_prefix.format('list-accesskeys') + ' --aks-custom-headers a=1,b=2',
+                checks=[self.check('primaryKey', 'primary-key-value')])
+
+        operations.list_access_keys.assert_called_with(
+            'rg', 'manager', 'namespace', headers={'a': '1', 'b': '2'})
         operations.rotate_keys.assert_called_once_with('rg', 'manager', 'namespace', headers={})

--- a/src/aimanager/setup.py
+++ b/src/aimanager/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     from distutils import log as logger
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
 
-VERSION = '1.2.0'
+VERSION = '1.2.1b1'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ⚠️ Review suggested

| Breaking Changes |
| :--: |
| ⚠️ None |

<!-- act-bot:section title="Azure CLI Extensions Breaking Change Test" category="breaking_change" label="Breaking Changes" status="Warning" summary="None" -->
<!-- Azure CLI Extensions Breaking Change Test --><details>
<summary>⚠️Azure CLI Extensions Breaking Change Test</summary>

><details>
> <summary>⚠️aimanager</summary>
>
>|rule|cmd_name|rule_message|suggest_message|
>|---|---|---|---|
>|⚠️ [1010 - ParaPropUpdate](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1010.md)|aimanager namespace add|cmd `aimanager namespace add` update parameter `ai_manager_name`: updated property `options` from `['--manager', '-m']` to `['--aimanager-name', '--manager', '-m']`||
>|⚠️ [1010 - ParaPropUpdate](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1010.md)|aimanager namespace delete|cmd `aimanager namespace delete` update parameter `ai_manager_name`: updated property `options` from `['--manager', '-m']` to `['--aimanager-name', '--manager', '-m']`||
>|⚠️ [1010 - ParaPropUpdate](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1010.md)|aimanager namespace get-credentials|cmd `aimanager namespace get-credentials` update parameter `ai_manager_name`: updated property `options` from `['--manager', '-m']` to `['--aimanager-name', '--manager', '-m']`||
>|⚠️ [1010 - ParaPropUpdate](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1010.md)|aimanager namespace list|cmd `aimanager namespace list` update parameter `ai_manager_name`: updated property `options` from `['--manager', '-m']` to `['--aimanager-name', '--manager', '-m']`||
>|⚠️ [1001 - CmdAdd](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1001.md)|aimanager namespace list-accesskeys|cmd `aimanager namespace list-accesskeys` added||
>|⚠️ [1001 - CmdAdd](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1001.md)|aimanager namespace rotate-accesskeys|cmd `aimanager namespace rotate-accesskeys` added||
>|⚠️ [1010 - ParaPropUpdate](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1010.md)|aimanager namespace show|cmd `aimanager namespace show` update parameter `ai_manager_name`: updated property `options` from `['--manager', '-m']` to `['--aimanager-name', '--manager', '-m']`||
>|⚠️ [1010 - ParaPropUpdate](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1010.md)|aimanager namespace update|cmd `aimanager namespace update` update parameter `ai_manager_name`: updated property `options` from `['--manager', '-m']` to `['--aimanager-name', '--manager', '-m']`||
>|⚠️ [1010 - ParaPropUpdate](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1010.md)|aimanager namespace wait|cmd `aimanager namespace wait` update parameter `ai_manager_name`: updated property `options` from `['--manager', '-m']` to `['--aimanager-name', '--manager', '-m']`||
>
></details>
</details>

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

Add the two remaining namespace-scoped access key commands to the `az aimanager namespace` group, backed by the `AIManagerNamespaces` operations of the vendored `2026-05-02-preview` SDK.

| Command | Endpoint |
| --- | --- |
| `az aimanager namespace list-accesskeys` | `POST .../aiManagers/{aiManagerName}/namespaces/{namespaceName}/listAccessKeys` |
| `az aimanager namespace rotate-accesskeys` | `POST .../aiManagers/{aiManagerName}/namespaces/{namespaceName}/rotateKeys` |

Both return `NamespaceAccessInfo`: the OpenAI-compatible inference gateway endpoint plus the primary and secondary API keys.

```
az aimanager namespace list-accesskeys -g myrg --aimanager-name my-ai-manager -n team-alpha
az aimanager namespace rotate-accesskeys -g myrg --aimanager-name my-ai-manager -n team-alpha
```

Behaviour notes:

* `rotate-accesskeys` generates a new key as `primaryKey` and demotes the previous `primaryKey` to `secondaryKey`, so clients can roll over without downtime. Because this invalidates whatever was previously in `secondaryKey`, the command requires confirmation (`--yes` to skip), consistent with the other destructive commands in this extension.
* The underlying SDK method for rotation is `rotate_keys`, mapped to the `rotate-accesskeys` command name so it reads consistently alongside `list-accesskeys`.
* Both commands accept `--aks-custom-headers`, like the rest of the group.

This PR also adds `--aimanager-name` as an **alias** of `--manager`/`-m` on the `az aimanager namespace` group. The nested `az aimanager namespace modeldeployment` group already uses `--aimanager-name`, so the tree is currently inconsistent depending on how deep you are. The existing `--manager`/`-m` options keep working unchanged, so this is not a breaking change - it just lets the same option name be used at both levels. Happy to drop this part if you would rather keep the groups as they are.

`az aimanager namespace get-credentials` already exists on `main` and already posts to `.../namespaces/{namespaceName}/listCredential`, so it is unchanged here.

Extension version bumped `1.2.0` -> `1.2.1b1` with a matching `HISTORY.rst` entry.

### Testing

* New `test_namespace_accesskeys.py` unit tests asserting both commands call the right SDK operation with the right arguments and that `--aks-custom-headers` is forwarded.
* New `test_namespace_accesskeys_scenario.py` mocked scenario test exercising both commands end-to-end through the CLI parser, including that rotation demotes the previous primary key and that `-m` still works.
* `azdev style` (flake8) clean and `pylint` 10.00/10 against the repo configs.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
`az aimanager namespace list-accesskeys | rotate-accesskeys`

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install azdev` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`.
