### PR TITLE
Move X agent skills into Azure CLI Extensions

### DIFF
--- a/.x/coordinator.md
+++ b/.x/coordinator.md
@@ -21,7 +21,13 @@ or triage an ordinary extension issue.
    `Azure/azure-cli-extensions`. Never act on a dispute from another
    repository.
 2. Handle explicit, deduplicated human feedback on an Agent-managed PR.
-3. Promote completed Copilot fork work.
+3. Promote completed Copilot fork work. When generated AAZ output in an
+   Agent-managed PR requires a durable source change, use the
+   repository-owned `start_aaz_source_task` custom skill. Discover completed
+   source work with `find_aaz_fork_prs_ready_for_promotion`, promote it with
+   `promote_aaz_fork_pr`, and confirm the live source PR with
+   `find_promoted_aaz_source_pr` before downstream readiness. Do not invoke
+   the neutral generation-source bridge primitives directly.
 4. For the first verified Agent-managed draft returned by
    `find_in_flight_prs` with `needs_ready_for_review`, call
    `mark_pr_ready_for_review` and stop after that write.

--- a/.x/reviewer.md
+++ b/.x/reviewer.md
@@ -7,9 +7,9 @@ Read the current PR, head SHA, changed files, CI summary, blocking human
 reviews, and live-test state once. Pending required validation is waiting.
 Honor a decisive human change request and do not post an Agent pass over it.
 
-Run `get_pr_regression_coverage_summary` and `get_pr_review_skill_summary` on
-the
-current diff. Require focused extension tests or recordings for behavior
+Run the repository-owned `get_pr_regression_coverage_summary` custom skill
+with the PR number, then run `get_pr_review_skill_summary` on the current
+diff. Require focused extension tests or recordings for behavior
 changes, valid command-table generation, no generated-file hand edits, and
 repository-compliant title, description, issue link, and History Notes.
 Confirm any shared or upstream REST API assumption against current source

--- a/.x/skills/README.md
+++ b/.x/skills/README.md
@@ -1,6 +1,0 @@
-# Custom skills
-
-This repository currently uses the approved X Engineering Agent base skill
-library. A repository-owned custom skill must be one Python file containing
-one public top-level function and must be mapped in `.x/x.yml`. Markdown files
-in this directory are documentation and are never executable.

--- a/.x/skills/changed_test_files.py
+++ b/.x/skills/changed_test_files.py
@@ -1,3 +1,8 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
 """Select changed Azure CLI Extensions live-test files."""
 
 

--- a/.x/skills/changed_test_files.py
+++ b/.x/skills/changed_test_files.py
@@ -1,0 +1,24 @@
+"""Select changed Azure CLI Extensions live-test files."""
+
+
+def changed_test_files(pr_files):
+    """Return unique changed pytest paths under an extension tests tree."""
+    selected = []
+    seen = set()
+    for path in pr_files or []:
+        normalized = str(path).replace("\\", "/")
+        lowered = normalized.casefold()
+        parts = normalized.split("/")
+        name = parts[-1]
+        if (
+            len(parts) < 2
+            or parts[0].casefold() != "src"
+            or "/tests/" not in f"/{lowered}"
+            or not name.casefold().startswith("test_")
+            or not name.casefold().endswith(".py")
+        ):
+            continue
+        if normalized not in seen:
+            seen.add(normalized)
+            selected.append(normalized)
+    return selected

--- a/.x/skills/find_aaz_fork_prs_ready_for_promotion.py
+++ b/.x/skills/find_aaz_fork_prs_ready_for_promotion.py
@@ -1,3 +1,8 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
 """Bind generation-source candidate discovery to Azure CLI Extensions."""
 
 

--- a/.x/skills/find_aaz_fork_prs_ready_for_promotion.py
+++ b/.x/skills/find_aaz_fork_prs_ready_for_promotion.py
@@ -1,0 +1,8 @@
+"""Bind generation-source candidate discovery to Azure CLI Extensions."""
+
+
+def find_aaz_fork_prs_ready_for_promotion():
+    """Find completed AAZ fork pull requests ready for promotion."""
+    return find_generation_source_fork_prs_ready_for_promotion(
+        repository=None,
+    )

--- a/.x/skills/find_aaz_fork_prs_ready_for_promotion.py
+++ b/.x/skills/find_aaz_fork_prs_ready_for_promotion.py
@@ -4,5 +4,5 @@
 def find_aaz_fork_prs_ready_for_promotion():
     """Find completed AAZ fork pull requests ready for promotion."""
     return find_generation_source_fork_prs_ready_for_promotion(
-        repository=None,
+        repository="Azure/azure-cli-extensions",
     )

