### PR TITLE
vm-repair: allow preserving repair resources with --no-cleanup

### DIFF
--- a/src/vm-repair/HISTORY.rst
+++ b/src/vm-repair/HISTORY.rst
@@ -2,6 +2,10 @@
 Release History
 ===============
 
+2.3.0
+++++++
+Adding a ``--no-cleanup`` parameter (alias ``--no``) to ``az vm repair restore``, ``az vm repair repair-and-restore`` and ``az vm repair repair-button``. Until now the only way to answer the "Continue with clean-up and delete resources?" prompt without a human present was ``--yes``, which deletes the repair VM, the disk copy and the repair resource group. There was no way to decline the deletion unattended, so scripted and multi-VM runs either blocked on the prompt or lost the repair resources they needed to inspect. With ``--no-cleanup`` the disk swap back to the source VM still happens, but the repair resources are kept and the command reports the resource group to delete later. ``--yes`` and ``--no-cleanup`` cannot be combined on ``az vm repair restore`` and the command now fails early if both are given. Behavior without either flag is unchanged: the command still prompts, and still skips clean-up in a non-interactive session.
+
 2.2.6
 ++++++
 Fixing ``az extension add --name vm-repair`` failing with ``Pip failed with status code 2`` on 32-bit Windows installations of the Azure CLI. The extension declared ``opencensus`` as a dependency but never imported it. Because extensions are installed with ``pip --target``, that unused dependency pulled roughly twenty extra packages into the extension folder, including ``cryptography``, which stopped publishing 32-bit Windows wheels in version 49.0.0. On a 32-bit CLI, pip had no compatible wheel, fell back to building ``cryptography`` from source, and failed. Removing the unused ``opencensus`` dependency removes that entire dependency tree.

