### PR TITLE
[dataprotection] Specify principal type for AKS backup roles

### DIFF
--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -14815,7 +14815,11 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             }
         )
 
-        role_assignment_cmd = 'role assignment create --role "DNS Zone Contributor" --assignee {web_app_routing_identity_obj_id} --scope {dns_zone_id}'
+        role_assignment_cmd = (
+            'role assignment create --role "DNS Zone Contributor" '
+            "--assignee-object-id {web_app_routing_identity_obj_id} "
+            "--assignee-principal-type ServicePrincipal --scope {dns_zone_id}"
+        )
         self.cmd(role_assignment_cmd)
 
         addon_update_cmd = "aks addon update -g {resource_group} -n {name} --addon web_application_routing --dns-zone-resource-ids={dns_zone_id}"

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -14815,11 +14815,7 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             }
         )
 
-        role_assignment_cmd = (
-            'role assignment create --role "DNS Zone Contributor" '
-            "--assignee-object-id {web_app_routing_identity_obj_id} "
-            "--assignee-principal-type ServicePrincipal --scope {dns_zone_id}"
-        )
+        role_assignment_cmd = 'role assignment create --role "DNS Zone Contributor" --assignee {web_app_routing_identity_obj_id} --scope {dns_zone_id}'
         self.cmd(role_assignment_cmd)
 
         addon_update_cmd = "aks addon update -g {resource_group} -n {name} --addon web_application_routing --dns-zone-resource-ids={dns_zone_id}"

--- a/src/dataprotection/HISTORY.rst
+++ b/src/dataprotection/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+1.11.4
+++++++
+* `az dataprotection enable-backup trigger`: Specify `ServicePrincipal` when creating role assignments for AKS managed identities.
+
 1.11.3
 ++++++++++++++++
 * [Breaking] `az dataprotection backup-policy retention-rule set` validates against duplicate retention-rule names. AzureBlob: OperationalStore retention lifecycles must now use the retention rule name `--name Default_OperationalStore`. Using `--name Default` with an OperationalStore lifecycle for AzureBlobis no longer accepted. 

--- a/src/dataprotection/azext_dataprotection/manual/aks/aks_helper.py
+++ b/src/dataprotection/azext_dataprotection/manual/aks/aks_helper.py
@@ -63,14 +63,15 @@ def _ensure_k8s_extension(cmd, yes=False):
     add_extension_to_path(K8S_EXTENSION_NAME)
 
 
