### PR TITLE
Scrub New Relic ingestion keys from test recordings

### DIFF
--- a/src/new-relic/azext_new_relic/tests/latest/recording_processors.py
+++ b/src/new-relic/azext_new_relic/tests/latest/recording_processors.py
@@ -26,7 +26,10 @@ class NewRelicSecretScrubber(RecordingProcessor):
 
     @staticmethod
     def _scrub(entity):
-        body = entity.get("body", {})
+        body = entity.get("body")
+        if not isinstance(body, dict):
+            return entity
+
         if is_text_payload(entity) and body.get("string"):
             entity["body"]["string"] = _INGESTION_KEY_RE.sub(
                 rf"\g<1>{MOCK_INGESTION_KEY}\g<2>",

--- a/src/new-relic/azext_new_relic/tests/latest/recording_processors.py
+++ b/src/new-relic/azext_new_relic/tests/latest/recording_processors.py
@@ -1,0 +1,35 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import re
+
+from azure.cli.testsdk.scenario_tests import RecordingProcessor
+from azure.cli.testsdk.scenario_tests.utilities import is_text_payload
+
+
+MOCK_INGESTION_KEY = "fake-ingestion-key"
+_INGESTION_KEY_RE = re.compile(
+    r'("ingestionKey"\s*:\s*")[^"]+(")',
+    re.IGNORECASE,
+)
+
+
+class NewRelicSecretScrubber(RecordingProcessor):
+
+    def process_request(self, request):
+        return self._scrub(request)
+
+    def process_response(self, response):
+        return self._scrub(response)
+
+    @staticmethod
+    def _scrub(entity):
+        body = entity.get("body", {})
+        if is_text_payload(entity) and body.get("string"):
+            entity["body"]["string"] = _INGESTION_KEY_RE.sub(
+                rf"\g<1>{MOCK_INGESTION_KEY}\g<2>",
+                entity["body"]["string"],
+            )
+        return entity

--- a/src/new-relic/azext_new_relic/tests/latest/recordings/test_new_relic_monitor.yaml
+++ b/src/new-relic/azext_new_relic/tests/latest/recordings/test_new_relic_monitor.yaml
@@ -1327,7 +1327,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_new_relic_monitor000001/providers/NewRelic.Observability/monitors/test-new-relic-monitor/vmHostPayloads?api-version=2026-06-01
   response:
     body:
-      string: '{"ingestionKey":"feafe32045caa054d172d9b7942a38d89a43NRAL"}'
+      string: '{"ingestionKey":"fake-ingestion-key"}'
     headers:
       cache-control:
       - no-cache

--- a/src/new-relic/azext_new_relic/tests/latest/test_new_relic.py
+++ b/src/new-relic/azext_new_relic/tests/latest/test_new_relic.py
@@ -8,8 +8,16 @@
 from azure.cli.testsdk.scenario_tests import AllowLargeResponse
 from azure.cli.testsdk import ScenarioTest, ResourceGroupPreparer
 
+from .recording_processors import NewRelicSecretScrubber
+
 
 class NewRelicScenario(ScenarioTest):
+
+    def __init__(self, method_name):
+        super().__init__(
+            method_name,
+            recording_processors=[NewRelicSecretScrubber()],
+        )
 
     @AllowLargeResponse(size_kb=10240)
     @ResourceGroupPreparer(name_prefix='cli_test_new_relic_monitor')

--- a/src/new-relic/azext_new_relic/tests/latest/test_recording_processors.py
+++ b/src/new-relic/azext_new_relic/tests/latest/test_recording_processors.py
@@ -1,0 +1,21 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from .recording_processors import MOCK_INGESTION_KEY, NewRelicSecretScrubber
+
+
+def test_new_relic_secret_scrubber():
+    processor = NewRelicSecretScrubber()
+    expected = f'{{"ingestionKey":"{MOCK_INGESTION_KEY}"}}'
+
+    for process in (processor.process_request, processor.process_response):
+        entity = {
+            "headers": {"content-type": ["application/json"]},
+            "body": {"string": '{"ingestionKey":"live-key-value"}'},
+        }
+
+        scrubbed = process(entity)
+
+        assert scrubbed["body"]["string"] == expected

--- a/src/new-relic/azext_new_relic/tests/latest/test_recording_processors.py
+++ b/src/new-relic/azext_new_relic/tests/latest/test_recording_processors.py
@@ -19,3 +19,15 @@ def test_new_relic_secret_scrubber():
         scrubbed = process(entity)
 
         assert scrubbed["body"]["string"] == expected
+
+
+def test_new_relic_secret_scrubber_ignores_unsupported_body():
+    processor = NewRelicSecretScrubber()
+
+    for process in (processor.process_request, processor.process_response):
+        for entity in (
+            {"headers": {}},
+            {"headers": {}, "body": None},
+            {"headers": {}, "body": "not-a-dictionary"},
+        ):
+            assert process(entity) == entity


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes |
| :--: |
| ️✔️ None |

<!-- act-bot:section title="Azure CLI Extensions Breaking Change Test" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

## Summary
- replace the recorded New Relic ingestion credential with a non-secret placeholder
- scrub `ingestionKey` values from recorded request and response bodies
- add regression coverage for both recording processor paths

## Security
Addresses secret-scanning alert #618. The exposed credential should be treated as compromised and invalidated by the service/security owner; this PR prevents it from remaining at the current default-branch path or recurring in future recordings.

## Validation
- `azdev test new-relic` (2 passed)
- `azdev style new-relic`
- `azdev linter new-relic`
- cassette scan: 0 key-shaped tokens