### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/actions/env-setup/action.yml
+++ b/.github/actions/env-setup/action.yml
@@ -12,17 +12,17 @@ runs:
       run: |
         echo start azdev env setup
     - name: Checkout CLI extension repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         fetch-depth: 0 # checkout all branches
         ref: ${{ github.event.pull_request.head.ref }}
         repository: ${{ github.event.pull_request.head.repo.full_name }}  # checkout pull request branch
     - name: Set up Python 3.11
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 # v3.1.4
       with:
         python-version: "3.11"
     - name: Checkout CLI main repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         repository: Azure/azure-cli
         path: ./azure-cli

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    groups:
+      github-actions:
+        patterns: ["*"]
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/AddIssueComment.yml
+++ b/.github/workflows/AddIssueComment.yml
@@ -10,7 +10,7 @@ jobs:
     name: Say thanks for the Issue
     steps:
       - name: comment on the issue
-        uses: hasura/comment-progress@v2.3.0
+        uses: hasura/comment-progress@146c635f3e325d478025e29e5043ec1c07c0e36c # v2.3.0
         with:
           github-token: ${{ secrets.CLI_BOT }}
           repository: 'Azure/azure-cli-extensions'

--- a/.github/workflows/AddIssueCommentWithLabel.yml
+++ b/.github/workflows/AddIssueCommentWithLabel.yml
@@ -12,12 +12,12 @@ jobs:
     name: Comment on issue
     steps:
       - name: Checkout comment message
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           sparse-checkout: |
             .github/template/non-security-comment.md
       - name: Comment on issue with no security label
-        uses: mshick/add-pr-comment@v2
+        uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2.8.2
         with:
            repo-token: ${{ secrets.GITHUB_TOKEN }}
            message-id: issueNoSecurityCommentBot

--- a/.github/workflows/AzdevLinter.yml
+++ b/.github/workflows/AzdevLinter.yml
@@ -17,7 +17,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout CLI extension repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 1
           sparse-checkout: |

--- a/.github/workflows/AzdevStyle.yml
+++ b/.github/workflows/AzdevStyle.yml
@@ -17,7 +17,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout CLI extension repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 1
           sparse-checkout: |

--- a/.github/workflows/BlockPRMerge.yml
+++ b/.github/workflows/BlockPRMerge.yml
@@ -14,7 +14,7 @@ jobs:
     permissions: {}
     steps:
       - name: Check blocked labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const labels = context.payload.pull_request.labels.map(label => label.name);

--- a/.github/workflows/CCOA.yml
+++ b/.github/workflows/CCOA.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Add do-not-merge label
         if: steps.date_check.outputs.continue == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -49,7 +49,7 @@ jobs:
 
       - name: Comment on PR
         if: steps.date_check.outputs.continue == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/CreateReleaseTag.yml
+++ b/.github/workflows/CreateReleaseTag.yml
@@ -14,12 +14,12 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         fetch-depth: 2
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: '3.x'
 

--- a/.github/workflows/GitHookNotice.yml
+++ b/.github/workflows/GitHookNotice.yml
@@ -15,7 +15,7 @@ jobs:
     name: Introduce git hook in developer env
     steps:
       - name: Checkout git hook notice message
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           sparse-checkout: |
             .github/template/git-hooks-note.md

--- a/.github/workflows/TestTriggerExtensionRelease.yml
+++ b/.github/workflows/TestTriggerExtensionRelease.yml
@@ -21,13 +21,13 @@ jobs:
           with:
             egress-policy: audit
         - name: Azure login
-          uses: azure/login@v2
+          uses: azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2.3.1
           with:
             client-id: ${{ secrets.ADO_SP_ClientID }}
             tenant-id: ${{ secrets.ADO_SP_TenantID }}
             allow-no-subscriptions: true
         - name: Test Trigger ADO Pipeline and Wait for Completion
-          uses: azure/cli@v2
+          uses: azure/cli@9f7ce6f37c31b777ec6c6b6d1dfe7db79f497956 # v2.2.0
           env:
             ado-org: ${{secrets.ADO_ORGANIZATION}}
             ado-project: ${{secrets.ADO_PROJECT}}

--- a/.github/workflows/TriggerExtensionRelease.yml
+++ b/.github/workflows/TriggerExtensionRelease.yml
@@ -21,13 +21,13 @@ jobs:
           with:
             egress-policy: audit
         - name: Azure login
-          uses: azure/login@v2
+          uses: azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2.3.1
           with:
             client-id: ${{ secrets.ADO_SP_ClientID }}
             tenant-id: ${{ secrets.ADO_SP_TenantID }}
             allow-no-subscriptions: true
         - name: Trigger ADO Pipeline and Wait for Completion
-          uses: azure/cli@v2
+          uses: azure/cli@9f7ce6f37c31b777ec6c6b6d1dfe7db79f497956 # v2.2.0
           env:
             ado-org: ${{secrets.ADO_ORGANIZATION}}
             ado-project: ${{secrets.ADO_PROJECT}}

