### PR TITLE
NetworkCloud 2026-01-15-preview breaking change notice.

### DIFF
--- a/src/managednetworkfabric/HISTORY.rst
+++ b/src/managednetworkfabric/HISTORY.rst
@@ -6,9 +6,10 @@ Release History
 10.0.0b2
 ++++++++
 * Adding breaking change notices for the following items that will be included in the upcoming 2026-07-15-preview CLI (10.0.x).
-* [Breaking Change] Command `bootstrapinterface list` will be will have parameter `bootstrap_device` added, and required parameter `network_bootstrap_device_name` removed.
-* [Breaking Change] Command `bootstrapinterface show` will be will have parameter `bootstrap_device` added, and required parameter `network_bootstrap_device_name` removed.
-* [Breaking Change] Command `bootstrapinterface wait` will be will have parameter `bootstrap_device` added, and required parameter `network_bootstrap_device_name` removed.
+* [Breaking Change] The listed command groups will be updated such that required parameter `--bootstrap-device` will replace `--network-bootstrap-device-name`:
+*  - `bootstrapinterface list`
+*  - `bootstrapinterface show`
+*  - `bootstrapinterface show`
 
 10.0.0b1
 ++++++++
@@ -54,8 +55,8 @@ Release History
 ++++++
 * Adding breaking change notices for the following items that will be included in the upcoming 2025-07-15-stable CLI (9.0.x).
 * [Breaking Change] Command group `fabric identity` will be removed as current az-cli-core does not support GET-PATCH. This includes the `assign`, `remove`, `show` sub-commands.
-* [Breaking Change] Parameter `route-prefix-limit` will be removed from `l3domain create` and `l3domain update` commands.
-* [Breaking Change] Parameter `version` on `device upgrade` command will become required.
+* [Breaking Change] Parameter `--route-prefix-limit` will be removed from `l3domain create` and `l3domain update` commands.
+* [Breaking Change] Parameter `--version` on `device upgrade` command will become required.
 
 8.0.0
 ++++++
@@ -70,11 +71,11 @@ Release History
 8.0.0b6
 ++++++
 * Enables the `device refresh-configuration` command that was previously disabled/removed.
-* Renames the `network-device-name` parameter on `device refresh-configuration` and `device reboot` operations to `resource-name` for better overall consistency.
+* Renames the `--network-device-name` parameter on `device refresh-configuration` and `device reboot` operations to `--resource-name` for better overall consistency.
 
 8.0.0b5
 ++++++
-* Fixes `taprule create` command as the API cannot support float values for `polling-interval-in-seconds` option, i.e. - `30.0`.
+* Fixes `taprule create` command as the API cannot support float values for `--polling-interval-in-seconds` option, i.e. - `30.0`.
 * Fixes the response object model for validate-configuration operations that cause response of the operation to not show any output.
 * az core cli updated to version 2.70, aaz_dev updated to version 4.2.0, and azdev to version 0.2.4.
 

--- a/src/managednetworkfabric/HISTORY.rst
+++ b/src/managednetworkfabric/HISTORY.rst
@@ -3,6 +3,13 @@
 Release History
 ===============
 
+10.0.0b2
+++++++++
+* Adding breaking change notices for the following items that will be included in the upcoming 2026-07-15-preview CLI (10.0.x).
+* [Breaking Change] Command `bootstrapinterface list` will be will have parameter `bootstrap_device` added, and required parameter `network_bootstrap_device_name` removed.
+* [Breaking Change] Command `bootstrapinterface show` will be will have parameter `bootstrap_device` added, and required parameter `network_bootstrap_device_name` removed.
+* [Breaking Change] Command `bootstrapinterface wait` will be will have parameter `bootstrap_device` added, and required parameter `network_bootstrap_device_name` removed.
+
 10.0.0b1
 ++++++++
 * New preview CLI version for latest api 2026-01-15-preview.

--- a/src/managednetworkfabric/HISTORY.rst
+++ b/src/managednetworkfabric/HISTORY.rst
@@ -6,10 +6,18 @@ Release History
 10.0.0b2
 ++++++++
 * Adding breaking change notices for the following items that will be included in the upcoming 2026-07-15-preview CLI (10.0.x).
-* [Breaking Change] The listed command groups will be updated such that required parameter `--bootstrap-device` will replace `--network-bootstrap-device-name`:
-*  - `bootstrapinterface list`
-*  - `bootstrapinterface show`
-*  - `bootstrapinterface show`
+* [Breaking Change] The following commands will be renamed:
+*  - `device refresh-configuration` to `device refresh-config`.
+*  - `fabric commit-configuration` to `fabric commit-config`.
+*  - `fabric validate-configuration` to `fabric validate-config`.
+*  - `fabric view-device-configuration` to `fabric view-device-config`.
+* [Breaking Change] The `--network-bootstrap-device-name` alias will be removed from the following commands; use `--bootstrap-device` instead:
+*  - `bootstrapinterface list`.
+*  - `bootstrapinterface show`.
+*  - `bootstrapinterface wait`.
+* [Breaking Change] The `--network-device-name` alias will be removed from the following commands; use `--resource-name` instead:
+*  - `device reboot`.
+*  - `device refresh-config`.
 
 10.0.0b1
 ++++++++

