### PR TITLE
Quantum: Don't use endpoint cache when workspace doesn't match

### DIFF
--- a/src/quantum/HISTORY.rst
+++ b/src/quantum/HISTORY.rst
@@ -3,6 +3,12 @@
 Release History
 ===============
 
+1.0.0b26
+++++++++++
+* Scoped the workspace endpoint cache to its subscription, resource group, workspace, cloud, and tenant so it is not reused for other workspaces.
+* Moved the cache to ``quantum.workspace_endpoint_cache``. Re-run ``az quantum workspace set`` to populate the new cache.
+* Clarified the persistent flag defaults and endpoint caching performed by ``az quantum workspace set``. Automatic stale-endpoint invalidation is not included.
+
 1.0.0b25
 ++++++++++++++
 * Added the ``az quantum suite-offer list`` command to list the suite offers available to the subscription, including provider, location, and subscription-level quota allocations.

--- a/src/quantum/README.rst
+++ b/src/quantum/README.rst
@@ -87,23 +87,33 @@ Prepare to submit and manage jobs in Azure Quantum using the `az quantum` extens
 
 
 4. You can use `quantum workspace set` to select a default workspace you want to use to list and submit jobs.
-   Note that you also need to specify the resource group. If you set a default workspace by providing a resource group,
-   workspace name and location, you don't need to include those parameters in commands #5 to #8 below.
-   Anternatively, you can include them in each call.
+   This saves the resource group and workspace name as persistent Azure CLI flag defaults. The resource-group default
+   also applies to other Azure CLI commands. The default subscription and location are not changed. Alternatively,
+   you can specify the resource group and workspace name in each call without setting defaults.
 
    .. code-block::
 
-      az quantum workspace set -g MyResourceGroup -w MyWorkspace -l MyLocation -o table
+      az quantum workspace set -g MyResourceGroup -w MyWorkspace -o table
 
       Location     Name                               ResourceGroup
       -----------  ---------------------------------  --------------------------------
       westus       ws-yyyyyy                          rg-yyyyyyyyy
 
 
-.. note:
+.. note::
    Commands below assume that a default workspace has been set. If you prefer to specify it
    for each call, include the following parameters with commands below:
-   `-g MyResourceGroup -w MyWorkspace -l MyLocation`
+   `-g MyResourceGroup -w MyWorkspace`.
+
+   Explicit flags override their respective defaults independently. For example, specifying only `-w OtherWorkspace`
+   uses the saved resource group. A one-off job read does not change the saved defaults:
+
+   .. code-block::
+
+      az quantum job show --subscription OtherSubscription -g OtherGroup -w OtherWorkspace -j MyJobId
+
+   Use `az quantum workspace clear` to clear the resource-group and workspace-name defaults without changing
+   other settings.
 
 
 5. You can check the current default workspace with command `az quantum workspace show`.

--- a/src/quantum/azext_quantum/_help.py
+++ b/src/quantum/azext_quantum/_help.py
@@ -317,6 +317,8 @@ helps['quantum workspace'] = """
 helps['quantum workspace clear'] = """
     type: command
     short-summary: Clear the default Azure Quantum workspace.
+    long-summary: |
+        Clear the saved resource-group and workspace-name defaults and the workspace's cached endpoint. Other settings, including the default subscription, location, and target, are unchanged.
     examples:
       - name: Clear the default Azure Quantum workspace if previously set.
         text: |-
@@ -379,6 +381,12 @@ helps['quantum workspace quotas'] = """
 helps['quantum workspace set'] = """
     type: command
     short-summary: Select a default Azure Quantum workspace for future commands.
+    long-summary: |
+        Save the resource group and workspace name as persistent Azure CLI flag defaults, and save the workspace's data-plane endpoint in quantum.workspace_endpoint_cache. The resource-group default is shared with other Azure CLI commands. These settings persist across terminal sessions.
+
+        Explicit --resource-group and --workspace-name arguments override their respective defaults independently. The endpoint cache is reused only when the resolved subscription, resource group, workspace name, cloud, and tenant match the saved identity. Data-plane commands targeting another workspace discover its endpoint through Azure Resource Manager without changing the saved defaults.
+
+        This command does not change the default subscription or location. Cached endpoints are not automatically refreshed; run this command again to refresh the saved endpoint. Use 'az quantum workspace clear' to clear the saved flag defaults and Quantum endpoint cache.
     examples:
       - name: Set the default Azure Quantum workspace.
         text: |-

