### PR TITLE
{AKS} Specify principal type in Web App Routing live test

### DIFF
--- a/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py
@@ -14815,7 +14815,11 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
             }
         )
 
-        role_assignment_cmd = 'role assignment create --role "DNS Zone Contributor" --assignee {web_app_routing_identity_obj_id} --scope {dns_zone_id}'
+        role_assignment_cmd = (
+            'role assignment create --role "DNS Zone Contributor" '
+            "--assignee-object-id {web_app_routing_identity_obj_id} "
+            "--assignee-principal-type ServicePrincipal --scope {dns_zone_id}"
+        )
         self.cmd(role_assignment_cmd)
 
         addon_update_cmd = "aks addon update -g {resource_group} -n {name} --addon web_application_routing --dns-zone-resource-ids={dns_zone_id}"


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes |
| :--: |
| ️✔️ None |

<!-- act-bot:section title="Azure CLI Extensions Breaking Change Test" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

---

### Related command
`az role assignment create` in `test_aks_create_and_update_web_application_routing_dns_zone`

### Description
The Web App Routing live test creates a DNS Zone Contributor assignment for a managed identity by passing its object ID through `--assignee`. Azure CLI then attempts to query Microsoft Graph to infer the principal type. In app-only environments without Graph directory permissions, the GUID fallback leaves the type unset and omits `principalType` from the role-assignment request.

Use `--assignee-object-id` with `--assignee-principal-type ServicePrincipal` so the request is unambiguous and compliant with PIM Only Mode enforcement without requiring Graph inference.

This is a test-only compliance hardening change and does not alter customer-facing `aks-preview` behavior. It was split from #10262 so that the Data Protection product fix and this AKS live-test fix can be reviewed independently.

### Validation

- `azdev style aks-preview --pep8 --pylint`
- `python -m py_compile src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py`
- `python scripts/ci/test_index.py -q` — 9 passed, 2 skipped

The live scenario was not run because it provisions an AKS cluster and DNS resources. No extension version bump is needed for a test-only change.

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install azdev` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).

### About Extension Publish

This PR changes only a live test, so it intentionally does not change the `aks-preview` version, history, or generated index.