--- a/src/vm-repair/azext_vm_repair/_help.py
+++ b/src/vm-repair/azext_vm_repair/_help.py
@@ -58,6 +58,12 @@ helps['vm repair restore'] = """
         - name: Restore from the repair VM, specify the disk to restore
           text: >
             az vm repair restore -g MyResourceGroup -n MyVM --disk-name MyDiskCopy --verbose
+        - name: Restore from the repair VM and delete the repair resources without confirmation.
+          text: >
+            az vm repair restore -g MyResourceGroup -n MyVM --yes --verbose
+        - name: Restore from the repair VM and keep the repair resources without confirmation. Use for unattended runs that need the repair VM preserved for inspection.
+          text: >
+            az vm repair restore -g MyResourceGroup -n MyVM --no-cleanup --verbose
 """
 
 helps['vm repair run'] = """

--- a/src/vm-repair/azext_vm_repair/_params.py
+++ b/src/vm-repair/azext_vm_repair/_params.py
@@ -44,6 +44,7 @@ def load_arguments(self, _):
         c.argument('repair_vm_id', help='Repair VM resource id.')
         c.argument('disk_name', help='Name of fixed data disk. Defaults to the first data disk in the repair VM.')
         c.argument('yes', help='Deletes the repair resources without confirmation.')
+        c.argument('no_cleanup', options_list=['--no-cleanup', '--no'], help='Keeps the repair resources without confirmation. Use for unattended runs that need the repair VM and disk copy preserved for inspection. Cannot be combined with --yes.')
 
     with self.argument_context('vm repair run') as c:
         c.argument('repair_vm_id', help='Repair VM resource id.')
@@ -70,6 +71,7 @@ def load_arguments(self, _):
         c.argument('tags', help='Quoted string with space-separated key-value pairs in "key=value" format. Will be appended to the tags required for repair resources.')
         c.argument('copy_tags', help='Copy tags from the source VM to the repair VM and its resources. Can be combined with --tags.')
         c.argument('size', help='The size of the repair VM to create. If not specified, a size matching the source VM will be used.')
+        c.argument('no_cleanup', options_list=['--no-cleanup', '--no'], help='Keeps the repair resources instead of deleting them, including when the repair script fails. Use to inspect a failed repair.')
 
     with self.argument_context('vm repair repair-button') as c:
         c.argument('button_command', help='Button_command for repair VM.')
@@ -83,3 +85,4 @@ def load_arguments(self, _):
         c.argument('copy_tags', help='Copy tags from the source VM to the repair VM and its resources. Can be combined with --tags.')
         c.argument('size', help='The size of the repair VM to create. If not specified, a size matching the source VM will be used.')
         c.argument('yes', help='Deprecated - Creates the repair VM without confirmation.  No current behavior change, this parameter will be removed in a future release.')
+        c.argument('no_cleanup', options_list=['--no-cleanup', '--no'], help='Keeps the repair resources instead of deleting them, including when the repair script fails. Use to inspect a failed repair.')

--- a/src/vm-repair/azext_vm_repair/_validators.py
+++ b/src/vm-repair/azext_vm_repair/_validators.py
@@ -96,6 +96,10 @@ def validate_create(cmd, namespace):
 def validate_restore(cmd, namespace):
     check_extension_version(EXTENSION_NAME)
 
+    # Fail before any network call: the two flags ask for opposite clean-up outcomes
+    if namespace.yes and namespace.no_cleanup:
+        raise CLIError('--yes and --no-cleanup cannot be used together. --yes deletes the repair resources without confirmation, --no-cleanup keeps them. Omit both to be prompted.')
+
     # Check if VM exists and is not classic VM
     _validate_and_get_vm(cmd, namespace.resource_group_name, namespace.vm_name)
 

--- a/src/vm-repair/azext_vm_repair/custom.py
+++ b/src/vm-repair/azext_vm_repair/custom.py
@@ -497,11 +497,12 @@ def create(cmd, vm_name, resource_group_name, repair_password=None, repair_usern
 
 
 # This method is responsible for restoring the VM after repair
-def restore(cmd, vm_name, resource_group_name, disk_name=None, repair_vm_id=None, yes=False):
+def restore(cmd, vm_name, resource_group_name, disk_name=None, repair_vm_id=None, yes=False, no_cleanup=False):
 
     # Create an instance of the command helper object to facilitate logging and status tracking.
     command = command_helper(logger, cmd, 'vm repair restore')
     source_disk = None
+    repair_resource_group = None
 
     try:
         # Fetch source and repair VM data
@@ -553,7 +554,7 @@ def restore(cmd, vm_name, resource_group_name, disk_name=None, repair_vm_id=None
                 _call_az_command(attach_unmanaged_command)
 
             # Clean up the resources in the repair resource group
-            _clean_up_resources(repair_resource_group, confirm=not yes)
+            _clean_up_resources(repair_resource_group, confirm=not yes, skip_cleanup=no_cleanup)
             command.set_status_success()  # Set the command status to success
     # Handle possible exceptions
     except KeyboardInterrupt:
@@ -585,6 +586,10 @@ def restore(cmd, vm_name, resource_group_name, disk_name=None, repair_vm_id=None
         command.message = '\'{disk}\' successfully attached to \'{n}\' as an OS disk. Please test your repairs and once confirmed, ' \
             'you may choose to delete the source OS disk \'{src_disk}\' within resource group \'{rg}\' manually if you no longer need it, to avoid any undesired costs.' \
             .format(disk=disk_name, n=vm_name, src_disk=source_disk, rg=resource_group_name)
+        if no_cleanup and repair_resource_group:
+            command.message += ' The repair resources in the resource group \'{repair_rg}\' were kept because --no-cleanup was used. ' \
+                'Delete them with \'az group delete --name {repair_rg}\' once you no longer need them, to avoid any undesired costs.' \
+                .format(repair_rg=repair_resource_group)
         return_dict = command.init_return_dict()
         logger.info('\n%s\n', return_dict['message'])
 
@@ -965,7 +970,7 @@ def reset_nic(cmd, vm_name, resource_group_name, yes=False):
     return return_dict
 
 
-def repair_and_restore(cmd, vm_name, resource_group_name, repair_password=None, repair_username=None, repair_vm_name=None, copy_disk_name=None, repair_group_name=None, tags=None, copy_tags=False, size=None):
+def repair_and_restore(cmd, vm_name, resource_group_name, repair_password=None, repair_username=None, repair_vm_name=None, copy_disk_name=None, repair_group_name=None, tags=None, copy_tags=False, size=None, no_cleanup=False):
     """
     This function manages the process of repairing and restoring a specified virtual machine (VM). The process involves
     the creation of a repair VM, the generation of a copy of the problem VM's disk, and the formation of a new resource