--- a/.x/skills/find_promoted_aaz_source_pr.py
+++ b/.x/skills/find_promoted_aaz_source_pr.py
@@ -4,6 +4,6 @@
 def find_promoted_aaz_source_pr(issue_number):
     """Find the promoted AAZ source pull request for an Agent issue."""
     return find_promoted_generation_source_pr(
-        repository=None,
+        repository="Azure/azure-cli-extensions",
         issue_number=issue_number,
     )

--- a/.x/skills/find_promoted_aaz_source_pr.py
+++ b/.x/skills/find_promoted_aaz_source_pr.py
@@ -1,3 +1,8 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
 """Bind promoted generation-source lookup to Azure CLI Extensions."""
 
 

--- a/.x/skills/find_promoted_aaz_source_pr.py
+++ b/.x/skills/find_promoted_aaz_source_pr.py
@@ -1,0 +1,9 @@
+"""Bind promoted generation-source lookup to Azure CLI Extensions."""
+
+
+def find_promoted_aaz_source_pr(issue_number):
+    """Find the promoted AAZ source pull request for an Agent issue."""
+    return find_promoted_generation_source_pr(
+        repository=None,
+        issue_number=issue_number,
+    )

--- a/.x/skills/get_pr_regression_coverage_summary.py
+++ b/.x/skills/get_pr_regression_coverage_summary.py
@@ -1,3 +1,8 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
 """Evaluate Azure CLI Extensions module regression coverage."""
 
 

--- a/.x/skills/get_pr_regression_coverage_summary.py
+++ b/.x/skills/get_pr_regression_coverage_summary.py
@@ -1,0 +1,64 @@
+"""Evaluate Azure CLI Extensions module regression coverage."""
+
+
+def get_pr_regression_coverage_summary(pr_number):
+    """Find changed extension modules without focused tests or recordings."""
+    changes = get_pr_file_changes(
+        owner=None,
+        repo=None,
+        pr_number=pr_number,
+    )
+    files = [
+        item.get("filename")
+        for item in changes
+        if isinstance(item, dict) and item.get("filename")
+    ]
+    production_files = []
+    modules = set()
+    for path in files:
+        normalized = str(path).replace("\\", "/")
+        parts = normalized.split("/")
+        name = parts[-1]
+        if (
+            len(parts) >= 2
+            and parts[0].casefold() == "src"
+            and normalized.endswith(".py")
+            and "/tests/" not in normalized
+            and name not in {"__init__.py", "_help.py", "setup.py"}
+        ):
+            production_files.append(normalized)
+            modules.add(parts[1].casefold())
+
+    test_files = []
+    recording_files = []
+    covered = set()
+    for path in files:
+        normalized = str(path).replace("\\", "/")
+        parts = normalized.split("/")
+        if (
+            len(parts) < 2
+            or parts[0].casefold() != "src"
+            or "/tests/" not in normalized
+        ):
+            continue
+        module = parts[1].casefold()
+        if module not in modules:
+            continue
+        name = parts[-1]
+        if name.casefold().startswith("test_") and name.casefold().endswith(".py"):
+            test_files.append(normalized)
+            covered.add(module)
+        if "/recordings/" in normalized:
+            recording_files.append(normalized)
+            covered.add(module)
+
+    uncovered = sorted(modules - covered)
+    return {
+        "applicable": bool(production_files),
+        "gap": bool(uncovered),
+        "modules": sorted(modules),
+        "uncovered_modules": uncovered,
+        "production_files": production_files,
+        "test_files": test_files,
+        "recording_files": recording_files,
+    }

