### PR TITLE
[Mission] GA mission extension (Microsoft.Mission 2026-04-01)

### DIFF
--- a/src/mission/HISTORY.rst
+++ b/src/mission/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+1.0.0
++++++
+* General availability release targeting Microsoft.Mission API version 2026-04-01.
+
 1.0.0b1
 ++++++
 * Initial release.

--- a/src/mission/README.md
+++ b/src/mission/README.md
@@ -1,5 +1,17 @@
 # Azure CLI Mission Extension #
-This is an extension to Azure CLI to manage Mission resources.
+This is an extension to Azure CLI to manage Azure Virtual Enclaves (Microsoft.Mission) resources.
 
 ## How to use ##
-Please add commands usage here.
+Install this extension using the below CLI command:
+```
+az extension add --name mission
+```
+
+Then use the `az mission` command group, for example:
+```
+az mission community create --resource-group MyRg --community-name MyCommunity --location eastus ...
+az mission community list --resource-group MyRg
+az mission virtual-enclave list --resource-group MyRg
+```
+
+Run `az mission --help` to see the full list of command groups and commands.

--- a/src/mission/README.md
+++ b/src/mission/README.md
@@ -9,9 +9,9 @@ az extension add --name mission
 
 Then use the `az mission` command group, for example:
 ```
-az mission community create --resource-group MyRg --community-name MyCommunity --location eastus ...
 az mission community list --resource-group MyRg
+az mission community show --resource-group MyRg --community-name MyCommunity
 az mission virtual-enclave list --resource-group MyRg
 ```
 
-Run `az mission --help` to see the full list of command groups and commands.
+Run `az mission --help` (or `az mission community create --help`) to see the full list of command groups, commands, and their parameters.

--- a/src/mission/azext_mission/aaz/latest/mission/approval/_create.py
+++ b/src/mission/azext_mission/aaz/latest/mission/approval/_create.py
@@ -22,9 +22,9 @@ class Create(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/{resourceuri}/providers/microsoft.mission/approvals/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/{resourceuri}/providers/microsoft.mission/approvals/{}", "2026-04-01"],
         ]
     }
 
@@ -227,7 +227,7 @@ class Create(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/approval/_delete.py
+++ b/src/mission/azext_mission/aaz/latest/mission/approval/_delete.py
@@ -23,9 +23,9 @@ class Delete(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/{resourceuri}/providers/microsoft.mission/approvals/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/{resourceuri}/providers/microsoft.mission/approvals/{}", "2026-04-01"],
         ]
     }
 
@@ -144,7 +144,7 @@ class Delete(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/approval/_list.py
+++ b/src/mission/azext_mission/aaz/latest/mission/approval/_list.py
@@ -22,9 +22,9 @@ class List(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/{resourceuri}/providers/microsoft.mission/approvals", "2026-03-01-preview"],
+            ["mgmt-plane", "/{resourceuri}/providers/microsoft.mission/approvals", "2026-04-01"],
         ]
     }
 
@@ -111,7 +111,7 @@ class List(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/approval/_notify_initiator.py
+++ b/src/mission/azext_mission/aaz/latest/mission/approval/_notify_initiator.py
@@ -22,9 +22,9 @@ class NotifyInitiator(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/{resourceuri}/providers/microsoft.mission/approvals/{}/notifyinitiator", "2026-03-01-preview"],
+            ["mgmt-plane", "/{resourceuri}/providers/microsoft.mission/approvals/{}/notifyinitiator", "2026-04-01"],
         ]
     }
 
@@ -149,7 +149,7 @@ class NotifyInitiator(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/approval/_show.py
+++ b/src/mission/azext_mission/aaz/latest/mission/approval/_show.py
@@ -22,9 +22,9 @@ class Show(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/{resourceuri}/providers/microsoft.mission/approvals/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/{resourceuri}/providers/microsoft.mission/approvals/{}", "2026-04-01"],
         ]
     }
 