--- a/src/quantum/azext_quantum/operations/workspace.py
+++ b/src/quantum/azext_quantum/operations/workspace.py
@@ -60,6 +60,8 @@ C4A_TERMS_ACCEPTANCE_MESSAGE = "\nBy continuing you accept the Azure Quantum ter
 
 
 class WorkspaceInfo:
+    _ENDPOINT_CACHE_KEY = 'workspace_endpoint_cache'
+
     def __init__(self, cmd, resource_group_name=None, workspace_name=None, endpoint=None):
         from azure.cli.core.commands.client_factory import get_subscription_id
 
@@ -75,7 +77,35 @@ class WorkspaceInfo:
         self.subscription = get_subscription_id(cmd.cli_ctx)
         self.resource_group = select_value('group', resource_group_name)
         self.name = select_value('workspace', workspace_name)
-        self.endpoint = select_value('endpoint', endpoint)
+        self.endpoint = endpoint if endpoint is not None else self._get_cached_endpoint(cmd)
+
+    def _endpoint_cache_identity(self, cmd):
+        from azure.cli.core._profile import Profile
+
+        if not all((self.subscription, self.resource_group, self.name)):
+            return None
+        subscription = Profile(cli_ctx=cmd.cli_ctx).get_subscription(self.subscription)
+        return {
+            'resource_id': _get_workspace_resource_id(self).lower(),
+            'arm_endpoint': cmd.cli_ctx.cloud.endpoints.resource_manager.rstrip('/').lower(),
+            'tenant_id': subscription['tenantId'].lower(),
+        }
+
+    def _get_cached_endpoint(self, cmd):
+        value = cmd.cli_ctx.config.get('quantum', self._ENDPOINT_CACHE_KEY, None)
+        if not value:
+            return None
+        try:
+            cache = json.loads(value)
+        except (TypeError, ValueError):
+            return None
+        if not isinstance(cache, dict) or cache.get('version') != 1:
+            return None
+        identity = self._endpoint_cache_identity(cmd)
+        if not identity or any(cache.get(key) != value for key, value in identity.items()):
+            return None
+        endpoint = cache.get('endpoint')
+        return endpoint if isinstance(endpoint, str) and endpoint else None
 
     def clear(self):
         self.subscription = ''
@@ -86,11 +116,15 @@ class WorkspaceInfo:
     def save(self, cmd, endpoint=''):
         from azure.cli.core.util import ConfiguredDefaultSetter
 
-        # Save in the global [defaults] section of the .azure\config file
+        identity = self._endpoint_cache_identity(cmd) if endpoint else None
         with ConfiguredDefaultSetter(cmd.cli_ctx.config, False):
             cmd.cli_ctx.config.set_value(cmd.cli_ctx.config.defaults_section_name, 'group', self.resource_group)
             cmd.cli_ctx.config.set_value(cmd.cli_ctx.config.defaults_section_name, 'workspace', self.name)
-            cmd.cli_ctx.config.set_value(cmd.cli_ctx.config.defaults_section_name, 'endpoint', endpoint)
+            if identity:
+                cache = dict(identity, version=1, endpoint=endpoint)
+                cmd.cli_ctx.config.set_value('quantum', self._ENDPOINT_CACHE_KEY, json.dumps(cache))
+            else:
+                cmd.cli_ctx.config.remove_option('quantum', self._ENDPOINT_CACHE_KEY)
 
 
 def _show_tip(msg):
@@ -454,7 +488,7 @@ def quotas(cmd, resource_group_name, workspace_name):
 
 def set(cmd, workspace_name, resource_group_name):
     """
-    Set the default Azure Quantum workspace.
+    Save resource-group and workspace-name defaults and the workspace's data-plane endpoint cache.
     """
     client = cf_workspaces(cmd.cli_ctx)
     info = WorkspaceInfo(cmd, resource_group_name, workspace_name)