--- a/.github/workflows/VersionCalPRComment.yml
+++ b/.github/workflows/VersionCalPRComment.yml
@@ -24,11 +24,11 @@ jobs:
         run: |
           echo version cal job start
       - name: Set up Python 3.11
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 # v3.1.4
         with:
            python-version: "3.11"
       - name: Checkout CLI extension repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0 # checkout all branches
           ref: ${{ github.event.pull_request.head.ref }}
@@ -93,7 +93,7 @@ jobs:
           echo ${#changed_module_list[@]}
       - name: Checkout CLI main repo
         if: ${{ env.no_changed_mod == 'false' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
            repository: Azure/azure-cli
            path: ./azure-cli
@@ -166,7 +166,7 @@ jobs:
           cat "$result_path"/"$output_file"
           # echo "commit_message=$(cat $output_file)" >> $GITHUB_ENV
       - name: Archive pr version cal output
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: version-cal-output
           path: |
@@ -197,7 +197,7 @@ jobs:
           cd ../
           ls "$result_path"
       - name: Archive pr version cal output
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: version-cal-output
           path: |
@@ -217,7 +217,7 @@ jobs:
         run: |
           echo version output job start
       - name: Download version cal result
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: version-cal-output
       - name: Show work directory after result downloaded
@@ -226,7 +226,7 @@ jobs:
           ls
       - name: Check comment file existence
         id: check_comment_file
-        uses: andstor/file-existence-action@v3
+        uses: andstor/file-existence-action@558493d6c74bf472d87c84eab196434afc2fa029 # v3.1.0
         with:
           files: "./version_update.txt"
       - name: Show version update notice
@@ -241,7 +241,7 @@ jobs:
           echo "Please refer to [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md) to update release versions."
       - name: Check add label file existence
         id: check_add_label_file
-        uses: andstor/file-existence-action@v3
+        uses: andstor/file-existence-action@558493d6c74bf472d87c84eab196434afc2fa029 # v3.1.0
         with:
           files: "./labels_added.json"
       - name: Add block release label
@@ -254,7 +254,7 @@ jobs:
           -d @labels_added.json
       - name: Check delete label file existence
         id: check_delete_label_file
-        uses: andstor/file-existence-action@v3
+        uses: andstor/file-existence-action@558493d6c74bf472d87c84eab196434afc2fa029 # v3.1.0
         with:
           files: "./labels_removed.txt"
       - name: Remove block release label
@@ -266,7 +266,7 @@ jobs:
              "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/${del_lab}" \
              -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}"
           done
-      - uses: snnaplab/get-labels-action@v1
+      - uses: snnaplab/get-labels-action@f426df40304808ace3b5282d4f036515f7609576 # v1.0.1
       - name: Check real time labels
         if: contains(fromJSON(env.LABELS), 'release-version-block')
         run: |


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes |
| :--: |
| ️✔️ None |

<!-- act-bot:section title="Azure CLI Extensions Breaking Change Test" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

## Summary

This PR pins GitHub Actions to full-length commit SHAs for improved security and reproducibility and adds a 7 day cooldown to Dependabot configuration for GitHub Actions. This work is described in more detail at https://aka.ms/action-pinning.

## Why?

Pinning actions to commit SHAs prevents supply-chain attacks where a tag could be moved to point to malicious code. This is a recommended security best practice per the [GitHub Actions security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

This change mitigates the risk of tag retargeting to malicious code as seen in incidents like the [tj-actions/changed-files action compromise](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) or [codfish/semantic-release-action compromise](https://www.stepsecurity.io/blog/supply-chain-compromise-codfish-semantic-release-action) and improves the integrity and reproducibility of the CI/CD pipeline.

## What changed?

**Action pinning:** Third-party action references in `.github/workflows/` that used mutable tag-based references (e.g., `actions/checkout@v4`) have been updated to full-length commit SHAs with a version comment (e.g., `actions/checkout@<sha> # v4`) using the [pinact](https://github.com/suzuki-shunsuke/pinact) tool. References that were already pinned to a SHA, or that used immutable release tags, were left unchanged.

**Dependabot configuration:** `.github/dependabot.yml` has been updated to ensure a `github-actions` package-ecosystem section is present with a `cooldown` configuration (`default-days: 7`). If the file did not exist, it was created. If a `github-actions` section already existed, only the `cooldown` block was added or its `default-days` value was increased to 7 if it was lower. The 7-day cooldown provides a window for the community to detect and report compromised releases before they are automatically proposed as updates, reducing exposure to supply-chain attacks via newly published malicious versions.

## Is this safe to merge?

Yes. The pinned SHAs correspond to the same commits that the existing tags pointed to. No behavioral changes in action execution are introduced. You can verify the pinned SHA value using the GitHub REST API (e.g., the commit hash for `actions/checkout@v7` can be found in the `sha` property in the JSON response for `GET https://api.github.com/repos/actions/checkout/commits/v7`).

## Additional Information

For more information, please see https://aka.ms/action-pinning
