### PR TITLE
vm-repair: add resource-shape telemetry dimensions

### DIFF
--- a/src/vm-repair/HISTORY.rst
+++ b/src/vm-repair/HISTORY.rst
@@ -2,6 +2,11 @@
 Release History
 ===============
 
+2.4.0
+++++++
+Adding resource-shape dimensions to ``vm repair`` telemetry: operating system family, VM size, source and repair VM disk controller type, and Hyper-V generation. Until now the telemetry recorded which command ran and whether it succeeded, but nothing about the shape of the VM it ran against, so it was not possible to tell how often repairs run against NVMe-attached disks or whether the repair VM controller selection added in 2.3.1 changes anything in practice. The new dimensions are resource shape only; no resource names or customer content are recorded by them.
+Also fixing ``az vm repair run`` emitting two telemetry events per invocation instead of one. Run counts in existing reports are inflated for that command and will drop to their true value from this release onward.
+
 2.3.2
 ++++++
 Adding a ``--no-cleanup`` parameter (alias ``--no``) to ``az vm repair restore``, ``az vm repair repair-and-restore`` and ``az vm repair repair-button``. Until now the only way to answer the "Continue with clean-up and delete resources?" prompt without a human present was ``--yes``, which deletes the repair VM, the disk copy and the repair resource group. There was no way to decline the deletion unattended, so scripted and multi-VM runs either blocked on the prompt or lost the repair resources they needed to inspect. With ``--no-cleanup`` the disk swap back to the source VM still happens, but the repair resources are kept and the command reports the resource group to delete later. ``--yes`` and ``--no-cleanup`` cannot be combined on ``az vm repair restore`` and the command now fails early if both are given. Behavior without either flag is unchanged: the command still prompts, and still skips clean-up in a non-interactive session.

--- a/src/vm-repair/HISTORY.rst
+++ b/src/vm-repair/HISTORY.rst
@@ -2,7 +2,7 @@
 Release History
 ===============
 
-2.4.0
+2.4.1
 ++++++
 Adding resource-shape dimensions to ``vm repair`` telemetry: operating system family, VM size, source and repair VM disk controller type, and Hyper-V generation. Until now the telemetry recorded which command ran and whether it succeeded, but nothing about the shape of the VM it ran against, so it was not possible to tell how often repairs run against NVMe-attached disks or whether the repair VM controller selection added in 2.3.1 changes anything in practice. The new dimensions are resource shape only; no resource names or customer content are recorded by them.
 Also fixing ``az vm repair run`` emitting two telemetry events per invocation instead of one. Run counts in existing reports are inflated for that command and will drop to their true value from this release onward.

--- a/src/vm-repair/azext_vm_repair/command_helper_class.py
+++ b/src/vm-repair/azext_vm_repair/command_helper_class.py
@@ -68,6 +68,13 @@ class command_helper:
         # Return dict
         self.return_dict = {}
 
+        # Resource shape used for telemetry. Commands populate this after fetching the source VM.
+        self.os_family = None
+        self.vm_size = None
+        self.disk_controller_type = None
+        self.repair_vm_disk_controller_type = None
+        self.hyperv_generation = None
+
         # Verbose flag for command
         self.is_verbose = any(handler.level == logging.INFO for handler in get_logger().handlers)
 
@@ -88,11 +95,25 @@ class command_helper:
         # Track telemetry data
         elapsed_time = timeit.default_timer() - self.start_time
         if self.command_name == VM_REPAIR_RUN_COMMAND:
-            _track_run_command_telemetry(self.logger, self.command_name, self.command_params, self.status, self.message, self.error_message, self.error_stack_trace, elapsed_time, get_subscription_id(self.cmd.cli_ctx), self.return_dict, self.script.run_id, self.script.status, self.script.output, self.script.run_time)
-        if self.command_name == VM_REPAIR_AND_RESTORE_COMMAND:
-            _track_command_telemetry_repair_and_restore(self.logger, self.command_name, self.status, self.message, self.error_message, self.error_stack_trace, elapsed_time, get_subscription_id(self.cmd.cli_ctx))
+            _track_run_command_telemetry(self.logger, self.command_name, self.command_params, self.status, self.message, self.error_message, self.error_stack_trace, elapsed_time, get_subscription_id(self.cmd.cli_ctx), self.return_dict, self.script.run_id, self.script.status, self.script.output, self.script.run_time, self.os_family, self.vm_size, self.disk_controller_type, self.repair_vm_disk_controller_type, self.hyperv_generation)
+        elif self.command_name == VM_REPAIR_AND_RESTORE_COMMAND:
+            _track_command_telemetry_repair_and_restore(self.logger, self.command_name, self.status, self.message, self.error_message, self.error_stack_trace, elapsed_time, get_subscription_id(self.cmd.cli_ctx), self.os_family, self.vm_size, self.disk_controller_type, self.repair_vm_disk_controller_type, self.hyperv_generation)
         else:
