### PR TITLE
{AKS} aks-preview: reject legacy --outbound-type managedNATGatewayV2 with a fail-fast error

### DIFF
--- a/src/aks-preview/HISTORY.rst
+++ b/src/aks-preview/HISTORY.rst
@@ -16,6 +16,7 @@ Pending
 * `az aks kollect` and `az aks kanalyze`: Fix compatibility with the keyword-only credential SDK parameters.
 * `az aks maintenanceconfiguration add` and `az aks maintenanceconfiguration update`: Preserve configuration-file fields with the typespec-generated SDK model.
 * Improve AKS live-test resilience for preview feature gates, transient resource and monitoring-table readiness, retired configurations, and service propagation delays.
+* `az aks create` and `az aks update`: Reject `--outbound-type managedNATGatewayV2` with an actionable error directing to `--outbound-type managedNATGateway --outbound-type-sku StandardV2` (the GA-aligned shape); the legacy value is no longer accepted on the target api-version.
 
 22.0.0b6
 +++++++++

--- a/src/aks-preview/azext_aks_preview/_help.py
+++ b/src/aks-preview/azext_aks_preview/_help.py
@@ -166,11 +166,11 @@ helps['aks create'] = f"""
         - name: --nat-gateway-managed-outbound-ip-count
           type: int
           short-summary: NAT gateway managed outbound IP count.
-          long-summary: Desired number of managed outbound IPs for NAT gateway outbound connection. Please specify a value in the range of [1, 16]. Valid for Standard SKU load balancer cluster with managedNATGateway or managedNATGatewayV2 outbound type only.
+          long-summary: Desired number of managed outbound IPs for NAT gateway outbound connection. Please specify a value in the range of [1, 16]. Valid for Standard SKU load balancer cluster with managedNATGateway outbound type only.
         - name: --nat-gateway-idle-timeout
           type: int
           short-summary: NAT gateway idle timeout in minutes.
-          long-summary: Desired idle timeout for NAT gateway outbound flows, default is 4 minutes. Please specify a value in the range of [4, 120]. Valid for Standard SKU load balancer cluster with managedNATGateway or managedNATGatewayV2 outbound type only.
+          long-summary: Desired idle timeout for NAT gateway outbound flows, default is 4 minutes. Please specify a value in the range of [4, 120]. Valid for Standard SKU load balancer cluster with managedNATGateway outbound type only.
         - name: --outbound-type-sku
           type: string
           short-summary: SKU of the managed NAT gateway (Standard or StandardV2).
@@ -1051,11 +1051,11 @@ helps['aks update'] = """
         - name: --nat-gateway-managed-outbound-ip-count
           type: int
           short-summary: NAT gateway managed outbound IP count.
-          long-summary: Desired number of managed outbound IPs for NAT gateway outbound connection. Please specify a value in the range of [1, 16]. Valid for Standard SKU load balancer cluster with managedNATGateway or managedNATGatewayV2 outbound type only.
+          long-summary: Desired number of managed outbound IPs for NAT gateway outbound connection. Please specify a value in the range of [1, 16]. Valid for Standard SKU load balancer cluster with managedNATGateway outbound type only.
         - name: --nat-gateway-idle-timeout
           type: int
           short-summary: NAT gateway idle timeout in minutes.
-          long-summary: Desired idle timeout for NAT gateway outbound flows, default is 4 minutes. Please specify a value in the range of [4, 120]. Valid for Standard SKU load balancer cluster with managedNATGateway or managedNATGatewayV2 outbound type only.
+          long-summary: Desired idle timeout for NAT gateway outbound flows, default is 4 minutes. Please specify a value in the range of [4, 120]. Valid for Standard SKU load balancer cluster with managedNATGateway outbound type only.
         - name: --outbound-type-sku
           type: string
           short-summary: SKU of the managed NAT gateway (Standard or StandardV2).