@@ -121,7 +121,7 @@ class Show(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/approval/_update.py
+++ b/src/mission/azext_mission/aaz/latest/mission/approval/_update.py
@@ -22,9 +22,9 @@ class Update(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/{resourceuri}/providers/microsoft.mission/approvals/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/{resourceuri}/providers/microsoft.mission/approvals/{}", "2026-04-01"],
         ]
     }
 
@@ -234,7 +234,7 @@ class Update(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }
@@ -330,7 +330,7 @@ class Update(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/approval/_wait.py
+++ b/src/mission/azext_mission/aaz/latest/mission/approval/_wait.py
@@ -20,7 +20,7 @@ class Wait(AAZWaitCommand):
 
     _aaz_info = {
         "resources": [
-            ["mgmt-plane", "/{resourceuri}/providers/microsoft.mission/approvals/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/{resourceuri}/providers/microsoft.mission/approvals/{}", "2026-04-01"],
         ]
     }
 
@@ -117,7 +117,7 @@ class Wait(AAZWaitCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/community/_check_address_space_availability.py
+++ b/src/mission/azext_mission/aaz/latest/mission/community/_check_address_space_availability.py
@@ -22,9 +22,9 @@ class CheckAddressSpaceAvailability(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/checkaddressspaceavailability", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/checkaddressspaceavailability", "2026-04-01"],
         ]
     }
 
@@ -181,7 +181,7 @@ class CheckAddressSpaceAvailability(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/community/_create.py
+++ b/src/mission/azext_mission/aaz/latest/mission/community/_create.py
@@ -22,9 +22,9 @@ class Create(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}", "2026-04-01"],
         ]
     }
 
@@ -469,7 +469,7 @@ class Create(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/community/_delete.py
+++ b/src/mission/azext_mission/aaz/latest/mission/community/_delete.py
@@ -23,9 +23,9 @@ class Delete(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}", "2026-04-01"],
         ]
     }
 
@@ -146,7 +146,7 @@ class Delete(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/community/_list.py
+++ b/src/mission/azext_mission/aaz/latest/mission/community/_list.py
@@ -25,10 +25,10 @@ class List(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/providers/microsoft.mission/communities", "2026-03-01-preview"],
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/providers/microsoft.mission/communities", "2026-04-01"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities", "2026-04-01"],
         ]
     }
 
@@ -115,7 +115,7 @@ class List(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }
@@ -475,7 +475,7 @@ class List(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/community/_show.py
+++ b/src/mission/azext_mission/aaz/latest/mission/community/_show.py
@@ -22,9 +22,9 @@ class Show(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}", "2026-04-01"],
         ]
     }
 
@@ -123,7 +123,7 @@ class Show(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/community/_update.py
+++ b/src/mission/azext_mission/aaz/latest/mission/community/_update.py
@@ -22,9 +22,9 @@ class Update(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}", "2026-04-01"],
         ]
     }
 
@@ -482,7 +482,7 @@ class Update(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }
@@ -581,7 +581,7 @@ class Update(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/community/_wait.py
+++ b/src/mission/azext_mission/aaz/latest/mission/community/_wait.py
@@ -20,7 +20,7 @@ class Wait(AAZWaitCommand):
 
     _aaz_info = {
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}", "2026-04-01"],
         ]
     }
 
@@ -119,7 +119,7 @@ class Wait(AAZWaitCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/community/community_endpoint/_create.py
+++ b/src/mission/azext_mission/aaz/latest/mission/community/community_endpoint/_create.py
@@ -22,9 +22,9 @@ class Create(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/communityendpoints/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/communityendpoints/{}", "2026-04-01"],
         ]
     }
 
@@ -221,7 +221,7 @@ class Create(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/community/community_endpoint/_delete.py
+++ b/src/mission/azext_mission/aaz/latest/mission/community/community_endpoint/_delete.py
@@ -23,9 +23,9 @@ class Delete(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/communityendpoints/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/communityendpoints/{}", "2026-04-01"],
         ]
     }
 
