### PR TITLE
[CDN] Add post-migration endpoint cutover warning

### DIFF
--- a/src/cdn/HISTORY.rst
+++ b/src/cdn/HISTORY.rst
@@ -3,11 +3,12 @@
 Release History
 ===============
 
-upcoming
-++++++++
+1.0.0b3
+++++++
 * Update CDN and AFD generated command models to API version 2026-04-01-preview, including AFD MTLS, origin authentication, rule-set batch rules, and refreshed scenario recordings.
 * Add support for configuring profile-level Web Application Firewall policies and route associations on AFD security policies.
 * Update AFD/CDN AAZ-generated command models and tests to use native JSON support, including AFD rule action and condition subcommands.
+* Add post-migration endpoint cutover guidance after committing a classic CDN profile migration.
 
 1.0.0b1
 +++++++

--- a/src/cdn/azext_cdn/commands.py
+++ b/src/cdn/azext_cdn/commands.py
@@ -68,6 +68,9 @@ def load_command_table(self, _):
     from .custom.custom_cdn import CDNProfileList
     self.command_table['cdn profile list'] = CDNProfileList(loader=self)
 
+    from .custom.custom_cdn import CDNProfileMigrationCommit
+    self.command_table['cdn profile-migration commit'] = CDNProfileMigrationCommit(loader=self)
+
     from azext_cdn.aaz.latest.cdn.endpoint import Show
     self.command_table['cdn endpoint rule show'] = Show(loader=self)
     self.command_table['cdn endpoint rule condition show'] = Show(loader=self)

--- a/src/cdn/azext_cdn/custom/custom_cdn.py
+++ b/src/cdn/azext_cdn/custom/custom_cdn.py
@@ -8,6 +8,7 @@ import argparse
 
 from azure.cli.core.aaz import AAZStrArg, AAZBoolArg, AAZListArg
 from azure.cli.core.aaz._base import has_value
+from knack.log import get_logger
 from knack.util import CLIError
 
 from azext_cdn.vendored_sdks.models import ResourceType
@@ -15,9 +16,27 @@ from azext_cdn.aaz.latest.afd.profile import Show as _AFDProfileShow, \
     Create as _AFDProfileCreate, Update as _AFDProfileUpdate, Delete as _AFDProfileDelete, \
     List as _AFDProfileList
 from azext_cdn.aaz.latest.cdn._name_exists import NameExists
+from azext_cdn.aaz.latest.cdn.profile_migration import Commit as _CDNProfileMigrationCommit
 from azext_cdn.aaz.latest.cdn.origin import Create as _CDNOriginCreate, Update as _CDNOriginUpdate
 from azext_cdn.aaz.latest.cdn.endpoint import Create as _CDNEndpointCreate, \
     Update as _CDNEndpointUpdate, Show as _CDNEndpointShow
+
+
+logger = get_logger(__name__)
+
+POST_MIGRATION_ENDPOINT_CUTOVER_WARNING = (
+    "Migration completed successfully. Traffic may still depend on the classic endpoint. Update your custom "
+    "domain DNS or application references to use the new Azure Front Door Standard/Premium endpoint before "
+    "April 1, 2028 to avoid any service disruption. Learn more: "
+    "https://learn.microsoft.com/en-us/azure/cdn/migrate-tier?toc=/azure/frontdoor/toc.json."
+)
+
+POST_MIGRATION_ENDPOINT_CUTOVER_NO_WAIT_WARNING = (
+    "Migration request submitted successfully. After migration completes, traffic may still depend on the "
+    "classic endpoint. Update your custom domain DNS or application references to use the new Azure Front Door "
+    "Standard/Premium endpoint before April 1, 2028 to avoid any service disruption. Learn more: "
+    "https://learn.microsoft.com/en-us/azure/cdn/migrate-tier?toc=/azure/frontdoor/toc.json."
+)
 
 
 def default_content_types():
@@ -79,6 +98,17 @@ class CDNProfileDelete(_AFDProfileDelete):
     def _build_arguments_schema(cls, *args, **kwargs):
         args_schema = super()._build_arguments_schema(*args, **kwargs)
         return args_schema