--- a/src/managednetworkfabric/azext_managednetworkfabric/__init__.py
+++ b/src/managednetworkfabric/azext_managednetworkfabric/__init__.py
@@ -8,6 +8,11 @@
 from azure.cli.core import AzCommandsLoader
 from azext_managednetworkfabric._help import helps  # pylint: disable=unused-import
 
+try:
+    from azext_managednetworkfabric import _breaking_change  # noqa: F401 pylint: disable=unused-import
+except ImportError:
+    pass
+
 
 class ManagednetworkfabricCommandsLoader(AzCommandsLoader):
 

--- a/src/managednetworkfabric/azext_managednetworkfabric/_breaking_change.py
+++ b/src/managednetworkfabric/azext_managednetworkfabric/_breaking_change.py
@@ -1,0 +1,33 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+from azure.cli.core.breaking_change import (
+    register_argument_deprecate,
+    register_required_flag_breaking_change,
+)
+
+register_argument_deprecate(
+    "networkfabric bootstrapinterface list",
+    "network_bootstrap_device_name",
+    target_version="10.0.x",
+)
+register_argument_deprecate(
+    "networkfabric bootstrapinterface show",
+    "network_bootstrap_device_name",
+    target_version="10.0.x",
+)
+register_argument_deprecate(
+    "networkfabric bootstrapinterface wait",
+    "network_bootstrap_device_name",
+    target_version="10.0.x",
+)
+register_required_flag_breaking_change(
+    "networkfabric bootstrapinterface list", "bootstrap_device", target_version="10.0.x"
+)
+register_required_flag_breaking_change(
+    "networkfabric bootstrapinterface show", "bootstrap_device", target_version="10.0.x"
+)
+register_required_flag_breaking_change(
+    "networkfabric bootstrapinterface wait", "bootstrap_device", target_version="10.0.x"
+)

