### PR TITLE
{Dataprotection} Isolate AKS backup vault discovery

### DIFF
--- a/src/dataprotection/HISTORY.rst
+++ b/src/dataprotection/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+1.11.5
+++++++
+* `az dataprotection enable-backup trigger`: Fixed AKS backup vault discovery to scope the lookup to `backupResourceGroupId` instead of the whole subscription, preventing concurrent enable-backup runs from racing over a shared, tag-matched vault. Also wait for a newly created vault's `provisioningState` to reach a terminal state before proceeding.
+
 1.11.4
 ++++++
 * `az dataprotection enable-backup trigger`: Specify `ServicePrincipal` when creating role assignments for AKS managed identities.

--- a/src/dataprotection/azext_dataprotection/manual/aks/aks_helper.py
+++ b/src/dataprotection/azext_dataprotection/manual/aks/aks_helper.py
@@ -686,11 +686,23 @@ def _get_storage_account_from_extension(cmd, extension, cluster_subscription_id)
         return None, None, None, None
 
 
-def _find_existing_backup_vault(cmd, cluster_subscription_id, cluster_location):
+def _find_existing_backup_vault(
+    cmd, cluster_subscription_id, cluster_location, backup_resource_group_name=None
+):
     """
-    Search for an existing AKS backup vault in the subscription by tag.
+    Search for an existing AKS backup vault by tag, scoped to the explicit
+    backup resource group when one is known.
 
     Looks for backup vaults with tag: AKSAzureBackup = <location>
+
+    Scoping the ``list`` call to ``backup_resource_group_name`` (derived from
+    the caller-supplied ``backupResourceGroupId``, or the per-cluster
+    resource group we just created/validated) is required: without it, every
+    parallel run/test that happens to omit ``backupResourceGroupId`` shares
+    the same subscription-wide, tag-matched vault, so one run's
+    ``aks delete``/vault cleanup can race another run's discovery and lookup
+    (``ResourceGroupBeingDeleted``/404 on the shared vault). Restricting
+    discovery to the caller's own resource group keeps each run isolated.
 
     Returns:
         backup_vault if found, None otherwise
@@ -698,10 +710,10 @@ def _find_existing_backup_vault(cmd, cluster_subscription_id, cluster_location):
     from azext_dataprotection.aaz.latest.dataprotection.backup_vault import List as _BackupVaultList
 
     try:
-        # List all backup vaults in the cluster's subscription
-        vaults = _BackupVaultList(cli_ctx=cmd.cli_ctx)(command_args={
-            "subscription": cluster_subscription_id
-        })
+        list_args = {"subscription": cluster_subscription_id}
+        if backup_resource_group_name:
+            list_args["resource_group"] = backup_resource_group_name
+        vaults = _BackupVaultList(cli_ctx=cmd.cli_ctx)(command_args=list_args)
 
         for vault in vaults:
             if vault.get('tags'):
@@ -713,6 +725,57 @@ def _find_existing_backup_vault(cmd, cluster_subscription_id, cluster_location):
         # If we can't list vaults, we'll create a new one
         pass
     return None
+
+
+def _wait_for_backup_vault_ready(
+    cmd, backup_vault_name, backup_resource_group_name,
+    cluster_subscription_id, retries=30, interval_seconds=10
+):
+    """
+    Poll the backup vault until its service-reported ``provisioningState``
+    reaches a terminal state (or a bounded number of retries is exhausted).
+
+    ``_BackupVaultCreate(...).result()`` returns as soon as the ARM PUT's LRO
+    completes, but the vault's own ``provisioningState`` can briefly lag
+    behind (eventual consistency) before role-assignment/backup-instance
+    operations against it will reliably succeed. This uses precise, bounded
+    polling against the service-visible state rather than a fixed sleep.
+
+    Returns the latest vault payload (refreshed via Show) when available;
+    falls back to whatever was last observed if polling itself fails.
+    """
+    import time
+    from azext_dataprotection.aaz.latest.dataprotection.backup_vault import Show as _BackupVaultShow
+
+    terminal_states = {"succeeded", "failed", "canceled"}
+    latest_vault = None
+    for attempt in range(retries):
+        try:
+            latest_vault = _BackupVaultShow(cli_ctx=cmd.cli_ctx)(command_args={
+                "vault_name": backup_vault_name,
+                "resource_group": backup_resource_group_name,
+                "subscription": cluster_subscription_id,
+            })
+            state = (latest_vault.get("properties", {}) or {}).get("provisioningState", "")
+            if state.lower() in terminal_states:
+                if state.lower() != "succeeded":
+                    raise InvalidArgumentValueError(
+                        f"Backup vault '{backup_vault_name}' reached terminal "
+                        f"provisioning state '{state}' instead of 'Succeeded'."
+                    )
+                return latest_vault
+        except InvalidArgumentValueError:
+            raise
+        except Exception:  # pylint: disable=broad-exception-caught
+            # Transient lookup failure (e.g. RP propagation delay); keep retrying.
+            pass
+        if attempt < retries - 1:
+            time.sleep(interval_seconds)
+    logger.warning(
+        "Backup vault '%s' did not report a terminal provisioning state "
+        "after %d retries; proceeding with the last known state.",
+        backup_vault_name, retries)
+    return latest_vault
 
 
 def _try_create_vault_with_storage_type(
@@ -773,9 +836,14 @@ def _setup_backup_vault(
             "subscription": cluster_subscription_id
         })
     else:
-        # Search for existing backup vault with matching tag
-        logger.warning("Searching for existing AKS backup vault in region %s...", cluster_location)
-        backup_vault = _find_existing_backup_vault(cmd, cluster_subscription_id, cluster_location)
+        # Search for existing backup vault with matching tag, scoped to the
+        # explicit backup resource group so parallel/other runs' vaults are
+        # never picked up (see _find_existing_backup_vault docstring).
+        logger.warning(
+            "Searching for existing AKS backup vault in region %s (resource group %s)...",
+            cluster_location, backup_resource_group_name)
+        backup_vault = _find_existing_backup_vault(
+            cmd, cluster_subscription_id, cluster_location, backup_resource_group_name)
 
         if backup_vault:
             # Found existing vault - reuse it
@@ -812,6 +880,16 @@ def _setup_backup_vault(
                     f"with any storage type (GeoRedundant, ZoneRedundant, LocallyRedundant).\n"
                     f"Please check region availability and try again."
                 )
+
+            # The vault create LRO can return before the vault's own
+            # provisioningState (and downstream role-assignment/backup-instance
+            # eligibility) is fully settled. Wait on the service-visible state
+            # with bounded retries rather than assuming immediate readiness.
+            logger.warning("Waiting for backup vault '%s' to become ready...", backup_vault_name)
+            refreshed_vault = _wait_for_backup_vault_ready(
+                cmd, backup_vault_name, backup_resource_group_name, cluster_subscription_id)
+            if refreshed_vault:
+                backup_vault = refreshed_vault
 
     logger.warning("Backup Vault: %s", backup_vault['id'])
     _check_and_assign_role(

--- a/src/dataprotection/azext_dataprotection/tests/latest/test_dataprotection_enable_backup.py
+++ b/src/dataprotection/azext_dataprotection/tests/latest/test_dataprotection_enable_backup.py
@@ -438,5 +438,108 @@ class TestCheckExistingBackupInstance(unittest.TestCase):
         self.assertIsNone(_check_existing_backup_instance(client, CLUSTER_ID, CLUSTER_NAME))
 
 
+# ---------------------------------------------------------------------------
+# _find_existing_backup_vault
+# ---------------------------------------------------------------------------
+class TestFindExistingBackupVault(unittest.TestCase):
+    """Tests for tag-based backup vault discovery, scoped to a resource group."""
+
+    @patch("azext_dataprotection.aaz.latest.dataprotection.backup_vault.List")
+    def test_finds_matching_vault_in_subscription(self, mock_list_cls):
+        vault = {"name": "aksbkp-eastus", "tags": {AKS_BACKUP_TAG_KEY: "eastus"}}
+        mock_list_cls.return_value = MagicMock(return_value=[vault])
+        from azext_dataprotection.manual.aks.aks_helper import _find_existing_backup_vault
+        result = _find_existing_backup_vault(MagicMock(), SUB_ID, "eastus")
+        self.assertEqual(result["name"], "aksbkp-eastus")
+
+    @patch("azext_dataprotection.aaz.latest.dataprotection.backup_vault.List")
+    def test_returns_none_when_no_tag_match(self, mock_list_cls):
+        vault = {"name": "other-vault", "tags": {"env": "prod"}}
+        mock_list_cls.return_value = MagicMock(return_value=[vault])
+        from azext_dataprotection.manual.aks.aks_helper import _find_existing_backup_vault
+        result = _find_existing_backup_vault(MagicMock(), SUB_ID, "eastus")
+        self.assertIsNone(result)
+
+    @patch("azext_dataprotection.aaz.latest.dataprotection.backup_vault.List")
+    def test_returns_none_on_exception(self, mock_list_cls):
+        mock_list_cls.return_value = MagicMock(side_effect=Exception("API error"))
+        from azext_dataprotection.manual.aks.aks_helper import _find_existing_backup_vault
+        result = _find_existing_backup_vault(MagicMock(), SUB_ID, "eastus", "my-backup-rg")
+        self.assertIsNone(result)
+
+    @patch("azext_dataprotection.aaz.latest.dataprotection.backup_vault.List")
+    def test_scopes_list_call_to_explicit_backup_resource_group(self, mock_list_cls):
+        """Passing backup_resource_group_name must be forwarded to the AAZ
+        List command as ``resource_group`` so discovery never crosses into
+        another run's/parallel test's resource group and vault."""
+        list_instance = MagicMock(return_value=[])
+        mock_list_cls.return_value = list_instance
+        from azext_dataprotection.manual.aks.aks_helper import _find_existing_backup_vault
+        _find_existing_backup_vault(MagicMock(), SUB_ID, "eastus", "my-backup-rg")
+        _, kwargs = list_instance.call_args
+        command_args = kwargs.get("command_args") or list_instance.call_args[0][0]
+        self.assertEqual(command_args.get("resource_group"), "my-backup-rg")
+        self.assertEqual(command_args.get("subscription"), SUB_ID)
+
+    @patch("azext_dataprotection.aaz.latest.dataprotection.backup_vault.List")
+    def test_omits_resource_group_when_not_provided(self, mock_list_cls):
+        list_instance = MagicMock(return_value=[])
+        mock_list_cls.return_value = list_instance
+        from azext_dataprotection.manual.aks.aks_helper import _find_existing_backup_vault
+        _find_existing_backup_vault(MagicMock(), SUB_ID, "eastus")
+        _, kwargs = list_instance.call_args
+        command_args = kwargs.get("command_args") or list_instance.call_args[0][0]
+        self.assertNotIn("resource_group", command_args)
+
+
+# ---------------------------------------------------------------------------
+# _wait_for_backup_vault_ready
+# ---------------------------------------------------------------------------
+class TestWaitForBackupVaultReady(unittest.TestCase):
+    """Tests for bounded polling of a newly-created vault's provisioning state."""
+
+    @patch("time.sleep", return_value=None)
+    @patch("azext_dataprotection.aaz.latest.dataprotection.backup_vault.Show")
+    def test_returns_immediately_when_succeeded(self, mock_show_cls, _mock_sleep):
+        vault = {"name": "v1", "properties": {"provisioningState": "Succeeded"}}
+        mock_show_cls.return_value = MagicMock(return_value=vault)
+        from azext_dataprotection.manual.aks.aks_helper import _wait_for_backup_vault_ready
+        result = _wait_for_backup_vault_ready(MagicMock(), "v1", "rg", SUB_ID, retries=5, interval_seconds=0)
+        self.assertEqual(result["properties"]["provisioningState"], "Succeeded")
+        mock_show_cls.return_value.assert_called_once()
+
+    @patch("time.sleep", return_value=None)
+    @patch("azext_dataprotection.aaz.latest.dataprotection.backup_vault.Show")
+    def test_retries_until_terminal_state(self, mock_show_cls, _mock_sleep):
+        show_instance = MagicMock(side_effect=[
+            {"name": "v1", "properties": {"provisioningState": "Updating"}},
+            {"name": "v1", "properties": {"provisioningState": "Succeeded"}},
+        ])
+        mock_show_cls.return_value = show_instance
+        from azext_dataprotection.manual.aks.aks_helper import _wait_for_backup_vault_ready
+        result = _wait_for_backup_vault_ready(MagicMock(), "v1", "rg", SUB_ID, retries=5, interval_seconds=0)
+        self.assertEqual(result["properties"]["provisioningState"], "Succeeded")
+        self.assertEqual(show_instance.call_count, 2)
+
+    @patch("time.sleep", return_value=None)
+    @patch("azext_dataprotection.aaz.latest.dataprotection.backup_vault.Show")
+    def test_raises_on_failed_terminal_state(self, mock_show_cls, _mock_sleep):
+        mock_show_cls.return_value = MagicMock(
+            return_value={"name": "v1", "properties": {"provisioningState": "Failed"}})
+        from azext_dataprotection.manual.aks.aks_helper import _wait_for_backup_vault_ready
+        with self.assertRaises(InvalidArgumentValueError):
+            _wait_for_backup_vault_ready(MagicMock(), "v1", "rg", SUB_ID, retries=3, interval_seconds=0)
+
+    @patch("time.sleep", return_value=None)
+    @patch("azext_dataprotection.aaz.latest.dataprotection.backup_vault.Show")
+    def test_gives_up_after_bounded_retries(self, mock_show_cls, _mock_sleep):
+        mock_show_cls.return_value = MagicMock(
+            return_value={"name": "v1", "properties": {"provisioningState": "Updating"}})
+        from azext_dataprotection.manual.aks.aks_helper import _wait_for_backup_vault_ready
+        result = _wait_for_backup_vault_ready(MagicMock(), "v1", "rg", SUB_ID, retries=3, interval_seconds=0)
+        self.assertEqual(result["properties"]["provisioningState"], "Updating")
+        self.assertEqual(mock_show_cls.return_value.call_count, 3)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/src/dataprotection/setup.py
+++ b/src/dataprotection/setup.py
@@ -10,7 +10,7 @@ from codecs import open
 from setuptools import setup, find_packages
 
 # HISTORY.rst entry.
