### PR TITLE
[AI Manager] Add manager aliases to nested commands

### DIFF
--- a/src/aimanager/HISTORY.rst
+++ b/src/aimanager/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+1.4.1
+++++++
+* ``az aimanager modelsource`` and ``az aimanager namespace modeldeployment``: Accept
+  ``--manager`` and ``-m`` as aliases of ``--aimanager-name``.
+
 1.4.0
 +++++++
 * Mark ``az aimanager`` command groups as preview.

--- a/src/aimanager/azext_aimanager/_params.py
+++ b/src/aimanager/azext_aimanager/_params.py
@@ -60,7 +60,7 @@ def load_arguments(self, _):
                    help='Comma-separated key=value pairs to specify custom headers.')
 
     with self.argument_context('aimanager modelsource') as c:
-        c.argument('ai_manager_name', options_list=['--aimanager-name'],
+        c.argument('ai_manager_name', options_list=['--aimanager-name', '--manager', '-m'],
                    validator=validate_ai_manager_name,
                    help='The name of the AI Manager resource.')
         c.argument('model_source_name', options_list=['--name', '-n'],
@@ -118,7 +118,7 @@ def load_arguments(self, _):
                        help='Comma-separated key=value pairs to specify custom headers.')
 
     with self.argument_context('aimanager namespace modeldeployment') as c:
-        c.argument('ai_manager_name', options_list=['--aimanager-name'],
+        c.argument('ai_manager_name', options_list=['--aimanager-name', '--manager', '-m'],
                    validator=validate_ai_manager_name,
                    help='The name of the AI Manager resource.')
         c.argument('namespace_name', options_list=['--namespace-name'],

--- a/src/aimanager/azext_aimanager/azext_metadata.json
+++ b/src/aimanager/azext_aimanager/azext_metadata.json
@@ -1,5 +1,5 @@
 {
     "azext.isPreview": true,
     "azext.minCliCoreVersion": "2.61.0",
-    "version": "1.2.1b1"
+    "version": "1.4.1"
 }

--- a/src/aimanager/azext_aimanager/tests/latest/test_modeldeployment_scenario.py
+++ b/src/aimanager/azext_aimanager/tests/latest/test_modeldeployment_scenario.py
@@ -90,6 +90,11 @@ class ModelDeploymentScenarioTest(ScenarioTest):
                 checks=[self.check("length([?name=='deployment'])", 1)])
 
             self.cmd(
+                'aimanager namespace modeldeployment list -g rg '
+                '-m manager --namespace-name namespace',
+                checks=[self.check("length([?name=='deployment'])", 1)])
+
+            self.cmd(
                 command_prefix.format('update') +
                 ' -n deployment --performance-mode Throughput --replicas 0 '
                 '--overrides engine=vllm max-model-len=4096 --no-wait',
@@ -101,6 +106,7 @@ class ModelDeploymentScenarioTest(ScenarioTest):
                 checks=[self.is_empty()])
 
         self.assertEqual(operations.begin_create_or_update.call_count, 2)
-        operations.list_by_ai_manager_namespace.assert_called_once_with(
+        self.assertEqual(operations.list_by_ai_manager_namespace.call_count, 2)
+        operations.list_by_ai_manager_namespace.assert_called_with(
             'rg', 'manager', 'namespace')
         operations.begin_delete.assert_called_once()

--- a/src/aimanager/azext_aimanager/tests/latest/test_modelsource_scenario.py
+++ b/src/aimanager/azext_aimanager/tests/latest/test_modelsource_scenario.py
@@ -57,6 +57,10 @@ class ModelSourceScenarioTest(ScenarioTest):
                 checks=[self.check("length([?name=='hf'])", 1)])
 
             self.cmd(
+                'aimanager modelsource list -g rg --manager manager',
+                checks=[self.check("length([?name=='hf'])", 1)])
+
+            self.cmd(
                 command_prefix.format('update') + ' -n hf --token hf_yyy --no-wait',
                 checks=[self.is_empty()])
 
@@ -66,7 +70,8 @@ class ModelSourceScenarioTest(ScenarioTest):
 
         self.assertEqual(operations.get.call_count, 4)
         self.assertEqual(operations.begin_create_or_update.call_count, 2)
-        operations.list.assert_called_once_with('rg', 'manager')
+        self.assertEqual(operations.list.call_count, 2)
+        operations.list.assert_called_with('rg', 'manager')
         operations.begin_delete.assert_called_once()
 
         # the source type is immutable and must be carried over on update

--- a/src/aimanager/setup.py
+++ b/src/aimanager/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     from distutils import log as logger
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
 
-VERSION = '1.4.0'
+VERSION = '1.4.1'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ⚠️ Review suggested

| Breaking Changes |
| :--: |
| ⚠️ None |

<!-- act-bot:section title="Azure CLI Extensions Breaking Change Test" category="breaking_change" label="Breaking Changes" status="Warning" summary="None" -->
<!-- Azure CLI Extensions Breaking Change Test --><details>
<summary>⚠️Azure CLI Extensions Breaking Change Test</summary>

><details>
> <summary>⚠️aimanager</summary>
>
>|rule|cmd_name|rule_message|suggest_message|
>|---|---|---|---|
>|⚠️ [1010 - ParaPropUpdate](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1010.md)|aimanager modelsource add|cmd `aimanager modelsource add` update parameter `ai_manager_name`: updated property `options` from `['--aimanager-name']` to `['--aimanager-name', '--manager', '-m']`||
>|⚠️ [1010 - ParaPropUpdate](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1010.md)|aimanager modelsource delete|cmd `aimanager modelsource delete` update parameter `ai_manager_name`: updated property `options` from `['--aimanager-name']` to `['--aimanager-name', '--manager', '-m']`||
>|⚠️ [1010 - ParaPropUpdate](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1010.md)|aimanager modelsource list|cmd `aimanager modelsource list` update parameter `ai_manager_name`: updated property `options` from `['--aimanager-name']` to `['--aimanager-name', '--manager', '-m']`||
>|⚠️ [1010 - ParaPropUpdate](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1010.md)|aimanager modelsource show|cmd `aimanager modelsource show` update parameter `ai_manager_name`: updated property `options` from `['--aimanager-name']` to `['--aimanager-name', '--manager', '-m']`||
>|⚠️ [1010 - ParaPropUpdate](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1010.md)|aimanager modelsource update|cmd `aimanager modelsource update` update parameter `ai_manager_name`: updated property `options` from `['--aimanager-name']` to `['--aimanager-name', '--manager', '-m']`||
>|⚠️ [1010 - ParaPropUpdate](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1010.md)|aimanager modelsource wait|cmd `aimanager modelsource wait` update parameter `ai_manager_name`: updated property `options` from `['--aimanager-name']` to `['--aimanager-name', '--manager', '-m']`||
>|⚠️ [1010 - ParaPropUpdate](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1010.md)|aimanager namespace modeldeployment add|cmd `aimanager namespace modeldeployment add` update parameter `ai_manager_name`: updated property `options` from `['--aimanager-name']` to `['--aimanager-name', '--manager', '-m']`||
>|⚠️ [1010 - ParaPropUpdate](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1010.md)|aimanager namespace modeldeployment delete|cmd `aimanager namespace modeldeployment delete` update parameter `ai_manager_name`: updated property `options` from `['--aimanager-name']` to `['--aimanager-name', '--manager', '-m']`||
>|⚠️ [1010 - ParaPropUpdate](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1010.md)|aimanager namespace modeldeployment list|cmd `aimanager namespace modeldeployment list` update parameter `ai_manager_name`: updated property `options` from `['--aimanager-name']` to `['--aimanager-name', '--manager', '-m']`||
>|⚠️ [1010 - ParaPropUpdate](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1010.md)|aimanager namespace modeldeployment show|cmd `aimanager namespace modeldeployment show` update parameter `ai_manager_name`: updated property `options` from `['--aimanager-name']` to `['--aimanager-name', '--manager', '-m']`||
>|⚠️ [1010 - ParaPropUpdate](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1010.md)|aimanager namespace modeldeployment update|cmd `aimanager namespace modeldeployment update` update parameter `ai_manager_name`: updated property `options` from `['--aimanager-name']` to `['--aimanager-name', '--manager', '-m']`||
>|⚠️ [1010 - ParaPropUpdate](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1010.md)|aimanager namespace modeldeployment wait|cmd `aimanager namespace modeldeployment wait` update parameter `ai_manager_name`: updated property `options` from `['--aimanager-name']` to `['--aimanager-name', '--manager', '-m']`||
>
></details>
</details>

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
Support --manager and -m for aimanager modelsource and namespace
modeldeployment commands. Bump the extension version to 1.4.1 as its a minor fix.

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install azdev` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [x] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