--- a/src/aks-preview/azext_aks_preview/_help.py
+++ b/src/aks-preview/azext_aks_preview/_help.py
@@ -178,7 +178,7 @@ helps['aks create'] = f"""
         - name: --outbound-type
           type: string
           short-summary: How outbound traffic will be configured for a cluster.
-          long-summary: Select between loadBalancer, userDefinedRouting, managedNATGateway, managedNATGatewayV2, userAssignedNATGateway, none and block. If not set, defaults to type loadBalancer. managedNATGatewayV2 uses Azure NAT Gateway Standard V2 SKU and supports IPv6, user-provided public IPs, and user-provided IP prefixes.
+          long-summary: Select between loadBalancer, userDefinedRouting, managedNATGateway, userAssignedNATGateway, none and block. If not set, defaults to type loadBalancer. For NAT Gateway V2 (IPv6, user-provided public IPs, and user-provided IP prefixes), use managedNATGateway with --outbound-type-sku StandardV2. The legacy managedNATGatewayV2 value is no longer supported.
         - name: --enable-addons -a
           type: string
           short-summary: Enable the Kubernetes addons in a comma-separated list.
@@ -1063,7 +1063,7 @@ helps['aks update'] = """
         - name: --outbound-type
           type: string
           short-summary: How outbound traffic will be configured for a cluster.
-          long-summary: This option will change the way how the outbound connections are managed in the AKS cluster. Available options are loadbalancer, managedNATGateway, managedNATGatewayV2, userAssignedNATGateway, userDefinedRouting, none and block. For clusters using a custom virtual network, supported values are loadbalancer, userAssignedNATGateway and userDefinedRouting. For clusters using an AKS-managed virtual network, supported values are loadbalancer, managedNATGateway, managedNATGatewayV2 and userDefinedRouting.
+          long-summary: This option will change the way how the outbound connections are managed in the AKS cluster. Available options are loadbalancer, managedNATGateway, userAssignedNATGateway, userDefinedRouting, none and block. For clusters using a custom virtual network, supported values are loadbalancer, userAssignedNATGateway and userDefinedRouting. For clusters using an AKS-managed virtual network, supported values are loadbalancer, managedNATGateway and userDefinedRouting. For NAT Gateway V2, use managedNATGateway with --outbound-type-sku StandardV2; the legacy managedNATGatewayV2 value is no longer supported.
         - name: --nrg-lockdown-restriction-level
           type: string
           short-summary: Restriction level on the managed node resource.

--- a/src/aks-preview/azext_aks_preview/_validators.py
+++ b/src/aks-preview/azext_aks_preview/_validators.py
@@ -1268,6 +1268,21 @@ def validate_nat_gateway_managed_outbound_ipv6_count(namespace):
             )
 
 
+def _reject_legacy_managed_nat_gateway_v2(namespace):
+    """Reject the retired ``managedNATGatewayV2`` outbound type value.
+
+    This extension targets the GA-aligned api-version, where NAT Gateway V2 is expressed as
+    ``--outbound-type managedNATGateway --outbound-type-sku StandardV2`` and the legacy
+    ``managedNATGatewayV2`` string is rejected by the server. Fail fast locally with an actionable
+    message instead of surfacing the RP's 400.
+    """
+    if getattr(namespace, 'outbound_type', None) == 'managedNATGatewayV2':
+        raise InvalidArgumentValueError(
+            "--outbound-type managedNATGatewayV2 is no longer supported. "
+            "Use --outbound-type managedNATGateway --outbound-type-sku StandardV2 instead."
+        )
+
+
 def validate_nat_gateway_v2_params(namespace):
     """Validate V2-only NAT gateway params on create.
 
@@ -1277,6 +1292,7 @@ def validate_nat_gateway_v2_params(namespace):
     cannot carry them. On create --outbound-type must be set explicitly to managedNATGateway;
     omitting it defaults the cluster to loadBalancer and produces an incompatible request.
     """