-            _track_command_telemetry(self.logger, self.command_name, self.command_params, self.status, self.message, self.error_message, self.error_stack_trace, elapsed_time, get_subscription_id(self.cmd.cli_ctx), self.return_dict)
+            _track_command_telemetry(self.logger, self.command_name, self.command_params, self.status, self.message, self.error_message, self.error_stack_trace, elapsed_time, get_subscription_id(self.cmd.cli_ctx), self.return_dict, self.os_family, self.vm_size, self.disk_controller_type, self.repair_vm_disk_controller_type, self.hyperv_generation)
+
+    def set_resource_context(self, os_family=None, vm_size=None, disk_controller_type=None,
+                             repair_vm_disk_controller_type=None, hyperv_generation=None):
+        """Store resource-shape dimensions for telemetry without recording resource identity."""
+        if os_family is not None:
+            self.os_family = os_family
+        if vm_size is not None:
+            self.vm_size = vm_size
+        if disk_controller_type is not None:
+            self.disk_controller_type = disk_controller_type
+        if repair_vm_disk_controller_type is not None:
+            self.repair_vm_disk_controller_type = repair_vm_disk_controller_type
+        if hyperv_generation is not None:
+            self.hyperv_generation = hyperv_generation
 
     def set_status_success(self):
         """ Set command status to success """