-def _check_and_assign_role(cmd, role, assignee, scope, identity_name="identity", max_retries=3, retry_delay=10):
+def _check_and_assign_role(
+        cmd, role, assignee_object_id, scope, identity_name="identity", max_retries=3, retry_delay=10):
     """
     Check if a role assignment already exists, and create it if not.
 
     Args:
         cmd: CLI command context
         role: Role name (e.g., 'Contributor', 'Reader')
-        assignee: Principal ID of the identity to assign the role to
+        assignee_object_id: Object ID of the managed identity to assign the role to
         scope: Resource ID scope for the role assignment
         identity_name: Friendly name for log messages
         max_retries: Max retries for transient failures
@@ -82,15 +83,16 @@ def _check_and_assign_role(cmd, role, assignee, scope, identity_name="identity",
     import time
     from azure.cli.command_modules.role.custom import list_role_assignments, create_role_assignment
 
+    # AKS backup assigns roles only to managed identities; use their object IDs to avoid Graph lookup.
     manual_command = (
-        f'az role assignment create --role "{role}" --assignee-object-id "{assignee}" '
+        f'az role assignment create --role "{role}" --assignee-object-id "{assignee_object_id}" '
         f'--assignee-principal-type "ServicePrincipal" --scope "{scope}"'
     )
 
     # Check if role assignment already exists
     try:
         if list_role_assignments(
-                cmd, assignee_object_id=assignee, role=role, scope=scope, include_inherited=True):
+                cmd, assignee_object_id=assignee_object_id, role=role, scope=scope, include_inherited=True):
             logger.warning("\tRole '%s' already assigned to %s", role, identity_name)
             return True
     except Exception as e:  # pylint: disable=broad-exception-caught
@@ -103,7 +105,7 @@ def _check_and_assign_role(cmd, role, assignee, scope, identity_name="identity",
             create_role_assignment(
                 cmd,
                 role=role,
-                assignee_object_id=assignee,
+                assignee_object_id=assignee_object_id,
                 assignee_principal_type="ServicePrincipal",
                 scope=scope)
             logger.warning("\tRole '%s' assigned to %s", role, identity_name)
@@ -453,7 +455,7 @@ def _setup_resource_group(cmd, resource_client, backup_resource_group_id,
     _check_and_assign_role(
         cmd,
         role="Contributor",
-        assignee=cluster_identity_principal_id,
+        assignee_object_id=cluster_identity_principal_id,
         scope=backup_resource_group.id,
         identity_name="cluster identity")
     logger.warning("[OK] Resource group ready")
@@ -579,7 +581,7 @@ def _install_backup_extension(cmd, cluster_subscription_id,
     _check_and_assign_role(
         cmd,
         role="Storage Blob Data Contributor",
-        assignee=backup_extension.aks_assigned_identity.principal_id,
+        assignee_object_id=backup_extension.aks_assigned_identity.principal_id,
         scope=backup_storage_account.id,
         identity_name="backup extension identity")
     logger.warning("[OK] Backup extension ready")
@@ -815,21 +817,21 @@ def _setup_backup_vault(
     _check_and_assign_role(
         cmd,
         role="Reader",
-        assignee=backup_vault["identity"]["principalId"],
+        assignee_object_id=backup_vault["identity"]["principalId"],
         scope=cluster_resource.id,
         identity_name="backup vault identity (on cluster)")
 
     _check_and_assign_role(
         cmd,
         role="Reader",
-        assignee=backup_vault["identity"]["principalId"],
+        assignee_object_id=backup_vault["identity"]["principalId"],
         scope=backup_resource_group.id,
         identity_name="backup vault identity (on resource group)")
 
     _check_and_assign_role(
         cmd,
         role="Disk Snapshot Contributor",
-        assignee=backup_vault["identity"]["principalId"],
+        assignee_object_id=backup_vault["identity"]["principalId"],
         scope=backup_resource_group.id,
         identity_name="backup vault identity (snapshot contributor on resource group)")
     logger.warning("[OK] Backup vault ready")
@@ -1111,7 +1113,7 @@ def _setup_extension_and_storage(
         _check_and_assign_role(
             cmd,
             role="Storage Blob Data Contributor",
-            assignee=existing_extension.aks_assigned_identity.principal_id,
+            assignee_object_id=existing_extension.aks_assigned_identity.principal_id,
             scope=backup_storage_account.id,
             identity_name="backup extension identity")
         logger.warning("[OK] Storage account ready")
@@ -1215,7 +1217,7 @@ def dataprotection_enable_backup_helper(
     _check_and_assign_role(
         cmd,
         role="Storage Blob Data Reader",
-        assignee=backup_vault["identity"]["principalId"],
+        assignee_object_id=backup_vault["identity"]["principalId"],
         scope=backup_storage_account.id,
         identity_name="backup vault identity (on storage account)")
 

--- a/src/dataprotection/azext_dataprotection/manual/aks/aks_helper.py
+++ b/src/dataprotection/azext_dataprotection/manual/aks/aks_helper.py
@@ -82,19 +82,30 @@ def _check_and_assign_role(cmd, role, assignee, scope, identity_name="identity",
     import time
     from azure.cli.command_modules.role.custom import list_role_assignments, create_role_assignment
 
+    manual_command = (
+        f'az role assignment create --role "{role}" --assignee-object-id "{assignee}" '
+        f'--assignee-principal-type "ServicePrincipal" --scope "{scope}"'
+    )
+
     # Check if role assignment already exists
     try:
-        if list_role_assignments(cmd, assignee=assignee, role=role, scope=scope, include_inherited=True):
+        if list_role_assignments(
+                cmd, assignee_object_id=assignee, role=role, scope=scope, include_inherited=True):
             logger.warning("\tRole '%s' already assigned to %s", role, identity_name)
             return True
     except Exception as e:  # pylint: disable=broad-exception-caught
         logger.warning("\tWarning: Could not list role assignments for %s: %s", identity_name, str(e)[:100])
         # Continue to try creating the assignment
 
-    # Try to create with retries for identity propagation delay
+    # Try to create with retries for transient identity propagation errors
     for attempt in range(max_retries):
         try:
-            create_role_assignment(cmd, role=role, assignee=assignee, scope=scope)
+            create_role_assignment(
+                cmd,
+                role=role,
+                assignee_object_id=assignee,
+                assignee_principal_type="ServicePrincipal",
+                scope=scope)
             logger.warning("\tRole '%s' assigned to %s", role, identity_name)
             return True
         except Exception as e:  # pylint: disable=broad-exception-caught
@@ -121,7 +132,7 @@ def _check_and_assign_role(cmd, role, assignee, scope, identity_name="identity",
                 raise InvalidArgumentValueError(
                     f"Insufficient permissions to assign '{role}' role to {identity_name}.\n"
                     f"Run manually:\n\n"
-                    f"  az role assignment create --role \"{role}\" --assignee \"{assignee}\" --scope \"{scope}\"\n"
+                    f"  {manual_command}\n"
                 )
 
             # Non-retryable error — break and raise
@@ -130,7 +141,7 @@ def _check_and_assign_role(cmd, role, assignee, scope, identity_name="identity",
     raise InvalidArgumentValueError(
         f"Failed to assign '{role}' role to {identity_name}.\n"
         f"Run manually:\n\n"
-        f"  az role assignment create --role \"{role}\" --assignee \"{assignee}\" --scope \"{scope}\"\n"
+        f"  {manual_command}\n"
     )
 
 

--- a/src/dataprotection/azext_dataprotection/tests/latest/test_dataprotection_backup_instance_create_and_delete.py
+++ b/src/dataprotection/azext_dataprotection/tests/latest/test_dataprotection_backup_instance_create_and_delete.py
@@ -57,7 +57,6 @@ class BackupInstanceCreateDeleteScenarioTest(ScenarioTest):
     def test_dataprotection_backup_instance_create_backup_delete_disk(test):
         test.kwargs.update({
             'subscriptionId': '59e574f1-e278-4b66-875b-e3e4fe74ad88',
-            'originalSubscriptionId': test.cmd('az account show --query id -o tsv').output.strip(),
             'dataSourceType': "AzureDisk",
             'permissionsScope': "Resource",
             'policyId': '/subscriptions/59e574f1-e278-4b66-875b-e3e4fe74ad88/resourceGroups/clitest-dpp-rg/providers/Microsoft.DataProtection/backupVaults/clitest-bkp-vault-donotdelete/backupPolicies/diskpolicy',
@@ -65,8 +64,10 @@ class BackupInstanceCreateDeleteScenarioTest(ScenarioTest):
             'diskId': '/subscriptions/59e574f1-e278-4b66-875b-e3e4fe74ad88/resourceGroups/clitest-dpp-rg/providers/Microsoft.Compute/disks/clitest-disk-donotdelete',
             'policyRuleName': "BackupHourly"
         })
-        test.addCleanup(lambda: test.cmd('az account set --subscription "{originalSubscriptionId}"'))
-        test.cmd('az account set --subscription "{subscriptionId}"')
+        if test.is_live:
+            test.kwargs['originalSubscriptionId'] = test.cmd('az account show --query id -o tsv').output.strip()
+            test.addCleanup(lambda: test.cmd('az account set --subscription "{originalSubscriptionId}"'))
+            test.cmd('az account set --subscription "{subscriptionId}"')
         backup_instance_guid = "b7e6f082-b310-11eb-8f55-9cfce85d4fa1"
         backup_instance_json = test.cmd('az dataprotection backup-instance initialize --datasource-type "{dataSourceType}" '
                                         '-l "{location}" --policy-id "{policyId}" --datasource-id "{diskId}" --snapshot-rg "{rg}" --tags Owner=dppclitest Purpose=Testing').get_output_in_json()

--- a/src/dataprotection/azext_dataprotection/tests/latest/test_dataprotection_backup_instance_operations.py
+++ b/src/dataprotection/azext_dataprotection/tests/latest/test_dataprotection_backup_instance_operations.py
@@ -70,7 +70,6 @@ class BackupInstanceOperationsScenarioTest(ScenarioTest):
     def test_dataprotection_backup_instance_update_policy(test):
         test.kwargs.update({
             'subscriptionId': '59e574f1-e278-4b66-875b-e3e4fe74ad88',
-            'originalSubscriptionId': test.cmd('az account show --query id -o tsv').output.strip(),
             'rg': 'clitest-dpp-rg',
             'vaultName': 'clitest-bkp-vault-donotdelete',
             'backupInstanceName': 'clitestblobsadnd-clitestblobsadnd-92e88a05-3816-418b-8987-1285f34c2030',
@@ -79,8 +78,10 @@ class BackupInstanceOperationsScenarioTest(ScenarioTest):
             'altPolicyName': 'vaultpolicy',
             'altPolicyId': '/subscriptions/59e574f1-e278-4b66-875b-e3e4fe74ad88/resourceGroups/clitest-dpp-rg/providers/Microsoft.DataProtection/backupVaults/clitest-bkp-vault-donotdelete/backupPolicies/vaultpolicy'
         })
-        test.addCleanup(lambda: test.cmd('az account set --subscription "{originalSubscriptionId}"'))
-        test.cmd('az account set --subscription "{subscriptionId}"')
+        if test.is_live:
+            test.kwargs['originalSubscriptionId'] = test.cmd('az account show --query id -o tsv').output.strip()
+            test.addCleanup(lambda: test.cmd('az account set --subscription "{originalSubscriptionId}"'))
+            test.cmd('az account set --subscription "{subscriptionId}"')
         test.cmd('az dataprotection backup-instance wait -g "{rg}" --vault-name "{vaultName}" --backup-instance-name "{backupInstanceName}" --timeout 300 '
                  '--custom "properties.currentProtectionState==\'ProtectionConfigured\'"')
 

--- a/src/dataprotection/azext_dataprotection/tests/latest/test_dataprotection_enable_backup.py
+++ b/src/dataprotection/azext_dataprotection/tests/latest/test_dataprotection_enable_backup.py
@@ -257,6 +257,8 @@ class TestCheckAndAssignRole(unittest.TestCase):
         cmd = MagicMock()
         result = _check_and_assign_role(cmd, "Reader", "pid", "/scope")
         self.assertTrue(result)
+        mock_list.assert_called_once_with(
+            cmd, assignee_object_id="pid", role="Reader", scope="/scope", include_inherited=True)
         mock_create.assert_not_called()
 
     @patch(f"{ROLE_MODULE}.create_role_assignment")
@@ -265,7 +267,12 @@ class TestCheckAndAssignRole(unittest.TestCase):
         cmd = MagicMock()
         result = _check_and_assign_role(cmd, "Reader", "pid", "/scope")
         self.assertTrue(result)
-        mock_create.assert_called_once()
+        mock_create.assert_called_once_with(
+            cmd,
+            role="Reader",
+            assignee_object_id="pid",
+            assignee_principal_type="ServicePrincipal",
+            scope="/scope")
 
     @patch(f"{ROLE_MODULE}.create_role_assignment", side_effect=Exception("Conflict: already exists"))
     @patch(f"{ROLE_MODULE}.list_role_assignments", return_value=[])
@@ -278,7 +285,9 @@ class TestCheckAndAssignRole(unittest.TestCase):
     @patch(f"{ROLE_MODULE}.list_role_assignments", return_value=[])
     def test_permission_denied_raises(self, mock_list, mock_create):
         cmd = MagicMock()
-        with self.assertRaises(InvalidArgumentValueError):
+        with self.assertRaisesRegex(
+                InvalidArgumentValueError,
+                "--assignee-object-id.*--assignee-principal-type"):
             _check_and_assign_role(cmd, "Reader", "pid", "/scope")
 
 

--- a/src/dataprotection/azext_dataprotection/tests/latest/test_dataprotection_enable_backup.py
+++ b/src/dataprotection/azext_dataprotection/tests/latest/test_dataprotection_enable_backup.py
@@ -255,7 +255,7 @@ class TestCheckAndAssignRole(unittest.TestCase):
     @patch(f"{ROLE_MODULE}.list_role_assignments", return_value=[{"id": "existing"}])
     def test_existing_role_returns_true(self, mock_list, mock_create):
         cmd = MagicMock()
-        result = _check_and_assign_role(cmd, "Reader", "pid", "/scope")
+        result = _check_and_assign_role(cmd, "Reader", assignee_object_id="pid", scope="/scope")
         self.assertTrue(result)
         mock_list.assert_called_once_with(
             cmd, assignee_object_id="pid", role="Reader", scope="/scope", include_inherited=True)
@@ -265,7 +265,7 @@ class TestCheckAndAssignRole(unittest.TestCase):
     @patch(f"{ROLE_MODULE}.list_role_assignments", return_value=[])
     def test_creates_role_when_missing(self, mock_list, mock_create):
         cmd = MagicMock()
-        result = _check_and_assign_role(cmd, "Reader", "pid", "/scope")
+        result = _check_and_assign_role(cmd, "Reader", assignee_object_id="pid", scope="/scope")
         self.assertTrue(result)
         mock_create.assert_called_once_with(
             cmd,
@@ -278,7 +278,7 @@ class TestCheckAndAssignRole(unittest.TestCase):
     @patch(f"{ROLE_MODULE}.list_role_assignments", return_value=[])
     def test_conflict_treated_as_success(self, mock_list, mock_create):
         cmd = MagicMock()
-        result = _check_and_assign_role(cmd, "Reader", "pid", "/scope")
+        result = _check_and_assign_role(cmd, "Reader", assignee_object_id="pid", scope="/scope")
         self.assertTrue(result)
 
     @patch(f"{ROLE_MODULE}.create_role_assignment", side_effect=Exception("Authorization failed: forbidden"))
@@ -288,7 +288,7 @@ class TestCheckAndAssignRole(unittest.TestCase):
         with self.assertRaisesRegex(
                 InvalidArgumentValueError,
                 "--assignee-object-id.*--assignee-principal-type"):
-            _check_and_assign_role(cmd, "Reader", "pid", "/scope")
+            _check_and_assign_role(cmd, "Reader", assignee_object_id="pid", scope="/scope")
 
 
 # ---------------------------------------------------------------------------

--- a/src/dataprotection/setup.py
+++ b/src/dataprotection/setup.py
@@ -10,7 +10,7 @@ from codecs import open
 from setuptools import setup, find_packages
 
 # HISTORY.rst entry.
-VERSION = '1.11.3'
+VERSION = '1.11.4'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes |
| :--: |
| ️✔️ None |

<!-- act-bot:section title="Azure CLI Extensions Breaking Change Test" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

---

### Related command
`az dataprotection enable-backup trigger`

`az aks create --enable-backup` / `az aks update --enable-backup`

### Description
AKS backup role-assignment helpers already receive managed-identity object IDs, but passed them through `assignee`. Azure CLI then queries Microsoft Graph to infer the principal type. In app-only environments without Graph directory permissions, the GUID fallback leaves the type unset and omits `principalType` from the role-assignment request.

This change:

- Uses `assignee_object_id` with an explicit `ServicePrincipal` type when checking and creating AKS backup role assignments.
- Makes the helper's object-ID-only contract explicit in its parameter name, documentation, callers, and unit tests.
- Updates manual remediation commands to use the same unambiguous arguments.
- Bumps the Data Protection extension to 1.11.4 and adds its release note.

Explicitly setting the type avoids Graph inference, reduces fresh-identity propagation failures, and keeps the requests compliant with PIM Only Mode enforcement.

The `aks-preview` live-test change originally included here was moved to [#10263](https://github.com/Azure/azure-cli-extensions/pull/10263) so that the Data Protection product fix and AKS test fix can be reviewed independently.

### CI follow-up
The initial CI run exposed two existing recorded Data Protection scenarios that unconditionally switched to a live persistent-resource subscription. Playback profiles contain only the sanitized CI subscription, so all Python versions failed before cassette replay with:

```text
The subscription of '59e574f1-e278-4b66-875b-e3e4fe74ad88' doesn't exist in cloud 'AzureCloud'.
```

The tests now switch subscriptions only during live runs. Recorded runs continue against the playback profile's subscription.

### Validation

- `azdev style dataprotection --pep8 --pylint`
- `azdev test azext_dataprotection --series --no-exitfirst` - 81 passed, 26 skipped
- `python scripts/ci/test_index.py -q` - 9 passed, 2 skipped
- `azdev extension build dataprotection` - built `dataprotection-1.11.4-py3-none-any.whl`
- `git diff --check`

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install azdev` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).

### About Extension Publish

Once merged, the normal release automation can publish Data Protection 1.11.4 and update `src/index.json`; this PR intentionally does not edit the generated index.