+
+
+class CDNProfileMigrationCommit(_CDNProfileMigrationCommit):
+    def _handler(self, command_args):
+        result = super()._handler(command_args)
+        if self.ctx.lro_no_wait:
+            logger.warning(POST_MIGRATION_ENDPOINT_CUTOVER_NO_WAIT_WARNING)
+        return result
+
+    def post_operations(self):
+        logger.warning(POST_MIGRATION_ENDPOINT_CUTOVER_WARNING)
 
 
 class CDNOriginCreate(_CDNOriginCreate):

--- a/src/cdn/azext_cdn/tests/latest/test_profile_migration_unit.py
+++ b/src/cdn/azext_cdn/tests/latest/test_profile_migration_unit.py
@@ -1,0 +1,52 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import patch
+
+from azext_cdn.aaz.latest.cdn.profile_migration import Commit as _CDNProfileMigrationCommit
+from azext_cdn.custom.custom_cdn import (
+    CDNProfileMigrationCommit,
+    POST_MIGRATION_ENDPOINT_CUTOVER_NO_WAIT_WARNING,
+    POST_MIGRATION_ENDPOINT_CUTOVER_WARNING,
+)
+
+
+class CDNProfileMigrationCommitTest(TestCase):
+
+    @patch('azext_cdn.custom.custom_cdn.logger.warning')
+    def test_warning_is_logged_after_synchronous_completion(self, warning_mock):
+        command = object.__new__(CDNProfileMigrationCommit)
+
+        command.post_operations()
+
+        warning_mock.assert_called_once_with(POST_MIGRATION_ENDPOINT_CUTOVER_WARNING)
+
+    @patch('azext_cdn.custom.custom_cdn.logger.warning')
+    @patch.object(_CDNProfileMigrationCommit, '_handler', return_value=None)
+    def test_warning_is_logged_after_no_wait_submission(self, handler_mock, warning_mock):
+        command = object.__new__(CDNProfileMigrationCommit)
+        command.ctx = SimpleNamespace(lro_no_wait=True)
+        command_args = {'no_wait': True}
+
+        result = command._handler(command_args)
+
+        self.assertIsNone(result)
+        handler_mock.assert_called_once_with(command_args)
+        warning_mock.assert_called_once_with(POST_MIGRATION_ENDPOINT_CUTOVER_NO_WAIT_WARNING)
+
+    @patch('azext_cdn.custom.custom_cdn.logger.warning')
+    @patch.object(_CDNProfileMigrationCommit, '_handler', return_value='poller')
+    def test_warning_waits_for_synchronous_post_operations(self, handler_mock, warning_mock):
+        command = object.__new__(CDNProfileMigrationCommit)
+        command.ctx = SimpleNamespace(lro_no_wait=False)
+        command_args = {'no_wait': False}
+
+        result = command._handler(command_args)
+
+        self.assertEqual('poller', result)
+        handler_mock.assert_called_once_with(command_args)
+        warning_mock.assert_not_called()

--- a/src/cdn/setup.py
+++ b/src/cdn/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup, find_packages
 
-VERSION = "1.0.0b2"
+VERSION = "1.0.0b3"
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes |
| :--: |
| ️✔️ None |

<!-- act-bot:section title="Azure CLI Extensions Breaking Change Test" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

## Summary
- emit post-migration endpoint cutover guidance after `az cdn profile-migration commit`
- distinguish synchronous completion from `--no-wait` request submission
- link customers to the CDN classic migration guidance for the April 1, 2028 deadline
- add focused unit coverage for both command paths

### Related command
`az cdn profile-migration commit`

### Related documentation
- https://github.com/MicrosoftDocs/azure-docs-pr/pull/319970
- https://learn.microsoft.com/en-us/azure/cdn/migrate-tier?toc=/azure/frontdoor/toc.json

### Validation
- `python -m pytest src/cdn/azext_cdn/tests/latest/test_profile_migration_unit.py -q`: 3 passed
- `python scripts/ci/test_index.py -q`: 9 passed, 2 skipped
- `git diff --check`: passed
- `azdev style cdn`: not completed because the local azdev environment has no configured environment path and fails during startup before reaching CDN

### General Guidelines
- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install azdev` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

### About Extension Publish
This PR bumps the CDN extension from published version `1.0.0b2` to `1.0.0b3` and updates `HISTORY.rst` and does not modify `src/index.json`.