+    _reject_legacy_managed_nat_gateway_v2(namespace)
     v2_params = [
         getattr(namespace, 'nat_gateway_managed_outbound_ipv6_count', None),
         getattr(namespace, 'nat_gateway_outbound_ip_ids', None),
@@ -1303,6 +1319,7 @@ def validate_nat_gateway_v2_params_for_update(namespace):
     only an explicit non-managed-NAT-gateway outbound type or the Standard SKU is rejected here. The
     update decorator additionally verifies the cluster's existing outbound type.
     """
+    _reject_legacy_managed_nat_gateway_v2(namespace)
     v2_params = [
         getattr(namespace, 'nat_gateway_managed_outbound_ipv6_count', None),
         getattr(namespace, 'nat_gateway_outbound_ip_ids', None),

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_natgateway.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_natgateway.py
@@ -349,6 +349,16 @@ class TestValidateNatGatewayV2Params(unittest.TestCase):
         )
         validate_nat_gateway_v2_params(ns)
 
+    def test_legacy_managed_nat_gateway_v2_outbound_type_rejected(self):
+        # The legacy managedNATGatewayV2 value is rejected up front, even with no V2 params, so
+        # users fail fast locally instead of hitting the RP's 400 on the GA-aligned api-version.
+        from azure.cli.core.azclierror import InvalidArgumentValueError
+        from azext_aks_preview._validators import validate_nat_gateway_v2_params
+        ns = self._make_namespace(outbound_type='managedNATGatewayV2')
+        with self.assertRaises(InvalidArgumentValueError) as ctx:
+            validate_nat_gateway_v2_params(ns)
+        self.assertIn('--outbound-type-sku StandardV2', str(ctx.exception))
+
 
 class TestValidateOutboundTypeSku(unittest.TestCase):
     """Test the --outbound-type-sku cross-parameter validator."""
@@ -486,6 +496,15 @@ class TestValidateNatGatewayV2ParamsForUpdate(unittest.TestCase):
         from azext_aks_preview._validators import validate_nat_gateway_v2_params_for_update
         ns = self._make_namespace(outbound_type='loadBalancer')
         validate_nat_gateway_v2_params_for_update(ns)
+
+    def test_legacy_managed_nat_gateway_v2_outbound_type_rejected(self):
+        # Same clean-break reject on update: an explicit managedNATGatewayV2 fails fast.
+        from azure.cli.core.azclierror import InvalidArgumentValueError
+        from azext_aks_preview._validators import validate_nat_gateway_v2_params_for_update
+        ns = self._make_namespace(outbound_type='managedNATGatewayV2')
+        with self.assertRaises(InvalidArgumentValueError) as ctx:
+            validate_nat_gateway_v2_params_for_update(ns)
+        self.assertIn('--outbound-type-sku StandardV2', str(ctx.exception))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes |
| :--: |
| ️✔️ None |

<!-- act-bot:section title="Azure CLI Extensions Breaking Change Test" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

### Related command
`az aks create` / `az aks update` (`--outbound-type`)

### Description

The aks-preview extension targets the GA-aligned `2026-06-02-preview` api-version, where NAT Gateway V2 is expressed as `--outbound-type managedNATGateway --outbound-type-sku StandardV2`. On that api-version the RP **rejects** the legacy `outboundType=managedNATGatewayV2` value with an HTTP 400.

Previously the CLI passed `managedNATGatewayV2` through unchanged (its client-side validators only rejected it when combined with the V2 flags/SKU), so a bare `--outbound-type managedNATGatewayV2` produced **no local error** and the user only discovered the failure after a round-trip to the RP.

This change fails fast locally, on both `az aks create` and `az aks update`, with an actionable message:

> `--outbound-type managedNATGatewayV2 is no longer supported. Use --outbound-type managedNATGateway --outbound-type-sku StandardV2 instead.`

The `--outbound-type` help text is updated to stop advertising `managedNATGatewayV2`, and the change is recorded under HISTORY.rst *Pending*.

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? flake8 clean; pylint 10.00/10 on the changed files.
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?
- [x] My extension version conforms to the Extension version schema — recorded under HISTORY.rst *Pending* (no version bump, consistent with the other unreleased entries at 22.0.0b6).

### Testing

Added unit tests to `TestValidateNatGatewayV2Params` and `TestValidateNatGatewayV2ParamsForUpdate`: a bare `--outbound-type managedNATGatewayV2` (no V2 flags) is rejected on both create and update, and the error text points to `--outbound-type-sku StandardV2`. All validator-class tests pass locally.