@@ -159,7 +159,7 @@ class Delete(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/community/community_endpoint/_handle_approval_creation.py
+++ b/src/mission/azext_mission/aaz/latest/mission/community/community_endpoint/_handle_approval_creation.py
@@ -19,9 +19,9 @@ class HandleApprovalCreation(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/communityendpoints/{}/handleapprovalcreation", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/communityendpoints/{}/handleapprovalcreation", "2026-04-01"],
         ]
     }
 
@@ -173,7 +173,7 @@ class HandleApprovalCreation(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/community/community_endpoint/_handle_approval_deletion.py
+++ b/src/mission/azext_mission/aaz/latest/mission/community/community_endpoint/_handle_approval_deletion.py
@@ -19,9 +19,9 @@ class HandleApprovalDeletion(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/communityendpoints/{}/handleapprovaldeletion", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/communityendpoints/{}/handleapprovaldeletion", "2026-04-01"],
         ]
     }
 
@@ -161,7 +161,7 @@ class HandleApprovalDeletion(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/community/community_endpoint/_list.py
+++ b/src/mission/azext_mission/aaz/latest/mission/community/community_endpoint/_list.py
@@ -25,10 +25,10 @@ class List(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/providers/microsoft.mission/communities/{}/communityendpoints", "2026-03-01-preview"],
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/communityendpoints", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/providers/microsoft.mission/communities/{}/communityendpoints", "2026-04-01"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/communityendpoints", "2026-04-01"],
         ]
     }
 
@@ -127,7 +127,7 @@ class List(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }
@@ -305,7 +305,7 @@ class List(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/community/community_endpoint/_show.py
+++ b/src/mission/azext_mission/aaz/latest/mission/community/community_endpoint/_show.py
@@ -22,9 +22,9 @@ class Show(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/communityendpoints/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/communityendpoints/{}", "2026-04-01"],
         ]
     }
 
@@ -136,7 +136,7 @@ class Show(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/community/community_endpoint/_update.py
+++ b/src/mission/azext_mission/aaz/latest/mission/community/community_endpoint/_update.py
@@ -22,9 +22,9 @@ class Update(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/communityendpoints/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/communityendpoints/{}", "2026-04-01"],
         ]
     }
 
@@ -227,7 +227,7 @@ class Update(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }
@@ -330,7 +330,7 @@ class Update(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/community/community_endpoint/_wait.py
+++ b/src/mission/azext_mission/aaz/latest/mission/community/community_endpoint/_wait.py
@@ -20,7 +20,7 @@ class Wait(AAZWaitCommand):
 
     _aaz_info = {
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/communityendpoints/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/communityendpoints/{}", "2026-04-01"],
         ]
     }
 
@@ -132,7 +132,7 @@ class Wait(AAZWaitCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/community/dedicated_hub/_create.py
+++ b/src/mission/azext_mission/aaz/latest/mission/community/dedicated_hub/_create.py
@@ -22,9 +22,9 @@ class Create(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/dedicatedhubs/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/dedicatedhubs/{}", "2026-04-01"],
         ]
     }
 
@@ -181,7 +181,7 @@ class Create(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/community/dedicated_hub/_delete.py
+++ b/src/mission/azext_mission/aaz/latest/mission/community/dedicated_hub/_delete.py
@@ -23,9 +23,9 @@ class Delete(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/dedicatedhubs/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/dedicatedhubs/{}", "2026-04-01"],
         ]
     }
 
@@ -159,7 +159,7 @@ class Delete(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/community/dedicated_hub/_list.py
+++ b/src/mission/azext_mission/aaz/latest/mission/community/dedicated_hub/_list.py
@@ -25,10 +25,10 @@ class List(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/providers/microsoft.mission/communities/{}/dedicatedhubs", "2026-03-01-preview"],
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/dedicatedhubs", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/providers/microsoft.mission/communities/{}/dedicatedhubs", "2026-04-01"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/dedicatedhubs", "2026-04-01"],
         ]
     }
 