--- a/.x/skills/get_pr_regression_coverage_summary.py
+++ b/.x/skills/get_pr_regression_coverage_summary.py
@@ -4,8 +4,8 @@
 def get_pr_regression_coverage_summary(pr_number):
     """Find changed extension modules without focused tests or recordings."""
     changes = get_pr_file_changes(
-        owner=None,
-        repo=None,
+        owner="Azure",
+        repo="azure-cli-extensions",
         pr_number=pr_number,
     )
     files = [

--- a/.x/skills/infer_target_for_repo.py
+++ b/.x/skills/infer_target_for_repo.py
@@ -1,3 +1,8 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
 """Infer an Azure CLI Extensions target from trusted repository structure."""
 
 

--- a/.x/skills/infer_target_for_repo.py
+++ b/.x/skills/infer_target_for_repo.py
@@ -1,0 +1,65 @@
+"""Infer an Azure CLI Extensions target from trusted repository structure."""
+
+
+def infer_target_for_repo(text, pr_files):
+    """Resolve sanitized issue text or PR files to a live extension target."""
+    extensions = list_repository_directories(
+        source_repository="Azure/azure-cli-extensions",
+    )
+
+    def normalize(value):
+        return "".join(
+            character
+            for character in str(value or "").casefold()
+            if character.isalnum()
+        )
+
+    def resolve(candidate):
+        candidate_normalized = normalize(candidate)
+        for extension in extensions:
+            if normalize(extension) == candidate_normalized:
+                return {
+                    "kind": "extension",
+                    "name": extension,
+                    "repo": "Azure/azure-cli-extensions",
+                }
+        return None
+
+    scores = {}
+    for path in pr_files or []:
+        parts = str(path).replace("\\", "/").split("/")
+        if len(parts) > 1 and parts[0].casefold() == "src":
+            candidate = parts[1]
+            scores[candidate] = scores.get(candidate, 0) + 10
+    if pr_files:
+        for candidate in sorted(scores, key=lambda item: (-scores[item], item)):
+            target = resolve(candidate)
+            if target is not None:
+                return target
+        return {"kind": "none", "name": None, "repo": None}
+
+    cleaned = "".join(
+        character if character.isalnum() or character in "-_./" else " "
+        for character in str(text or "").casefold()
+    )
+    words = cleaned.split()
+    for index, word in enumerate(words):
+        if word == "az" and index + 1 < len(words):
+            candidate = words[index + 1]
+            scores[candidate] = scores.get(candidate, 0) + 5
+        if word.startswith("src/"):
+            parts = word.split("/")
+            if len(parts) > 1:
+                candidate = parts[1]
+                scores[candidate] = scores.get(candidate, 0) + 3
+        if word.startswith("azext_"):
+            candidate = word[len("azext_"):]
+            scores[candidate] = scores.get(candidate, 0) + 3
+        if word.startswith("azext-"):
+            candidate = word[len("azext-"):]
+            scores[candidate] = scores.get(candidate, 0) + 3
+    for candidate in sorted(scores, key=lambda item: (-scores[item], item)):
+        target = resolve(candidate)
+        if target is not None:
+            return target
+    return {"kind": "unknown", "name": None, "repo": None}

--- a/.x/skills/promote_aaz_fork_pr.py
+++ b/.x/skills/promote_aaz_fork_pr.py
@@ -1,0 +1,11 @@
+"""Bind generation-source promotion to Azure CLI Extensions."""
+
+
+def promote_aaz_fork_pr(fork_pr_number, title, body):
+    """Promote one validated AAZ fork pull request."""
+    return promote_generation_source_fork_pr(
+        repository=None,
+        fork_pr_number=fork_pr_number,
+        title=title,
+        body=body,
+    )

--- a/.x/skills/promote_aaz_fork_pr.py
+++ b/.x/skills/promote_aaz_fork_pr.py
@@ -1,3 +1,8 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
 """Bind generation-source promotion to Azure CLI Extensions."""
 
 

--- a/.x/skills/promote_aaz_fork_pr.py
+++ b/.x/skills/promote_aaz_fork_pr.py
@@ -4,7 +4,7 @@
 def promote_aaz_fork_pr(fork_pr_number, title, body):
     """Promote one validated AAZ fork pull request."""
     return promote_generation_source_fork_pr(
-        repository=None,
+        repository="Azure/azure-cli-extensions",
         fork_pr_number=fork_pr_number,
         title=title,
         body=body,

--- a/.x/skills/start_aaz_source_task.py
+++ b/.x/skills/start_aaz_source_task.py
@@ -1,3 +1,8 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
 """Bind durable generation-source task creation to Azure CLI Extensions."""
 
 

--- a/.x/skills/start_aaz_source_task.py
+++ b/.x/skills/start_aaz_source_task.py
@@ -4,7 +4,7 @@
 def start_aaz_source_task(issue_number, downstream_pr_url, changed_files, prompt_context):
     """Start the configured AAZ source task for an Azure CLI Extensions pull request."""
     return start_generation_source_task(
-        repository=None,
+        repository="Azure/azure-cli-extensions",
         issue_number=issue_number,
         downstream_pr_url=downstream_pr_url,
         changed_files=changed_files,

--- a/.x/skills/start_aaz_source_task.py
+++ b/.x/skills/start_aaz_source_task.py
@@ -1,0 +1,12 @@
+"""Bind durable generation-source task creation to Azure CLI Extensions."""
+
+
+def start_aaz_source_task(issue_number, downstream_pr_url, changed_files, prompt_context):
+    """Start the configured AAZ source task for an Azure CLI Extensions pull request."""
+    return start_generation_source_task(
+        repository=None,
+        issue_number=issue_number,
+        downstream_pr_url=downstream_pr_url,
+        changed_files=changed_files,
+        prompt_context=prompt_context,
+    )

--- a/.x/tester.md
+++ b/.x/tester.md
@@ -5,10 +5,16 @@ the Coordinator whose current head either has a completed Copilot task marker
 or is a verified human-requested review candidate, and has no completed
 live-test run for that head.
 
-Use `dispatch_live_test_workflow` with the PR number and
-`pr_repo="Azure/azure-cli-extensions"`. Do not guess the extension name; the
-dispatcher resolves it from current changed files and the workflow validates
-the target.
+Read the PR and `get_pr_file_changes` once. Pass the filenames to the
+repository-owned `changed_test_files` custom skill and call the
+repository-owned `infer_target_for_repo` custom skill with `text` set to the
+PR title/body and `pr_files` set to those filenames. Use
+`dispatch_live_test_workflow` with the PR number,
+`pr_repo="Azure/azure-cli-extensions"`, the resolved extension module,
+`target_kind="extension"`, and `test_files` set to the paths returned by
+`changed_test_files`. Never guess an extension or test path, and never let
+the central dispatcher infer them; repository custom skills own both
+decisions and the workflow validates them against the current PR.
 
 Reuse any queued, in-progress, or completed run for the same head SHA. Read
 state with `get_workflow_run` once. Return pending without waiting when the run

--- a/.x/tester.md
+++ b/.x/tester.md
@@ -16,6 +16,11 @@ PR title/body and `pr_files` set to those filenames. Use
 the central dispatcher infer them; repository custom skills own both
 decisions and the workflow validates them against the current PR.
 
+If no test path is selected, call the dispatcher with the empty list so it
+records a neutral skip for the current revision. If tests are selected but
+target inference does not return a named extension, stop with a pending
+result and do not dispatch.
+
 Reuse any queued, in-progress, or completed run for the same head SHA. Read
 state with `get_workflow_run` once. Return pending without waiting when the run
 is incomplete. Never provision infrastructure, authenticate to Azure, SSH,

--- a/.x/x.yml
+++ b/.x/x.yml
@@ -5,16 +5,15 @@ agents:
 skills:
   - auto_trigger_pr_validation
   - build_promoted_pr_body
-  - changed_test_files
   - codegen_execution_guidance
   - copilot_iteration_cap_reached
   - copilot_iteration_state
   - dispatch_live_test_workflow
-  - find_aaz_fork_prs_ready_for_promotion
   - find_copilot_fork_prs_ready_for_promotion
   - find_fork_prs_needing_ci
+  - find_generation_source_fork_prs_ready_for_promotion
   - find_in_flight_prs
-  - find_promoted_aaz_source_pr
+  - find_promoted_generation_source_pr
   - find_sensitive_redaction_dispute
   - find_stale_prs
   - format_actionable_ci_failures
@@ -26,19 +25,18 @@ skills:
   - get_pr_check_runs
   - get_pr_check_summary
   - get_pr_file_changes
-  - get_pr_regression_coverage_summary
   - get_pr_review_skill_summary
   - get_profile
   - get_workflow_run
   - handle_sensitive_redaction_dispute
   - has_agent_reviewed_head
-  - infer_target_for_repo
+  - list_repository_directories
   - mark_pr_ready_for_review
   - post_comment
   - post_copilot_human_review_handoff
   - post_pr_review
-  - promote_aaz_fork_pr
   - promote_copilot_fork_pr
+  - promote_generation_source_fork_pr
   - recall_repository_memory
   - remediate_sensitive_issue
   - remediate_sensitive_pull_request
@@ -48,8 +46,15 @@ skills:
   - request_copilot_human_review_changes
   - rerun_stale_pr_checks
   - safe_issue_view
-  - start_aaz_source_task
+  - start_generation_source_task
   - synchronize_pull_request_feedback
   - synchronize_repository_feedback
   - update_pr_branch
-custom_skills: {}
+custom_skills:
+  changed_test_files: changed_test_files
+  find_aaz_fork_prs_ready_for_promotion: find_aaz_fork_prs_ready_for_promotion
+  find_promoted_aaz_source_pr: find_promoted_aaz_source_pr
+  get_pr_regression_coverage_summary: get_pr_regression_coverage_summary
+  infer_target_for_repo: infer_target_for_repo
+  promote_aaz_fork_pr: promote_aaz_fork_pr
+  start_aaz_source_task: start_aaz_source_task


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes |
| :--: |
| ️✔️ None |

<!-- act-bot:section title="Azure CLI Extensions Breaking Change Test" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

## Summary

This moves repository policy into `.x/skills`.

It adds repository owned target inference, test selection and regression coverage. It also adds repository owned wrappers for generation source workflows.

The central runtime keeps only generic scoped effects.

## Validation

The manifest loads against the central skill catalog. All custom skills compile under the repository sandbox.