--- a/src/quantum/azext_quantum/tests/latest/test_workspace_endpoint_cache.py
+++ b/src/quantum/azext_quantum/tests/latest/test_workspace_endpoint_cache.py
@@ -1,0 +1,213 @@
+import json
+import os
+import unittest
+from contextlib import ExitStack
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from azure.core.exceptions import ResourceNotFoundError
+from knack.config import CLIConfig
+
+from ..._client_factory import cf_jobs, cf_providers, cf_quotas
+from ...operations.job import job_show
+from ...operations.workspace import WorkspaceInfo, clear, set as set_workspace
+
+
+class WorkspaceEndpointCacheTest(unittest.TestCase):
+    def setUp(self):
+        directory = TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        self.config = CLIConfig(config_dir=directory.name, config_env_var_prefix='QUANTUM_CACHE_TEST',
+                                use_local_config=False)
+        self.cloud = SimpleNamespace(endpoints=SimpleNamespace(resource_manager='https://management.azure.com/'))
+        self.cmd = SimpleNamespace(cli_ctx=SimpleNamespace(config=self.config, cloud=self.cloud))
+        stack = ExitStack()
+        self.addCleanup(stack.close)
+        self.subscription = stack.enter_context(patch(
+            'azure.cli.core.commands.client_factory.get_subscription_id', return_value='saved-subscription'))
+        self.profile = stack.enter_context(patch('azure.cli.core._profile.Profile'))
+        self.profile.return_value.get_subscription.return_value = {'tenantId': 'saved-tenant'}
+        self.endpoint = 'https://saved-workspace.eastus.quantum.azure.com'
+        self.other_endpoint = 'https://other-workspace.westus-v2.quantum.azure.com'
+        self.arm = stack.enter_context(patch('azext_quantum._client_factory.cf_workspaces'))
+        self.arm.return_value.get.return_value.properties.endpoint_uri = self.other_endpoint
+        self.credentials = stack.enter_context(patch('azext_quantum._client_factory._get_data_credentials'))
+        self.client = stack.enter_context(patch('azext_quantum._client_factory.WorkspaceClient'))
+
+    def save_workspace(self):
+        WorkspaceInfo(self.cmd, 'saved-group', 'saved-workspace').save(self.cmd, self.endpoint)
+
+    def test_save_namespaced_cache_with_identity(self):
+        self.config.set_value('defaults', 'endpoint', 'devcenter-endpoint')
+        self.save_workspace()
+
+        cache = json.loads(self.config.get('quantum', 'workspace_endpoint_cache', '{}'))
+        self.assertEqual(cache, {
+            'version': 1,
+            'resource_id': '/subscriptions/saved-subscription/resourcegroups/saved-group/'
+                           'providers/microsoft.quantum/workspaces/saved-workspace',
+            'arm_endpoint': 'https://management.azure.com',
+            'tenant_id': 'saved-tenant',
+            'endpoint': self.endpoint,
+        })
+        self.assertEqual(self.config.get('defaults', 'endpoint'), 'devcenter-endpoint')
+        self.assertEqual(self.config.get('defaults', 'group'), 'saved-group')
+        self.assertEqual(self.config.get('defaults', 'workspace'), 'saved-workspace')
+        self.profile.return_value.get_subscription.assert_called_with('saved-subscription')
+
+    def test_matching_identity_uses_cache_without_arm(self):
+        self.save_workspace()
+        for group, workspace in [(None, None), ('saved-group', 'saved-workspace'),
+                                 ('SAVED-GROUP', 'SAVED-WORKSPACE')]:
+            for factory in (cf_jobs, cf_providers, cf_quotas):
+                with self.subTest(group=group, workspace=workspace, factory=factory.__name__):
+                    info = WorkspaceInfo(self.cmd, group, workspace)
+                    factory(self.cmd.cli_ctx, info.subscription, info.resource_group, info.name, info.endpoint)
+                    self.client.assert_called_with(self.endpoint, self.credentials.return_value)
+        self.arm.assert_not_called()
+
+    def test_other_workspace_uses_arm_without_changing_saved_state(self):
+        self.save_workspace()
+        before = self.config.items('defaults'), self.config.items('quantum')
+        self.client.return_value.services.jobs.get.return_value.as_dict.return_value = {'id': 'job-id'}
+
+        result = job_show(self.cmd, 'job-id', 'other-group', 'other-workspace')
+
+        self.assertEqual(result, {'id': 'job-id'})
+        self.arm.return_value.get.assert_called_once_with('other-group', 'other-workspace')
+        self.client.assert_called_once_with(self.other_endpoint, self.credentials.return_value)
+        self.client.return_value.services.jobs.get.assert_called_once_with(
+            'saved-subscription', 'other-group', 'other-workspace', 'job-id')
+        self.assertEqual((self.config.items('defaults'), self.config.items('quantum')), before)
+
+    def test_partial_overrides_keep_independent_defaults_but_not_endpoint(self):
+        self.save_workspace()
+        for group, workspace, expected_group, expected_workspace in [
+            (None, 'other-workspace', 'saved-group', 'other-workspace'),
+            ('other-group', None, 'other-group', 'saved-workspace'),
+        ]:
+            with self.subTest(group=group, workspace=workspace):
+                info = WorkspaceInfo(self.cmd, group, workspace)
+                self.assertEqual((info.resource_group, info.name), (expected_group, expected_workspace))
+                self.assertIsNone(info.endpoint)
+
+    def test_other_subscription_does_not_reuse_cache(self):
+        self.save_workspace()
+        self.subscription.return_value = 'other-subscription'
+        self.assertIsNone(WorkspaceInfo(self.cmd).endpoint)
+
+    def test_other_cloud_does_not_reuse_cache(self):
+        self.save_workspace()
+        self.cloud.endpoints.resource_manager = 'https://management.usgovcloudapi.net/'
+        self.assertIsNone(WorkspaceInfo(self.cmd).endpoint)
+
+    def test_other_tenant_does_not_reuse_cache(self):
+        self.save_workspace()
+        self.profile.return_value.get_subscription.return_value = {'tenantId': 'other-tenant'}
+        self.assertIsNone(WorkspaceInfo(self.cmd).endpoint)
+
+    def test_changed_defaults_do_not_reuse_cache(self):
+        self.save_workspace()
+        self.config.set_value('defaults', 'workspace', 'other-workspace')
+        self.assertIsNone(WorkspaceInfo(self.cmd).endpoint)
+
+    def test_legacy_endpoint_is_ignored_in_config_and_environment(self):
+        self.config.set_value('defaults', 'endpoint', self.endpoint)
+        self.assertIsNone(WorkspaceInfo(self.cmd, 'other-group', 'other-workspace').endpoint)
+        with patch.dict(os.environ, {self.config.env_var_name('defaults', 'endpoint'): self.endpoint}):
+            self.assertIsNone(WorkspaceInfo(self.cmd, 'other-group', 'other-workspace').endpoint)
+
+    def test_legacy_environment_cannot_override_namespaced_cache(self):
+        self.save_workspace()
+        with patch.dict(os.environ, {self.config.env_var_name('defaults', 'endpoint'): self.other_endpoint}):
+            self.assertEqual(WorkspaceInfo(self.cmd).endpoint, self.endpoint)
+
+    def test_cache_survives_config_reload(self):
+        self.save_workspace()
+        self.cmd.cli_ctx.config = CLIConfig(config_dir=self.config.config_dir,
+                                            config_env_var_prefix='QUANTUM_CACHE_TEST', use_local_config=False)
+        self.assertEqual(WorkspaceInfo(self.cmd).endpoint, self.endpoint)
+        self.assertFalse(self.cmd.cli_ctx.config.has_option('defaults', 'endpoint'))
+
+    def test_no_cache_uses_arm_without_saving_defaults(self):
+        job_show(self.cmd, 'job-id', 'other-group', 'other-workspace')
+        self.arm.return_value.get.assert_called_once_with('other-group', 'other-workspace')
+        self.assertEqual(self.config.items('defaults'), [])
+        self.assertEqual(self.config.items('quantum'), [])
+
+    def test_cache_assumes_endpoint_valid_and_preserves_service_error(self):
+        self.save_workspace()
+        before = self.config.get('quantum', 'workspace_endpoint_cache')
+        error = ResourceNotFoundError('Job cannot be found')
+        self.client.return_value.services.jobs.get.side_effect = error
+
+        with self.assertRaises(ResourceNotFoundError) as raised:
+            job_show(self.cmd, 'job-id', 'saved-group', 'saved-workspace')
+
+        self.assertIs(raised.exception, error)
+        self.client.return_value.services.jobs.get.assert_called_once()
+        self.arm.assert_not_called()
+        self.assertEqual(self.config.get('quantum', 'workspace_endpoint_cache'), before)
+
+    def test_missing_workspace_identity_does_not_use_cache(self):
+        self.save_workspace()
+        self.config.remove_option('defaults', 'workspace')
+        self.assertIsNone(WorkspaceInfo(self.cmd).endpoint)
+
+    def test_cache_identity_is_case_insensitive(self):
+        self.save_workspace()
+        self.subscription.return_value = 'SAVED-SUBSCRIPTION'
+        self.profile.return_value.get_subscription.return_value = {'tenantId': 'SAVED-TENANT'}
+        self.cloud.endpoints.resource_manager = 'https://MANAGEMENT.AZURE.COM'
+        self.assertEqual(WorkspaceInfo(self.cmd, 'SAVED-GROUP', 'SAVED-WORKSPACE').endpoint, self.endpoint)
+
+    def test_clear_removes_owned_cache_and_preserves_unrelated_settings(self):
+        self.config.set_value('defaults', 'endpoint', 'devcenter-endpoint')
+        self.config.set_value('defaults', 'location', 'westus')
+        self.config.set_value('defaults', 'target_id', 'target')
+        self.config.set_value('quantum', 'version_check_date', '2026-09-10')
+        self.save_workspace()
+
+        clear(self.cmd)
+
+        self.assertEqual(self.config.get('defaults', 'group'), '')
+        self.assertEqual(self.config.get('defaults', 'workspace'), '')
+        self.assertFalse(self.config.has_option('quantum', 'workspace_endpoint_cache'))
+        self.assertEqual(self.config.get('defaults', 'endpoint'), 'devcenter-endpoint')
+        self.assertEqual(self.config.get('defaults', 'location'), 'westus')
+        self.assertEqual(self.config.get('defaults', 'target_id'), 'target')
+        self.assertEqual(self.config.get('quantum', 'version_check_date'), '2026-09-10')
+
+    def test_explicit_internal_endpoint_still_takes_precedence(self):
+        self.save_workspace()
+        self.assertEqual(WorkspaceInfo(self.cmd, endpoint=self.other_endpoint).endpoint, self.other_endpoint)
+        self.assertEqual(WorkspaceInfo(self.cmd, endpoint='').endpoint, '')
+
+    def test_unreadable_cache_is_a_miss(self):
+        self.save_workspace()
+        for value in ('not-json', '[]', 'null', '{"version": 99}', '{"version": 1}', ''):
+            with self.subTest(value=value):
+                self.config.set_value('quantum', 'workspace_endpoint_cache', value)
+                self.assertIsNone(WorkspaceInfo(self.cmd).endpoint)
+
+    def test_incomplete_cache_is_a_miss(self):
+        self.save_workspace()
+        cache = json.loads(self.config.get('quantum', 'workspace_endpoint_cache'))
+        for key in cache:
+            with self.subTest(key=key):
+                incomplete = {name: value for name, value in cache.items() if name != key}
+                self.config.set_value('quantum', 'workspace_endpoint_cache', json.dumps(incomplete))
+                self.assertIsNone(WorkspaceInfo(self.cmd).endpoint)
+
+    def test_set_replaces_cache_using_arm_metadata(self):
+        self.save_workspace()
+        with patch('azext_quantum.operations.workspace.cf_workspaces') as workspaces:
+            workspace = workspaces.return_value.get.return_value
+            workspace.properties.endpoint_uri = self.other_endpoint
+            result = set_workspace(self.cmd, 'other-workspace', 'other-group')
+
+        self.assertIs(result, workspace)
+        workspaces.return_value.get.assert_called_once_with('other-group', 'other-workspace')
+        self.assertEqual(WorkspaceInfo(self.cmd).endpoint, self.other_endpoint)
+        self.assertIsNone(WorkspaceInfo(self.cmd, 'saved-group', 'saved-workspace').endpoint)

--- a/src/quantum/setup.py
+++ b/src/quantum/setup.py
@@ -17,7 +17,7 @@ except ImportError:
 # This version should match the latest entry in HISTORY.rst
 # Also, when updating this, please review the version used by the extension to
 # submit requests, which can be found at './azext_quantum/__init__.py'
-VERSION = '1.0.0b25'
+VERSION = '1.0.0b26'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes |
| :--: |
| ️✔️ None |

<!-- act-bot:section title="Azure CLI Extensions Breaking Change Test" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

Currently setting a default quantum workspace caches the workspace's endpoint, but then that endpoint is still used for all other workspaces, preventing them from being accessed.

This PR saves the workspace information together with the endpoint so that the cached endpoint value is not used for any other workspace.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

`az quantum workspace set`


### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install azdev` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
