### PR TITLE
vm-repair: remove unused opencensus dependency, and declare applicationinsights

### DIFF
--- a/src/vm-repair/HISTORY.rst
+++ b/src/vm-repair/HISTORY.rst
@@ -2,6 +2,11 @@
 Release History
 ===============
 
+2.2.6
+++++++
+Fixing ``az extension add --name vm-repair`` failing with ``Pip failed with status code 2`` on 32-bit Windows installations of the Azure CLI. The extension declared ``opencensus`` as a dependency but never imported it. Because extensions are installed with ``pip --target``, that unused dependency pulled roughly twenty extra packages into the extension folder, including ``cryptography``, which stopped publishing 32-bit Windows wheels in version 49.0.0. On a 32-bit CLI, pip had no compatible wheel, fell back to building ``cryptography`` from source, and failed. Removing the unused ``opencensus`` dependency removes that entire dependency tree.
+Also declaring ``applicationinsights``, which the telemetry module imports on every command but which was never listed as a dependency. It previously resolved only because the Azure CLI happened to ship it, even though no Azure CLI package requires it, so any future CLI that dropped it would have broken every ``vm repair`` command at import time.
+
 2.2.5
 ++++++
 Fixing a regression introduced in 2.2.1 that could break every ``vm repair`` command on Windows when ``az`` resolves to the ``az.cmd`` launcher (the default for MSI installations). The command-injection hardening quoted every token of the nested ``az`` call, including the ``az`` program name itself. cmd.exe then treated it as a literal path instead of a PATH search, so ``%~dp0`` inside ``az.cmd`` no longer pointed at the launcher directory, the bundled Python interpreter was not found, and the call failed with ``Failed to load python executable.`` and exit code 1. The ``az`` token is no longer quoted; all arguments are still individually quoted, so the injection protection added in 2.2.1 (MSRC 115198) is unchanged.

--- a/src/vm-repair/azext_vm_repair/tests/latest/test_dependency_declarations.py
+++ b/src/vm-repair/azext_vm_repair/tests/latest/test_dependency_declarations.py
@@ -6,6 +6,7 @@
 import ast
 import os
 import sys
+import sysconfig
 import unittest
 
 
@@ -64,11 +65,40 @@ class DependencyDeclarationTests(unittest.TestCase):
                         modules.add(node.module.split('.')[0])
         return modules
 
+    @staticmethod
+    def _stdlib_module_names():
+        # sys.stdlib_module_names is 3.10+, and setup.py still advertises 3.9.
+        names = getattr(sys, 'stdlib_module_names', None)
+        if names is not None:
+            return set(names)
+
+        names = set(sys.builtin_module_names)
+        paths = sysconfig.get_paths()
+        directories = [paths.get('stdlib'), paths.get('platstdlib')]
+        directories = [d for d in directories if d]
+        # Extension modules live outside the stdlib root: DLLs on Windows, lib-dynload elsewhere.
+        directories += [os.path.join(d, 'lib-dynload') for d in list(directories)]
+        # base_prefix differs from prefix inside a virtualenv, which is how CI runs.
+        directories += [os.path.join(p, 'DLLs') for p in {sys.prefix, sys.base_prefix}]
+
+        for directory in directories:
+            if not os.path.isdir(directory):
+                continue
+            for entry in os.listdir(directory):
+                if entry.startswith('.'):
+                    continue
+                if entry.endswith(('.py', '.pyd', '.so')):
+                    names.add(entry.split('.')[0])
+                elif os.path.isfile(os.path.join(directory, entry, '__init__.py')):
+                    names.add(entry)
+        return names
+
     def _third_party_imports(self):
         modules = self._imported_modules()
+        stdlib = self._stdlib_module_names()
         return {
             module for module in modules
-            if module not in sys.stdlib_module_names
+            if module not in stdlib
             and module not in self.CLI_PROVIDED
             and module != 'azext_vm_repair'
         }