@@ -127,7 +127,7 @@ class List(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }
@@ -284,7 +284,7 @@ class List(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/community/dedicated_hub/_show.py
+++ b/src/mission/azext_mission/aaz/latest/mission/community/dedicated_hub/_show.py
@@ -22,9 +22,9 @@ class Show(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/dedicatedhubs/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/dedicatedhubs/{}", "2026-04-01"],
         ]
     }
 
@@ -136,7 +136,7 @@ class Show(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/community/dedicated_hub/_update.py
+++ b/src/mission/azext_mission/aaz/latest/mission/community/dedicated_hub/_update.py
@@ -22,9 +22,9 @@ class Update(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/dedicatedhubs/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/dedicatedhubs/{}", "2026-04-01"],
         ]
     }
 
@@ -178,7 +178,7 @@ class Update(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }
@@ -281,7 +281,7 @@ class Update(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/community/dedicated_hub/_wait.py
+++ b/src/mission/azext_mission/aaz/latest/mission/community/dedicated_hub/_wait.py
@@ -20,7 +20,7 @@ class Wait(AAZWaitCommand):
 
     _aaz_info = {
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/dedicatedhubs/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/dedicatedhubs/{}", "2026-04-01"],
         ]
     }
 
@@ -132,7 +132,7 @@ class Wait(AAZWaitCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/community/identity/_assign.py
+++ b/src/mission/azext_mission/aaz/latest/mission/community/identity/_assign.py
@@ -22,9 +22,9 @@ class Assign(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}", "2026-03-01-preview", "identity"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}", "2026-04-01", "identity"],
         ]
     }
 
@@ -166,7 +166,7 @@ class Assign(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }
@@ -265,7 +265,7 @@ class Assign(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/community/identity/_remove.py
+++ b/src/mission/azext_mission/aaz/latest/mission/community/identity/_remove.py
@@ -22,9 +22,9 @@ class Remove(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}", "2026-03-01-preview", "identity"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}", "2026-04-01", "identity"],
         ]
     }
 
@@ -166,7 +166,7 @@ class Remove(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }
@@ -265,7 +265,7 @@ class Remove(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/community/identity/_show.py
+++ b/src/mission/azext_mission/aaz/latest/mission/community/identity/_show.py
@@ -22,9 +22,9 @@ class Show(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}", "2026-03-01-preview", "identity"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}", "2026-04-01", "identity"],
         ]
     }
 
@@ -134,7 +134,7 @@ class Show(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/community/identity/_wait.py
+++ b/src/mission/azext_mission/aaz/latest/mission/community/identity/_wait.py
@@ -20,7 +20,7 @@ class Wait(AAZWaitCommand):
 
     _aaz_info = {
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}", "2026-03-01-preview", "identity"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}", "2026-04-01", "identity"],
         ]
     }
 
@@ -119,7 +119,7 @@ class Wait(AAZWaitCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/community/transit_hub/_create.py
+++ b/src/mission/azext_mission/aaz/latest/mission/community/transit_hub/_create.py
@@ -22,9 +22,9 @@ class Create(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/transithubs/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/transithubs/{}", "2026-04-01"],
         ]
     }
 
@@ -213,7 +213,7 @@ class Create(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/community/transit_hub/_delete.py
+++ b/src/mission/azext_mission/aaz/latest/mission/community/transit_hub/_delete.py
@@ -23,9 +23,9 @@ class Delete(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/transithubs/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/transithubs/{}", "2026-04-01"],
         ]
     }
 
@@ -159,7 +159,7 @@ class Delete(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/community/transit_hub/_list.py
+++ b/src/mission/azext_mission/aaz/latest/mission/community/transit_hub/_list.py
@@ -25,10 +25,10 @@ class List(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/providers/microsoft.mission/communities/{}/transithubs", "2026-03-01-preview"],
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/transithubs", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/providers/microsoft.mission/communities/{}/transithubs", "2026-04-01"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/transithubs", "2026-04-01"],
         ]
     }
 