--- a/src/vm-repair/azext_vm_repair/custom.py
+++ b/src/vm-repair/azext_vm_repair/custom.py
@@ -59,13 +59,15 @@ from .repair_utils import (
 logger = get_logger(__name__)
 
 
-def _set_source_resource_context(command, source_vm, source_vm_instance_view=None):
+def _set_source_resource_context(command, source_vm, source_vm_instance_view=None, disk_controller_type=None):
     """Populate telemetry-only resource shape without allowing enrichment to fail a command."""
-    storage_profile = getattr(source_vm, 'storage_profile', None)
-    source_controller = getattr(storage_profile, 'disk_controller_type', None)
-    source_controller = getattr(source_controller, 'value', source_controller)
-    if source_controller is not None:
-        source_controller = str(source_controller)
+    source_controller = disk_controller_type
+    if source_controller is None:
+        try:
+            # Shared helper falls back to an ARM query when the SDK does not model the field.
+            source_controller = _fetch_source_disk_controller_type(source_vm)
+        except Exception as exception:
+            logger.debug('Could not determine source VM disk controller type for telemetry: %s', exception)
 
     hyperv_generation = None
     if source_vm_instance_view:
@@ -161,7 +163,9 @@ def create(cmd, vm_name, resource_group_name, repair_password=None, repair_usern
         # Checking if the OS of the source VM is Linux and what the Hyper-V generation is.
         is_linux = _is_linux_os(source_vm)
         vm_hypervgen = _is_gen2(source_vm_instance_view)
-        _set_source_resource_context(command, source_vm, source_vm_instance_view)
+        source_controller = _fetch_source_disk_controller_type(source_vm)
+        _set_source_resource_context(command, source_vm, source_vm_instance_view,
+                                     disk_controller_type=source_controller)
 
         # Fetching the name of the OS disk and checking if it's managed.
         target_disk_name = source_vm.storage_profile.os_disk.name
@@ -280,9 +284,6 @@ def create(cmd, vm_name, resource_group_name, repair_password=None, repair_usern
         # Adding the size to the command.
         create_repair_vm_command += ' --size {sku}'.format(sku=sku)
 
-        source_controller = _fetch_source_disk_controller_type(source_vm)
-        if hasattr(command, 'set_resource_context'):
-            command.set_resource_context(disk_controller_type=source_controller)
         supported_controllers = []
         if not disk_controller_type and source_controller and str(source_controller).lower() == 'nvme':
             supported_controllers = _fetch_sku_disk_controller_types(sku, source_vm.location)

--- a/src/vm-repair/azext_vm_repair/custom.py
+++ b/src/vm-repair/azext_vm_repair/custom.py
@@ -59,6 +59,53 @@ from .repair_utils import (
 logger = get_logger(__name__)
 
 
+def _set_source_resource_context(command, source_vm, source_vm_instance_view=None):
+    """Populate telemetry-only resource shape without allowing enrichment to fail a command."""
+    storage_profile = getattr(source_vm, 'storage_profile', None)
+    source_controller = getattr(storage_profile, 'disk_controller_type', None)
+    source_controller = getattr(source_controller, 'value', source_controller)
+    if source_controller is not None:
+        source_controller = str(source_controller)
+
+    hyperv_generation = None
+    if source_vm_instance_view:
+        try:
+            hyperv_generation = 'V{}'.format(_is_gen2(source_vm_instance_view))
+        except (AttributeError, TypeError, ValueError) as exception:
+            logger.debug('Could not determine source VM Hyper-V generation for telemetry: %s', exception)
+
+    if hasattr(command, 'set_resource_context'):
+        hardware_profile = getattr(source_vm, 'hardware_profile', None)
+        command.set_resource_context(
+            os_family='linux' if _is_linux_os(source_vm) else 'windows',
+            vm_size=getattr(hardware_profile, 'vm_size', None),
+            disk_controller_type=source_controller,
+            hyperv_generation=hyperv_generation)
+    return source_controller
+
+
+def _enrich_source_resource_context(command, cmd, source_vm, resource_group_name, vm_name):
+    """Add instance-view telemetry when available without changing command success or failure."""
+    try:
+        source_vm_instance_view = get_vm(cmd, resource_group_name, vm_name, 'instanceView')
+    except Exception as exception:
+        logger.debug('Could not fetch source VM instance view for telemetry: %s', exception)
+        source_vm_instance_view = None
+    _set_source_resource_context(command, source_vm, source_vm_instance_view)
+
+
+def _enrich_repair_controller_context(command, cmd, resource_group_name, vm_name):
+    """Add the actual repair VM controller when available without changing command behavior."""
+    if not hasattr(command, 'set_resource_context'):
+        return
+    try:
+        repair_vm = get_vm(cmd, resource_group_name, vm_name)
+        repair_controller = _fetch_source_disk_controller_type(repair_vm)
+        command.set_resource_context(repair_vm_disk_controller_type=repair_controller)
+    except Exception as exception:
+        logger.debug('Could not fetch repair VM disk controller type for telemetry: %s', exception)
+
+
 def create(cmd, vm_name, resource_group_name, repair_password=None, repair_username=None, repair_vm_name=None, copy_disk_name=None, repair_group_name=None, unlock_encrypted_vm=False, enable_nested=False, associate_public_ip=False, distro='ubuntu', encrypt_recovery_key="", disable_trusted_launch=False, os_disk_type=None, tags=None, copy_tags=False, size=None, disk_controller_type=None, yes=False):
     """
     This function creates a repair VM.
@@ -114,6 +161,7 @@ def create(cmd, vm_name, resource_group_name, repair_password=None, repair_usern
         # Checking if the OS of the source VM is Linux and what the Hyper-V generation is.
         is_linux = _is_linux_os(source_vm)
         vm_hypervgen = _is_gen2(source_vm_instance_view)
+        _set_source_resource_context(command, source_vm, source_vm_instance_view)
 
         # Fetching the name of the OS disk and checking if it's managed.
         target_disk_name = source_vm.storage_profile.os_disk.name
@@ -232,15 +280,19 @@ def create(cmd, vm_name, resource_group_name, repair_password=None, repair_usern
         # Adding the size to the command.
         create_repair_vm_command += ' --size {sku}'.format(sku=sku)
 
-        source_controller = None if disk_controller_type else _fetch_source_disk_controller_type(source_vm)
+        source_controller = _fetch_source_disk_controller_type(source_vm)
+        if hasattr(command, 'set_resource_context'):
+            command.set_resource_context(disk_controller_type=source_controller)
         supported_controllers = []
-        if source_controller and str(source_controller).lower() == 'nvme':
+        if not disk_controller_type and source_controller and str(source_controller).lower() == 'nvme':
             supported_controllers = _fetch_sku_disk_controller_types(sku, source_vm.location)
         selected_controller, level, message = _select_repair_disk_controller_type(
             source_controller, supported_controllers, disk_controller_type)
         getattr(logger, level)(message)
         if selected_controller:
             create_repair_vm_command += ' --disk-controller-type {controller}'.format(controller=selected_controller)
+        if hasattr(command, 'set_resource_context'):
+            command.set_resource_context(repair_vm_disk_controller_type=selected_controller)
 
         # Setting the availability zone for the repair VM.
         # If the source VM has availability zones, the first one is chosen for the repair VM.
@@ -521,12 +573,16 @@ def restore(cmd, vm_name, resource_group_name, disk_name=None, repair_vm_id=None
     try:
         # Fetch source and repair VM data
         source_vm = get_vm(cmd, resource_group_name, vm_name)  # Fetch the source VM data
+        _enrich_source_resource_context(
+            command, cmd, source_vm, resource_group_name, vm_name)
         is_managed = _uses_managed_disk(source_vm)  # Check if the source VM uses managed disks
         if repair_vm_id:
             logger.info('Repair VM ID: %s', repair_vm_id)
             repair_vm_id = parse_resource_id(repair_vm_id)  # Parse the repair VM ID
             repair_vm_name = repair_vm_id['name']
             repair_resource_group = repair_vm_id['resource_group']
+            _enrich_repair_controller_context(
+                command, cmd, repair_resource_group, repair_vm_name)
 
             # For MANAGED DISK
             if is_managed:
@@ -634,6 +690,8 @@ def run(cmd, vm_name, resource_group_name, run_id=None, repair_vm_id=None, custo
 
         # Determine the OS of the source VM
         is_linux = _is_linux_os(source_vm)
+        _enrich_source_resource_context(
+            command, cmd, source_vm, resource_group_name, vm_name)
 
         # Choose the appropriate script based on the OS of the source VM
         if is_linux:
@@ -646,9 +704,14 @@ def run(cmd, vm_name, resource_group_name, run_id=None, repair_vm_id=None, custo
             repair_vm_id = parse_resource_id(repair_vm_id)
             repair_vm_name = repair_vm_id['name']
             repair_resource_group = repair_vm_id['resource_group']
+            _enrich_repair_controller_context(
+                command, cmd, repair_resource_group, repair_vm_name)
         else:
             repair_vm_name = vm_name
             repair_resource_group = resource_group_name
+            if hasattr(command, 'set_resource_context'):
+                command.set_resource_context(
+                    repair_vm_disk_controller_type=command.disk_controller_type)
 
         run_command_params = []
         additional_scripts = []
@@ -1010,6 +1073,13 @@ def repair_and_restore(cmd, vm_name, resource_group_name, repair_password=None, 
     # Initialize command helper object
     command = command_helper(logger, cmd, 'vm repair repair-and-restore')
 
+    try:
+        source_vm = get_vm(cmd, resource_group_name, vm_name)
+        _enrich_source_resource_context(
+            command, cmd, source_vm, resource_group_name, vm_name)
+    except Exception as exception:
+        logger.debug('Could not fetch source VM resource shape for telemetry: %s', exception)
+
     # Generate a random password for the repair operation
     password_length = 30
     password_characters = string.ascii_lowercase + string.digits + string.ascii_uppercase
@@ -1039,6 +1109,8 @@ def repair_and_restore(cmd, vm_name, resource_group_name, repair_password=None, 
     repair_vm_name = create_out['repair_vm_name']
     copy_disk_name = create_out['copied_disk_name']
     repair_group_name = create_out['repair_resource_group']
+    _enrich_repair_controller_context(
+        command, cmd, repair_group_name, repair_vm_name)
 
     # Log that the fstab run command is about to be executed
     logger.info('Running fstab run command')

--- a/src/vm-repair/azext_vm_repair/telemetry.py
+++ b/src/vm-repair/azext_vm_repair/telemetry.py
@@ -16,7 +16,18 @@ tc = TelemetryClient(PROD_KEY)
 tc.context.application.ver = _get_current_vmrepair_version()
 
 
-def _track_command_telemetry(logger, command_name, parameters, status, message, error_message, error_stack_trace, duration, subscription_id, result_json):
+def _resource_context_properties(os_family, vm_size, disk_controller_type,
+                                 repair_vm_disk_controller_type, hyperv_generation):
+    return {
+        'os_family': os_family,
+        'vm_size': vm_size,
+        'disk_controller_type': disk_controller_type,
+        'repair_vm_disk_controller_type': repair_vm_disk_controller_type,
+        'hyperv_generation': hyperv_generation
+    }
+
+
+def _track_command_telemetry(logger, command_name, parameters, status, message, error_message, error_stack_trace, duration, subscription_id, result_json, os_family=None, vm_size=None, disk_controller_type=None, repair_vm_disk_controller_type=None, hyperv_generation=None):
     try:
         properties = {
             'command_name': command_name,
@@ -28,6 +39,9 @@ def _track_command_telemetry(logger, command_name, parameters, status, message, 
             'subscription_id': subscription_id,
             'result_json': json.dumps(result_json)
         }
+        properties.update(_resource_context_properties(
+            os_family, vm_size, disk_controller_type,
+            repair_vm_disk_controller_type, hyperv_generation))
         measurements = {'command_duration': duration}
         tc.track_event(command_name, properties, measurements)
         tc.flush()
@@ -35,7 +49,7 @@ def _track_command_telemetry(logger, command_name, parameters, status, message, 
         logger.error('Unexpected error sending telemetry with exception: %s', str(exception))
 
 
-def _track_run_command_telemetry(logger, command_name, parameters, status, message, error_message, error_stack_trace, duration, subscription_id, result_json, script_run_id, script_status, script_output, script_duration):
+def _track_run_command_telemetry(logger, command_name, parameters, status, message, error_message, error_stack_trace, duration, subscription_id, result_json, script_run_id, script_status, script_output, script_duration, os_family=None, vm_size=None, disk_controller_type=None, repair_vm_disk_controller_type=None, hyperv_generation=None):
     try:
         properties = {
             'command_name': command_name,
@@ -50,6 +64,9 @@ def _track_run_command_telemetry(logger, command_name, parameters, status, messa
             'script_status': script_status,
             'script_output': script_output
         }
+        properties.update(_resource_context_properties(
+            os_family, vm_size, disk_controller_type,
+            repair_vm_disk_controller_type, hyperv_generation))
         measurements = {'command_duration': duration, 'script_duration': script_duration}
         tc.track_event(command_name, properties, measurements)
         tc.flush()
@@ -57,7 +74,7 @@ def _track_run_command_telemetry(logger, command_name, parameters, status, messa
         logger.error('Unexpected error sending telemetry with exception: %s', str(exception))
 
 
-def _track_command_telemetry_repair_and_restore(logger, command_name, status, message, error_message, error_stack_trace, duration, subscription_id):
+def _track_command_telemetry_repair_and_restore(logger, command_name, status, message, error_message, error_stack_trace, duration, subscription_id, os_family=None, vm_size=None, disk_controller_type=None, repair_vm_disk_controller_type=None, hyperv_generation=None):
     try:
         properties = {
             'command_name': command_name,
@@ -67,6 +84,9 @@ def _track_command_telemetry_repair_and_restore(logger, command_name, status, me
             'error_stack_trace': error_stack_trace,
             'subscription_id': subscription_id
         }
+        properties.update(_resource_context_properties(
+            os_family, vm_size, disk_controller_type,
+            repair_vm_disk_controller_type, hyperv_generation))
         measurements = {'command_duration': duration}
         tc.track_event(command_name, properties, measurements)
         tc.flush()

--- a/src/vm-repair/azext_vm_repair/tests/latest/test_telemetry_dimensions.py
+++ b/src/vm-repair/azext_vm_repair/tests/latest/test_telemetry_dimensions.py
@@ -1,0 +1,138 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import gc
+import unittest
+from unittest.mock import Mock, patch
+
+from azext_vm_repair import telemetry
+from azext_vm_repair.command_helper_class import command_helper, script_data
+
+
+RESOURCE_DIMENSIONS = {
+    'os_family': 'windows',
+    'vm_size': 'Standard_D2ds_v6',
+    'disk_controller_type': 'NVMe',
+    'repair_vm_disk_controller_type': 'SCSI',
+    'hyperv_generation': 'V2'
+}
+
+
+class ResourceContextOnlyHelper(command_helper):
+    def __del__(self):
+        pass
+
+
+class TelemetryDimensionTests(unittest.TestCase):
+
+    def setUp(self):
+        self.logger = Mock()
+
+    def _track_generic(self, **resource_context):
+        telemetry._track_command_telemetry(
+            self.logger, 'vm repair create', {}, 'SUCCESS', '', '', '', 1.0,
+            'subscription', {}, **resource_context)
+
+    @patch.object(telemetry.tc, 'flush')
+    @patch.object(telemetry.tc, 'track_event')
+    def test_dimensions_present(self, track_event, _):
+        self._track_generic(**RESOURCE_DIMENSIONS)
+
+        properties = track_event.call_args.args[1]
+        for name, value in RESOURCE_DIMENSIONS.items():
+            self.assertEqual(value, properties[name])
+
+    @patch.object(telemetry.tc, 'flush')
+    @patch.object(telemetry.tc, 'track_event')
+    def test_dimensions_default_none(self, track_event, _):
+        self._track_generic()
+
+        properties = track_event.call_args.args[1]
+        for name in RESOURCE_DIMENSIONS:
+            self.assertIn(name, properties)
+            self.assertIsNone(properties[name])
+
+    @patch.object(telemetry.tc, 'flush')
+    @patch.object(telemetry.tc, 'track_event')
+    def test_all_event_types_include_dimensions(self, track_event, _):
+        telemetry._track_run_command_telemetry(
+            self.logger, 'vm repair run', {}, 'SUCCESS', '', '', '', 1.0,
+            'subscription', {}, 'run-id', 'SUCCESS', '', 0.5,
+            **RESOURCE_DIMENSIONS)
+        telemetry._track_command_telemetry_repair_and_restore(
+            self.logger, 'vm repair repair-and-restore', 'SUCCESS', '', '', '',
+            1.0, 'subscription', **RESOURCE_DIMENSIONS)
+
+        self.assertEqual(2, track_event.call_count)
+        for call in track_event.call_args_list:
+            properties = call.args[1]
+            for name, value in RESOURCE_DIMENSIONS.items():
+                self.assertEqual(value, properties[name])
+
+    @patch.object(telemetry.tc, 'flush')
+    @patch.object(telemetry.tc, 'track_event')
+    def test_no_customer_content(self, track_event, _):
+        self._track_generic(**RESOURCE_DIMENSIONS)
+
+        properties = track_event.call_args.args[1]
+        resource_shape = {name: properties[name] for name in RESOURCE_DIMENSIONS}
+        serialized_shape = str(resource_shape)
+        self.assertNotIn('customer-vm-name', serialized_shape)
+        self.assertNotIn('customer-resource-group', serialized_shape)
+        self.assertNotIn('customer-disk-name', serialized_shape)
+
+    def test_set_resource_context_preserves_existing_values(self):
+        helper = ResourceContextOnlyHelper.__new__(ResourceContextOnlyHelper)
+        helper.os_family = None
+        helper.vm_size = None
+        helper.disk_controller_type = None
+        helper.repair_vm_disk_controller_type = None
+        helper.hyperv_generation = None
+
+        helper.set_resource_context(
+            os_family='linux', vm_size='Standard_D2ds_v6',
+            disk_controller_type='NVMe', hyperv_generation='V2')
+        helper.set_resource_context(repair_vm_disk_controller_type='SCSI')
+
+        self.assertEqual('linux', helper.os_family)
+        self.assertEqual('Standard_D2ds_v6', helper.vm_size)
+        self.assertEqual('NVMe', helper.disk_controller_type)
+        self.assertEqual('SCSI', helper.repair_vm_disk_controller_type)
+        self.assertEqual('V2', helper.hyperv_generation)
+
+    @patch('azext_vm_repair.command_helper_class.get_subscription_id', return_value='subscription')
+    @patch('azext_vm_repair.command_helper_class._track_command_telemetry_repair_and_restore')
+    @patch('azext_vm_repair.command_helper_class._track_command_telemetry')
+    @patch('azext_vm_repair.command_helper_class._track_run_command_telemetry')
+    def test_run_command_emits_once(self, track_run, track_generic, track_repair_and_restore, _):
+        helper = command_helper.__new__(command_helper)
+        helper.start_time = 0
+        helper.logger = self.logger
+        helper.cmd = Mock()
+        helper.command_name = 'vm repair run'
+        helper.command_params = {'run_id': 'linux-alar2'}
+        helper.status = 'SUCCESS'
+        helper.message = ''
+        helper.error_message = ''
+        helper.error_stack_trace = ''
+        helper.return_dict = {}
+        helper.is_verbose = True
+        helper.script = script_data()
+        helper.os_family = 'linux'
+        helper.vm_size = 'Standard_D2ds_v6'
+        helper.disk_controller_type = 'NVMe'
+        helper.repair_vm_disk_controller_type = 'SCSI'
+        helper.hyperv_generation = 'V2'
+
+        del helper
+        gc.collect()
+
+        track_run.assert_called_once()
+        track_generic.assert_not_called()
+        track_repair_and_restore.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/vm-repair/azext_vm_repair/tests/latest/test_telemetry_dimensions.py
+++ b/src/vm-repair/azext_vm_repair/tests/latest/test_telemetry_dimensions.py
@@ -7,7 +7,7 @@ import gc
 import unittest
 from unittest.mock import Mock, patch
 
-from azext_vm_repair import telemetry
+from azext_vm_repair import custom, telemetry
 from azext_vm_repair.command_helper_class import command_helper, script_data
 
 
@@ -132,6 +132,51 @@ class TelemetryDimensionTests(unittest.TestCase):
         track_run.assert_called_once()
         track_generic.assert_not_called()
         track_repair_and_restore.assert_not_called()
+
+
+class SourceResourceContextTests(unittest.TestCase):
+
+    def setUp(self):
+        self.command = ResourceContextOnlyHelper.__new__(ResourceContextOnlyHelper)
+        self.command.os_family = None
+        self.command.vm_size = None
+        self.command.disk_controller_type = None
+        self.command.repair_vm_disk_controller_type = None
+        self.command.hyperv_generation = None
+
+    @staticmethod
+    def _legacy_sdk_vm():
+        """Source VM as returned by an older compute SDK that does not model diskControllerType."""
+        source_vm = Mock()
+        source_vm.id = '/subscriptions/s/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm'
+        source_vm.storage_profile = Mock(spec=[])
+        source_vm.hardware_profile = Mock(vm_size='Standard_D2ds_v6')
+        return source_vm
+
+    @patch('azext_vm_repair.custom._is_linux_os', return_value=False)
+    @patch('azext_vm_repair.repair_utils._call_az_command', return_value='NVMe\n')
+    def test_controller_uses_arm_fallback_on_older_sdk(self, call_az, _):
+        custom._set_source_resource_context(self.command, self._legacy_sdk_vm())
+
+        self.assertEqual('NVMe', self.command.disk_controller_type)
+        call_az.assert_called_once()
+
+    @patch('azext_vm_repair.custom._is_linux_os', return_value=False)
+    @patch('azext_vm_repair.repair_utils._call_az_command', side_effect=Exception('ARM unavailable'))
+    def test_controller_fallback_failure_does_not_raise(self, call_az, _):
+        custom._set_source_resource_context(self.command, self._legacy_sdk_vm())
+
+        self.assertIsNone(self.command.disk_controller_type)
+        self.assertEqual('windows', self.command.os_family)
+
+    @patch('azext_vm_repair.custom._is_linux_os', return_value=False)
+    @patch('azext_vm_repair.repair_utils._call_az_command')
+    def test_supplied_controller_skips_extra_arm_call(self, call_az, _):
+        custom._set_source_resource_context(
+            self.command, self._legacy_sdk_vm(), disk_controller_type='SCSI')
+
+        self.assertEqual('SCSI', self.command.disk_controller_type)
+        call_az.assert_not_called()
 
 
 if __name__ == '__main__':

--- a/src/vm-repair/setup.py
+++ b/src/vm-repair/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup, find_packages
 
-VERSION = "2.3.2"
+VERSION = "2.4.0"
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',

--- a/src/vm-repair/setup.py
+++ b/src/vm-repair/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup, find_packages
 
-VERSION = "2.4.0"
+VERSION = "2.4.1"
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes |
| :--: |
| ️✔️ None |

<!-- act-bot:section title="Azure CLI Extensions Breaking Change Test" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->



---
### Related command

`az vm repair create`, `az vm repair run`, `az vm repair restore`, and `az vm repair repair-and-restore`

## Requested by / source

- Feature 37971694
- Requested by Bila / Gabriela Limoli
- Implementation plan: `NVMe-PR-Extension.md`

## Type

- [x] Feature (minor)
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation only

## Changes

- `azext_vm_repair/telemetry.py`
  - Adds `os_family`, `vm_size`, `disk_controller_type`, `repair_vm_disk_controller_type`, and `hyperv_generation` to generic, run-specific, and repair-and-restore telemetry events.
- `azext_vm_repair/command_helper_class.py`
  - Adds a plain `set_resource_context` setter with `None` defaults.
  - Passes resource context through all telemetry event paths.
  - Changes telemetry dispatch to `if` / `elif` / `else`, preventing `vm repair run` from also emitting a generic event.
- `azext_vm_repair/custom.py`
  - Populates resource context in create, run, restore, and repair-and-restore paths.
  - Keeps telemetry-only enrichment non-fatal and outside the destructor.
  - Records the controller selected for the repair VM and, where available, the actual controller reported by an existing repair VM.
- `azext_vm_repair/tests/latest/test_telemetry_dimensions.py`
  - Verifies all dimensions are emitted by all three telemetry functions.
  - Verifies dimensions default to `None`.
  - Verifies resource-shape dimensions exclude VM, resource-group, and disk identity.
  - Adds a regression test proving `vm repair run` emits exactly once.
- `setup.py` / `HISTORY.rst`
  - Bumps 2.3.2 to 2.4.0 and documents the metrics discontinuity.

## Version & changelog

- `setup.py` VERSION: 2.3.2 → 2.4.0
- `HISTORY.rst` top entry added: yes
- Release metadata explicitly approved before commit.

This is a minor version bump because the PR adds a backward-compatible telemetry capability and schema dimensions. Version 2.3.3 would indicate a patch-only bug fix, but this PR does more than correct duplicate events: it adds five new observable fields and resource-context collection across command paths. No command-line surface is broken.

## Testing

- Regression proof against `origin/main`: `test_run_command_emits_once` fails because `_track_command_telemetry` is called once in addition to run telemetry.
- Branch result: the same regression test passes.
- Unit suite: 70 tests passed, 35 live-only tests skipped.
- Focused telemetry/controller/no-cleanup suite: 28 tests passed.
- Intended-file `git diff --check`: passed.
- VS Code diagnostics: no errors in changed source and test files.
- `azdev style vm-repair`: passed (Pylint and Flake8).
- `azdev linter vm-repair`: passed.
- `python scripts/ci/test_index.py -q`: passed (9 tests, 2 skipped).
- `azdev test vm-repair`: blocked before test discovery by local `az cloud show` launch failure (`WinError 2`). The direct extension unit suite above passed.
- Live Azure tests: not run.

### General Guidelines

- [x] Have you run `azdev style vm-repair` locally?
- [x] Have you run `python scripts/ci/test_index.py -q` locally?
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md).

The “For new extensions” checklist does not apply because `vm-repair` is an existing extension.

### About Extension Publish

Only `setup.py` and `HISTORY.rst` were updated for release metadata. `src/index.json` was not modified; the publication pipeline will create the index update after merge.

## N3 measurement

Pending. Existing telemetry has no disk-controller dimension, so retrospective NVMe volume cannot be measured directly. The N3 report must deduplicate historical run events and present any affected-volume estimate as an upper bound rather than an NVMe count.

## Privacy review

The five new values are resource shape only:

- OS family: `linux` or `windows`
- VM size/SKU
- Source disk controller: `SCSI` or `NVMe` when available
- Repair VM disk controller: `SCSI` or `NVMe` when available
- Hyper-V generation: `V1` or `V2` when available

The new dimensions do not include VM names, resource-group names, disk names, resource IDs, credentials, tags, script arguments, or script output. Formal privacy sign-off remains required before merge.

## Security review

- No new shell command construction from untrusted input.
- No credentials or secrets added to telemetry.
- No network work is performed from `command_helper.__del__`.
- Telemetry enrichment failures are caught and logged at debug level so they do not change repair command success or failure.

## Cross-repo impact

No `repair-script-library` run-id, script, or `map.json` contract is changed by this PR. The companion script-library work is separate.

## Backward compatibility

- No command names, parameters, defaults, or repair behavior changed.
- Missing resource context is emitted as `None` rather than causing command failure.
- Dashboard trends across 2.4.0 will show an apparent drop in `vm repair run` counts because duplicate events are removed.