--- a/src/vm-repair/azext_vm_repair/tests/latest/test_dependency_declarations.py
+++ b/src/vm-repair/azext_vm_repair/tests/latest/test_dependency_declarations.py
@@ -1,0 +1,101 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import ast
+import os
+import sys
+import unittest
+
+
+class DependencyDeclarationTests(unittest.TestCase):
+    """Keep setup.py's DEPENDENCIES in sync with what the shipped code actually imports.
+
+    Extensions are installed with ``pip install --target``, so the declared list is
+    vendored wholesale into the extension folder: an unused entry drags its whole
+    transitive tree along (this is what broke 32-bit installs via opencensus ->
+    google-api-core -> google-auth -> cryptography), and a missing entry only works
+    by accident for as long as the CLI happens to ship that package.
+
+    This is a static, dependency-free scan so it runs anywhere without network access.
+    """
+
+    PACKAGE_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    SETUP_PY = os.path.join(os.path.dirname(PACKAGE_ROOT), 'setup.py')
+
+    # Top-level modules azure-cli-core guarantees, so the extension must not vendor them:
+    # 'azure'/'knack' are the CLI framework itself and 'requests' is required by msal/msrest.
+    CLI_PROVIDED = {'azure', 'knack', 'requests'}
+
+    # Distribution name -> imported module name, where the two differ.
+    DIST_TO_MODULE = {}
+
+    def _declared_distributions(self):
+        with open(self.SETUP_PY, encoding='utf-8') as handle:
+            tree = ast.parse(handle.read())
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assign):
+                continue
+            if not any(isinstance(t, ast.Name) and t.id == 'DEPENDENCIES' for t in node.targets):
+                continue
+            declared = set()
+            for element in node.value.elts:
+                requirement = element.value
+                name = requirement.split('~=')[0].split('==')[0].split('>=')[0].split('<')[0]
+                declared.add(name.strip().lower().replace('-', '_'))
+            return declared
+        self.fail('Could not find a DEPENDENCIES assignment in setup.py')
+
+    def _imported_modules(self):
+        modules = set()
+        for root, _, files in os.walk(self.PACKAGE_ROOT):
+            if 'tests' in root.split(os.sep):
+                continue
+            for name in files:
+                if not name.endswith('.py'):
+                    continue
+                with open(os.path.join(root, name), encoding='utf-8') as handle:
+                    tree = ast.parse(handle.read())
+                for node in ast.walk(tree):
+                    if isinstance(node, ast.Import):
+                        modules.update(alias.name.split('.')[0] for alias in node.names)
+                    elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+                        modules.add(node.module.split('.')[0])
+        return modules
+
+    def _third_party_imports(self):
+        modules = self._imported_modules()
+        return {
+            module for module in modules
+            if module not in sys.stdlib_module_names
+            and module not in self.CLI_PROVIDED
+            and module != 'azext_vm_repair'
+        }
+
+    def test_every_third_party_import_is_declared(self):
+        declared = self._declared_distributions()
+        declared_modules = {self.DIST_TO_MODULE.get(dist, dist) for dist in declared}
+        undeclared = sorted(self._third_party_imports() - declared_modules)
+        self.assertEqual(
+            undeclared, [],
+            'Shipped code imports packages that setup.py does not declare: {}. They resolve '
+            'only while the Azure CLI happens to ship them.'.format(', '.join(undeclared))
+        )
+
+    def test_no_declared_dependency_is_unused(self):
+        imported = self._third_party_imports()
+        unused = sorted(
+            dist for dist in self._declared_distributions()
+            if self.DIST_TO_MODULE.get(dist, dist) not in imported
+        )
+        self.assertEqual(
+            unused, [],
+            'setup.py declares dependencies that no shipped module imports: {}. Because '
+            'extensions install with pip --target, each one vendors its full transitive '
+            'tree into the extension folder.'.format(', '.join(unused))
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/vm-repair/setup.py
+++ b/src/vm-repair/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup, find_packages
 
-VERSION = "2.2.5"
+VERSION = "2.2.6"
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
@@ -24,7 +24,10 @@ CLASSIFIERS = [
     'License :: OSI Approved :: MIT License',
 ]
 
-DEPENDENCIES = ['opencensus~=0.11.4']
+# Only declare packages that azure-cli-core does not already guarantee; extensions are
+# pip-installed with --target, so every entry here is vendored into the extension folder.
+# 'requests' is intentionally omitted: azure-cli-core pulls it in via msal/msrest.
+DEPENDENCIES = ['applicationinsights~=0.11.9']
 
 with open('HISTORY.rst', 'r', encoding='utf-8') as f:
     HISTORY = f.read()


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes |
| :--: |
| ️✔️ None |

<!-- act-bot:section title="Azure CLI Extensions Breaking Change Test" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

### Related command
`az vm repair` (all commands) — extension install/upgrade path.

Fixes the install failure reported in ICM 854928087: `az extension add --name vm-repair` fails with `Pip failed with status code 2` on 32-bit Windows installations of the Azure CLI.

---

## Summary

`src/vm-repair/setup.py` had its dependency declarations inverted:

1. **`opencensus` was declared but never imported.** It appears in no import statement anywhere in `azext_vm_repair`. Because extensions are installed with `pip install --target <extension dir>` — fully isolated from the CLI's own site-packages — that dead declaration vendored roughly **20 packages** into the extension folder:

   ```
   vm-repair -> opencensus -> google-api-core -> google-auth -> cryptography
   ```

   plus `protobuf`, `cffi`, `proto-plus`, `googleapis-common-protos`, `requests`, `urllib3`, `certifi`, `idna`, `charset-normalizer`, `pyasn1`, `pyasn1-modules`, `pycparser`, `six`, `opencensus-context`.

   `cryptography` **stopped publishing 32-bit Windows wheels at version 49.0.0** (48.0.1 was the last with `win32` wheels):

   | Version | win32 wheels | win_amd64 wheels | Uploaded |
   |---|---|---|---|
   | 48.0.1 | 3 | 4 | 2026-06-09 |
   | **49.0.0** | **0** | 4 | 2026-06-12 |
   | 50.0.0 | 0 | 4 | 2026-07-31 |

   On 32-bit Windows pip finds no compatible wheel, falls back to the sdist, and the source build requires a Rust toolchain — producing the reported `Pip failed with status code 2`.

2. **`applicationinsights` was imported but never declared.** `azext_vm_repair/telemetry.py` does `from applicationinsights import TelemetryClient`, and `command_helper_class.py` imports telemetry at module scope, so it is on the hot path of every command. It resolved only because the Azure CLI happens to ship `applicationinsights` 0.11.9 — `pip show applicationinsights` reports `Required-by:` as empty, meaning no Azure CLI package requires it. A future CLI that dropped it would break every `az vm repair` command at import time.

## Changes

```python
# Only declare packages that azure-cli-core does not already guarantee; extensions are
# pip-installed with --target, so every entry here is vendored into the extension folder.
# 'requests' is intentionally omitted: azure-cli-core pulls it in via msal/msrest.
DEPENDENCIES = ['applicationinsights~=0.11.9']
```

- `src/vm-repair/setup.py` — drop `opencensus`, declare `applicationinsights`, bump `VERSION` 2.2.5 → 2.2.6.
- `src/vm-repair/HISTORY.rst` — 2.2.6 changelog entry in user-facing language.
- `src/vm-repair/azext_vm_repair/tests/latest/test_dependency_declarations.py` — **new** static AST regression test.

`applicationinsights` 0.11.10 is a zero-dependency `py2.py3-none-any` wheel, so this removes ~20 vendored packages and adds one small universal one.

**`requests` is deliberately left undeclared.** It is imported by shipped code, but it is guaranteed by the CLI dependency graph (`Required-by: msal, msrest, PyGithub, requests-oauthlib`). Vendoring it into the extension folder would risk shadowing the CLI's own `requests` on `sys.path`. The reasoning is recorded in a code comment so it is not "corrected" later.

## Regression test

The new test asserts both directions of the invariant, so this class of defect cannot silently return:

- every third-party import is declared → catches the missing `applicationinsights`
- every declared dependency is imported → catches the dead `opencensus`

Verified it actually bites: forcing the declared set back to `{'opencensus'}` fails both assertions (`['applicationinsights'] != []` and `['opencensus'] != []`).

## Testing

All gates run locally in a proper `azdev` environment (azdev 0.2.13, Python 3.13.15 x64):

- `azdev style vm-repair` → **PASSED** (pylint PASSED, flake8 PASSED)
- `azdev linter vm-repair` → **PASSED** (no violations; custom pylint rules also clean)
- `azdev test vm-repair` → **96 passed, 35 skipped** in 12.55s (skips are the live-Azure scenarios)
- `python scripts/ci/test_index.py -q` → **9 tests, OK** (2 skipped)
- **32-bit repro on real `win32` Python 3.14.7** → old dependency fails, new dependency succeeds (details below)

The two new regression tests are collected and pass as part of the azdev run:

```
test_dependency_declarations.py::DependencyDeclarationTests::test_every_third_party_import_is_declared PASSED
test_dependency_declarations.py::DependencyDeclarationTests::test_no_declared_dependency_is_unused    PASSED
```

### 32-bit reproduction (confirmed)

Reproduced on a real 32-bit **Python 3.14.7** (`sysconfig.get_platform() == 'win32'`, `struct.calcsize('P')*8 == 32`), using the same install shape the CLI uses — `pip install --target`, no wheel-only restriction:

**Before (old dependency) — fails:**

```
> python.exe -m pip install --target <dir> "opencensus~=0.11.4" --no-cache-dir

  $HOST   = i686-pc-windows-msvc
  $TARGET = i686-pc-windows-msvc
  openssl-sys = 0.9.117
  It looks like you're compiling for MSVC but we couldn't detect an OpenSSL installation.
  maturin failed: Cargo build finished with "exit code: 101"
ERROR: Failed building wheel for cryptography
Failed to build cryptography
```

pip selects a `cryptography` release with no `win32` wheel, falls back to the sdist, and attempts a Rust/OpenSSL source build for `i686-pc-windows-msvc`.

**After (new dependency) — succeeds:**

```
> python.exe -m pip install --target <dir> "applicationinsights~=0.11.9" --no-cache-dir

Downloading applicationinsights-0.11.10-py2.py3-none-any.whl (55 kB)
Successfully installed applicationinsights-0.11.10
exit=0
```

Vendored contents afterwards are just `applicationinsights/` and its `.dist-info` — no `cryptography`, `cffi`, `google-*`, `protobuf`, or `opencensus`. Zero native code.

> [!NOTE]
> Two honest caveats on this repro. It used a standalone 32-bit CPython rather than a 32-bit Azure CLI, because no 32-bit CLI was installable here; the failing component is pip's resolver, which is what was exercised. And pip returned exit code `1` here versus the `2` in the incident report — the failure mode is identical (`cryptography` source build), and the numeric code varies by pip version.
>
> Also worth recording: resolving the same tree with `pip download --only-binary=:all: --platform win32` **succeeds**, because that flag forces pip to backtrack to `cryptography 48.0.1` (the last release with `win32` wheels). That flag is not used by `az extension add`, so it masks the bug — a wheel-only check is not a valid test for this issue.

Positive control also captured: an isolated 64-bit install of 2.2.5 (fresh `AZURE_CONFIG_DIR`) succeeded and its debug log shows the full `opencensus` tree — including `cryptography` — being vendored.

## Version & changelog

- `setup.py` VERSION: `2.2.5` → `2.2.6`
- `HISTORY.rst` entry added: yes

## Cross-repo impact (repair-script-library)

None. No `--run-id`, `map.json`, or script changes.

## Security review

Reduces supply-chain surface by removing ~20 unnecessary vendored packages. No untrusted-input → shell paths touched; no credential handling or logging changed.

## Backward compatibility

No command, parameter, default, or behavior changes. Patch-level and backward compatible.

## Note on the original triage

The ICM was initially attributed to `pkgutil.get_loader()` under Python 3.14, with a recommendation to publish 2.2.5. `vm-repair` 2.2.5 was in fact already published on 2026-08-20 (before the ICM was filed), and `pkgutil` is runtime code that cannot cause pip to exit 2 during install. The reporter's own 64-bit run installed 2.2.5 from the same index at the same time the 32-bit run failed — the differentiator was architecture, not the index. This change addresses the actual install-time cause.

---

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? — passed, as did `azdev linter vm-repair` and `azdev test vm-repair`
- [x] Have you run `python scripts/ci/test_index.py -q` locally? — passes
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md) — patch bump, no surface change

### About Extension Publish

`src/index.json` is intentionally **not** modified in this PR.