@@ -127,7 +127,7 @@ class List(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }
@@ -297,7 +297,7 @@ class List(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/community/transit_hub/_show.py
+++ b/src/mission/azext_mission/aaz/latest/mission/community/transit_hub/_show.py
@@ -22,9 +22,9 @@ class Show(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/transithubs/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/transithubs/{}", "2026-04-01"],
         ]
     }
 
@@ -136,7 +136,7 @@ class Show(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/community/transit_hub/_update.py
+++ b/src/mission/azext_mission/aaz/latest/mission/community/transit_hub/_update.py
@@ -22,9 +22,9 @@ class Update(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/transithubs/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/transithubs/{}", "2026-04-01"],
         ]
     }
 
@@ -216,7 +216,7 @@ class Update(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }
@@ -319,7 +319,7 @@ class Update(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/community/transit_hub/_wait.py
+++ b/src/mission/azext_mission/aaz/latest/mission/community/transit_hub/_wait.py
@@ -20,7 +20,7 @@ class Wait(AAZWaitCommand):
 
     _aaz_info = {
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/transithubs/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/communities/{}/transithubs/{}", "2026-04-01"],
         ]
     }
 
@@ -132,7 +132,7 @@ class Wait(AAZWaitCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/enclave_connection/_create.py
+++ b/src/mission/azext_mission/aaz/latest/mission/enclave_connection/_create.py
@@ -22,9 +22,9 @@ class Create(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/enclaveconnections/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/enclaveconnections/{}", "2026-04-01"],
         ]
     }
 
@@ -183,7 +183,7 @@ class Create(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/enclave_connection/_delete.py
+++ b/src/mission/azext_mission/aaz/latest/mission/enclave_connection/_delete.py
@@ -23,9 +23,9 @@ class Delete(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/enclaveconnections/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/enclaveconnections/{}", "2026-04-01"],
         ]
     }
 
@@ -146,7 +146,7 @@ class Delete(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/enclave_connection/_handle_approval_creation.py
+++ b/src/mission/azext_mission/aaz/latest/mission/enclave_connection/_handle_approval_creation.py
@@ -16,9 +16,9 @@ class HandleApprovalCreation(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/enclaveconnections/{}/handleapprovalcreation", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/enclaveconnections/{}/handleapprovalcreation", "2026-04-01"],
         ]
     }
 
@@ -157,7 +157,7 @@ class HandleApprovalCreation(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/enclave_connection/_handle_approval_deletion.py
+++ b/src/mission/azext_mission/aaz/latest/mission/enclave_connection/_handle_approval_deletion.py
@@ -19,9 +19,9 @@ class HandleApprovalDeletion(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/enclaveconnections/{}/handleapprovaldeletion", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/enclaveconnections/{}/handleapprovaldeletion", "2026-04-01"],
         ]
     }
 
@@ -148,7 +148,7 @@ class HandleApprovalDeletion(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/enclave_connection/_list.py
+++ b/src/mission/azext_mission/aaz/latest/mission/enclave_connection/_list.py
@@ -25,10 +25,10 @@ class List(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/providers/microsoft.mission/enclaveconnections", "2026-03-01-preview"],
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/enclaveconnections", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/providers/microsoft.mission/enclaveconnections", "2026-04-01"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/enclaveconnections", "2026-04-01"],
         ]
     }
 
@@ -115,7 +115,7 @@ class List(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }
@@ -284,7 +284,7 @@ class List(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/enclave_connection/_show.py
+++ b/src/mission/azext_mission/aaz/latest/mission/enclave_connection/_show.py
@@ -22,9 +22,9 @@ class Show(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/enclaveconnections/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/enclaveconnections/{}", "2026-04-01"],
         ]
     }
 
@@ -123,7 +123,7 @@ class Show(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/enclave_connection/_update.py
+++ b/src/mission/azext_mission/aaz/latest/mission/enclave_connection/_update.py
@@ -22,9 +22,9 @@ class Update(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/enclaveconnections/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/enclaveconnections/{}", "2026-04-01"],
         ]
     }
 
