### PR TITLE
{Packaging} test-files.pythonhosted.org updated by azcliprod

### DIFF
--- a/src/aks-preview/azext_aks_preview/tests/latest/recordings/test_aks_extension_backup.yaml
+++ b/src/aks-preview/azext_aks_preview/tests/latest/recordings/test_aks_extension_backup.yaml
@@ -40543,7 +40543,7 @@ interactions:
         Command-Line Tools Microsoft Fabric Extension.\",\n                    \"version\":
         \"1.0.0b1\"\n                },\n                \"sha256Digest\": \"8ba450a5a3daafa8b9b6b6e9ee8224f468fd972332e905000f2acc7ff00cd9bb\"\n
         \           }\n        ],\n        \"mixed-reality\": [\n            {\n                \"downloadUrl\":
-        \"https://test-files.pythonhosted.org/packages/e4/fa/14628eb512ef4f0c38e4e6c8ee2d0624e03d352ca0ec1b1167a32f9de9a3/mixed_reality-0.0.1-py2.py3-none-any.whl\",\n
+        \"https://azcliprod.blob.core.windows.net/cli-extensions/mixed_reality-0.0.1-py2.py3-none-any.whl\",\n
         \               \"filename\": \"mixed_reality-0.0.1-py2.py3-none-any.whl\",\n
         \               \"metadata\": {\n                    \"classifiers\": [\n
         \                       \"Development Status :: 4 - Beta\",\n                        \"Intended

--- a/src/aks-preview/azext_aks_preview/tests/latest/recordings/test_aks_extension_type_backup.yaml
+++ b/src/aks-preview/azext_aks_preview/tests/latest/recordings/test_aks_extension_type_backup.yaml
@@ -40543,7 +40543,7 @@ interactions:
         Command-Line Tools Microsoft Fabric Extension.\",\n                    \"version\":
         \"1.0.0b1\"\n                },\n                \"sha256Digest\": \"8ba450a5a3daafa8b9b6b6e9ee8224f468fd972332e905000f2acc7ff00cd9bb\"\n
         \           }\n        ],\n        \"mixed-reality\": [\n            {\n                \"downloadUrl\":
-        \"https://test-files.pythonhosted.org/packages/e4/fa/14628eb512ef4f0c38e4e6c8ee2d0624e03d352ca0ec1b1167a32f9de9a3/mixed_reality-0.0.1-py2.py3-none-any.whl\",\n
+        \"https://azcliprod.blob.core.windows.net/cli-extensions/mixed_reality-0.0.1-py2.py3-none-any.whl\",\n
         \               \"filename\": \"mixed_reality-0.0.1-py2.py3-none-any.whl\",\n
         \               \"metadata\": {\n                    \"classifiers\": [\n
         \                       \"Development Status :: 4 - Beta\",\n                        \"Intended

--- a/src/azure-firewall/azext_firewall/tests/latest/recordings/test_azure_firewall_with_firewall_policy.yaml
+++ b/src/azure-firewall/azext_firewall/tests/latest/recordings/test_azure_firewall_with_firewall_policy.yaml
@@ -42895,7 +42895,7 @@ interactions:
         Command-Line Tools Microsoft Fabric Extension.\",\n                    \"version\":
         \"1.0.0b1\"\n                },\n                \"sha256Digest\": \"8ba450a5a3daafa8b9b6b6e9ee8224f468fd972332e905000f2acc7ff00cd9bb\"\n
         \           }\n        ],\n        \"mixed-reality\": [\n            {\n                \"downloadUrl\":
-        \"https://test-files.pythonhosted.org/packages/e4/fa/14628eb512ef4f0c38e4e6c8ee2d0624e03d352ca0ec1b1167a32f9de9a3/mixed_reality-0.0.1-py2.py3-none-any.whl\",\n
+        \"https://azcliprod.blob.core.windows.net/cli-extensions/mixed_reality-0.0.1-py2.py3-none-any.whl\",\n
         \               \"filename\": \"mixed_reality-0.0.1-py2.py3-none-any.whl\",\n
         \               \"metadata\": {\n                    \"classifiers\": [\n
         \                       \"Development Status :: 4 - Beta\",\n                        \"Intended

--- a/src/azure-firewall/azext_firewall/tests/latest/recordings/test_firewall_basic_sku.yaml
+++ b/src/azure-firewall/azext_firewall/tests/latest/recordings/test_firewall_basic_sku.yaml
@@ -44644,7 +44644,7 @@ interactions:
         Command-Line Tools Microsoft Fabric Extension.\",\n                    \"version\":
         \"1.0.0b1\"\n                },\n                \"sha256Digest\": \"8ba450a5a3daafa8b9b6b6e9ee8224f468fd972332e905000f2acc7ff00cd9bb\"\n
         \           }\n        ],\n        \"mixed-reality\": [\n            {\n                \"downloadUrl\":
