### PR TITLE
[VM Repair] Add --no flag to az vm repair restore to preserve resources

### DIFF
--- a/src/vm-repair/HISTORY.rst
+++ b/src/vm-repair/HISTORY.rst
@@ -2,6 +2,10 @@
 Release History
 ===============
 
+2.2.7
+++++++
+Adding ``--no`` flag to ``az vm repair restore`` to automatically preserve the repair resources (repair VM, copied disk, and repair resource group) without prompting. This is the opposite of ``--yes`` and is intended for batch testing workflows (for example VMRepairMint and CSS-driven multi-VM validations) where the same repair environment is reused across many scripts and interactive prompts would stall the batch. ``--yes`` and ``--no`` are mutually exclusive; passing both raises a ``CLIError``. When neither flag is passed the existing interactive prompt behavior is unchanged. Preserved resource IDs are logged so the operator has an audit trail of what was kept behind. (ADO Bug 39509209)
+
 2.2.6
 ++++++
 Fixing ``az extension add --name vm-repair`` failing with ``Pip failed with status code 2`` on 32-bit Windows installations of the Azure CLI. The extension declared ``opencensus`` as a dependency but never imported it. Because extensions are installed with ``pip --target``, that unused dependency pulled roughly twenty extra packages into the extension folder, including ``cryptography``, which stopped publishing 32-bit Windows wheels in version 49.0.0. On a 32-bit CLI, pip had no compatible wheel, fell back to building ``cryptography`` from source, and failed. Removing the unused ``opencensus`` dependency removes that entire dependency tree.