@@ -164,7 +164,7 @@ class Update(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }
@@ -263,7 +263,7 @@ class Update(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/enclave_connection/_wait.py
+++ b/src/mission/azext_mission/aaz/latest/mission/enclave_connection/_wait.py
@@ -20,7 +20,7 @@ class Wait(AAZWaitCommand):
 
     _aaz_info = {
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/enclaveconnections/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/enclaveconnections/{}", "2026-04-01"],
         ]
     }
 
@@ -119,7 +119,7 @@ class Wait(AAZWaitCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/_create.py
+++ b/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/_create.py
@@ -22,9 +22,9 @@ class Create(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}", "2026-04-01"],
         ]
     }
 
@@ -536,7 +536,7 @@ class Create(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/_delete.py
+++ b/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/_delete.py
@@ -23,9 +23,9 @@ class Delete(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}", "2026-04-01"],
         ]
     }
 
@@ -146,7 +146,7 @@ class Delete(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/_handle_approval_creation.py
+++ b/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/_handle_approval_creation.py
@@ -16,9 +16,9 @@ class HandleApprovalCreation(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}/handleapprovalcreation", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}/handleapprovalcreation", "2026-04-01"],
         ]
     }
 
@@ -157,7 +157,7 @@ class HandleApprovalCreation(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/_handle_approval_deletion.py
+++ b/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/_handle_approval_deletion.py
@@ -19,9 +19,9 @@ class HandleApprovalDeletion(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}/handleapprovaldeletion", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}/handleapprovaldeletion", "2026-04-01"],
         ]
     }
 
@@ -148,7 +148,7 @@ class HandleApprovalDeletion(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/_list.py
+++ b/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/_list.py
@@ -25,10 +25,10 @@ class List(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/providers/microsoft.mission/virtualenclaves", "2026-03-01-preview"],
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/providers/microsoft.mission/virtualenclaves", "2026-04-01"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves", "2026-04-01"],
         ]
     }
 
@@ -115,7 +115,7 @@ class List(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }
@@ -505,7 +505,7 @@ class List(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/_show.py
+++ b/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/_show.py
@@ -22,9 +22,9 @@ class Show(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}", "2026-04-01"],
         ]
     }
 
@@ -123,7 +123,7 @@ class Show(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/_update.py
+++ b/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/_update.py
@@ -22,9 +22,9 @@ class Update(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}", "2026-04-01"],
         ]
     }
 
@@ -536,7 +536,7 @@ class Update(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }
@@ -635,7 +635,7 @@ class Update(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/_wait.py
+++ b/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/_wait.py
@@ -20,7 +20,7 @@ class Wait(AAZWaitCommand):
 
     _aaz_info = {
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}", "2026-04-01"],
         ]
     }
 
@@ -119,7 +119,7 @@ class Wait(AAZWaitCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/enclave_endpoint/_create.py
+++ b/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/enclave_endpoint/_create.py
@@ -22,9 +22,9 @@ class Create(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}/enclaveendpoints/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}/enclaveendpoints/{}", "2026-04-01"],
         ]
     }
 
@@ -212,7 +212,7 @@ class Create(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/enclave_endpoint/_delete.py
+++ b/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/enclave_endpoint/_delete.py
@@ -23,9 +23,9 @@ class Delete(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}/enclaveendpoints/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}/enclaveendpoints/{}", "2026-04-01"],
         ]
     }
 
@@ -159,7 +159,7 @@ class Delete(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/enclave_endpoint/_handle_approval_creation.py
+++ b/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/enclave_endpoint/_handle_approval_creation.py
@@ -19,9 +19,9 @@ class HandleApprovalCreation(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}/enclaveendpoints/{}/handleapprovalcreation", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}/enclaveendpoints/{}/handleapprovalcreation", "2026-04-01"],
         ]
     }
 