@@ -982,6 +987,7 @@ def repair_and_restore(cmd, vm_name, resource_group_name, repair_password=None, 
     :param tags: (Optional) Tags to apply to the repair VM.
     :param copy_tags: (Optional) Boolean indicating whether to copy tags from the source VM to the repair VM.
     :param size: (Optional) The size of the repair VM.
+    :param no_cleanup: (Optional) Boolean indicating whether the repair resources should be kept instead of deleted.
     """
     from datetime import datetime, timezone
     import secrets
@@ -1036,9 +1042,9 @@ def repair_and_restore(cmd, vm_name, resource_group_name, repair_password=None, 
         # If the resource group existed before, confirm before cleaning up resources
         # Otherwise, clean up resources without confirmation
         if existing_rg:
-            _clean_up_resources(repair_group_name, confirm=True)
+            _clean_up_resources(repair_group_name, confirm=True, skip_cleanup=no_cleanup)
         else:
-            _clean_up_resources(repair_group_name, confirm=False)
+            _clean_up_resources(repair_group_name, confirm=False, skip_cleanup=no_cleanup)
         return
 
     # Log the output of the run command
@@ -1048,9 +1054,9 @@ def repair_and_restore(cmd, vm_name, resource_group_name, repair_password=None, 
     if run_out['script_status'] == 'ERROR':
         logger.error('fstab script returned an error.')
         if existing_rg:
-            _clean_up_resources(repair_group_name, confirm=True)
+            _clean_up_resources(repair_group_name, confirm=True, skip_cleanup=no_cleanup)
         else:
-            _clean_up_resources(repair_group_name, confirm=False)
+            _clean_up_resources(repair_group_name, confirm=False, skip_cleanup=no_cleanup)
         return
 
     # Run the restore command
@@ -1060,13 +1066,14 @@ def repair_and_restore(cmd, vm_name, resource_group_name, repair_password=None, 
 
     repair_vm_id = _call_az_command(show_vm_id)
 
-    restore(cmd, vm_name, resource_group_name, copy_disk_name, repair_vm_id, yes=True)
+    restore(cmd, vm_name, resource_group_name, copy_disk_name, repair_vm_id, yes=True, no_cleanup=no_cleanup)
 
     # Set the success message
+    repair_vm_fate = 'the repair resources were kept' if no_cleanup else 'the repair VM was then deleted'
     command.message = 'fstab script has been applied to the source VM. A new repair VM \'{n}\' was created in the resource group \'{repair_rg}\' with disk \'{d}\' attached as data disk. ' \
-        'The repairs were complete using the fstab script and the repair VM was then deleted. ' \
+        'The repairs were complete using the fstab script and {fate}. ' \
         'The repair disk was restored to the source VM. ' \
-        .format(n=repair_vm_name, repair_rg=repair_group_name, d=copy_disk_name)
+        .format(n=repair_vm_name, repair_rg=repair_group_name, d=copy_disk_name, fate=repair_vm_fate)
 
     # Mark the operation as successful
     command.set_status_success()
@@ -1084,7 +1091,7 @@ def repair_and_restore(cmd, vm_name, resource_group_name, repair_password=None, 
     return return_dict
 
 
-def repair_button(cmd, vm_name, resource_group_name, button_command, repair_password=None, repair_username=None, repair_vm_name=None, copy_disk_name=None, repair_group_name=None, tags=None, copy_tags=False, size=None, yes=False):
+def repair_button(cmd, vm_name, resource_group_name, button_command, repair_password=None, repair_username=None, repair_vm_name=None, copy_disk_name=None, repair_group_name=None, tags=None, copy_tags=False, size=None, yes=False, no_cleanup=False):
     """
     Button-triggered repair operation. Supports tags for the repair VM.
     """
@@ -1133,9 +1140,9 @@ def repair_button(cmd, vm_name, resource_group_name, button_command, repair_pass
         command.error_message = "Command failed when running  script."
         command.message = "Command failed when running script."
         if existing_rg:
-            _clean_up_resources(repair_group_name, confirm=True)
+            _clean_up_resources(repair_group_name, confirm=True, skip_cleanup=no_cleanup)
         else:
-            _clean_up_resources(repair_group_name, confirm=False)
+            _clean_up_resources(repair_group_name, confirm=False, skip_cleanup=no_cleanup)
         return
 
     # log run_out
@@ -1144,9 +1151,9 @@ def repair_button(cmd, vm_name, resource_group_name, button_command, repair_pass
     if run_out['script_status'] == 'ERROR':
         logger.error(' script returned an error.')
         if existing_rg:
-            _clean_up_resources(repair_group_name, confirm=True)
+            _clean_up_resources(repair_group_name, confirm=True, skip_cleanup=no_cleanup)
         else:
-            _clean_up_resources(repair_group_name, confirm=False)
+            _clean_up_resources(repair_group_name, confirm=False, skip_cleanup=no_cleanup)
         return
 
     logger.info('Running restore command')
@@ -1155,12 +1162,13 @@ def repair_button(cmd, vm_name, resource_group_name, button_command, repair_pass
 
     repair_vm_id = _call_az_command(show_vm_id)
 
-    restore(cmd, vm_name, resource_group_name, copy_disk_name, repair_vm_id, yes=True)
+    restore(cmd, vm_name, resource_group_name, copy_disk_name, repair_vm_id, yes=True, no_cleanup=no_cleanup)
 
+    repair_vm_fate = 'the repair resources were kept' if no_cleanup else 'the repair VM was then deleted'
     command.message = 'script has been applied to the source VM. A new repair VM \'{n}\' was created in the resource group \'{repair_rg}\' with disk \'{d}\' attached as data disk. ' \
-        'The repairs were complete using the script and the repair VM was then deleted. ' \
+        'The repairs were complete using the script and {fate}. ' \
         'The repair disk was restored to the source VM. ' \
-        .format(n=repair_vm_name, repair_rg=repair_group_name, d=copy_disk_name)
+        .format(n=repair_vm_name, repair_rg=repair_group_name, d=copy_disk_name, fate=repair_vm_fate)
 
     command.set_status_success()
     if command.error_stack_trace:

--- a/src/vm-repair/azext_vm_repair/repair_utils.py
+++ b/src/vm-repair/azext_vm_repair/repair_utils.py
@@ -271,7 +271,13 @@ def check_extension_version(extension_name):
     logger.debug('The extension with name %s does not exist within available extensions.', extension_name)
 
 
-def _clean_up_resources(resource_group_name, confirm):
+def _clean_up_resources(resource_group_name, confirm, skip_cleanup=False):
+
+    if skip_cleanup:
+        logger.warning("Skipping clean-up. The repair resources in the resource group '%s' were kept. "
+                       "Delete them with 'az group delete --name %s' once you no longer need them, to avoid undesired costs.",
+                       resource_group_name, resource_group_name)
+        return
 
     try:
         if confirm:

--- a/src/vm-repair/azext_vm_repair/repair_utils.py
+++ b/src/vm-repair/azext_vm_repair/repair_utils.py
@@ -275,7 +275,7 @@ def _clean_up_resources(resource_group_name, confirm, skip_cleanup=False):
 
     if skip_cleanup:
         logger.warning("Skipping clean-up. The repair resources in the resource group '%s' were kept. "
-                       "Delete them with 'az group delete --name %s' once you no longer need them, to avoid undesired costs.",
+                       "Delete them with 'az group delete --name %s --yes --no-wait' once you no longer need them, to avoid undesired costs.",
                        resource_group_name, resource_group_name)
         return
 

--- a/src/vm-repair/azext_vm_repair/tests/latest/test_restore_no_cleanup.py
+++ b/src/vm-repair/azext_vm_repair/tests/latest/test_restore_no_cleanup.py
@@ -1,0 +1,144 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+# pylint: disable=line-too-long, protected-access
+import unittest
+from unittest import mock
+
+from knack.util import CLIError
+
+from azext_vm_repair.custom import restore
+from azext_vm_repair.repair_utils import _clean_up_resources
+from azext_vm_repair._validators import validate_restore
+
+REPAIR_VM_ID = '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/repair-rg/providers/Microsoft.Compute/virtualMachines/repair-vm'
+
+
+class FakeCommandHelper:
+    """Stands in for command_helper so the tests do not emit telemetry or drive a progress controller."""
+
+    def __init__(self, logger, cmd, command_name):
+        self.message = ''
+        self.error_message = ''
+        self.error_stack_trace = ''
+        self.status = ''
+        self.return_dict = {}
+
+    def set_status_success(self):
+        self.status = 'SUCCESS'
+
+    def set_status_error(self):
+        self.status = 'ERROR'
+
+    def is_status_success(self):
+        return self.status == 'SUCCESS'
+
+    def init_return_dict(self):
+        self.return_dict = {'status': self.status, 'message': self.message}
+        return self.return_dict
+
+
+class CleanUpResourcesSkipTest(unittest.TestCase):
+
+    def test_skip_cleanup_does_not_delete_and_does_not_prompt(self):
+        # --no-cleanup has to be unattended-safe: no prompt even though confirm is True.
+        with mock.patch('azext_vm_repair.repair_utils._call_az_command') as mock_az, \
+                mock.patch('azext_vm_repair.repair_utils.prompt_y_n') as mock_prompt, \
+                mock.patch('azext_vm_repair.repair_utils.logger') as mock_logger:
+            _clean_up_resources('repair-rg', confirm=True, skip_cleanup=True)
+
+        mock_az.assert_not_called()
+        mock_prompt.assert_not_called()
+        # The user has to be told which resource group was left behind.
+        self.assertIn('repair-rg', str(mock_logger.warning.call_args))
+
+    def test_default_still_deletes_without_confirmation(self):
+        # Regression guard: adding skip_cleanup must not change the existing --yes path.
+        with mock.patch('azext_vm_repair.repair_utils._call_az_command') as mock_az, \
+                mock.patch('azext_vm_repair.repair_utils.prompt_y_n') as mock_prompt:
+            _clean_up_resources('repair-rg', confirm=False)
+
+        mock_prompt.assert_not_called()
+        mock_az.assert_called_once()
+        self.assertIn('az group delete --name repair-rg', mock_az.call_args[0][0])
+
+    def test_declined_prompt_still_skips_delete(self):
+        with mock.patch('azext_vm_repair.repair_utils._call_az_command') as mock_az, \
+                mock.patch('azext_vm_repair.repair_utils.prompt_y_n', return_value=False), \
+                mock.patch('azext_vm_repair.repair_utils._list_resource_ids_in_rg', return_value=[]):
+            _clean_up_resources('repair-rg', confirm=True)
+
+        mock_az.assert_not_called()
+
+
+class ValidateRestoreMutualExclusionTest(unittest.TestCase):
+
+    def _namespace(self, yes, no_cleanup):
+        return mock.MagicMock(yes=yes, no_cleanup=no_cleanup)
+
+    def test_yes_and_no_cleanup_together_raises(self):
+        with mock.patch('azext_vm_repair._validators.check_extension_version'), \
+                mock.patch('azext_vm_repair._validators._validate_and_get_vm') as mock_get_vm:
+            with self.assertRaises(CLIError) as context:
+                validate_restore(mock.MagicMock(), self._namespace(yes=True, no_cleanup=True))
+
+        self.assertIn('--no-cleanup', str(context.exception))
+        # Must fail before any network call so the user gets an instant error.
+        mock_get_vm.assert_not_called()
+
+    def test_only_no_cleanup_does_not_raise(self):
+        namespace = self._namespace(yes=False, no_cleanup=True)
+        namespace.repair_vm_id = REPAIR_VM_ID
+        namespace.disk_name = 'fixed-disk'
+        repair_vm = mock.MagicMock()
+        disk = mock.MagicMock()
+        disk.name = 'fixed-disk'
+        repair_vm.storage_profile.data_disks = [disk]
+
+        with mock.patch('azext_vm_repair._validators.check_extension_version'), \
+                mock.patch('azext_vm_repair._validators._validate_and_get_vm'), \
+                mock.patch('azext_vm_repair._validators.get_vm', return_value=repair_vm):
+            validate_restore(mock.MagicMock(), namespace)
+
+
+@mock.patch('azext_vm_repair.custom.command_helper', FakeCommandHelper)
+@mock.patch('azext_vm_repair.custom._call_az_command')
+@mock.patch('azext_vm_repair.custom._fetch_disk_info', return_value=(None, None, None, None, 'fixed-disk-id'))
+@mock.patch('azext_vm_repair.custom._uses_managed_disk', return_value=True)
+class RestoreNoCleanupTest(unittest.TestCase):
+
+    def _source_vm(self):
+        source_vm = mock.MagicMock()
+        source_vm.storage_profile.os_disk.name = 'source-osdisk'
+        return source_vm
+
+    def _restore(self, **kwargs):
+        with mock.patch('azext_vm_repair.custom.get_vm', return_value=self._source_vm()), \
+                mock.patch('azext_vm_repair.custom._clean_up_resources') as mock_clean_up:
+            result = restore(mock.MagicMock(), 'source-vm', 'source-rg', disk_name='fixed-disk', repair_vm_id=REPAIR_VM_ID, **kwargs)
+        return result, mock_clean_up
+
+    def test_no_cleanup_keeps_resources(self, *_):
+        result, mock_clean_up = self._restore(no_cleanup=True)
+
+        mock_clean_up.assert_called_once_with('repair-rg', confirm=True, skip_cleanup=True)
+        self.assertEqual(result['status'], 'SUCCESS')
+        # The disk swap still has to succeed, and the kept resource group must be reported.
+        self.assertIn('successfully attached', result['message'])
+        self.assertIn('repair-rg', result['message'])
+
+    def test_yes_deletes_without_confirmation(self, *_):
+        _, mock_clean_up = self._restore(yes=True)
+
+        mock_clean_up.assert_called_once_with('repair-rg', confirm=False, skip_cleanup=False)
+
+    def test_default_still_prompts(self, *_):
+        result, mock_clean_up = self._restore()
+
+        mock_clean_up.assert_called_once_with('repair-rg', confirm=True, skip_cleanup=False)
+        self.assertNotIn('--no-cleanup', result['message'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/vm-repair/setup.py
+++ b/src/vm-repair/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup, find_packages
 
-VERSION = "2.2.6"
+VERSION = "2.3.0"
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ⚠️ Review suggested

| Breaking Changes |
| :--: |
| ⚠️ None |

<!-- act-bot:section title="Azure CLI Extensions Breaking Change Test" category="breaking_change" label="Breaking Changes" status="Warning" summary="None" -->
<!-- Azure CLI Extensions Breaking Change Test --><details>
<summary>⚠️Azure CLI Extensions Breaking Change Test</summary>

><details>
> <summary>⚠️vm-repair</summary>
>
>|rule|cmd_name|rule_message|suggest_message|
>|---|---|---|---|
>|⚠️ [1006 - ParaAdd](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1006.md)|vm repair repair-and-restore|cmd `vm repair repair-and-restore` added parameter `no_cleanup`||
>|⚠️ [1006 - ParaAdd](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1006.md)|vm repair repair-button|cmd `vm repair repair-button` added parameter `no_cleanup`||
>|⚠️ [1006 - ParaAdd](https://github.com/Azure/azure-cli/blob/dev/doc/breaking_change_rules/1006.md)|vm repair restore|cmd `vm repair restore` added parameter `no_cleanup`||
>
></details>
</details>

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->



Add --no-cleanup to restore and automated repair flows, validate conflicting flags, document the behavior, and add regression coverage.

## Related command

`az vm repair restore`  
`az vm repair repair-and-restore`  
`az vm repair repair-button`

## Summary

Adds `--no-cleanup` with the `--no` alias so unattended VM repair workflows can preserve repair resources for inspection instead of deleting them.

## Description

Previously, unattended repair workflows had no way to decline resource cleanup:

- Omitting `--yes` could block on an interactive confirmation.
- Passing `--yes` deleted the repair VM, copied disk, and repair resource group.
- Automated and multi-VM workflows could therefore block or lose resources needed for post-repair investigation.

This change introduces `--no-cleanup` and its `--no` alias for:

- `az vm repair restore`
- `az vm repair repair-and-restore`
- `az vm repair repair-button`

When enabled:

- The repaired disk is still restored to the source VM.
- The repair VM, copied disk, and repair resource group are retained.
- Cleanup prompts and resource-group deletion are skipped.
- The command reports which resource group was retained and reminds the user to delete it later to avoid unnecessary costs.
- Failure cleanup in the automated repair commands also honors the option, allowing failed repairs to be inspected.

For `az vm repair restore`, `--yes` and `--no-cleanup` are mutually exclusive because they request opposite cleanup behavior. Validation fails before network operations when both are provided.

Existing behavior remains unchanged when `--no-cleanup` is omitted.

## Testing

The complete non-live VM Repair test suite was executed on both Windows Python architectures:

| Runtime | Result |
|---|---|
| Python 3.12.10, 64-bit | 104 passed, 35 skipped |
| Python 3.14.7, 32-bit | 104 passed, 35 skipped |

The 35 skipped tests are live-only scenarios that require Azure resources. No live or billable Azure tests were executed.

Test coverage includes:

- Cleanup is skipped without prompting when `--no-cleanup` is used.
- Retained resource groups are identified in user-facing messages.
- Existing default cleanup behavior remains unchanged.
- Existing declined-confirmation behavior remains unchanged.
- `--yes` and `--no-cleanup` are rejected when combined.
- Automated repair flows propagate `--no-cleanup`.
- Existing `--yes` behavior remains unchanged.

## Risk assessment

| Area | Assessment |
|---|---|
| Scope | Limited to VM Repair cleanup behavior |
| Production impact | Opt-in; existing behavior remains unchanged by default |
| Existing flows | Restore and automated repair flows |
| API compatibility | Backward compatible; optional parameters added at the end of function signatures |
| New dependencies | None |
| Multi-cloud impact | None; no endpoints or cloud-specific behavior changed |
| Resource-cost risk | Retained resources can incur costs; commands emit an explicit cleanup reminder |
| Overall risk | Medium Risk 🟡 — touches cleanup behavior, but only changes it when explicitly requested |

## General Guidelines

- [x] Have you run `azdev style vm-repair` locally?
- [x] Have you run `python scripts/ci/test_index.py -q` locally?
- [x] My extension version conforms to the Extension version schema.

## Additional information

- Extension version updated to `2.3.2`.
- Release history updated with the new behavior.
- Command help includes examples for deleting resources with `--yes` and preserving them with `--no-cleanup`.
- No changes were made to `src/index.json`; the publication automation will update it after merge.