### PR TITLE
chore(arcdata): version bump to 1.5.32

### DIFF
--- a/src/index.json
+++ b/src/index.json
@@ -26839,6 +26839,80 @@
         ],
         "arcdata": [
             {
+                "downloadUrl": "https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.5.32-py2.py3-none-any.whl",
+                "filename": "arcdata-1.5.32-py2.py3-none-any.whl",
+                "metadata": {
+                    "azext.isExperimental": false,
+                    "azext.minCliCoreVersion": "2.3.1",
+                    "classifiers": [
+                        "Development Status :: 1 - Beta",
+                        "Intended Audience :: Developers",
+                        "Programming Language :: Python :: 3",
+                        "Programming Language :: Python :: 3.10",
+                        "Programming Language :: Python :: 3.11",
+                        "Programming Language :: Python :: 3.12",
+                        "Programming Language :: Python :: 3.13",
+                        "Programming Language :: Python :: 3.14",
+                        "License :: OSI Approved :: MIT License"
+                    ],
+                    "extensions": {
+                        "python.details": {
+                            "contacts": [
+                                {
+                                    "email": "dpgswdist@microsoft.com",
+                                    "name": "Microsoft Corporation",
+                                    "role": "author"
+                                }
+                            ],
+                            "document_names": {
+                                "description": "DESCRIPTION.rst"
+                            },
+                            "project_urls": {
+                                "Home": "https://docs.microsoft.com/en-us/azure/azure-arc/data/"
+                            }
+                        }
+                    },
+                    "extras": [],
+                    "generator": "bdist_wheel (0.30.0)",
+                    "license": "MIT",
+                    "license_file": "LICENSE",
+                    "metadata_version": "2.0",
+                    "name": "arcdata",
+                    "requires_python": ">=3.10",
+                    "run_requires": [
+                        {
+                            "requires": [
+                                "colorama (>=0.4.4)",
+                                "colorama>=0.4.4",
+                                "jinja2 (>=3.1.6)",
+                                "jinja2>=3.1.6",
+                                "jsonpatch (==1.24)",
+                                "jsonpatch==1.24",
+                                "jsonpath-ng (==1.4.3)",
+                                "jsonpath_ng==1.4.3",
+                                "jsonschema (==3.2.0)",
+                                "jsonschema==3.2.0",
+                                "kubernetes (>=31.0.0)",
+                                "kubernetes>=31.0.0",
+                                "msrestazure (>=0.6.4.post1)",
+                                "msrestazure>=0.6.4.post1",
+                                "ndjson (>=0.3.1)",
+                                "ndjson>=0.3.1",
+                                "pem (>=21.2.0)",
+                                "pem>=21.2.0",
+                                "pydash (>=7.0.6)",
+                                "pydash>=7.0.6",
+                                "regex (>=2023.10.3)",
+                                "regex>=2023.10.3"
+                            ]
+                        }
+                    ],
+                    "summary": "Tools for managing ArcData.",
+                    "version": "1.5.32"
+                },
+                "sha256Digest": "78013698cf878cae5ae7744a1a1887db598e2b0d282132bf1dc4db3aaa5eee1a"
+            },
+            {
                 "downloadUrl": "https://azurearcdatacli.z13.web.core.windows.net/arcdata-1.5.31-py2.py3-none-any.whl",
                 "filename": "arcdata-1.5.31-py2.py3-none-any.whl",
                 "metadata": {


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes |
| :--: |
| ️✔️ None |

<!-- act-bot:section title="Azure CLI Extensions Breaking Change Test" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command

`az arcdata`

This change adds the published `1.5.32` ArcData entry to `src/index.json` and preserves all existing entries.

Validation performed:
- `src/index.json` parses as JSON.
- The diff changes one file with 74 insertions and 0 deletions.
- The added entry equals the source artifact entry.
- Version ordering is preserved (`1.5.32` precedes `1.5.31`).
- The published wheel SHA-256 matches `78013698cf878cae5ae7744a1a1887db598e2b0d282132bf1dc4db3aaa5eee1a`.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required) — N/A: this is an index-only change.
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install azdev` required) — Not run: Python is unavailable locally.
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md). — N/A: `arcdata` is an existing extension.

### About Extension Publish

The `1.5.32` wheel is already published at the download URL recorded in the new entry. This PR changes only `src/index.json`; it does not modify extension source or executable code.