-        \"https://test-files.pythonhosted.org/packages/e4/fa/14628eb512ef4f0c38e4e6c8ee2d0624e03d352ca0ec1b1167a32f9de9a3/mixed_reality-0.0.1-py2.py3-none-any.whl\",\n
+        \"https://azcliprod.blob.core.windows.net/cli-extensions/mixed_reality-0.0.1-py2.py3-none-any.whl\",\n
         \               \"filename\": \"mixed_reality-0.0.1-py2.py3-none-any.whl\",\n
         \               \"metadata\": {\n                    \"classifiers\": [\n
         \                       \"Development Status :: 4 - Beta\",\n                        \"Intended

--- a/src/azure-firewall/azext_firewall/tests/latest/recordings/test_firewall_v2.yaml
+++ b/src/azure-firewall/azext_firewall/tests/latest/recordings/test_firewall_v2.yaml
@@ -21222,7 +21222,7 @@ interactions:
         \"Support for Microsoft Azure Service Fabric Mesh - Public Preview\",\n                    \"version\":
         \"0.10.7\"\n                },\n                \"sha256Digest\": \"9433191eba661716d5f42fd53dcbc9c2711ec568ed444bfcd0fe3555a717fa0b\"\n
         \           }\n        ],\n        \"mixed-reality\": [\n            {\n                \"downloadUrl\":
-        \"https://test-files.pythonhosted.org/packages/e4/fa/14628eb512ef4f0c38e4e6c8ee2d0624e03d352ca0ec1b1167a32f9de9a3/mixed_reality-0.0.1-py2.py3-none-any.whl\",\n
+        \"https://azcliprod.blob.core.windows.net/cli-extensions/mixed_reality-0.0.1-py2.py3-none-any.whl\",\n
         \               \"filename\": \"mixed_reality-0.0.1-py2.py3-none-any.whl\",\n
         \               \"metadata\": {\n                    \"classifiers\": [\n
         \                       \"Development Status :: 4 - Beta\",\n                        \"Intended

--- a/src/azure-firewall/azext_firewall/tests/latest/recordings/test_firewall_vhub_create_with_public_ip.yaml
+++ b/src/azure-firewall/azext_firewall/tests/latest/recordings/test_firewall_vhub_create_with_public_ip.yaml
@@ -42895,7 +42895,7 @@ interactions:
         Command-Line Tools Microsoft Fabric Extension.\",\n                    \"version\":
         \"1.0.0b1\"\n                },\n                \"sha256Digest\": \"8ba450a5a3daafa8b9b6b6e9ee8224f468fd972332e905000f2acc7ff00cd9bb\"\n
         \           }\n        ],\n        \"mixed-reality\": [\n            {\n                \"downloadUrl\":
-        \"https://test-files.pythonhosted.org/packages/e4/fa/14628eb512ef4f0c38e4e6c8ee2d0624e03d352ca0ec1b1167a32f9de9a3/mixed_reality-0.0.1-py2.py3-none-any.whl\",\n
+        \"https://azcliprod.blob.core.windows.net/cli-extensions/mixed_reality-0.0.1-py2.py3-none-any.whl\",\n
         \               \"filename\": \"mixed_reality-0.0.1-py2.py3-none-any.whl\",\n
         \               \"metadata\": {\n                    \"classifiers\": [\n
         \                       \"Development Status :: 4 - Beta\",\n                        \"Intended

--- a/src/azure-firewall/azext_firewall/tests/latest/recordings/test_firewall_with_route_server.yaml
+++ b/src/azure-firewall/azext_firewall/tests/latest/recordings/test_firewall_with_route_server.yaml
@@ -42895,7 +42895,7 @@ interactions:
         Command-Line Tools Microsoft Fabric Extension.\",\n                    \"version\":
         \"1.0.0b1\"\n                },\n                \"sha256Digest\": \"8ba450a5a3daafa8b9b6b6e9ee8224f468fd972332e905000f2acc7ff00cd9bb\"\n
         \           }\n        ],\n        \"mixed-reality\": [\n            {\n                \"downloadUrl\":