@@ -173,7 +173,7 @@ class HandleApprovalCreation(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/enclave_endpoint/_handle_approval_deletion.py
+++ b/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/enclave_endpoint/_handle_approval_deletion.py
@@ -19,9 +19,9 @@ class HandleApprovalDeletion(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}/enclaveendpoints/{}/handleapprovaldeletion", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}/enclaveendpoints/{}/handleapprovaldeletion", "2026-04-01"],
         ]
     }
 
@@ -161,7 +161,7 @@ class HandleApprovalDeletion(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/enclave_endpoint/_list.py
+++ b/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/enclave_endpoint/_list.py
@@ -25,10 +25,10 @@ class List(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/providers/microsoft.mission/virtualenclaves/{}/enclaveendpoints", "2026-03-01-preview"],
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}/enclaveendpoints", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/providers/microsoft.mission/virtualenclaves/{}/enclaveendpoints", "2026-04-01"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}/enclaveendpoints", "2026-04-01"],
         ]
     }
 
@@ -127,7 +127,7 @@ class List(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }
@@ -299,7 +299,7 @@ class List(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/enclave_endpoint/_show.py
+++ b/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/enclave_endpoint/_show.py
@@ -22,9 +22,9 @@ class Show(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}/enclaveendpoints/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}/enclaveendpoints/{}", "2026-04-01"],
         ]
     }
 
@@ -136,7 +136,7 @@ class Show(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/enclave_endpoint/_update.py
+++ b/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/enclave_endpoint/_update.py
@@ -22,9 +22,9 @@ class Update(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}/enclaveendpoints/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}/enclaveendpoints/{}", "2026-04-01"],
         ]
     }
 
@@ -216,7 +216,7 @@ class Update(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }
@@ -319,7 +319,7 @@ class Update(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/enclave_endpoint/_wait.py
+++ b/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/enclave_endpoint/_wait.py
@@ -20,7 +20,7 @@ class Wait(AAZWaitCommand):
 
     _aaz_info = {
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}/enclaveendpoints/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}/enclaveendpoints/{}", "2026-04-01"],
         ]
     }
 
@@ -132,7 +132,7 @@ class Wait(AAZWaitCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/identity/_assign.py
+++ b/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/identity/_assign.py
@@ -22,9 +22,9 @@ class Assign(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}", "2026-03-01-preview", "identity"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}", "2026-04-01", "identity"],
         ]
     }
 
@@ -166,7 +166,7 @@ class Assign(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }
@@ -265,7 +265,7 @@ class Assign(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/identity/_remove.py
+++ b/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/identity/_remove.py
@@ -22,9 +22,9 @@ class Remove(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}", "2026-03-01-preview", "identity"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}", "2026-04-01", "identity"],
         ]
     }
 
@@ -166,7 +166,7 @@ class Remove(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }
@@ -265,7 +265,7 @@ class Remove(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/identity/_show.py
+++ b/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/identity/_show.py
@@ -22,9 +22,9 @@ class Show(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}", "2026-03-01-preview", "identity"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}", "2026-04-01", "identity"],
         ]
     }
 
@@ -134,7 +134,7 @@ class Show(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/identity/_wait.py
+++ b/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/identity/_wait.py
@@ -20,7 +20,7 @@ class Wait(AAZWaitCommand):
 
     _aaz_info = {
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}", "2026-03-01-preview", "identity"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}", "2026-04-01", "identity"],
         ]
     }
 
@@ -119,7 +119,7 @@ class Wait(AAZWaitCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/workload/_create.py
+++ b/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/workload/_create.py
@@ -22,9 +22,9 @@ class Create(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}/workloads/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}/workloads/{}", "2026-04-01"],
         ]
     }
 
@@ -183,7 +183,7 @@ class Create(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/workload/_delete.py
+++ b/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/workload/_delete.py
@@ -23,9 +23,9 @@ class Delete(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}/workloads/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}/workloads/{}", "2026-04-01"],
         ]
     }
 
