### PR TITLE
{Packaging} test-files.pythonhosted.org updated by azcliprod

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -87054,7 +87054,7 @@
         ],
         "mixed-reality": [
             {
-                "downloadUrl": "https://test-files.pythonhosted.org/packages/e4/fa/14628eb512ef4f0c38e4e6c8ee2d0624e03d352ca0ec1b1167a32f9de9a3/mixed_reality-0.0.1-py2.py3-none-any.whl",
+                "downloadUrl": "https://azcliprod.blob.core.windows.net/cli-extensions/mixed_reality-0.0.1-py2.py3-none-any.whl",
                 "filename": "mixed_reality-0.0.1-py2.py3-none-any.whl",
                 "metadata": {
                     "classifiers": [


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes |
| :--: |
| ️✔️ None |

<!-- act-bot:section title="Azure CLI Extensions Breaking Change Test" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

Background
The following URL/Domain is marked non compliant by network isolation policy, S360 items were also raised to highlight it

Policy: Default Deny - Policy required for SFI compliance. Status = [ NOT COMPLIANT ] (10 violations)
test-files.pythonhosted.org
  Domain name: test-files.pythonhosted.org
Solution
This PR Updates the Azure CLI extensions index entry for mixed-reality v0.0.1 to use the azcliprod blob-hosted wheel instead of test-files.pythonhosted.org,

Changes:

Switch mixed_reality-0.0.1-py2.py3-none-any.whl downloadUrl to https://azcliprod.blob.core.windows.net/cli-extensions/mixed_reality-0.0.1-py2.py3-none-any.whl in the extension index.