-VERSION = '1.11.4'
+VERSION = '1.11.5'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes |
| :--: |
| ️✔️ None |

<!-- act-bot:section title="Azure CLI Extensions Breaking Change Test" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command

`az dataprotection enable-backup trigger`

### What / Why

Fixes a race in AKS backup setup when multiple runs operate in the same subscription:

- Scope reusable backup vault discovery to the resolved `backupResourceGroupId` instead of searching the entire subscription for a location-tagged vault. This prevents concurrent runs from sharing a vault that another run may delete during cleanup.
- Poll a newly created backup vault's service-visible `provisioningState` with bounded retries before starting dependent role-assignment and backup-instance operations.
- Add regression coverage for resource-group scoping, tag matching, transient state polling, terminal failures, and bounded retries.

### Validation

- `pytest src/dataprotection/azext_dataprotection/tests/latest/test_dataprotection_enable_backup.py -q` - 48 passed.
- `flake8` on the changed helper and test files using the extension's configured ignores - passed.
- `python -m py_compile` for all changed Python files - passed.
- `git diff --check upstream/main...HEAD` - passed.

### Scope / Index / History

- Dataprotection extension version is bumped from `1.11.4` to `1.11.5`.
- `HISTORY.rst` contains the matching `1.11.5` release note.
- `src/index.json` is not modified; it will be updated by the post-merge automation.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required) - `azdev` is unavailable locally; targeted `flake8`, syntax, and unit checks passed, and the PR's style workflow provides the repository check.
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install azdev` required) - N/A, `src/index.json` is unchanged.
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md).

For new extensions:

- [ ] N/A - not a new extension.