@@ -159,7 +159,7 @@ class Delete(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/workload/_list.py
+++ b/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/workload/_list.py
@@ -25,10 +25,10 @@ class List(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/providers/microsoft.mission/virtualenclaves/{}/workloads", "2026-03-01-preview"],
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}/workloads", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/providers/microsoft.mission/virtualenclaves/{}/workloads", "2026-04-01"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}/workloads", "2026-04-01"],
         ]
     }
 
@@ -127,7 +127,7 @@ class List(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }
@@ -292,7 +292,7 @@ class List(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/workload/_show.py
+++ b/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/workload/_show.py
@@ -22,9 +22,9 @@ class Show(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}/workloads/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}/workloads/{}", "2026-04-01"],
         ]
     }
 
@@ -136,7 +136,7 @@ class Show(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/workload/_update.py
+++ b/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/workload/_update.py
@@ -22,9 +22,9 @@ class Update(AAZCommand):
     """
 
     _aaz_info = {
-        "version": "2026-03-01-preview",
+        "version": "2026-04-01",
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}/workloads/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}/workloads/{}", "2026-04-01"],
         ]
     }
 
@@ -182,7 +182,7 @@ class Update(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }
@@ -285,7 +285,7 @@ class Update(AAZCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/workload/_wait.py
+++ b/src/mission/azext_mission/aaz/latest/mission/virtual_enclave/workload/_wait.py
@@ -20,7 +20,7 @@ class Wait(AAZWaitCommand):
 
     _aaz_info = {
         "resources": [
-            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}/workloads/{}", "2026-03-01-preview"],
+            ["mgmt-plane", "/subscriptions/{}/resourcegroups/{}/providers/microsoft.mission/virtualenclaves/{}/workloads/{}", "2026-04-01"],
         ]
     }
 
@@ -132,7 +132,7 @@ class Wait(AAZWaitCommand):
         def query_parameters(self):
             parameters = {
                 **self.serialize_query_param(
-                    "api-version", "2026-03-01-preview",
+                    "api-version", "2026-04-01",
                     required=True,
                 ),
             }

--- a/src/mission/azext_mission/azext_metadata.json
+++ b/src/mission/azext_mission/azext_metadata.json
@@ -1,4 +1,4 @@
 {
-    "azext.isPreview": true,
+    "azext.isPreview": false,
     "azext.minCliCoreVersion": "2.75.0"
 }

--- a/src/mission/setup.py
+++ b/src/mission/setup.py
@@ -10,12 +10,12 @@ from setuptools import setup, find_packages
 
 
 # HISTORY.rst entry.
-VERSION = '1.0.0b1'
+VERSION = '1.0.0'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
 CLASSIFIERS = [
-    'Development Status :: 4 - Beta',
+    'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',
     'Intended Audience :: System Administrators',
     'Programming Language :: Python',


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes |
| :--: |
| ️✔️ None |

<!-- act-bot:section title="Azure CLI Extensions Breaking Change Test" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

### Related command

`az mission`

---

GA release of the **mission** CLI extension for the **Microsoft.Mission** resource provider (Azure Virtual Enclaves / AVE), promoting it from preview to the **stable** API version **2026-04-01**.

The stable `2026-04-01` surface is a byte-for-byte mirror of `2026-03-01-preview` (the preview shipped in #10149), so this is a pure GA promotion — no command, argument, or property changes.

### What changed

- Retarget every aaz command model from `2026-03-01-preview` to **`2026-04-01`** (72 files).
- `azext.isPreview`: `true` -> **`false`**.
- Extension version `1.0.0b1` -> **`1.0.0`**; `Development Status :: 4 - Beta` -> **`5 - Production/Stable`**.
- `HISTORY.rst` / `README.md` GA updates.

### Source

Stable API `2026-04-01` merged to `azure-rest-api-specs` main in Azure/azure-rest-api-specs#45804 (tag `package-2026-04-01` -> `stable/2026-04-01/openapi.json`).

### Notes

- Command surface unchanged from preview: 11 command groups / 72 leaf commands across all 9 Microsoft.Mission resource types + POST actions + Operations list.
- `linter_exclusions.yml` waivers carried over unchanged.