-        \"https://test-files.pythonhosted.org/packages/e4/fa/14628eb512ef4f0c38e4e6c8ee2d0624e03d352ca0ec1b1167a32f9de9a3/mixed_reality-0.0.1-py2.py3-none-any.whl\",\n
+        \"https://azcliprod.blob.core.windows.net/cli-extensions/mixed_reality-0.0.1-py2.py3-none-any.whl\",\n
         \               \"filename\": \"mixed_reality-0.0.1-py2.py3-none-any.whl\",\n
         \               \"metadata\": {\n                    \"classifiers\": [\n
         \                       \"Development Status :: 4 - Beta\",\n                        \"Intended

--- a/src/index.json
+++ b/src/index.json
@@ -86757,7 +86757,7 @@
         ],
         "mixed-reality": [
             {
-                "downloadUrl": "https://test-files.pythonhosted.org/packages/e4/fa/14628eb512ef4f0c38e4e6c8ee2d0624e03d352ca0ec1b1167a32f9de9a3/mixed_reality-0.0.1-py2.py3-none-any.whl",
+                "downloadUrl": "https://azcliprod.blob.core.windows.net/cli-extensions/mixed_reality-0.0.1-py2.py3-none-any.whl",
                 "filename": "mixed_reality-0.0.1-py2.py3-none-any.whl",
                 "metadata": {
                     "classifiers": [

--- a/src/virtual-wan/azext_vwan/tests/latest/recordings/test_azure_vwan_route_table.yaml
+++ b/src/virtual-wan/azext_vwan/tests/latest/recordings/test_azure_vwan_route_table.yaml
@@ -39774,7 +39774,7 @@ interactions:
         \ Preview\",\n                    \"version\": \"1.0.0a1\"\n             \
         \   },\n                \"sha256Digest\": \"fe52e3ed5bd7252a120bbebc0a578b0138a257a22dd264adeed97862ede07a35\"\
         \n            }\n        ],\n        \"mixed-reality\": [\n            {\n\
-        \                \"downloadUrl\": \"https://test-files.pythonhosted.org/packages/e4/fa/14628eb512ef4f0c38e4e6c8ee2d0624e03d352ca0ec1b1167a32f9de9a3/mixed_reality-0.0.1-py2.py3-none-any.whl\"\
+        \                \"downloadUrl\": \"https://azcliprod.blob.core.windows.net/cli-extensions/mixed_reality-0.0.1-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"mixed_reality-0.0.1-py2.py3-none-any.whl\"\
         ,\n                \"metadata\": {\n                    \"classifiers\": [\n\
         \                        \"Development Status :: 4 - Beta\",\n           \

--- a/src/virtual-wan/azext_vwan/tests/latest/recordings/test_routing_intent_crud.yaml
+++ b/src/virtual-wan/azext_vwan/tests/latest/recordings/test_routing_intent_crud.yaml
@@ -40633,7 +40633,7 @@ interactions:
         \ Preview\",\n                    \"version\": \"1.0.0a1\"\n             \
         \   },\n                \"sha256Digest\": \"fe52e3ed5bd7252a120bbebc0a578b0138a257a22dd264adeed97862ede07a35\"\
         \n            }\n        ],\n        \"mixed-reality\": [\n            {\n\
-        \                \"downloadUrl\": \"https://test-files.pythonhosted.org/packages/e4/fa/14628eb512ef4f0c38e4e6c8ee2d0624e03d352ca0ec1b1167a32f9de9a3/mixed_reality-0.0.1-py2.py3-none-any.whl\"\
+        \                \"downloadUrl\": \"https://azcliprod.blob.core.windows.net/cli-extensions/mixed_reality-0.0.1-py2.py3-none-any.whl\"\
         ,\n                \"filename\": \"mixed_reality-0.0.1-py2.py3-none-any.whl\"\
         ,\n                \"metadata\": {\n                    \"classifiers\": [\n\
         \                        \"Development Status :: 4 - Beta\",\n           \


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes |
| :--: |
| ️✔️ None |

<!-- act-bot:section title="Azure CLI Extensions Breaking Change Test" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->



**Background**
The following URL/Domain is marked non compliant by network isolation policy, S360 items were also raised to highlight it

```
Policy: Default Deny - Policy required for SFI compliance. Status = [ NOT COMPLIANT ] (10 violations)
test-files.pythonhosted.org
  Domain name: test-files.pythonhosted.org
```
**Solution**
This PR Updates the Azure CLI extensions index entry for mixed-reality v0.0.1 to use the azcliprod blob-hosted wheel instead of test-files.pythonhosted.org, and aligns the corresponding test recording to the same URL so playback matches the current index content.

**Changes:**

- Switch mixed_reality-0.0.1-py2.py3-none-any.whl downloadUrl to https://azcliprod.blob.core.windows.net/cli-extensions/... in the extension index.

- Update the azure-firewall test recording that includes the extension index payload to reflect the new URL.