--- a/src/managednetworkfabric/azext_managednetworkfabric/_breaking_change.py
+++ b/src/managednetworkfabric/azext_managednetworkfabric/_breaking_change.py
@@ -9,25 +9,25 @@ from azure.cli.core.breaking_change import (
 
 register_argument_deprecate(
     "networkfabric bootstrapinterface list",
-    "network_bootstrap_device_name",
+    "--network-bootstrap-device-name",
     target_version="10.0.x",
 )
 register_argument_deprecate(
     "networkfabric bootstrapinterface show",
-    "network_bootstrap_device_name",
+    "--network-bootstrap-device-name",
     target_version="10.0.x",
 )
 register_argument_deprecate(
     "networkfabric bootstrapinterface wait",
-    "network_bootstrap_device_name",
+    "--network-bootstrap-device-name",
     target_version="10.0.x",
 )
 register_required_flag_breaking_change(
-    "networkfabric bootstrapinterface list", "bootstrap_device", target_version="10.0.x"
+    "networkfabric bootstrapinterface list", "--bootstrap-device", target_version="10.0.x"
 )
 register_required_flag_breaking_change(
-    "networkfabric bootstrapinterface show", "bootstrap_device", target_version="10.0.x"
+    "networkfabric bootstrapinterface show", "--bootstrap-device", target_version="10.0.x"
 )
 register_required_flag_breaking_change(
-    "networkfabric bootstrapinterface wait", "bootstrap_device", target_version="10.0.x"
+    "networkfabric bootstrapinterface wait", "--bootstrap-device", target_version="10.0.x"
 )

--- a/src/managednetworkfabric/azext_managednetworkfabric/_breaking_change.py
+++ b/src/managednetworkfabric/azext_managednetworkfabric/_breaking_change.py
@@ -23,11 +23,17 @@ register_argument_deprecate(
     target_version="10.0.x",
 )
 register_required_flag_breaking_change(
-    "networkfabric bootstrapinterface list", "--bootstrap-device", target_version="10.0.x"
+    "networkfabric bootstrapinterface list",
+    "--bootstrap-device",
+    target_version="10.0.x",
 )
 register_required_flag_breaking_change(
-    "networkfabric bootstrapinterface show", "--bootstrap-device", target_version="10.0.x"
+    "networkfabric bootstrapinterface show",
+    "--bootstrap-device",
+    target_version="10.0.x",
 )
 register_required_flag_breaking_change(
-    "networkfabric bootstrapinterface wait", "--bootstrap-device", target_version="10.0.x"
+    "networkfabric bootstrapinterface wait",
+    "--bootstrap-device",
+    target_version="10.0.x",
 )

--- a/src/managednetworkfabric/azext_managednetworkfabric/_breaking_change.py
+++ b/src/managednetworkfabric/azext_managednetworkfabric/_breaking_change.py
@@ -4,36 +4,56 @@
 # --------------------------------------------------------------------------------------------
 from azure.cli.core.breaking_change import (
     register_argument_deprecate,
-    register_required_flag_breaking_change,
+    register_command_deprecate,
 )
 
+register_command_deprecate(
+    "networkfabric device refresh-configuration",
+    redirect="networkfabric device refresh-config",
+    target_version="10.0.x",
+)
+register_command_deprecate(
+    "networkfabric fabric commit-configuration",
+    redirect="networkfabric fabric commit-config",
+    target_version="10.0.x",
+)
+register_command_deprecate(
+    "networkfabric fabric validate-configuration",
+    redirect="networkfabric fabric validate-config",
+    target_version="10.0.x",
+)
+register_command_deprecate(
+    "networkfabric fabric view-device-configuration",
+    redirect="networkfabric fabric view-device-config",
+    target_version="10.0.x",
+)
 register_argument_deprecate(
     "networkfabric bootstrapinterface list",
     "--network-bootstrap-device-name",
+    redirect="--bootstrap-device",
     target_version="10.0.x",
 )
 register_argument_deprecate(
     "networkfabric bootstrapinterface show",
     "--network-bootstrap-device-name",
+    redirect="--bootstrap-device",
     target_version="10.0.x",
 )
 register_argument_deprecate(
     "networkfabric bootstrapinterface wait",
     "--network-bootstrap-device-name",
+    redirect="--bootstrap-device",
     target_version="10.0.x",
 )
-register_required_flag_breaking_change(
-    "networkfabric bootstrapinterface list",
-    "--bootstrap-device",
+register_argument_deprecate(
+    "networkfabric device reboot",
+    "--network-device-name",
+    redirect="--resource-name",
     target_version="10.0.x",
 )
-register_required_flag_breaking_change(
-    "networkfabric bootstrapinterface show",
-    "--bootstrap-device",
-    target_version="10.0.x",
-)
-register_required_flag_breaking_change(
-    "networkfabric bootstrapinterface wait",
-    "--bootstrap-device",
+register_argument_deprecate(
+    "networkfabric device refresh-config",
+    "--network-device-name",
+    redirect="--resource-name",
     target_version="10.0.x",
 )

--- a/src/managednetworkfabric/azext_managednetworkfabric/tests/latest/test_nf_rotate_certificate.py
+++ b/src/managednetworkfabric/azext_managednetworkfabric/tests/latest/test_nf_rotate_certificate.py
@@ -48,7 +48,7 @@ def step_rotate_certificate_scenario1(test, checks=None):
 
 
 def step_rotate_certificate_scenario2(test, checks=None):
-    """nf rotate password operation"""
+    """nf rotate certificate operation"""
     if checks is None:
         checks = []
     test.cmd(

--- a/src/managednetworkfabric/setup.py
+++ b/src/managednetworkfabric/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 
 
 # HISTORY.rst entry.
-VERSION = '10.0.0b1'
+VERSION = '10.0.0b2'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ⚠️ Review suggested

| Breaking Changes |
| :--: |
| ⚠️ None |

<!-- act-bot:section title="Azure CLI Extensions Breaking Change Test" category="breaking_change" label="Breaking Changes" status="Warning" summary="None" -->
<!-- Azure CLI Extensions Breaking Change Test --><details>
<summary>⚠️Azure CLI Extensions Breaking Change Test</summary>

><details>
> <summary>⚠️managednetworkfabric</summary>
>
>|rule|cmd_name|rule_message|suggest_message|
>|---|---|---|---|
>|⚠️ [1003 - CmdPropAdd](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1003.md)|networkfabric device refresh-configuration|cmd `networkfabric device refresh-configuration` added property `deprecate_info_redirect`||
>|⚠️ [1003 - CmdPropAdd](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1003.md)|networkfabric device refresh-configuration|cmd `networkfabric device refresh-configuration` added property `deprecate_info_target`||
>|⚠️ [1003 - CmdPropAdd](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1003.md)|networkfabric fabric commit-configuration|cmd `networkfabric fabric commit-configuration` added property `deprecate_info_redirect`||
>|⚠️ [1003 - CmdPropAdd](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1003.md)|networkfabric fabric commit-configuration|cmd `networkfabric fabric commit-configuration` added property `deprecate_info_target`||
>|⚠️ [1003 - CmdPropAdd](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1003.md)|networkfabric fabric validate-configuration|cmd `networkfabric fabric validate-configuration` added property `deprecate_info_redirect`||
>|⚠️ [1003 - CmdPropAdd](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1003.md)|networkfabric fabric validate-configuration|cmd `networkfabric fabric validate-configuration` added property `deprecate_info_target`||
>|⚠️ [1003 - CmdPropAdd](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1003.md)|networkfabric fabric view-device-configuration|cmd `networkfabric fabric view-device-configuration` added property `deprecate_info_redirect`||
>|⚠️ [1003 - CmdPropAdd](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1003.md)|networkfabric fabric view-device-configuration|cmd `networkfabric fabric view-device-configuration` added property `deprecate_info_target`||
>
></details>
</details>

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

NetworkCloud 2026-01-15-preview breaking change notice.

aaz: N/A

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install azdev` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