--- a/src/vm-repair/azext_vm_repair/_help.py
+++ b/src/vm-repair/azext_vm_repair/_help.py
@@ -58,6 +58,12 @@ helps['vm repair restore'] = """
         - name: Restore from the repair VM, specify the disk to restore
           text: >
             az vm repair restore -g MyResourceGroup -n MyVM --disk-name MyDiskCopy --verbose
+        - name: Restore and automatically delete the repair resources without confirmation
+          text: >
+            az vm repair restore -g MyResourceGroup -n MyVM --yes --verbose
+        - name: Restore and automatically preserve the repair resources (repair VM, disk copy, resource group) without confirmation. Useful for batch testing scenarios.
+          text: >
+            az vm repair restore -g MyResourceGroup -n MyVM --no --verbose
 """
 
 helps['vm repair run'] = """

--- a/src/vm-repair/azext_vm_repair/_params.py
+++ b/src/vm-repair/azext_vm_repair/_params.py
@@ -43,7 +43,8 @@ def load_arguments(self, _):
     with self.argument_context('vm repair restore') as c:
         c.argument('repair_vm_id', help='Repair VM resource id.')
         c.argument('disk_name', help='Name of fixed data disk. Defaults to the first data disk in the repair VM.')
-        c.argument('yes', help='Deletes the repair resources without confirmation.')
+        c.argument('yes', help='Deletes the repair resources without confirmation. Mutually exclusive with --no.')
+        c.argument('no', help='Do not delete any resources created as part of the repair. Skips the confirmation prompt. Mutually exclusive with --yes.')
 
     with self.argument_context('vm repair run') as c:
         c.argument('repair_vm_id', help='Repair VM resource id.')

--- a/src/vm-repair/azext_vm_repair/custom.py
+++ b/src/vm-repair/azext_vm_repair/custom.py
@@ -12,6 +12,7 @@ import requests
 
 from knack.log import get_logger
 
+from azure.cli.core.azclierror import CLIError
 from azure.cli.command_modules.vm.custom import get_vm, _is_linux_os
 from azure.cli.command_modules.storage.storage_url_helpers import StorageResourceIdentifier
 from azure.mgmt.core.tools import parse_resource_id
@@ -497,11 +498,16 @@ def create(cmd, vm_name, resource_group_name, repair_password=None, repair_usern
 
 
 # This method is responsible for restoring the VM after repair
-def restore(cmd, vm_name, resource_group_name, disk_name=None, repair_vm_id=None, yes=False):
+def restore(cmd, vm_name, resource_group_name, disk_name=None, repair_vm_id=None, yes=False, no=False):
 
     # Create an instance of the command helper object to facilitate logging and status tracking.
     command = command_helper(logger, cmd, 'vm repair restore')
     source_disk = None
+
+    # Validate that --yes and --no are not both specified. They are opposite choices for the
+    # post-restore cleanup prompt and cannot be combined.
+    if yes and no:
+        raise CLIError('--yes and --no are mutually exclusive.')
 
     try:
         # Fetch source and repair VM data
@@ -552,8 +558,9 @@ def restore(cmd, vm_name, resource_group_name, disk_name=None, repair_vm_id=None
                 logger.info('Attaching repaired data disk to source VM as an OS disk...')
                 _call_az_command(attach_unmanaged_command)
 
-            # Clean up the resources in the repair resource group
-            _clean_up_resources(repair_resource_group, confirm=not yes)
+            # Clean up the resources in the repair resource group. --yes bypasses the prompt and
+            # deletes; --no preserves the resources and skips both the prompt and the delete.
+            _clean_up_resources(repair_resource_group, confirm=not yes, skip_cleanup=no)
             command.set_status_success()  # Set the command status to success
     # Handle possible exceptions
     except KeyboardInterrupt:

--- a/src/vm-repair/azext_vm_repair/repair_utils.py
+++ b/src/vm-repair/azext_vm_repair/repair_utils.py
@@ -271,9 +271,21 @@ def check_extension_version(extension_name):
     logger.debug('The extension with name %s does not exist within available extensions.', extension_name)
 
 
-def _clean_up_resources(resource_group_name, confirm):
+def _clean_up_resources(resource_group_name, confirm, skip_cleanup=False):
 
     try:
+        # --no on the restore command sets skip_cleanup=True to preserve every repair resource
+        # (repair VM, copied disk, resource group) without prompting. Log the preserved resource
+        # IDs so the operator has an audit trail of what was kept behind.
+        if skip_cleanup:
+            preserved = _list_resource_ids_in_rg(resource_group_name)
+            logger.warning(
+                'Skipping clean-up. The following repair resources have been preserved in resource group \'%s\':\n%s',
+                resource_group_name,
+                '\n'.join(preserved) if preserved else '(no resources found)'
+            )
+            return
+
         if confirm:
             message = 'The clean-up will remove the resource group \'{rg}\' and all repair resources within:\n\n{r}' \
                       .format(rg=resource_group_name, r='\n'.join(_list_resource_ids_in_rg(resource_group_name)))

--- a/src/vm-repair/azext_vm_repair/tests/latest/test_restore_no_flag.py
+++ b/src/vm-repair/azext_vm_repair/tests/latest/test_restore_no_flag.py
@@ -1,0 +1,73 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+# pylint: disable=line-too-long
+"""Unit tests for the --no flag on ``az vm repair restore`` (ADO Bug 39509209).
+
+These are pure unit tests: they exercise the parameter-validation and cleanup
+short-circuit logic directly and do not require an Azure session, an Azure CLI
+context object, or ``LiveScenarioTest`` infrastructure.
+"""
+import unittest
+from unittest import mock
+
+from azure.cli.core.azclierror import CLIError
+
+from azext_vm_repair.custom import restore
+from azext_vm_repair.repair_utils import _clean_up_resources
+
+
+class RestoreNoFlagMutexTest(unittest.TestCase):
+    """Passing both --yes and --no to ``az vm repair restore`` must fail fast."""
+
+    def test_yes_and_no_together_raises_cli_error(self):
+        with self.assertRaises(CLIError) as ctx:
+            restore(
+                cmd=mock.MagicMock(),
+                vm_name='dummy-vm',
+                resource_group_name='dummy-rg',
+                disk_name='dummy-disk',
+                repair_vm_id='/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/dummy-rg/providers/Microsoft.Compute/virtualMachines/repair-vm',
+                yes=True,
+                no=True,
+            )
+        self.assertIn('mutually exclusive', str(ctx.exception).lower())
+
+
+class CleanUpResourcesSkipTest(unittest.TestCase):
+    """``skip_cleanup=True`` must short-circuit before any delete call and log preserved IDs."""
+
+    def test_skip_cleanup_true_does_not_delete(self):
+        preserved_ids = [
+            '/subscriptions/x/resourceGroups/repair-rg/providers/Microsoft.Compute/virtualMachines/repair-vm',
+            '/subscriptions/x/resourceGroups/repair-rg/providers/Microsoft.Compute/disks/repair-disk',
+        ]
+        with mock.patch('azext_vm_repair.repair_utils._list_resource_ids_in_rg', return_value=preserved_ids), \
+                mock.patch('azext_vm_repair.repair_utils._call_az_command') as mock_call, \
+                mock.patch('azext_vm_repair.repair_utils.prompt_y_n') as mock_prompt, \
+                mock.patch('azext_vm_repair.repair_utils.logger') as mock_logger:
+            _clean_up_resources('repair-rg', confirm=True, skip_cleanup=True)
+
+        # No az command was invoked and no prompt was shown.
+        mock_call.assert_not_called()
+        mock_prompt.assert_not_called()
+        # The preserved resource IDs were logged so the operator has an audit trail.
+        warning_calls = ' '.join(str(c) for c in mock_logger.warning.call_args_list)
+        self.assertIn('repair-vm', warning_calls)
+        self.assertIn('repair-disk', warning_calls)
+
+    def test_skip_cleanup_false_and_confirm_false_deletes(self):
+        with mock.patch('azext_vm_repair.repair_utils._list_resource_ids_in_rg', return_value=[]), \
+                mock.patch('azext_vm_repair.repair_utils._call_az_command') as mock_call, \
+                mock.patch('azext_vm_repair.repair_utils.prompt_y_n') as mock_prompt:
+            _clean_up_resources('repair-rg', confirm=False, skip_cleanup=False)
+
+        mock_prompt.assert_not_called()
+        mock_call.assert_called_once()
+        self.assertIn('az group delete', mock_call.call_args[0][0])
+        self.assertIn('repair-rg', mock_call.call_args[0][0])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/vm-repair/setup.py
+++ b/src/vm-repair/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup, find_packages
 
-VERSION = "2.2.6"
+VERSION = "2.2.7"
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',


### PR DESCRIPTION
## Related work items
- Fixes ADO Bug **[39509209](https://msazure.visualstudio.com/One/_workitems/edit/39509209)** — *[VMRepair feature request] Add `--no` flag to `az vm repair restore`*
- Tracked by ADO PBI **[39517755](https://msazure.visualstudio.com/One/_workitems/edit/39517755)** (under Feature 29041289 *VM Repair Bug fixes*)
- Reporter: Ryan McCallum (rymccall@microsoft.com)
- VM Repair extension owner: Edwin Bernal (@edwinbernal)

## Motivation

Batch testing workflows (VMRepairMint, CSS-driven multi-VM validations, and other engineers who script ``vm repair`` across many VMs at once) frequently want to run ``az vm repair create`` -> ``az vm repair run`` -> ``az vm repair restore`` and then **keep** the repair VM / copied disk / repair resource group around for further investigation, re-running scripts, or reusing the environment across the next VM in the batch.

Today ``az vm repair restore`` has only two options for cleanup:

- **No flag** - prompt the operator ``Continue with clean-up and delete resources? [y/n]`` (stalls batch jobs and non-interactive runs).
- **``--yes``** - auto-answer ``y`` and delete everything.

There is no non-interactive way to auto-answer ``n`` (preserve the repair resources). Batch operators today work around this by piping ``n`` to stdin, disabling the prompt, or scripting ``az resource delete`` cleanup themselves - all fragile.

This PR adds the missing option.

## Change summary

Adds a new ``--no`` flag to ``az vm repair restore``:

- When ``--no`` is passed -> all repair resources are **preserved** without prompting. Equivalent to answering ``n`` at the cleanup prompt.
- When ``--yes`` is passed -> existing behavior (auto-delete).
- When neither is passed -> existing interactive prompt behavior.
- When **both** ``--yes`` and ``--no`` are passed -> ``CLIError('--yes and --no are mutually exclusive.')``.

When ``--no`` is used, the preserved resource IDs are logged so the operator has an audit trail of what was kept behind.

### Behavior matrix

| ``--yes`` | ``--no`` | Behavior |
|---------|--------|----------|
| _(not set)_ | _(not set)_ | Interactive prompt (unchanged) |
| yes | _(not set)_ | Auto-delete (unchanged) |
| _(not set)_ | yes | **New:** auto-preserve, log preserved IDs |
| yes | yes | ``CLIError`` - mutually exclusive |

## Files changed

| File | Change |
|------|--------|
| ``src/vm-repair/azext_vm_repair/_params.py`` | Register ``--no`` argument on the ``restore`` command. |
| ``src/vm-repair/azext_vm_repair/custom.py`` | Add ``no=False`` parameter to ``restore()``; validate mutex with ``--yes``; import ``CLIError``; pass ``skip_cleanup=no`` through to ``_clean_up_resources``. |
| ``src/vm-repair/azext_vm_repair/repair_utils.py`` | Add ``skip_cleanup=False`` parameter to ``_clean_up_resources``; short-circuit before any delete call when ``skip_cleanup=True``; log preserved resource IDs. |
| ``src/vm-repair/azext_vm_repair/_help.py`` | Add ``--yes`` and ``--no`` examples to the ``vm repair restore`` help. |
| ``src/vm-repair/azext_vm_repair/tests/latest/test_restore_no_flag.py`` | New unit tests: (1) ``--yes`` + ``--no`` raises ``CLIError``; (2) ``skip_cleanup=True`` performs no deletes / no prompt and logs preserved IDs; (3) ``skip_cleanup=False, confirm=False`` deletes as before. |
| ``src/vm-repair/HISTORY.rst`` | New ``2.2.7`` release entry. |
| ``src/vm-repair/setup.py`` | Version bump ``2.2.6`` -> ``2.2.7``. |

Total: **7 files, ~109 additions, 6 deletions**.

## Manual test plan

Reviewers can validate as follows (Ryan McCallum has agreed to run through this against a live subscription):

1. **``--no`` preserves resources**
   ``````
   az vm repair create -g MyRG -n MyVM --repair-username azureadmin --repair-password '!Passw0rd2018'
   az vm repair restore -g MyRG -n MyVM --no --verbose
   ``````
   Expected: OS disk is swapped, no prompt shown, warning line lists the preserved repair resource IDs, and ``az resource list -g <repair-rg>`` still shows the repair VM + copied disk + NIC + IP.

2. **``--yes`` deletes resources (regression check)**
   ``````
   az vm repair restore -g MyRG -n MyVM --yes --verbose
   ``````
   Expected: OS disk swapped, no prompt shown, repair resource group is deleted (unchanged behavior).

3. **Neither flag -> prompt (regression check)**
   ``````
   az vm repair restore -g MyRG -n MyVM --verbose
   ``````
   Expected: existing ``[y/n]`` prompt (unchanged behavior).

4. **Both flags -> error**
   ``````
   az vm repair restore -g MyRG -n MyVM --yes --no
   ``````
   Expected: ``CLIError: --yes and --no are mutually exclusive.`` and exit non-zero, no Azure calls made.

5. **Unit tests**
   ``````
   azdev test vm-repair --tests test_restore_no_flag
   ``````
   Expected: 3 tests pass.

## Follow-up (out of scope for this PR)

``--yes`` on ``az vm repair create`` and ``az vm repair repair-button`` is already marked deprecated in ``2.2.0``. Once operators have migrated, a natural next step is to consolidate cleanup control on ``restore`` into a single tri-state ``--cleanup {yes,no,prompt}`` argument and formally deprecate ``--yes``/``--no``. This PR intentionally preserves ``--yes`` semantics to keep the change minimal and non-breaking.

## Checklist

- [x] Extension version bumped per [Extension versioning guidelines](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md) (patch bump ``2.2.6`` -> ``2.2.7``)
- [x] ``HISTORY.rst`` updated
- [x] Unit tests added
- [x] No secrets, PAT tokens, or subscription IDs committed
- [x] Existing ``--yes`` behavior unchanged
- [x] Change scoped to ``src/vm-repair/``

/cc @edwinbernal
